### PR TITLE
feat: native OMC/OMX session lifecycle events with clawhip emit CLI (fixes #30, closes #18, closes #19)

### DIFF
--- a/skills/omc/SKILL.md
+++ b/skills/omc/SKILL.md
@@ -4,6 +4,7 @@ Launch [OMC](https://github.com/Yeachan-Heo/oh-my-claudecode) coding sessions wi
 
 ## What you get
 
+- Native `agent.started`, `agent.finished`, and `agent.failed` lifecycle events via `clawhip emit`
 - Session keyword alerts (error, PR created, complete, etc.)
 - Stale session detection (no output for N minutes)
 - All notifications routed to the correct Discord channel
@@ -30,6 +31,8 @@ Launch [OMC](https://github.com/Yeachan-Heo/oh-my-claudecode) coding sessions wi
 ./create.sh issue-123 ~/my-project/worktrees/issue-123 1234567890 "<@user-id>"
 ```
 
+`create.sh` now emits lifecycle notifications directly from the OMC shell session, so you no longer need a separate lifecycle watcher command.
+
 ### Send a prompt
 
 ```bash
@@ -52,6 +55,7 @@ Launch [OMC](https://github.com/Yeachan-Heo/oh-my-claudecode) coding sessions wi
 | `CLAWHIP_OMC_STALE_MIN` | `30` | Minutes before stale alert |
 | `CLAWHIP_OMC_FLAGS` | `--openclaw --madmax` | Extra flags passed to `omc` |
 | `CLAWHIP_OMC_ENV` | *(empty)* | Extra env vars prepended to omc command |
+| `CLAWHIP_OMC_PROJECT` | detected from the git common dir (fallback: worktree name) | Override the project name sent in lifecycle events |
 
 ### Config defaults
 

--- a/skills/omc/create.sh
+++ b/skills/omc/create.sh
@@ -19,6 +19,18 @@ if [ ! -d "$WORKDIR" ]; then
   exit 1
 fi
 
+detect_project() {
+  local common_dir
+  common_dir="$(git -C "$WORKDIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$common_dir" ]; then
+    basename "$(dirname "$common_dir")"
+  else
+    basename "$WORKDIR"
+  fi
+}
+
+PROJECT="${CLAWHIP_OMC_PROJECT:-$(detect_project)}"
+
 # Build clawhip tmux new args
 ARGS=(
   tmux new
@@ -31,10 +43,37 @@ ARGS=(
 [ -n "$CHANNEL" ] && ARGS+=(--channel "$CHANNEL")
 [ -n "$MENTION" ] && ARGS+=(--mention "$MENTION")
 
-# Build the omc command
-OMC_CMD="source ~/.zshrc"
-[ -n "$OMC_ENV" ] && OMC_CMD="$OMC_CMD && $OMC_ENV"
-OMC_CMD="$OMC_CMD && omc $OMC_FLAGS --worktree $WORKDIR"
+EMIT_ARGS=()
+[ -n "$CHANNEL" ] && EMIT_ARGS+=(--channel "$CHANNEL")
+[ -n "$MENTION" ] && EMIT_ARGS+=(--mention "$MENTION")
+EMIT_SUFFIX=""
+if [ ${#EMIT_ARGS[@]} -gt 0 ]; then
+  printf -v EMIT_SUFFIX ' %q' "${EMIT_ARGS[@]}"
+fi
+
+quote() {
+  printf '%q' "$1"
+}
+
+# Build the OMC command with native clawhip lifecycle emits
+OMC_CMD=$(cat <<EOF
+source ~/.zshrc
+START_TS=\$(date +%s)
+cleanup() {
+  local exit_code=\$?
+  local elapsed=\$(( \$(date +%s) - START_TS ))
+  if [ "\$exit_code" -eq 0 ]; then
+    clawhip emit agent.finished --agent omc --session $(quote "$SESSION") --project $(quote "$PROJECT") --elapsed "\$elapsed"$EMIT_SUFFIX || true
+  else
+    clawhip emit agent.failed --agent omc --session $(quote "$SESSION") --project $(quote "$PROJECT") --elapsed "\$elapsed" --error "exit \$exit_code"$EMIT_SUFFIX || true
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+clawhip emit agent.started --agent omc --session $(quote "$SESSION") --project $(quote "$PROJECT")$EMIT_SUFFIX || true
+${OMC_ENV:+$OMC_ENV }omc $OMC_FLAGS --worktree $(quote "$WORKDIR")
+EOF
+)
 
 ARGS+=(-- "$OMC_CMD")
 
@@ -42,5 +81,6 @@ ARGS+=(-- "$OMC_CMD")
 nohup clawhip "${ARGS[@]}" &>/dev/null &
 
 echo "✓ Created session: $SESSION in $WORKDIR (clawhip monitored)"
+echo "  Project: $PROJECT"
 echo "  Monitor: tmux attach -t $SESSION"
 echo "  Tail:    $(dirname "$0")/tail.sh $SESSION"

--- a/skills/omx/SKILL.md
+++ b/skills/omx/SKILL.md
@@ -4,6 +4,7 @@ Launch [OMX](https://github.com/Yeachan-Heo/oh-my-codex) coding sessions with au
 
 ## What you get
 
+- Native `agent.started`, `agent.finished`, and `agent.failed` lifecycle events via `clawhip emit`
 - Session keyword alerts (error, PR created, complete, etc.)
 - Stale session detection (no output for N minutes)
 - All notifications routed to the correct Discord channel
@@ -30,6 +31,8 @@ Launch [OMX](https://github.com/Yeachan-Heo/oh-my-codex) coding sessions with au
 ./create.sh issue-123 ~/my-project/worktrees/issue-123 1234567890 "<@user-id>"
 ```
 
+`create.sh` now emits lifecycle notifications directly from the OMX shell session, so you no longer need a separate lifecycle watcher command.
+
 ### Send a prompt
 
 ```bash
@@ -52,6 +55,7 @@ Launch [OMX](https://github.com/Yeachan-Heo/oh-my-codex) coding sessions with au
 | `CLAWHIP_OMX_STALE_MIN` | `30` | Minutes before stale alert |
 | `CLAWHIP_OMX_FLAGS` | `--madmax` | Extra flags passed to `omx` |
 | `CLAWHIP_OMX_ENV` | *(empty)* | Extra env vars prepended to omx command (e.g. `FOO=1 BAR=2`) |
+| `CLAWHIP_OMX_PROJECT` | detected from the git common dir (fallback: worktree name) | Override the project name sent in lifecycle events |
 
 ### Config defaults
 

--- a/skills/omx/create.sh
+++ b/skills/omx/create.sh
@@ -19,6 +19,18 @@ if [ ! -d "$WORKDIR" ]; then
   exit 1
 fi
 
+detect_project() {
+  local common_dir
+  common_dir="$(git -C "$WORKDIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [ -n "$common_dir" ]; then
+    basename "$(dirname "$common_dir")"
+  else
+    basename "$WORKDIR"
+  fi
+}
+
+PROJECT="${CLAWHIP_OMX_PROJECT:-$(detect_project)}"
+
 # Build clawhip tmux new args
 ARGS=(
   tmux new
@@ -31,10 +43,37 @@ ARGS=(
 [ -n "$CHANNEL" ] && ARGS+=(--channel "$CHANNEL")
 [ -n "$MENTION" ] && ARGS+=(--mention "$MENTION")
 
-# Build the omx command
-OMX_CMD="source ~/.zshrc"
-[ -n "$OMX_ENV" ] && OMX_CMD="$OMX_CMD && $OMX_ENV"
-OMX_CMD="$OMX_CMD && omx $OMX_FLAGS"
+EMIT_ARGS=()
+[ -n "$CHANNEL" ] && EMIT_ARGS+=(--channel "$CHANNEL")
+[ -n "$MENTION" ] && EMIT_ARGS+=(--mention "$MENTION")
+EMIT_SUFFIX=""
+if [ ${#EMIT_ARGS[@]} -gt 0 ]; then
+  printf -v EMIT_SUFFIX ' %q' "${EMIT_ARGS[@]}"
+fi
+
+quote() {
+  printf '%q' "$1"
+}
+
+# Build the OMX command with native clawhip lifecycle emits
+OMX_CMD=$(cat <<EOF
+source ~/.zshrc
+START_TS=\$(date +%s)
+cleanup() {
+  local exit_code=\$?
+  local elapsed=\$(( \$(date +%s) - START_TS ))
+  if [ "\$exit_code" -eq 0 ]; then
+    clawhip emit agent.finished --agent omx --session $(quote "$SESSION") --project $(quote "$PROJECT") --elapsed "\$elapsed"$EMIT_SUFFIX || true
+  else
+    clawhip emit agent.failed --agent omx --session $(quote "$SESSION") --project $(quote "$PROJECT") --elapsed "\$elapsed" --error "exit \$exit_code"$EMIT_SUFFIX || true
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+clawhip emit agent.started --agent omx --session $(quote "$SESSION") --project $(quote "$PROJECT")$EMIT_SUFFIX || true
+${OMX_ENV:+$OMX_ENV }omx $OMX_FLAGS
+EOF
+)
 
 ARGS+=(-- "$OMX_CMD")
 
@@ -42,5 +81,6 @@ ARGS+=(-- "$OMX_CMD")
 nohup clawhip "${ARGS[@]}" &>/dev/null &
 
 echo "✓ Created session: $SESSION in $WORKDIR (clawhip monitored)"
+echo "  Project: $PROJECT"
 echo "  Monitor: tmux attach -t $SESSION"
 echo "  Tail:    $(dirname "$0")/tail.sh $SESSION"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use serde_json::Value;
+
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 use crate::events::MessageFormat;
@@ -44,6 +46,8 @@ pub enum Commands {
         #[arg(long)]
         message: String,
     },
+    /// Emit an arbitrary event to the local daemon.
+    Emit(EmitArgs),
     /// Send git-related events to the local daemon.
     Git {
         #[command(subcommand)]
@@ -86,6 +90,78 @@ pub enum Commands {
         #[command(subcommand)]
         command: Option<ConfigCommand>,
     },
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct EmitArgs {
+    pub event_type: String,
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub fields: Vec<String>,
+}
+
+impl EmitArgs {
+    pub fn into_event(self) -> crate::Result<crate::events::IncomingEvent> {
+        let mut channel = None;
+        let mut mention = None;
+        let mut format = None;
+        let mut template = None;
+        let mut payload = None;
+        let mut payload_map = serde_json::Map::new();
+
+        if !self.fields.len().is_multiple_of(2) {
+            return Err("emit fields must be provided as --key value pairs".into());
+        }
+
+        for pair in self.fields.chunks_exact(2) {
+            let key = pair[0]
+                .strip_prefix("--")
+                .ok_or_else(|| format!("emit field names must start with --, got {}", pair[0]))?;
+            let key = normalize_emit_key(key);
+            let raw_value = pair[1].clone();
+            match key {
+                "channel" => channel = Some(raw_value),
+                "mention" => mention = Some(raw_value),
+                "format" => format = Some(MessageFormat::from_label(&raw_value)?),
+                "template" => template = Some(raw_value),
+                "payload" => payload = Some(serde_json::from_str::<Value>(&raw_value)?),
+                _ => {
+                    payload_map.insert(key.to_string(), parse_emit_value(&raw_value));
+                }
+            }
+        }
+
+        let payload = match payload {
+            Some(Value::Object(mut object)) => {
+                object.extend(payload_map);
+                Value::Object(object)
+            }
+            Some(other) => other,
+            None => Value::Object(payload_map),
+        };
+
+        Ok(crate::events::IncomingEvent {
+            kind: self.event_type,
+            channel,
+            mention,
+            format,
+            template,
+            payload,
+        })
+    }
+}
+
+fn normalize_emit_key(key: &str) -> &str {
+    match key {
+        "agent" => "agent_name",
+        "session" => "session_id",
+        "elapsed" => "elapsed_secs",
+        "error" => "error_message",
+        other => other,
+    }
+}
+
+fn parse_emit_value(raw: &str) -> Value {
+    serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
 }
 
 #[derive(Debug, Subcommand)]
@@ -280,6 +356,84 @@ pub enum ConfigCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_emit_subcommand_with_top_level_fields() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "emit",
+            "agent.started",
+            "--channel",
+            "alerts",
+            "--mention",
+            "<@123>",
+            "--format",
+            "alert",
+            "--template",
+            "agent {agent_name}",
+            "--agent",
+            "omc",
+            "--elapsed",
+            "17",
+        ]);
+
+        let Commands::Emit(args) = cli.command.expect("emit command") else {
+            panic!("expected emit command");
+        };
+
+        let event = args.into_event().expect("event");
+        assert_eq!(event.kind, "agent.started");
+        assert_eq!(event.channel.as_deref(), Some("alerts"));
+        assert_eq!(event.mention.as_deref(), Some("<@123>"));
+        assert!(matches!(event.format, Some(MessageFormat::Alert)));
+        assert_eq!(event.template.as_deref(), Some("agent {agent_name}"));
+        assert_eq!(event.payload["agent_name"], Value::String("omc".into()));
+        assert_eq!(event.payload["elapsed_secs"], Value::from(17));
+    }
+
+    #[test]
+    fn emit_args_merge_payload_json_with_extra_fields() {
+        let args = EmitArgs {
+            event_type: "agent.failed".into(),
+            fields: vec![
+                "--payload".into(),
+                r#"{"session":"sess-1","ok":true}"#.into(),
+                "--error".into(),
+                "boom".into(),
+            ],
+        };
+
+        let event = args.into_event().expect("event");
+        assert_eq!(event.payload["session"], Value::String("sess-1".into()));
+        assert_eq!(event.payload["ok"], Value::Bool(true));
+        assert_eq!(event.payload["error_message"], Value::String("boom".into()));
+    }
+
+    #[test]
+    fn emit_args_reject_invalid_format() {
+        let args = EmitArgs {
+            event_type: "agent.started".into(),
+            fields: vec!["--format".into(), "loud".into()],
+        };
+
+        let error = args.into_event().expect_err("invalid format should fail");
+        assert!(error.to_string().contains("unsupported message format"));
+    }
+
+    #[test]
+    fn emit_args_reject_invalid_field_shape() {
+        let args = EmitArgs {
+            event_type: "agent.started".into(),
+            fields: vec!["agent".into(), "omc".into(), "--session".into()],
+        };
+
+        let error = args.into_event().expect_err("invalid fields should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("emit fields must be provided as --key value pairs")
+        );
+    }
 
     #[test]
     fn parses_agent_finished_subcommand() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,7 @@ impl DaemonClient {
     }
 
     pub async fn send_event(&self, event: &IncomingEvent) -> Result<()> {
-        self.post_json("/api/event", event).await.map(|_| ())
+        self.post_json("/event", event).await.map(|_| ())
     }
 
     pub async fn register_tmux(&self, registration: &RegisteredTmuxSession) -> Result<()> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -45,6 +45,7 @@ pub async fn run(config: Arc<AppConfig>, port_override: Option<u16>) -> Result<(
     let app = AxumRouter::new()
         .route("/health", get(health))
         .route("/api/status", get(status))
+        .route("/event", post(post_event))
         .route("/api/event", post(post_event))
         .route("/events", post(post_event))
         .route("/api/tmux/register", post(register_tmux))

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,11 @@ async fn real_main() -> Result<()> {
             println!("{}", serde_json::to_string_pretty(&health)?);
             Ok(())
         }
+        Commands::Emit(args) => {
+            let client = DaemonClient::from_config(config.as_ref());
+            let event = args.into_event()?;
+            client.send_event(&event).await
+        }
         Commands::Send { channel, message } => {
             let client = DaemonClient::from_config(config.as_ref());
             client


### PR DESCRIPTION
## Summary
- add a native `clawhip emit` CLI for posting lifecycle events to the local daemon
- wire OMC/OMX session create hooks to emit started/finished/failed events directly
- document the native lifecycle hook behavior in the OMC/OMX skill docs

## Verification
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- bash -n skills/omc/create.sh skills/omx/create.sh