### PR TITLE
feat: add version and token-source diagnostics to status (fixes #15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clawhip"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "clap",

--- a/src/config.rs
+++ b/src/config.rs
@@ -213,6 +213,28 @@ fn default_true() -> bool {
     true
 }
 
+const DISCORD_TOKEN_ENV_VARS: [&str; 2] = ["DISCORD_TOKEN", "CLAWHIP_DISCORD_BOT_TOKEN"];
+
+fn normalize_secret(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn discord_token_from_env_with<F>(mut get_env: F) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    DISCORD_TOKEN_ENV_VARS
+        .iter()
+        .find_map(|name| normalize_secret(get_env(name)))
+}
+
 impl AppConfig {
     pub fn load_or_default(path: &Path) -> Result<Self> {
         if !path.exists() {
@@ -239,10 +261,32 @@ impl AppConfig {
     }
 
     pub fn effective_token(&self) -> Option<String> {
-        env::var("CLAWHIP_DISCORD_BOT_TOKEN")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
-            .or_else(|| self.discord.bot_token.clone())
+        self.effective_token_with(|name| env::var(name).ok())
+    }
+
+    fn effective_token_with<F>(&self, get_env: F) -> Option<String>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        discord_token_from_env_with(get_env)
+            .or_else(|| normalize_secret(self.discord.bot_token.clone()))
+    }
+
+    pub fn discord_token_source(&self) -> &'static str {
+        self.discord_token_source_with(|name| env::var(name).ok())
+    }
+
+    fn discord_token_source_with<F>(&self, get_env: F) -> &'static str
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        if discord_token_from_env_with(get_env).is_some() {
+            "env"
+        } else if normalize_secret(self.discord.bot_token.clone()).is_some() {
+            "config"
+        } else {
+            "missing"
+        }
     }
 
     pub fn daemon_base_url(&self) -> String {
@@ -299,19 +343,8 @@ impl AppConfig {
     }
 
     fn print_summary(&self) {
-        let token_status = if self
-            .discord
-            .bot_token
-            .as_deref()
-            .unwrap_or_default()
-            .is_empty()
-        {
-            "missing"
-        } else {
-            "configured"
-        };
         println!("Current config summary:");
-        println!("  Discord token: {token_status}");
+        println!("  Discord token source: {}", self.discord_token_source());
         println!("  Daemon base URL: {}", self.daemon.base_url);
         println!(
             "  Bind host/port: {}:{}",
@@ -368,5 +401,58 @@ fn empty_to_none(value: String) -> Option<String> {
         None
     } else {
         Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discord_token_source_prefers_env_over_config() {
+        let mut config = AppConfig::default();
+        config.discord.bot_token = Some("config-token".into());
+
+        assert_eq!(config.discord_token_source_with(|_| None), "config");
+        assert_eq!(
+            config.effective_token_with(|_| None).as_deref(),
+            Some("config-token")
+        );
+
+        let token = config.effective_token_with(|name| {
+            (name == "DISCORD_TOKEN").then(|| "env-token".to_string())
+        });
+        assert_eq!(token.as_deref(), Some("env-token"));
+        assert_eq!(
+            config.discord_token_source_with(|name| {
+                (name == "DISCORD_TOKEN").then(|| "env-token".to_string())
+            }),
+            "env"
+        );
+    }
+
+    #[test]
+    fn discord_token_source_reports_missing_when_unset() {
+        let config = AppConfig::default();
+
+        assert_eq!(config.discord_token_source_with(|_| None), "missing");
+        assert_eq!(config.effective_token_with(|_| None), None);
+    }
+
+    #[test]
+    fn legacy_env_token_is_still_supported() {
+        let config = AppConfig::default();
+
+        let token = config.effective_token_with(|name| {
+            (name == "CLAWHIP_DISCORD_BOT_TOKEN").then(|| "legacy-token".to_string())
+        });
+
+        assert_eq!(token.as_deref(), Some("legacy-token"));
+        assert_eq!(
+            config.discord_token_source_with(|name| {
+                (name == "CLAWHIP_DISCORD_BOT_TOKEN").then(|| "legacy-token".to_string())
+            }),
+            "env"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -11,6 +11,7 @@ use serde_json::{Value, json};
 use tokio::sync::RwLock;
 
 use crate::Result;
+use crate::VERSION;
 use crate::config::AppConfig;
 use crate::discord::DiscordClient;
 use crate::events::{IncomingEvent, normalize_event};
@@ -27,6 +28,9 @@ struct AppState {
 }
 
 pub async fn run(config: Arc<AppConfig>, port_override: Option<u16>) -> Result<()> {
+    let token_source = config.discord_token_source();
+    println!("clawhip v{VERSION} starting (token_source: {token_source})");
+
     let discord = Arc::new(DiscordClient::from_config(config.clone())?);
     let router = Arc::new(Router::new(config.clone()));
     let tmux_registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
@@ -57,7 +61,7 @@ pub async fn run(config: Arc<AppConfig>, port_override: Option<u16>) -> Result<(
     let addr: SocketAddr = format!("{}:{}", config.daemon.bind_host, port).parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
     println!(
-        "clawhip daemon listening on http://{}",
+        "clawhip daemon v{VERSION} listening on http://{} (token_source: {token_source})",
         listener.local_addr()?
     );
     axum::serve(listener, app).await?;
@@ -66,14 +70,24 @@ pub async fn run(config: Arc<AppConfig>, port_override: Option<u16>) -> Result<(
 
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let registered = state.tmux_registry.read().await.len();
-    Json(json!({
+    Json(health_payload(
+        state.config.as_ref(),
+        state.port,
+        registered,
+    ))
+}
+
+fn health_payload(config: &AppConfig, port: u16, registered_tmux_sessions: usize) -> Value {
+    json!({
         "ok": true,
-        "port": state.port,
-        "daemon_base_url": state.config.daemon.base_url,
-        "configured_git_monitors": state.config.monitors.git.repos.len(),
-        "configured_tmux_monitors": state.config.monitors.tmux.sessions.len(),
-        "registered_tmux_sessions": registered,
-    }))
+        "version": VERSION,
+        "token_source": config.discord_token_source(),
+        "port": port,
+        "daemon_base_url": config.daemon.base_url,
+        "configured_git_monitors": config.monitors.git.repos.len(),
+        "configured_tmux_monitors": config.monitors.tmux.sessions.len(),
+        "registered_tmux_sessions": registered_tmux_sessions,
+    })
 }
 
 async fn status(State(state): State<AppState>) -> impl IntoResponse {
@@ -209,5 +223,29 @@ async fn post_github(
             Json(json!({"ok": false, "error": error.to_string()})),
         )
             .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AppConfig;
+
+    #[test]
+    fn health_payload_includes_version_and_token_source() {
+        let mut config = AppConfig::default();
+        config.discord.bot_token = Some("config-token".into());
+        config.monitors.git.repos.push(Default::default());
+        config.monitors.tmux.sessions.push(Default::default());
+
+        let payload = health_payload(&config, 25294, 3);
+
+        assert_eq!(payload["ok"], Value::Bool(true));
+        assert_eq!(payload["version"], Value::String(VERSION.to_string()));
+        assert_eq!(payload["token_source"], Value::String("config".to_string()));
+        assert_eq!(payload["port"], Value::from(25294));
+        assert_eq!(payload["configured_git_monitors"], Value::from(1));
+        assert_eq!(payload["configured_tmux_monitors"], Value::from(1));
+        assert_eq!(payload["registered_tmux_sessions"], Value::from(3));
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -16,7 +16,7 @@ impl DiscordClient {
     pub fn from_config(config: Arc<AppConfig>) -> Result<Self> {
         let token = config
             .effective_token()
-            .ok_or_else(|| "missing Discord bot token; configure ~/.clawhip/config.toml or CLAWHIP_DISCORD_BOT_TOKEN".to_string())?;
+            .ok_or_else(|| "missing Discord bot token; configure ~/.clawhip/config.toml or DISCORD_TOKEN (CLAWHIP_DISCORD_BOT_TOKEN is also supported)".to_string())?;
         let mut headers = HeaderMap::new();
         headers.insert(
             AUTHORIZATION,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ use crate::client::DaemonClient;
 use crate::config::AppConfig;
 use crate::events::IncomingEvent;
 
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub type DynError = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, DynError>;
 


### PR DESCRIPTION
## Summary
- add crate version and token_source diagnostics to daemon health/status responses
- report token source on daemon startup and support DISCORD_TOKEN with legacy env fallback
- add regression tests for token-source resolution and health payload diagnostics

## Testing
- cargo test