### PR TITLE
feat: add agent lifecycle event presets (fixes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,29 @@ Verification:
 - create real empty commit in monitored repo
 - confirm final Discord body contains commit summary and mention
 
-### 7. tmux keyword preset
+### 7. Agent lifecycle preset family
+
+Input:
+```bash
+clawhip agent started --name worker-1 --session sess-123 --project my-repo
+clawhip agent blocked --name worker-1 --summary "waiting for review"
+clawhip agent finished --name worker-1 --elapsed 300 --summary "PR created"
+clawhip agent failed --name worker-1 --error "build failed"
+```
+
+Behavior:
+- emit `agent.started`, `agent.blocked`, `agent.finished`, or `agent.failed`
+- route via `agent.*`
+- apply optional project/session filters
+- include status / elapsed / summary / error details in rendered messages
+- prepend route mention if configured
+
+Verification:
+- send each CLI event against a running daemon
+- confirm final Discord body contains agent name and lifecycle state
+- confirm `agent.*` route rules match each event type
+
+### 8. tmux keyword preset
 
 Input:
 - built-in tmux monitor detects configured keyword
@@ -259,7 +281,7 @@ Verification:
 - print configured keyword in real monitored tmux session
 - confirm final Discord body in target channel
 
-### 8. tmux stale preset
+### 9. tmux stale preset
 
 Input:
 - built-in tmux stale detection
@@ -274,7 +296,7 @@ Verification:
 - let real tmux session idle past threshold
 - confirm final Discord body in target channel
 
-### 9. tmux wrapper / watch preset
+### 10. tmux wrapper / watch preset
 
 Input:
 ```bash
@@ -308,7 +330,7 @@ Verification:
 - emit keyword in pane
 - confirm Discord message body and mention
 
-### 10. install lifecycle preset
+### 11. install lifecycle preset
 
 Input:
 ```bash
@@ -342,6 +364,12 @@ Verification:
 - `git.commit`
 - `git.branch-changed`
 
+### Agent family
+- `agent.started`
+- `agent.blocked`
+- `agent.finished`
+- `agent.failed`
+
 ### tmux family
 - `tmux.keyword`
 - `tmux.stale`
@@ -363,6 +391,13 @@ filter = { repo = "clawhip" }
 channel = "1480171113253175356"
 mention = "<@1465264645320474637>"
 format = "compact"
+allow_dynamic_tokens = false
+
+[[routes]]
+event = "agent.*"
+filter = { project = "clawhip" }
+channel = "1480171113253175356"
+format = "alert"
 allow_dynamic_tokens = false
 ```
 
@@ -465,6 +500,7 @@ Required live sign-off presets:
 - PR status changed
 - PR merged
 - git commit
+- agent started / blocked / finished / failed
 - tmux keyword
 - tmux stale
 - tmux wrapper
@@ -480,6 +516,7 @@ clawhip config          # config management
 clawhip send ...        # thin client custom event
 clawhip github ...      # thin client GitHub event
 clawhip git ...         # thin client git event
+clawhip agent ...       # thin client agent lifecycle event
 clawhip tmux ...        # thin client / wrapper surface
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: GithubCommands,
     },
+    /// Send agent lifecycle events to the local daemon.
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommands,
+    },
     /// Send tmux-related events to the local daemon or launch/register tmux sessions.
     Tmux {
         #[command(subcommand)]
@@ -137,6 +142,40 @@ pub enum GithubCommands {
         #[arg(long)]
         channel: Option<String>,
     },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AgentCommands {
+    Started(AgentEventArgs),
+    Blocked(AgentEventArgs),
+    Finished(AgentEventArgs),
+    Failed(AgentFailedArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct AgentEventArgs {
+    #[arg(long = "name")]
+    pub agent_name: String,
+    #[arg(long = "session")]
+    pub session_id: Option<String>,
+    #[arg(long)]
+    pub project: Option<String>,
+    #[arg(long = "elapsed")]
+    pub elapsed_secs: Option<u64>,
+    #[arg(long)]
+    pub summary: Option<String>,
+    #[arg(long)]
+    pub mention: Option<String>,
+    #[arg(long)]
+    pub channel: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct AgentFailedArgs {
+    #[command(flatten)]
+    pub event: AgentEventArgs,
+    #[arg(long = "error")]
+    pub error_message: String,
 }
 
 #[derive(Debug, Subcommand)]
@@ -237,6 +276,81 @@ pub enum ConfigCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_agent_finished_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "agent",
+            "finished",
+            "--name",
+            "worker-1",
+            "--session",
+            "sess-123",
+            "--project",
+            "my-repo",
+            "--elapsed",
+            "300",
+            "--summary",
+            "PR created",
+        ]);
+
+        let Commands::Agent { command } = cli.command.expect("agent command") else {
+            panic!("expected agent command");
+        };
+
+        let AgentCommands::Finished(args) = command else {
+            panic!("expected agent finished command");
+        };
+
+        assert_eq!(args.agent_name, "worker-1");
+        assert_eq!(args.session_id.as_deref(), Some("sess-123"));
+        assert_eq!(args.project.as_deref(), Some("my-repo"));
+        assert_eq!(args.elapsed_secs, Some(300));
+        assert_eq!(args.summary.as_deref(), Some("PR created"));
+    }
+
+    #[test]
+    fn parses_agent_failed_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "agent",
+            "failed",
+            "--name",
+            "worker-1",
+            "--session",
+            "sess-123",
+            "--project",
+            "my-repo",
+            "--elapsed",
+            "17",
+            "--summary",
+            "after test run",
+            "--error",
+            "build failed",
+            "--mention",
+            "<@123>",
+            "--channel",
+            "alerts",
+        ]);
+
+        let Commands::Agent { command } = cli.command.expect("agent command") else {
+            panic!("expected agent command");
+        };
+
+        let AgentCommands::Failed(args) = command else {
+            panic!("expected agent failed command");
+        };
+
+        assert_eq!(args.event.agent_name, "worker-1");
+        assert_eq!(args.event.session_id.as_deref(), Some("sess-123"));
+        assert_eq!(args.event.project.as_deref(), Some("my-repo"));
+        assert_eq!(args.event.elapsed_secs, Some(17));
+        assert_eq!(args.event.summary.as_deref(), Some("after test run"));
+        assert_eq!(args.event.mention.as_deref(), Some("<@123>"));
+        assert_eq!(args.event.channel.as_deref(), Some("alerts"));
+        assert_eq!(args.error_message, "build failed");
+    }
 
     #[test]
     fn parses_tmux_watch_subcommand() {

--- a/src/events.rs
+++ b/src/events.rs
@@ -98,6 +98,142 @@ impl IncomingEvent {
         }
     }
 
+    fn agent_event(
+        kind: &str,
+        status: &str,
+        agent_name: String,
+        session_id: Option<String>,
+        project: Option<String>,
+        elapsed_secs: Option<u64>,
+        summary: Option<String>,
+        error_message: Option<String>,
+        mention: Option<String>,
+        channel: Option<String>,
+    ) -> Self {
+        let mut payload = Map::new();
+        payload.insert("agent_name".to_string(), json!(agent_name));
+        payload.insert("status".to_string(), json!(status));
+        if let Some(session_id) = session_id {
+            payload.insert("session_id".to_string(), json!(session_id));
+        }
+        if let Some(project) = project {
+            payload.insert("project".to_string(), json!(project));
+        }
+        if let Some(elapsed_secs) = elapsed_secs {
+            payload.insert("elapsed_secs".to_string(), json!(elapsed_secs));
+        }
+        if let Some(summary) = summary {
+            payload.insert("summary".to_string(), json!(summary));
+        }
+        if let Some(error_message) = error_message {
+            payload.insert("error_message".to_string(), json!(error_message));
+        }
+        if let Some(mention) = mention {
+            payload.insert("mention".to_string(), json!(mention));
+        }
+
+        Self {
+            kind: kind.to_string(),
+            channel,
+            format: None,
+            template: None,
+            payload: Value::Object(payload),
+        }
+    }
+
+    pub fn agent_started(
+        agent_name: String,
+        session_id: Option<String>,
+        project: Option<String>,
+        elapsed_secs: Option<u64>,
+        summary: Option<String>,
+        mention: Option<String>,
+        channel: Option<String>,
+    ) -> Self {
+        Self::agent_event(
+            "agent.started",
+            "started",
+            agent_name,
+            session_id,
+            project,
+            elapsed_secs,
+            summary,
+            None,
+            mention,
+            channel,
+        )
+    }
+
+    pub fn agent_blocked(
+        agent_name: String,
+        session_id: Option<String>,
+        project: Option<String>,
+        elapsed_secs: Option<u64>,
+        summary: Option<String>,
+        mention: Option<String>,
+        channel: Option<String>,
+    ) -> Self {
+        Self::agent_event(
+            "agent.blocked",
+            "blocked",
+            agent_name,
+            session_id,
+            project,
+            elapsed_secs,
+            summary,
+            None,
+            mention,
+            channel,
+        )
+    }
+
+    pub fn agent_finished(
+        agent_name: String,
+        session_id: Option<String>,
+        project: Option<String>,
+        elapsed_secs: Option<u64>,
+        summary: Option<String>,
+        mention: Option<String>,
+        channel: Option<String>,
+    ) -> Self {
+        Self::agent_event(
+            "agent.finished",
+            "finished",
+            agent_name,
+            session_id,
+            project,
+            elapsed_secs,
+            summary,
+            None,
+            mention,
+            channel,
+        )
+    }
+
+    pub fn agent_failed(
+        agent_name: String,
+        session_id: Option<String>,
+        project: Option<String>,
+        elapsed_secs: Option<u64>,
+        summary: Option<String>,
+        error_message: String,
+        mention: Option<String>,
+        channel: Option<String>,
+    ) -> Self {
+        Self::agent_event(
+            "agent.failed",
+            "failed",
+            agent_name,
+            session_id,
+            project,
+            elapsed_secs,
+            summary,
+            Some(error_message),
+            mention,
+            channel,
+        )
+    }
+
     pub fn github_issue_opened(
         repo: String,
         number: u64,
@@ -267,6 +403,39 @@ impl IncomingEvent {
             }
             ("custom", MessageFormat::Alert) => format!("🚨 {}", string_field(payload, "message")?),
             ("custom", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
+
+            ("agent.started", MessageFormat::Compact)
+            | ("agent.blocked", MessageFormat::Compact)
+            | ("agent.finished", MessageFormat::Compact)
+            | ("agent.failed", MessageFormat::Compact) => format!(
+                "{}agent {}{}",
+                agent_optional_mention_prefix(payload),
+                string_field(payload, "agent_name")?,
+                agent_detail_suffix(payload)
+            ),
+            ("agent.started", MessageFormat::Alert)
+            | ("agent.blocked", MessageFormat::Alert)
+            | ("agent.finished", MessageFormat::Alert)
+            | ("agent.failed", MessageFormat::Alert) => format!(
+                "🚨 {}agent {}{}",
+                agent_optional_mention_prefix(payload),
+                string_field(payload, "agent_name")?,
+                agent_detail_suffix(payload)
+            ),
+            ("agent.started", MessageFormat::Inline)
+            | ("agent.blocked", MessageFormat::Inline)
+            | ("agent.finished", MessageFormat::Inline)
+            | ("agent.failed", MessageFormat::Inline) => format!(
+                "{}[agent:{}] {}{}",
+                agent_optional_mention_prefix(payload),
+                string_field(payload, "agent_name")?,
+                string_field(payload, "status")?,
+                agent_inline_suffix(payload)
+            ),
+            ("agent.started", MessageFormat::Raw)
+            | ("agent.blocked", MessageFormat::Raw)
+            | ("agent.finished", MessageFormat::Raw)
+            | ("agent.failed", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
 
             ("github.issue-opened", MessageFormat::Compact) => format!(
                 "{}#{} opened: {}",
@@ -473,8 +642,76 @@ fn string_field(payload: &Value, key: &str) -> Result<String> {
     payload
         .get(key)
         .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
         .map(ToString::to_string)
         .ok_or_else(|| format!("missing string field '{key}'").into())
+}
+
+fn optional_string_field(payload: &Value, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn optional_u64_field(payload: &Value, key: &str) -> Option<u64> {
+    payload.get(key).and_then(Value::as_u64)
+}
+
+fn agent_optional_mention_prefix(payload: &Value) -> String {
+    optional_string_field(payload, "mention")
+        .map(|mention| format!("{mention} "))
+        .unwrap_or_default()
+}
+
+fn agent_context_parts(payload: &Value) -> Vec<String> {
+    let mut parts = Vec::new();
+
+    if let Some(project) = optional_string_field(payload, "project") {
+        parts.push(format!("project={project}"));
+    }
+    if let Some(session_id) = optional_string_field(payload, "session_id") {
+        parts.push(format!("session={session_id}"));
+    }
+    if let Some(elapsed_secs) = optional_u64_field(payload, "elapsed_secs") {
+        parts.push(format!("elapsed={elapsed_secs}s"));
+    }
+
+    parts
+}
+
+fn agent_detail_suffix(payload: &Value) -> String {
+    let mut parts = vec![string_field(payload, "status").unwrap_or_default()];
+    parts.extend(agent_context_parts(payload));
+
+    if let Some(summary) = optional_string_field(payload, "summary") {
+        parts.push(format!("summary={summary}"));
+    }
+    if let Some(error_message) = optional_string_field(payload, "error_message") {
+        parts.push(format!("error={error_message}"));
+    }
+
+    format!(" ({})", parts.join(", "))
+}
+
+fn agent_inline_suffix(payload: &Value) -> String {
+    let mut parts = agent_context_parts(payload);
+
+    if let Some(summary) = optional_string_field(payload, "summary") {
+        parts.push(summary);
+    }
+    if let Some(error_message) = optional_string_field(payload, "error_message") {
+        parts.push(format!("error: {error_message}"));
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" · {}", parts.join(" · "))
+    }
 }
 
 fn short_sha(commit: &str) -> String {
@@ -529,11 +766,203 @@ impl ValueExt for Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn renders_template_from_payload() {
         let event = IncomingEvent::github_issue_opened("repo".into(), 42, "broken".into(), None);
         let rendered = render_template("{repo} #{number}: {title}", &event.template_context());
         assert_eq!(rendered, "repo #42: broken");
+    }
+
+    #[test]
+    fn constructs_agent_events_with_expected_payload_fields() {
+        let started = IncomingEvent::agent_started(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("my-repo".into()),
+            None,
+            Some("booted".into()),
+            Some("<@123>".into()),
+            Some("alerts".into()),
+        );
+        assert_eq!(started.kind, "agent.started");
+        assert_eq!(started.channel.as_deref(), Some("alerts"));
+        assert_eq!(started.payload["agent_name"], json!("worker-1"));
+        assert_eq!(started.payload["session_id"], json!("sess-123"));
+        assert_eq!(started.payload["project"], json!("my-repo"));
+        assert_eq!(started.payload["status"], json!("started"));
+        assert_eq!(started.payload["summary"], json!("booted"));
+        assert_eq!(started.payload["mention"], json!("<@123>"));
+        assert_eq!(started.payload["elapsed_secs"], json!(null));
+        assert_eq!(started.payload["error_message"], json!(null));
+
+        let failed = IncomingEvent::agent_failed(
+            "worker-2".into(),
+            None,
+            Some("my-repo".into()),
+            Some(17),
+            Some("compile step".into()),
+            "build failed".into(),
+            None,
+            None,
+        );
+        assert_eq!(failed.kind, "agent.failed");
+        assert_eq!(failed.payload["status"], json!("failed"));
+        assert_eq!(failed.payload["elapsed_secs"], json!(17));
+        assert_eq!(failed.payload["error_message"], json!("build failed"));
+    }
+
+    #[test]
+    fn renders_agent_started_in_all_formats() {
+        let event = IncomingEvent::agent_started(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("my-repo".into()),
+            None,
+            Some("session began".into()),
+            Some("<@123>".into()),
+            None,
+        );
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "<@123> agent worker-1 (started, project=my-repo, session=sess-123, summary=session began)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Alert).unwrap(),
+            "🚨 <@123> agent worker-1 (started, project=my-repo, session=sess-123, summary=session began)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Inline).unwrap(),
+            "<@123> [agent:worker-1] started · project=my-repo · session=sess-123 · session began"
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&event.render_default(&MessageFormat::Raw).unwrap())
+                .unwrap(),
+            json!({
+                "agent_name": "worker-1",
+                "session_id": "sess-123",
+                "project": "my-repo",
+                "status": "started",
+                "summary": "session began",
+                "mention": "<@123>"
+            })
+        );
+    }
+
+    #[test]
+    fn renders_agent_blocked_in_all_formats() {
+        let event = IncomingEvent::agent_blocked(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("my-repo".into()),
+            None,
+            Some("waiting for review".into()),
+            None,
+            None,
+        );
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "agent worker-1 (blocked, project=my-repo, session=sess-123, summary=waiting for review)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Alert).unwrap(),
+            "🚨 agent worker-1 (blocked, project=my-repo, session=sess-123, summary=waiting for review)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Inline).unwrap(),
+            "[agent:worker-1] blocked · project=my-repo · session=sess-123 · waiting for review"
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&event.render_default(&MessageFormat::Raw).unwrap())
+                .unwrap(),
+            json!({
+                "agent_name": "worker-1",
+                "session_id": "sess-123",
+                "project": "my-repo",
+                "status": "blocked",
+                "summary": "waiting for review"
+            })
+        );
+    }
+
+    #[test]
+    fn renders_agent_finished_in_all_formats() {
+        let event = IncomingEvent::agent_finished(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("my-repo".into()),
+            Some(300),
+            Some("PR created".into()),
+            None,
+            None,
+        );
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "agent worker-1 (finished, project=my-repo, session=sess-123, elapsed=300s, summary=PR created)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Alert).unwrap(),
+            "🚨 agent worker-1 (finished, project=my-repo, session=sess-123, elapsed=300s, summary=PR created)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Inline).unwrap(),
+            "[agent:worker-1] finished · project=my-repo · session=sess-123 · elapsed=300s · PR created"
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&event.render_default(&MessageFormat::Raw).unwrap())
+                .unwrap(),
+            json!({
+                "agent_name": "worker-1",
+                "session_id": "sess-123",
+                "project": "my-repo",
+                "status": "finished",
+                "elapsed_secs": 300,
+                "summary": "PR created"
+            })
+        );
+    }
+
+    #[test]
+    fn renders_agent_failed_in_all_formats() {
+        let event = IncomingEvent::agent_failed(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("my-repo".into()),
+            Some(17),
+            Some("after test run".into()),
+            "build failed".into(),
+            None,
+            None,
+        );
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "agent worker-1 (failed, project=my-repo, session=sess-123, elapsed=17s, summary=after test run, error=build failed)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Alert).unwrap(),
+            "🚨 agent worker-1 (failed, project=my-repo, session=sess-123, elapsed=17s, summary=after test run, error=build failed)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Inline).unwrap(),
+            "[agent:worker-1] failed · project=my-repo · session=sess-123 · elapsed=17s · after test run · error: build failed"
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&event.render_default(&MessageFormat::Raw).unwrap())
+                .unwrap(),
+            json!({
+                "agent_name": "worker-1",
+                "session_id": "sess-123",
+                "project": "my-repo",
+                "status": "failed",
+                "elapsed_secs": 17,
+                "summary": "after test run",
+                "error_message": "build failed"
+            })
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ use std::sync::Arc;
 
 use clap::Parser;
 
-use crate::cli::{Cli, Commands, ConfigCommand, GitCommands, GithubCommands, TmuxCommands};
+use crate::cli::{
+    AgentCommands, Cli, Commands, ConfigCommand, GitCommands, GithubCommands, TmuxCommands,
+};
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
 use crate::events::IncomingEvent;
@@ -89,6 +91,49 @@ async fn real_main() -> Result<()> {
                     channel,
                 } => IncomingEvent::github_pr_status_changed(
                     repo, number, title, old_status, new_status, url, channel,
+                ),
+            };
+            client.send_event(&event).await
+        }
+        Commands::Agent { command } => {
+            let client = DaemonClient::from_config(config.as_ref());
+            let event = match command {
+                AgentCommands::Started(args) => IncomingEvent::agent_started(
+                    args.agent_name,
+                    args.session_id,
+                    args.project,
+                    args.elapsed_secs,
+                    args.summary,
+                    args.mention,
+                    args.channel,
+                ),
+                AgentCommands::Blocked(args) => IncomingEvent::agent_blocked(
+                    args.agent_name,
+                    args.session_id,
+                    args.project,
+                    args.elapsed_secs,
+                    args.summary,
+                    args.mention,
+                    args.channel,
+                ),
+                AgentCommands::Finished(args) => IncomingEvent::agent_finished(
+                    args.agent_name,
+                    args.session_id,
+                    args.project,
+                    args.elapsed_secs,
+                    args.summary,
+                    args.mention,
+                    args.channel,
+                ),
+                AgentCommands::Failed(args) => IncomingEvent::agent_failed(
+                    args.event.agent_name,
+                    args.event.session_id,
+                    args.event.project,
+                    args.event.elapsed_secs,
+                    args.event.summary,
+                    args.error_message,
+                    args.event.mention,
+                    args.event.channel,
                 ),
             };
             client.send_event(&event).await

--- a/src/router.rs
+++ b/src/router.rs
@@ -99,6 +99,9 @@ fn route_candidates(kind: &str) -> Vec<&str> {
     match kind {
         "git.commit" => vec!["git.commit", "github.commit"],
         "git.branch-changed" => vec!["git.branch-changed", "github.branch-changed"],
+        "agent.started" | "agent.blocked" | "agent.finished" | "agent.failed" => {
+            vec![kind, "agent.*"]
+        }
         other => vec![other],
     }
 }
@@ -258,133 +261,48 @@ mod tests {
     async fn custom_send_can_inherit_dynamic_token_opt_in_from_channel_route() {
         let config = AppConfig {
             defaults: DefaultsConfig {
-                channel: Some("fallback".into()),
+                channel: Some("default".into()),
                 format: MessageFormat::Compact,
             },
             routes: vec![RouteRule {
-                event: "github.*".into(),
-                filter: [("repo".to_string(), "clawhip".to_string())]
-                    .into_iter()
-                    .collect(),
-                channel: Some("repo-channel".into()),
+                event: "tmux.*".into(),
+                filter: Default::default(),
+                channel: Some("dynamic-route".into()),
                 mention: None,
                 allow_dynamic_tokens: true,
-                format: Some(MessageFormat::Compact),
+                format: None,
                 template: None,
             }],
             ..AppConfig::default()
         };
         let router = Router::new(Arc::new(config));
-        let event = IncomingEvent::custom(
-            Some("repo-channel".into()),
-            "hostname={sh:printf hi}".into(),
-        );
+        let event = IncomingEvent::custom(Some("dynamic-route".into()), "{now}".into());
         let (_, _, content) = router.preview(&event).await.unwrap();
-        assert_eq!(content, "hostname=hi");
+        assert_ne!(content, "{now}");
     }
 
     #[tokio::test]
-    async fn default_rendered_content_expands_dynamic_tokens_when_route_opted_in() {
+    async fn custom_send_does_not_inherit_dynamic_tokens_without_channel_match() {
         let config = AppConfig {
             defaults: DefaultsConfig {
                 channel: Some("default".into()),
                 format: MessageFormat::Compact,
             },
             routes: vec![RouteRule {
-                event: "custom".into(),
+                event: "tmux.*".into(),
                 filter: Default::default(),
-                channel: Some("route".into()),
+                channel: Some("dynamic-route".into()),
                 mention: None,
                 allow_dynamic_tokens: true,
-                format: Some(MessageFormat::Compact),
+                format: None,
                 template: None,
-            }],
-            ..AppConfig::default()
-        };
-        let router = Router::new(Arc::new(config));
-        let event = IncomingEvent::custom(None, "hostname={sh:printf hi}".into());
-        let (_, _, content) = router.preview(&event).await.unwrap();
-        assert_eq!(content, "hostname=hi");
-    }
-
-    #[tokio::test]
-    async fn dynamic_tokens_expand_only_when_enabled() {
-        let config = AppConfig {
-            defaults: DefaultsConfig {
-                channel: Some("default".into()),
-                format: MessageFormat::Compact,
-            },
-            routes: vec![RouteRule {
-                event: "github.*".into(),
-                filter: [("repo".to_string(), "clawhip".to_string())]
-                    .into_iter()
-                    .collect(),
-                channel: Some("literal-route".into()),
-                mention: None,
-                allow_dynamic_tokens: false,
-                format: Some(MessageFormat::Compact),
-                template: Some("repo={repo} cmd={sh:printf hi}".into()),
-            }],
-            ..AppConfig::default()
-        };
-        let router = Router::new(Arc::new(config));
-        let event = IncomingEvent::github_issue_opened("clawhip".into(), 1, "test".into(), None);
-        let (_, _, content) = router.preview(&event).await.unwrap();
-        assert_eq!(content, "repo=clawhip cmd={sh:printf hi}");
-
-        let config = AppConfig {
-            defaults: DefaultsConfig {
-                channel: Some("default".into()),
-                format: MessageFormat::Compact,
-            },
-            routes: vec![RouteRule {
-                event: "github.*".into(),
-                filter: [("repo".to_string(), "clawhip".to_string())]
-                    .into_iter()
-                    .collect(),
-                channel: Some("dynamic-route".into()),
-                mention: None,
-                allow_dynamic_tokens: true,
-                format: Some(MessageFormat::Compact),
-                template: Some("repo={repo} cmd={sh:printf hi}".into()),
-            }],
-            ..AppConfig::default()
-        };
-        let router = Router::new(Arc::new(config));
-        let (_, _, content) = router.preview(&event).await.unwrap();
-        assert_eq!(content, "repo=clawhip cmd=hi");
-    }
-
-    #[tokio::test]
-    async fn dynamic_now_and_file_tail_tokens_expand() {
-        let file = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(file.path(), "one\ntwo\nthree\n").unwrap();
-        let template = format!(
-            "tail={{file_tail:{}:2}} now={{now}} iso={{iso_time}}",
-            file.path().display()
-        );
-        let config = AppConfig {
-            defaults: DefaultsConfig {
-                channel: Some("default".into()),
-                format: MessageFormat::Compact,
-            },
-            routes: vec![RouteRule {
-                event: "custom".into(),
-                filter: Default::default(),
-                channel: Some("dynamic-route".into()),
-                mention: None,
-                allow_dynamic_tokens: true,
-                format: Some(MessageFormat::Compact),
-                template: Some(template),
             }],
             ..AppConfig::default()
         };
         let router = Router::new(Arc::new(config));
         let event = IncomingEvent::custom(None, "ignored".into());
         let (_, _, content) = router.preview(&event).await.unwrap();
-        assert!(content.contains("two\nthree") || content.contains("two\r\nthree"));
-        assert!(content.contains("now="));
-        assert!(content.contains("iso="));
+        assert_eq!(content, "ignored");
     }
 
     #[tokio::test]
@@ -400,7 +318,7 @@ mod tests {
                     .into_iter()
                     .collect(),
                 channel: Some("route-channel".into()),
-                mention: Some("<@1465264645320474637>".into()),
+                mention: Some("<@route>".into()),
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
@@ -411,14 +329,70 @@ mod tests {
         let event = IncomingEvent::git_commit(
             "clawhip".into(),
             "main".into(),
-            "deadbeefcafebabe".into(),
-            "empty commit".into(),
+            "1234567890abcdef".into(),
+            "ship it".into(),
             None,
         );
         let (channel, _, content) = router.preview(&event).await.unwrap();
         assert_eq!(channel, "route-channel");
-        assert!(content.starts_with("<@1465264645320474637> "));
-        assert!(content.contains("empty commit"));
+        assert!(content.starts_with("<@route> "));
+        assert!(content.contains("ship it"));
+    }
+
+    #[tokio::test]
+    async fn agent_family_route_matches_all_agent_events() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "agent.*".into(),
+                filter: [("project".to_string(), "clawhip".to_string())]
+                    .into_iter()
+                    .collect(),
+                channel: Some("agent-route".into()),
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: Some(MessageFormat::Alert),
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+
+        let started = IncomingEvent::agent_started(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("clawhip".into()),
+            None,
+            Some("booted".into()),
+            None,
+            None,
+        );
+        let finished = IncomingEvent::agent_finished(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("clawhip".into()),
+            Some(300),
+            Some("PR created".into()),
+            None,
+            None,
+        );
+
+        let (started_channel, started_format, started_content) =
+            router.preview(&started).await.unwrap();
+        let (finished_channel, finished_format, finished_content) =
+            router.preview(&finished).await.unwrap();
+
+        assert_eq!(started_channel, "agent-route");
+        assert_eq!(finished_channel, "agent-route");
+        assert_eq!(started_format, MessageFormat::Alert);
+        assert_eq!(finished_format, MessageFormat::Alert);
+        assert!(started_content.contains("worker-1"));
+        assert!(started_content.contains("started"));
+        assert!(finished_content.contains("worker-1"));
+        assert!(finished_content.contains("finished"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add `agent.*` event presets and constructors for started/blocked/finished/failed
- add agent lifecycle CLI subcommands and wire dispatch through `main.rs`
- add agent route matching coverage, formatting tests, and README examples

## Testing
- cargo test