### PR TITLE
feat: add clawhip tmux watch for existing sessions (fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ clawhip tmux new -s issue-123 \
   --mention "<@your-user-id>" \
   --keywords "error,PR created,complete" \
   -- 'source ~/.zshrc && omx --madmax'
+
+# or attach monitoring to an existing tmux session
+clawhip tmux watch -s issue-123 \
+  --channel YOUR_CHANNEL_ID \
+  --mention "<@your-user-id>" \
+  --keywords "error,PR created,complete"
 ```
 
 See [`skills/omx/`](skills/omx/) for ready-to-use scripts.
@@ -244,7 +250,7 @@ Verification:
 - let real tmux session idle past threshold
 - confirm final Discord body in target channel
 
-### 9. tmux wrapper preset
+### 9. tmux wrapper / watch preset
 
 Input:
 ```bash
@@ -256,17 +262,25 @@ clawhip tmux new -s <session> \
   --format alert \
   --shell /bin/zsh \
   -- command args
+
+clawhip tmux watch -s <existing-session> \
+  --channel <id> \
+  --mention '<@id>' \
+  --keywords 'error,PR created,FAILED,complete' \
+  --stale-minutes 10 \
+  --format alert
 ```
 
 Behavior:
-- create tmux session using the user's default shell (or `--shell` override)
-- send the requested command into the session
-- register session with daemon
+- `tmux new` creates a tmux session using the user's default shell (or `--shell` override)
+- `tmux new` sends the requested command into the session
+- `tmux watch` attaches monitoring to an already-running tmux session
+- both commands register the session with the daemon
 - daemon monitors keyword/stale events
 - final delivery goes through daemon routing
 
 Verification:
-- run wrapper
+- run wrapper or watch an existing session
 - emit keyword in pane
 - confirm Discord message body and mention
 
@@ -430,6 +444,7 @@ Required live sign-off presets:
 - tmux keyword
 - tmux stale
 - tmux wrapper
+- tmux watch
 - install/update/uninstall
 
 ## Minimal operational commands

--- a/SKILL.md
+++ b/SKILL.md
@@ -52,6 +52,7 @@ clawhip git commit ...
 clawhip tmux keyword ...
 clawhip tmux stale ...
 clawhip tmux new -s <session> --channel <id> --keywords error,complete --shell /bin/zsh -- command
+clawhip tmux watch -s <existing-session> --channel <id> --mention '<@id>' --keywords error,complete
 ```
 
 ## Lifecycle surface
@@ -114,7 +115,7 @@ Preset verification targets:
 - GitHub issue opened / commented / closed
 - GitHub PR opened / status changed / merged
 - git commit monitor
-- tmux keyword / stale / wrapper
+- tmux keyword / stale / wrapper / watch
 - install / update / uninstall
 
 ## Attachment summary

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,6 +164,7 @@ pub enum TmuxCommands {
         channel: Option<String>,
     },
     New(TmuxNewArgs),
+    Watch(TmuxWatchArgs),
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -209,10 +210,67 @@ pub struct TmuxNewArgs {
     pub command: Vec<String>,
 }
 
+#[derive(Debug, Clone, Args)]
+pub struct TmuxWatchArgs {
+    #[arg(short = 's', long = "session")]
+    pub session: String,
+    #[arg(long)]
+    pub channel: Option<String>,
+    #[arg(long)]
+    pub mention: Option<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub keywords: Vec<String>,
+    #[arg(long, default_value_t = 10)]
+    pub stale_minutes: u64,
+    #[arg(long)]
+    pub format: Option<TmuxWrapperFormat>,
+}
+
 #[derive(Debug, Clone, Default, Subcommand)]
 pub enum ConfigCommand {
     #[default]
     Interactive,
     Show,
     Path,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_tmux_watch_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "tmux",
+            "watch",
+            "-s",
+            "issue-13",
+            "--channel",
+            "alerts",
+            "--mention",
+            "<@123>",
+            "--keywords",
+            "error,complete",
+            "--stale-minutes",
+            "15",
+            "--format",
+            "alert",
+        ]);
+
+        let Commands::Tmux { command } = cli.command.expect("tmux command") else {
+            panic!("expected tmux command");
+        };
+
+        let TmuxCommands::Watch(args) = command else {
+            panic!("expected tmux watch command");
+        };
+
+        assert_eq!(args.session, "issue-13");
+        assert_eq!(args.channel.as_deref(), Some("alerts"));
+        assert_eq!(args.mention.as_deref(), Some("<@123>"));
+        assert_eq!(args.keywords, vec!["error", "complete"]);
+        assert_eq!(args.stale_minutes, 15);
+        assert!(matches!(args.format, Some(TmuxWrapperFormat::Alert)));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ async fn real_main() -> Result<()> {
                     .await
             }
             TmuxCommands::New(args) => tmux_wrapper::run(args, config.as_ref()).await,
