### PR TITLE
feat: plugin architecture for tool-specific integrations (fixes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ clawhip tmux new -s issue-456 \
 
 See [`skills/omc/`](skills/omc/) for ready-to-use scripts.
 
+## Plugin architecture
+
+clawhip now includes a simple `plugins/` directory for tool-specific shell bridges.
+Each plugin lives in its own subdirectory with:
+
+- `plugin.toml` for lightweight metadata
+- `bridge.sh` for shell hook entrypoints
+
+Built-in starter plugins:
+
+- `plugins/codex/`
+- `plugins/claude-code/`
+
+List installed plugins with:
+
+```bash
+clawhip plugin list
+```
+
 ## Description
 
 Operational spec for OpenClaw / Clawdbot agents consuming this repo.
@@ -520,5 +539,5 @@ clawhip github ...      # thin client GitHub event
 clawhip git ...         # thin client git event
 clawhip agent ...       # thin client agent lifecycle event
 clawhip tmux ...        # thin client / wrapper surface
+clawhip plugin list     # list installed/bundled shell-hook plugins
 ```
-

--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,20 @@ MSG
   cargo install --path . --force
 }
 
+sync_plugins() {
+  local source_dir="$REPO_ROOT/plugins"
+  local target_dir="$HOME/.clawhip/plugins"
+
+  if [[ ! -d "$source_dir" ]]; then
+    return 0
+  fi
+
+  rm -rf "$target_dir"
+  mkdir -p "$(dirname "$target_dir")"
+  cp -R "$source_dir" "$target_dir"
+  log "synced plugins to $target_dir"
+}
+
 installed_binary_path() {
   if [[ -x "$CARGO_HOME/bin/clawhip" ]]; then
     printf '%s\n' "$CARGO_HOME/bin/clawhip"
@@ -111,6 +125,7 @@ fi
 
 mkdir -p "$HOME/.clawhip"
 log "ensured config dir $HOME/.clawhip"
+sync_plugins
 log "next: read SKILL.md and attach the skill surface"
 
 if [[ "$SYSTEMD" == "1" ]]; then

--- a/plugins/claude-code/bridge.sh
+++ b/plugins/claude-code/bridge.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[clawhip:claude-code] hook=$*"

--- a/plugins/claude-code/plugin.toml
+++ b/plugins/claude-code/plugin.toml
@@ -1,0 +1,3 @@
+name = "claude-code"
+description = "Shell bridge for Claude Code-specific integrations"
+bridge = "bridge.sh"

--- a/plugins/codex/bridge.sh
+++ b/plugins/codex/bridge.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[clawhip:codex] hook=$*"

--- a/plugins/codex/plugin.toml
+++ b/plugins/codex/plugin.toml
@@ -1,0 +1,3 @@
+name = "codex"
+description = "Shell bridge for Codex-specific integrations"
+bridge = "bridge.sh"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,11 @@ pub enum Commands {
         #[arg(long, default_value_t = false)]
         remove_config: bool,
     },
+    /// Manage tool integration plugins.
+    Plugin {
+        #[command(subcommand)]
+        command: PluginCommands,
+    },
     /// Manage configuration.
     Config {
         #[command(subcommand)]
@@ -176,6 +181,11 @@ pub struct AgentFailedArgs {
     pub event: AgentEventArgs,
     #[arg(long = "error")]
     pub error_message: String,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum PluginCommands {
+    List,
 }
 
 #[derive(Debug, Subcommand)]
@@ -417,5 +427,16 @@ mod tests {
         assert_eq!(args.session, "issue-22");
         assert!(!args.retry_enter);
         assert_eq!(args.command, vec!["codex"]);
+    }
+
+    #[test]
+    fn parses_plugin_list_subcommand() {
+        let cli = Cli::parse_from(["clawhip", "plugin", "list"]);
+
+        let Commands::Plugin { command } = cli.command.expect("plugin command") else {
+            panic!("expected plugin command");
+        };
+
+        assert!(matches!(command, PluginCommands::List));
     }
 }

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::Result;
+use crate::{Result, plugins};
 
 pub fn install(systemd: bool) -> Result<()> {
     let repo_root = current_repo_root()?;
@@ -12,6 +12,7 @@ pub fn install(systemd: bool) -> Result<()> {
         .arg("--path")
         .arg(&repo_root))?;
     ensure_config_dir()?;
+    plugins::install_bundled_plugins(&config_dir().join("plugins"))?;
     if systemd {
         install_systemd(&repo_root)?;
     }
@@ -31,6 +32,8 @@ pub fn update(restart: bool) -> Result<()> {
         .arg("--path")
         .arg(&repo_root)
         .arg("--force"))?;
+    ensure_config_dir()?;
+    plugins::install_bundled_plugins(&config_dir().join("plugins"))?;
     if restart {
         restart_systemd_if_present()?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod dynamic_tokens;
 mod events;
 mod lifecycle;
 mod monitor;
+mod plugins;
 mod router;
 mod tmux_wrapper;
 
@@ -15,7 +16,8 @@ use std::sync::Arc;
 use clap::Parser;
 
 use crate::cli::{
-    AgentCommands, Cli, Commands, ConfigCommand, GitCommands, GithubCommands, TmuxCommands,
+    AgentCommands, Cli, Commands, ConfigCommand, GitCommands, GithubCommands, PluginCommands,
+    TmuxCommands,
 };
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
@@ -186,6 +188,28 @@ async fn real_main() -> Result<()> {
             }
             ConfigCommand::Path => {
                 println!("{}", config_path.display());
+                Ok(())
+            }
+        },
+        Commands::Plugin { command } => match command {
+            PluginCommands::List => {
+                let plugins_dir = plugins::default_plugins_dir()?;
+                let discovered = plugins::load_plugins(&plugins_dir)?;
+
+                if discovered.is_empty() {
+                    println!("No plugins found in {}", plugins_dir.display());
+                    return Ok(());
+                }
+
+                println!("NAME\tBRIDGE\tDESCRIPTION");
+                for plugin in discovered {
+                    println!(
+                        "{}\t{}\t{}",
+                        plugin.name,
+                        plugin.bridge_path.display(),
+                        plugin.description.as_deref().unwrap_or("-"),
+                    );
+                }
                 Ok(())
             }
         },

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,0 +1,256 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::Result;
+
+const PLUGIN_DIR_ENV: &str = "CLAWHIP_PLUGIN_DIR";
+
+#[derive(Debug, Clone, Deserialize)]
+struct PluginManifest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default = "default_bridge")]
+    pub bridge: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Plugin {
+    pub name: String,
+    pub description: Option<String>,
+    pub bridge_path: PathBuf,
+}
+
+impl Plugin {
+    fn from_manifest(dir: &Path, manifest: PluginManifest) -> Result<Self> {
+        let bridge_path = dir.join(&manifest.bridge);
+        if !bridge_path.is_file() {
+            return Err(format!(
+                "plugin '{}' is missing bridge script {}",
+                manifest.name,
+                bridge_path.display()
+            )
+            .into());
+        }
+
+        Ok(Self {
+            name: manifest.name,
+            description: manifest.description,
+            bridge_path,
+        })
+    }
+}
+
+pub fn default_plugins_dir() -> Result<PathBuf> {
+    Ok(resolve_plugins_dir().unwrap_or_else(app_plugins_dir))
+}
+
+pub fn load_plugins(root: &Path) -> Result<Vec<Plugin>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut directories = fs::read_dir(root)?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    directories.sort();
+
+    let mut plugins = Vec::new();
+    for dir in directories {
+        let manifest_path = dir.join("plugin.toml");
+        if !manifest_path.is_file() {
+            continue;
+        }
+
+        let raw = fs::read_to_string(&manifest_path)?;
+        let manifest: PluginManifest = toml::from_str(&raw)?;
+        plugins.push(Plugin::from_manifest(&dir, manifest)?);
+    }
+
+    Ok(plugins)
+}
+
+pub fn install_bundled_plugins(destination_root: &Path) -> Result<()> {
+    let source_root = bundled_plugins_dir();
+    if !source_root.is_dir() {
+        return Ok(());
+    }
+
+    copy_dir_all(&source_root, destination_root)
+}
+
+fn resolve_plugins_dir() -> Option<PathBuf> {
+    plugin_dir_candidates()
+        .into_iter()
+        .find(|path| path.is_dir())
+}
+
+fn plugin_dir_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(dir) = env::var_os(PLUGIN_DIR_ENV)
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        candidates.push(dir);
+    }
+
+    candidates.push(app_plugins_dir());
+    candidates.push(bundled_plugins_dir());
+
+    if let Ok(exe) = env::current_exe()
+        && let Some(bin_dir) = exe.parent()
+    {
+        candidates.push(bin_dir.join("plugins"));
+        if let Some(parent) = bin_dir.parent() {
+            candidates.push(parent.join("plugins"));
+        }
+    }
+
+    dedupe_paths(candidates)
+}
+
+fn bundled_plugins_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("plugins")
+}
+
+fn app_plugins_dir() -> PathBuf {
+    PathBuf::from(env::var("HOME").unwrap_or_else(|_| ".".to_string()))
+        .join(".clawhip")
+        .join("plugins")
+}
+
+fn copy_dir_all(source: &Path, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)?;
+
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let path = entry.path();
+        let target = destination.join(entry.file_name());
+
+        if path.is_dir() {
+            copy_dir_all(&path, &target)?;
+        } else {
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(&path, &target)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut unique = Vec::new();
+    for path in paths {
+        if !unique.contains(&path) {
+            unique.push(path);
+        }
+    }
+    unique
+}
+
+fn default_bridge() -> String {
+    "bridge.sh".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_plugins_from_plugin_toml_files() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let plugins_dir = tempdir.path().join("plugins");
+        let codex_dir = plugins_dir.join("codex");
+        let claude_dir = plugins_dir.join("claude-code");
+
+        fs::create_dir_all(&codex_dir).expect("create codex dir");
+        fs::create_dir_all(&claude_dir).expect("create claude dir");
+
+        fs::write(
+            codex_dir.join("plugin.toml"),
+            r#"
+name = "codex"
+description = "Codex bridge"
+bridge = "bridge.sh"
+"#,
+        )
+        .expect("write codex manifest");
+        fs::write(
+            codex_dir.join("bridge.sh"),
+            "#!/usr/bin/env bash
+",
+        )
+        .expect("write codex bridge");
+
+        fs::write(
+            claude_dir.join("plugin.toml"),
+            r#"
+name = "claude-code"
+description = "Claude Code bridge"
+"#,
+        )
+        .expect("write claude manifest");
+        fs::write(
+            claude_dir.join("bridge.sh"),
+            "#!/usr/bin/env bash
+",
+        )
+        .expect("write claude bridge");
+
+        let plugins = load_plugins(&plugins_dir).expect("load plugins");
+
+        assert_eq!(plugins.len(), 2);
+        assert_eq!(plugins[0].name, "claude-code");
+        assert_eq!(plugins[0].bridge_path, claude_dir.join("bridge.sh"));
+        assert_eq!(plugins[1].name, "codex");
+        assert_eq!(plugins[1].bridge_path, codex_dir.join("bridge.sh"));
+    }
+
+    #[test]
+    fn rejects_plugin_without_bridge_script() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let plugins_dir = tempdir.path().join("plugins");
+        let broken_dir = plugins_dir.join("broken");
+
+        fs::create_dir_all(&broken_dir).expect("create broken dir");
+        fs::write(
+            broken_dir.join("plugin.toml"),
+            r#"
+name = "broken"
+bridge = "bridge.sh"
+"#,
+        )
+        .expect("write broken manifest");
+
+        let error = load_plugins(&plugins_dir).expect_err("missing bridge should fail");
+        let message = error.to_string();
+        assert!(message.contains("missing bridge script"));
+        assert!(message.contains("broken"));
+    }
+
+    #[test]
+    fn installs_bundled_plugins_into_destination() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let destination = tempdir.path().join("installed-plugins");
+
+        install_bundled_plugins(&destination).expect("install bundled plugins");
+
+        assert!(destination.join("codex").join("plugin.toml").is_file());
+        assert!(destination.join("codex").join("bridge.sh").is_file());
+        assert!(
+            destination
+                .join("claude-code")
+                .join("plugin.toml")
+                .is_file()
+        );
+        assert!(destination.join("claude-code").join("bridge.sh").is_file());
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple plugin loader for shell-hook integrations in `plugins/`
- add starter `codex` and `claude-code` plugin manifests and bridge scripts
- add `clawhip plugin list` plus install/update syncing for bundled plugins

## Testing
- cargo test
- cargo run -- plugin list
- (cd /tmp && target/debug/clawhip plugin list)