### PR TITLE
fix: propagate tmux monitor mentions

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -399,6 +399,11 @@ impl IncomingEvent {
         }
     }
 
+    pub fn with_mention(mut self, mention: Option<String>) -> Self {
+        self.mention = mention;
+        self
+    }
+
     pub fn with_format(mut self, format: Option<MessageFormat>) -> Self {
         self.format = format;
         self
@@ -804,6 +809,19 @@ mod tests {
             Some("alerts".into()),
         );
         assert_eq!(keyword.mention, None);
+    }
+
+    #[test]
+    fn with_mention_sets_top_level_mention() {
+        let event = IncomingEvent::tmux_keyword(
+            "issue-24".into(),
+            "error".into(),
+            "boom".into(),
+            Some("alerts".into()),
+        )
+        .with_mention(Some("<@123>".into()));
+
+        assert_eq!(event.mention.as_deref(), Some("<@123>"));
     }
 
     #[test]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -403,6 +403,7 @@ async fn poll_tmux(
                                         hit.line,
                                         registration.channel.clone(),
                                     )
+                                    .with_mention(registration.mention.clone())
                                     .with_format(registration.format.clone());
                                     if let Err(error) = dispatch_event(
                                         router,
@@ -439,6 +440,7 @@ async fn poll_tmux(
                                         latest_line,
                                         registration.channel.clone(),
                                     )
+                                    .with_mention(registration.mention.clone())
                                     .with_format(registration.format.clone());
                                     if let Err(error) = dispatch_event(
                                         router,
@@ -481,11 +483,13 @@ async fn dispatch_event(
     event: &IncomingEvent,
     mention: Option<&str>,
 ) -> Result<()> {
-    let (channel, _format, content) = router.preview(event).await?;
-    let content = match mention {
-        Some(mention) if !mention.trim().is_empty() => format!("{} {}", mention.trim(), content),
-        _ => content,
+    let event = match (event.mention.as_ref(), mention.map(str::trim)) {
+        (None, Some(mention)) if !mention.is_empty() => {
+            event.clone().with_mention(Some(mention.to_string()))
+        }
+        _ => event.clone(),
     };
+    let (channel, _format, content) = router.preview(&event).await?;
     discord.send_message(&channel, &content).await
 }
 


### PR DESCRIPTION
## Summary
- add `IncomingEvent::with_mention` for setting top-level event mentions
- attach mentions to tmux keyword and stale monitor events before preview/dispatch
- have monitor dispatch fall back to the explicit mention argument by copying it onto the event before routing

## Testing
- cargo clippy -- -D warnings
- cargo test