+            TmuxCommands::Watch(args) => tmux_wrapper::watch(args, config.as_ref()).await,
         },
         Commands::Config { command } => match command.unwrap_or(ConfigCommand::Interactive) {
             ConfigCommand::Interactive => {

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -6,7 +6,7 @@ use tokio::process::Command;
 use tokio::time::sleep;
 
 use crate::Result;
-use crate::cli::TmuxNewArgs;
+use crate::cli::{TmuxNewArgs, TmuxWatchArgs, TmuxWrapperFormat};
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
 use crate::events::IncomingEvent;
@@ -14,6 +14,67 @@ use crate::monitor::RegisteredTmuxSession;
 
 pub async fn run(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
     launch_session(&args).await?;
+    let monitor_args = TmuxMonitorArgs::from(&args);
+    let monitor = register_and_start_monitor(monitor_args, config).await?;
+
+    if args.attach {
+        attach_session(&args.session).await?;
+    }
+
+    monitor.await??;
+    Ok(())
+}
+
+pub async fn watch(args: TmuxWatchArgs, config: &AppConfig) -> Result<()> {
+    if !session_exists(&args.session).await? {
+        return Err(format!("tmux session '{}' does not exist", args.session).into());
+    }
+
+    let monitor = register_and_start_monitor(TmuxMonitorArgs::from(&args), config).await?;
+    monitor.await??;
+    Ok(())
+}
+
+#[derive(Clone)]
+struct TmuxMonitorArgs {
+    session: String,
+    channel: Option<String>,
+    mention: Option<String>,
+    keywords: Vec<String>,
+    stale_minutes: u64,
+    format: Option<TmuxWrapperFormat>,
+}
+
+impl From<&TmuxNewArgs> for TmuxMonitorArgs {
+    fn from(value: &TmuxNewArgs) -> Self {
+        Self {
+            session: value.session.clone(),
+            channel: value.channel.clone(),
+            mention: value.mention.clone(),
+            keywords: value.keywords.clone(),
+            stale_minutes: value.stale_minutes,
+            format: value.format,
+        }
+    }
+}
+
+impl From<&TmuxWatchArgs> for TmuxMonitorArgs {
+    fn from(value: &TmuxWatchArgs) -> Self {
+        Self {
+            session: value.session.clone(),
+            channel: value.channel.clone(),
+            mention: value.mention.clone(),
+            keywords: value.keywords.clone(),
+            stale_minutes: value.stale_minutes,
+            format: value.format,
+        }
+    }
+}
+
+async fn register_and_start_monitor(
+    args: TmuxMonitorArgs,
+    config: &AppConfig,
+) -> Result<tokio::task::JoinHandle<Result<()>>> {
     let client = DaemonClient::from_config(config);
     let registration = RegisteredTmuxSession {
         session: args.session.clone(),
@@ -26,16 +87,10 @@ pub async fn run(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
     };
     client.register_tmux(&registration).await?;
 
-    let monitor_args = args.clone();
     let monitor_client = client.clone();
-    let monitor = tokio::spawn(async move { monitor_session(monitor_args, monitor_client).await });
-
-    if args.attach {
-        attach_session(&args.session).await?;
-    }
-
-    monitor.await??;
-    Ok(())
+    Ok(tokio::spawn(async move {
+        monitor_session(args, monitor_client).await
+    }))
 }
 
 #[derive(Clone)]
@@ -62,7 +117,7 @@ struct KeywordHit {
     line: String,
 }
 
-async fn monitor_session(args: TmuxNewArgs, client: DaemonClient) -> Result<()> {
+async fn monitor_session(args: TmuxMonitorArgs, client: DaemonClient) -> Result<()> {
     let mut state: HashMap<String, PaneState> = HashMap::new();
     let poll_interval = Duration::from_secs(1);
     let stale_after = Duration::from_secs(args.stale_minutes.max(1) * 60);
@@ -454,5 +509,29 @@ PR created #7",
             build_command_to_send(&args).as_deref(),
             Some("source ~/.zshrc && omx --madmax")
         );
+    }
+
+    #[test]
+    fn watch_args_convert_to_monitor_args() {
+        let args = TmuxWatchArgs {
+            session: "existing".into(),
+            channel: Some("alerts".into()),
+            mention: Some("<@123>".into()),
+            keywords: vec!["error".into(), "complete".into()],
+            stale_minutes: 15,
+            format: Some(TmuxWrapperFormat::Inline),
+        };
+
+        let monitor_args = TmuxMonitorArgs::from(&args);
+
+        assert_eq!(monitor_args.session, "existing");
+        assert_eq!(monitor_args.channel.as_deref(), Some("alerts"));
+        assert_eq!(monitor_args.mention.as_deref(), Some("<@123>"));
+        assert_eq!(monitor_args.keywords, vec!["error", "complete"]);
+        assert_eq!(monitor_args.stale_minutes, 15);
+        assert!(matches!(
+            monitor_args.format,
+            Some(TmuxWrapperFormat::Inline)
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add `clawhip tmux watch` to monitor an existing tmux session without launching a new one
- reuse the wrapper registration/monitoring path for both `tmux new` and `tmux watch`
- document the new command in README and SKILL.md and add CLI parsing coverage

## Testing
- cargo test