### PR TITLE
fix(skills): accept prompt in create.sh + literal send-keys mode

### DIFF
--- a/skills/omc/SKILL.md
+++ b/skills/omc/SKILL.md
@@ -20,24 +20,29 @@ Launch [OMC](https://github.com/Yeachan-Heo/oh-my-claudecode) coding sessions wi
 ### Create a session
 
 ```bash
-./create.sh <session-name> <worktree-path> [channel-id] [mention]
+./create.sh <session-name> <worktree-path> [prompt] [channel-id] [mention]
 ```
 
 ```bash
 # Basic — uses clawhip default channel
 ./create.sh issue-123 ~/my-project/worktrees/issue-123
 
-# With specific channel and mention
-./create.sh issue-123 ~/my-project/worktrees/issue-123 1234567890 "<@user-id>"
+# Start a session and auto-send an initial prompt after the TUI initializes
+./create.sh issue-123 ~/my-project/worktrees/issue-123 "Fix the bug in src/main.rs and create a PR to dev"
+
+# With prompt, specific channel, and mention
+./create.sh issue-123 ~/my-project/worktrees/issue-123 "Fix the bug in src/main.rs and create a PR to dev" 1234567890 "<@user-id>"
 ```
 
-`create.sh` now emits lifecycle notifications directly from the OMC shell session, so you no longer need a separate lifecycle watcher command.
+`create.sh` now emits lifecycle notifications directly from the OMC shell session, so you no longer need a separate lifecycle watcher command. If you pass a prompt, the script waits 10 seconds for the TUI to initialize, then sends the prompt via `tmux send-keys -l` before pressing Enter.
 
 ### Send a prompt
 
 ```bash
 ./prompt.sh <session-name> "Fix the bug in src/main.rs and create a PR to dev"
 ```
+
+`prompt.sh` sends prompt text in tmux literal mode (`send-keys -l`) and presses Enter separately so quotes, punctuation, and leading dashes are preserved exactly.
 
 ### Monitor output
 

--- a/skills/omc/create.sh
+++ b/skills/omc/create.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # clawhip × OMC — Create a monitored OMC tmux session
-# Usage: create.sh <session-name> <worktree-path> [channel-id] [mention]
+# Usage: create.sh <session-name> <worktree-path> [prompt] [channel-id] [mention]
 
 set -euo pipefail
 
-SESSION="${1:?Usage: $0 <session-name> <worktree-path> [channel-id] [mention]}"
-WORKDIR="${2:?Usage: $0 <session-name> <worktree-path> [channel-id] [mention]}"
-CHANNEL="${3:-}"
-MENTION="${4:-}"
+SESSION="${1:?Usage: $0 <session-name> <worktree-path> [prompt] [channel-id] [mention]}"
+WORKDIR="${2:?Usage: $0 <session-name> <worktree-path> [prompt] [channel-id] [mention]}"
+PROMPT="${3:-}"
+CHANNEL="${4:-}"
+MENTION="${5:-}"
 
 KEYWORDS="${CLAWHIP_OMC_KEYWORDS:-error,Error,FAILED,PR created,panic,complete}"
 STALE_MIN="${CLAWHIP_OMC_STALE_MIN:-30}"
@@ -84,3 +85,10 @@ echo "✓ Created session: $SESSION in $WORKDIR (clawhip monitored)"
 echo "  Project: $PROJECT"
 echo "  Monitor: tmux attach -t $SESSION"
 echo "  Tail:    $(dirname "$0")/tail.sh $SESSION"
+
+if [ -n "$PROMPT" ]; then
+  sleep 10
+  tmux send-keys -t "$SESSION" -l "$PROMPT"
+  tmux send-keys -t "$SESSION" Enter
+  echo "  Prompt: sent literal text after 10s init delay"
+fi

--- a/skills/omc/prompt.sh
+++ b/skills/omc/prompt.sh
@@ -12,7 +12,8 @@ if ! tmux has-session -t "$SESSION" 2>/dev/null; then
   exit 1
 fi
 
-# Send the prompt text followed by Enter
-tmux send-keys -t "$SESSION" "$PROMPT" Enter
+# Send the prompt text literally, then press Enter separately
+tmux send-keys -t "$SESSION" -l "$PROMPT"
+tmux send-keys -t "$SESSION" Enter
 
 echo "✓ Sent to $SESSION (unverified): ${PROMPT:0:80}..."

--- a/skills/omx/SKILL.md
+++ b/skills/omx/SKILL.md
@@ -20,24 +20,29 @@ Launch [OMX](https://github.com/Yeachan-Heo/oh-my-codex) coding sessions with au
 ### Create a session
 
 ```bash
-./create.sh <session-name> <worktree-path> [channel-id] [mention]
+./create.sh <session-name> <worktree-path> [prompt] [channel-id] [mention]
 ```
 
 ```bash
 # Basic — uses clawhip default channel
 ./create.sh issue-123 ~/my-project/worktrees/issue-123
 
-# With specific channel and mention
-./create.sh issue-123 ~/my-project/worktrees/issue-123 1234567890 "<@user-id>"
+# Start a session and auto-send an initial prompt after the TUI initializes
+./create.sh issue-123 ~/my-project/worktrees/issue-123 "Fix the bug in src/main.rs and create a PR to dev"
+
+# With prompt, specific channel, and mention
+./create.sh issue-123 ~/my-project/worktrees/issue-123 "Fix the bug in src/main.rs and create a PR to dev" 1234567890 "<@user-id>"
 ```
 
-`create.sh` now emits lifecycle notifications directly from the OMX shell session, so you no longer need a separate lifecycle watcher command.
+`create.sh` now emits lifecycle notifications directly from the OMX shell session, so you no longer need a separate lifecycle watcher command. If you pass a prompt, the script waits 10 seconds for the TUI to initialize, then sends the prompt via `tmux send-keys -l` before pressing Enter.
 
 ### Send a prompt
 
 ```bash
 ./prompt.sh <session-name> "Fix the bug in src/main.rs and create a PR to dev"
 ```
+
+`prompt.sh` sends prompt text in tmux literal mode (`send-keys -l`) and presses Enter separately so quotes, punctuation, and leading dashes are preserved exactly.
 
 ### Monitor output
 

--- a/skills/omx/create.sh
+++ b/skills/omx/create.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # clawhip × OMX — Create a monitored OMX tmux session
-# Usage: create.sh <session-name> <worktree-path> [channel-id] [mention]
+# Usage: create.sh <session-name> <worktree-path> [prompt] [channel-id] [mention]
 
 set -euo pipefail
 
-SESSION="${1:?Usage: $0 <session-name> <worktree-path> [channel-id] [mention]}"
-WORKDIR="${2:?Usage: $0 <session-name> <worktree-path> [channel-id] [mention]}"
-CHANNEL="${3:-}"
-MENTION="${4:-}"
+SESSION="${1:?Usage: $0 <session-name> <worktree-path> [prompt] [channel-id] [mention]}"
+WORKDIR="${2:?Usage: $0 <session-name> <worktree-path> [prompt] [channel-id] [mention]}"
+PROMPT="${3:-}"
+CHANNEL="${4:-}"
+MENTION="${5:-}"
 
 KEYWORDS="${CLAWHIP_OMX_KEYWORDS:-error,Error,FAILED,PR created,panic,complete}"
 STALE_MIN="${CLAWHIP_OMX_STALE_MIN:-30}"
@@ -84,3 +85,10 @@ echo "✓ Created session: $SESSION in $WORKDIR (clawhip monitored)"
 echo "  Project: $PROJECT"
 echo "  Monitor: tmux attach -t $SESSION"
 echo "  Tail:    $(dirname "$0")/tail.sh $SESSION"
+
+if [ -n "$PROMPT" ]; then
+  sleep 10
+  tmux send-keys -t "$SESSION" -l "$PROMPT"
+  tmux send-keys -t "$SESSION" Enter
+  echo "  Prompt: sent literal text after 10s init delay"
+fi

--- a/skills/omx/prompt.sh
+++ b/skills/omx/prompt.sh
@@ -12,11 +12,8 @@ if ! tmux has-session -t "$SESSION" 2>/dev/null; then
   exit 1
 fi
 
-# Send the prompt text followed by Enter
-tmux send-keys -t "$SESSION" "$PROMPT" C-m
-
-# Wait briefly then send another Enter to ensure TUI processes input
-sleep 1
-tmux send-keys -t "$SESSION" C-m
+# Send the prompt text literally, then press Enter separately
+tmux send-keys -t "$SESSION" -l "$PROMPT"
+tmux send-keys -t "$SESSION" Enter
 
 echo "✓ Sent to $SESSION (unverified): ${PROMPT:0:80}..."


### PR DESCRIPTION
## Summary
- accept an optional prompt arg in OMC/OMX create.sh and auto-send it after a 10s TUI init delay
- switch OMC/OMX prompt.sh to tmux literal send mode with Enter sent separately
- document the new prompt flow in both skill guides

Fixes #44