### PR TITLE
Fix #39: batch and dedup tmux keyword hits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,8 @@ pub struct TmuxSessionMonitor {
     pub session: String,
     #[serde(default)]
     pub keywords: Vec<String>,
+    #[serde(default = "default_keyword_window_secs")]
+    pub keyword_window_secs: u64,
     #[serde(default = "default_stale_minutes")]
     pub stale_minutes: u64,
     pub channel: Option<String>,
@@ -173,6 +175,7 @@ impl Default for TmuxSessionMonitor {
         Self {
             session: String::new(),
             keywords: Vec::new(),
+            keyword_window_secs: default_keyword_window_secs(),
             stale_minutes: default_stale_minutes(),
             channel: None,
             mention: None,
@@ -209,6 +212,9 @@ fn default_remote() -> String {
 }
 fn default_stale_minutes() -> u64 {
     10
+}
+fn default_keyword_window_secs() -> u64 {
+    30
 }
 fn default_true() -> bool {
     true
@@ -615,5 +621,11 @@ mod tests {
             Some("https://discord.com/api/webhooks/123/abc")
         );
         assert_eq!(config.routes[0].channel, None);
+    }
+
+    #[test]
+    fn tmux_session_monitor_defaults_keyword_window_to_thirty_seconds() {
+        let session = TmuxSessionMonitor::default();
+        assert_eq!(session.keyword_window_secs, 30);
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -416,13 +416,35 @@ impl IncomingEvent {
         line: String,
         channel: Option<String>,
     ) -> Self {
+        Self::tmux_keywords(session, vec![(keyword, line)], channel)
+    }
+
+    pub fn tmux_keywords(
+        session: String,
+        hits: Vec<(String, String)>,
+        channel: Option<String>,
+    ) -> Self {
+        let hit_count = hits.len();
+        let (keyword, line) = hits
+            .first()
+            .cloned()
+            .unwrap_or_else(|| (String::new(), String::new()));
         Self {
             kind: "tmux.keyword".to_string(),
             channel,
             mention: None,
             format: None,
             template: None,
-            payload: json!({ "session": session, "keyword": keyword, "line": line }),
+            payload: json!({
+                "session": session,
+                "keyword": keyword,
+                "line": line,
+                "hit_count": hit_count,
+                "hits": hits
+                    .into_iter()
+                    .map(|(keyword, line)| json!({ "keyword": keyword, "line": line }))
+                    .collect::<Vec<_>>(),
+            }),
         }
     }
 
@@ -470,6 +492,11 @@ impl IncomingEvent {
         let payload = &self.payload;
         if self.canonical_kind() == "git.commit"
             && let Some(rendered) = render_aggregated_git_commit(payload, format)?
+        {
+            return Ok(rendered);
+        }
+        if self.canonical_kind() == "tmux.keyword"
+            && let Some(rendered) = render_aggregated_tmux_keyword(payload, format)?
         {
             return Ok(rendered);
         }
@@ -846,6 +873,54 @@ fn render_aggregated_git_commit(payload: &Value, format: &MessageFormat) -> Resu
     Ok(Some(lines.join("\n")))
 }
 
+fn render_aggregated_tmux_keyword(
+    payload: &Value,
+    format: &MessageFormat,
+) -> Result<Option<String>> {
+    let Some(hits) = payload.get("hits").and_then(Value::as_array) else {
+        return Ok(None);
+    };
+    if hits.len() <= 1 {
+        return Ok(None);
+    }
+
+    let session = string_field(payload, "session")?;
+    let hit_count = optional_u64_field(payload, "hit_count")
+        .map(|count| count as usize)
+        .unwrap_or(hits.len());
+    let summaries = hits
+        .iter()
+        .filter_map(|hit| {
+            let keyword = hit.get("keyword").and_then(Value::as_str)?.trim();
+            let line = hit.get("line").and_then(Value::as_str)?.trim();
+            if keyword.is_empty() || line.is_empty() {
+                None
+            } else {
+                Some(format!("'{keyword}': {line}"))
+            }
+        })
+        .collect::<Vec<_>>();
+
+    match format {
+        MessageFormat::Compact | MessageFormat::Alert => {
+            let header = match format {
+                MessageFormat::Alert => {
+                    format!("🚨 tmux session {session} hit {hit_count} keyword matches:")
+                }
+                MessageFormat::Compact => {
+                    format!("tmux:{session} matched {hit_count} keyword hits:")
+                }
+                _ => unreachable!(),
+            };
+            let mut lines = vec![header];
+            lines.extend(summaries.into_iter().map(|summary| format!("- {summary}")));
+            Ok(Some(lines.join("\n")))
+        }
+        MessageFormat::Inline => Ok(Some(format!("[tmux:{session}] {}", summaries.join(" · ")))),
+        MessageFormat::Raw => Ok(None),
+    }
+}
+
 fn flatten_json(prefix: &str, value: &Value, out: &mut BTreeMap<String, String>) {
     match value {
         Value::Object(map) => {
@@ -1216,6 +1291,36 @@ mod tests {
         assert_eq!(
             event.render_default(&MessageFormat::Alert).unwrap(),
             "🚨 git:repo@main pushed 6 commits:\n- one\n- two\n- three\n... and 1 more\n- five\n- six"
+        );
+    }
+
+    #[test]
+    fn tmux_keyword_events_aggregate_multi_hit_windows() {
+        let event = IncomingEvent::tmux_keywords(
+            "issue-24".into(),
+            vec![
+                ("error".into(), "build failed".into()),
+                ("complete".into(), "job complete".into()),
+            ],
+            Some("alerts".into()),
+        );
+
+        assert_eq!(event.kind, "tmux.keyword");
+        assert_eq!(event.payload["keyword"], json!("error"));
+        assert_eq!(event.payload["line"], json!("build failed"));
+        assert_eq!(event.payload["hit_count"], json!(2));
+        assert_eq!(event.payload["hits"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "tmux:issue-24 matched 2 keyword hits:\n- 'error': build failed\n- 'complete': job complete"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Alert).unwrap(),
+            "🚨 tmux session issue-24 hit 2 keyword matches:\n- 'error': build failed\n- 'complete': job complete"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Inline).unwrap(),
+            "[tmux:issue-24] 'error': build failed · 'complete': job complete"
         );
     }
 }

--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -1,0 +1,147 @@
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeywordHit {
+    pub keyword: String,
+    pub line: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingKeywordHits {
+    started_at: Instant,
+    hits: Vec<KeywordHit>,
+    seen: HashSet<(String, String)>,
+}
+
+impl PendingKeywordHits {
+    pub fn new(started_at: Instant) -> Self {
+        Self {
+            started_at,
+            hits: Vec::new(),
+            seen: HashSet::new(),
+        }
+    }
+
+    pub fn push(&mut self, hits: Vec<KeywordHit>) {
+        for hit in hits {
+            let key = (hit.keyword.clone(), hit.line.clone());
+            if self.seen.insert(key) {
+                self.hits.push(hit);
+            }
+        }
+    }
+
+    pub fn ready_to_flush(&self, now: Instant, window: Duration) -> bool {
+        now.duration_since(self.started_at) >= window
+    }
+
+    pub fn into_hits(self) -> Vec<KeywordHit> {
+        self.hits
+    }
+}
+
+pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) -> Vec<KeywordHit> {
+    if keywords.is_empty() {
+        return Vec::new();
+    }
+
+    let previous_lines: HashSet<&str> = previous.lines().collect();
+    let normalized_keywords = keywords
+        .iter()
+        .map(|keyword| (keyword.clone(), keyword.to_ascii_lowercase()))
+        .collect::<Vec<_>>();
+    let mut seen = HashSet::new();
+    let mut hits = Vec::new();
+
+    for line in current
+        .lines()
+        .filter(|line| !previous_lines.contains(*line))
+    {
+        let lower_line = line.to_ascii_lowercase();
+        for (keyword, lower_keyword) in &normalized_keywords {
+            if lower_line.contains(lower_keyword) {
+                let key = (keyword.clone(), line.to_string());
+                if seen.insert(key.clone()) {
+                    hits.push(KeywordHit {
+                        keyword: key.0,
+                        line: key.1,
+                    });
+                }
+            }
+        }
+    }
+
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_keyword_hits_dedups_same_keyword_and_line() {
+        let hits = collect_keyword_hits(
+            "done",
+            "done\nerror: failed\nerror: failed\nERROR: FAILED",
+            &["error".into()],
+        );
+
+        assert_eq!(
+            hits,
+            vec![
+                KeywordHit {
+                    keyword: "error".into(),
+                    line: "error: failed".into(),
+                },
+                KeywordHit {
+                    keyword: "error".into(),
+                    line: "ERROR: FAILED".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn pending_keyword_hits_dedups_across_window_additions() {
+        let start = Instant::now();
+        let mut pending = PendingKeywordHits::new(start);
+        pending.push(vec![KeywordHit {
+            keyword: "error".into(),
+            line: "error: failed".into(),
+        }]);
+        pending.push(vec![
+            KeywordHit {
+                keyword: "error".into(),
+                line: "error: failed".into(),
+            },
+            KeywordHit {
+                keyword: "complete".into(),
+                line: "complete".into(),
+            },
+        ]);
+
+        assert_eq!(
+            pending.into_hits(),
+            vec![
+                KeywordHit {
+                    keyword: "error".into(),
+                    line: "error: failed".into(),
+                },
+                KeywordHit {
+                    keyword: "complete".into(),
+                    line: "complete".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn pending_keyword_hits_flush_when_window_expires() {
+        let start = Instant::now();
+        let pending = PendingKeywordHits::new(start);
+
+        assert!(!pending.ready_to_flush(start + Duration::from_secs(29), Duration::from_secs(30)));
+        assert!(pending.ready_to_flush(start + Duration::from_secs(30), Duration::from_secs(30)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod daemon;
 mod discord;
 mod dynamic_tokens;
 mod events;
+mod keyword_window;
 mod lifecycle;
 mod monitor;
 mod plugins;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -14,6 +14,7 @@ use crate::Result;
 use crate::config::{AppConfig, GitRepoMonitor, TmuxSessionMonitor};
 use crate::discord::DiscordClient;
 use crate::events::{IncomingEvent, MessageFormat};
+use crate::keyword_window::{PendingKeywordHits, collect_keyword_hits};
 use crate::router::Router;
 
 pub type SharedTmuxRegistry = Arc<RwLock<HashMap<String, RegisteredTmuxSession>>>;
@@ -25,6 +26,8 @@ pub struct RegisteredTmuxSession {
     pub mention: Option<String>,
     #[serde(default)]
     pub keywords: Vec<String>,
+    #[serde(default = "default_keyword_window_secs")]
+    pub keyword_window_secs: u64,
     pub stale_minutes: u64,
     pub format: Option<MessageFormat>,
     #[serde(default)]
@@ -38,6 +41,7 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             channel: value.channel.clone(),
             mention: value.mention.clone(),
             keywords: value.keywords.clone(),
+            keyword_window_secs: value.keyword_window_secs,
             stale_minutes: value.stale_minutes,
             format: value.format.clone(),
             active_wrapper_monitor: false,
@@ -99,6 +103,7 @@ struct TmuxPaneState {
     content_hash: u64,
     last_change: Instant,
     last_stale_notification: Option<Instant>,
+    pending_keyword_hits: Option<PendingKeywordHits>,
 }
 
 #[derive(Clone)]
@@ -349,14 +354,31 @@ async fn poll_tmux(
     let mut active_panes = HashSet::new();
     let mut sessions_to_unregister = Vec::new();
 
-    for (session_name, registration) in sessions {
+    for (session_name, registration) in &sessions {
         if registration.active_wrapper_monitor {
             continue;
         }
-        match session_exists(&session_name).await {
+        match session_exists(session_name).await {
             Ok(false) => {
                 sessions_to_unregister.push(session_name.clone());
-                state.retain(|key, pane| !key.starts_with(&format!("{}::", pane.session)));
+                let keys_to_remove = state
+                    .iter()
+                    .filter(|(_, pane)| pane.session == *session_name)
+                    .map(|(key, _)| key.clone())
+                    .collect::<Vec<_>>();
+                for key in keys_to_remove {
+                    if let Some(mut pane) = state.remove(&key) {
+                        flush_pending_keyword_hits(
+                            &mut pane,
+                            registration,
+                            router,
+                            discord,
+                            Instant::now(),
+                            true,
+                        )
+                        .await;
+                    }
+                }
                 continue;
             }
             Err(error) => {
@@ -369,7 +391,7 @@ async fn poll_tmux(
             Ok(true) => {}
         }
 
-        match snapshot_tmux_session(&session_name).await {
+        match snapshot_tmux_session(session_name).await {
             Ok(panes) => {
                 for pane in panes {
                     let pane_key = format!("{}::{}", pane.session, pane.pane_id);
@@ -388,37 +410,31 @@ async fn poll_tmux(
                                     content_hash: hash,
                                     last_change: now,
                                     last_stale_notification: None,
+                                    pending_keyword_hits: None,
                                 },
                             );
                         }
                         Some(existing) => {
+                            flush_pending_keyword_hits(
+                                existing,
+                                registration,
+                                router,
+                                discord,
+                                now,
+                                false,
+                            )
+                            .await;
                             if existing.content_hash != hash {
                                 let hits = collect_keyword_hits(
                                     &existing.snapshot,
                                     &pane.content,
                                     &registration.keywords,
                                 );
-                                for hit in hits {
-                                    let event = IncomingEvent::tmux_keyword(
-                                        pane.session.clone(),
-                                        hit.keyword,
-                                        hit.line,
-                                        registration.channel.clone(),
-                                    )
-                                    .with_mention(registration.mention.clone())
-                                    .with_format(registration.format.clone());
-                                    if let Err(error) = dispatch_event(
-                                        router,
-                                        discord,
-                                        &event,
-                                        registration.mention.as_deref(),
-                                    )
-                                    .await
-                                    {
-                                        eprintln!(
-                                            "clawhip monitor tmux keyword dispatch failed: {error}"
-                                        );
-                                    }
+                                if !hits.is_empty() {
+                                    existing
+                                        .pending_keyword_hits
+                                        .get_or_insert_with(|| PendingKeywordHits::new(now))
+                                        .push(hits);
                                 }
                                 existing.pane_name = pane.pane_name;
                                 existing.snapshot = pane.content;
@@ -470,12 +486,79 @@ async fn poll_tmux(
         }
     }
 
+    let keys_to_remove = state
+        .iter()
+        .filter(|(key, _)| !active_panes.contains(*key))
+        .map(|(key, _)| key.clone())
+        .collect::<Vec<_>>();
+    for key in keys_to_remove {
+        if let Some(mut pane) = state.remove(&key)
+            && let Some(registration) = sessions.get(&pane.session)
+        {
+            flush_pending_keyword_hits(
+                &mut pane,
+                registration,
+                router,
+                discord,
+                Instant::now(),
+                true,
+            )
+            .await;
+        }
+    }
     state.retain(|key, _| active_panes.contains(key));
     if !sessions_to_unregister.is_empty() {
         let mut write = registry.write().await;
         for session in sessions_to_unregister {
             write.remove(&session);
         }
+    }
+}
+
+async fn flush_pending_keyword_hits(
+    pane: &mut TmuxPaneState,
+    registration: &RegisteredTmuxSession,
+    router: &Router,
+    discord: &DiscordClient,
+    now: Instant,
+    force: bool,
+) {
+    let should_flush = pane
+        .pending_keyword_hits
+        .as_ref()
+        .map(|pending| {
+            force
+                || pending.ready_to_flush(
+                    now,
+                    Duration::from_secs(registration.keyword_window_secs.max(1)),
+                )
+        })
+        .unwrap_or(false);
+
+    if !should_flush {
+        return;
+    }
+
+    let Some(pending) = pane.pending_keyword_hits.take() else {
+        return;
+    };
+    let hits = pending
+        .into_hits()
+        .into_iter()
+        .map(|hit| (hit.keyword, hit.line))
+        .collect::<Vec<_>>();
+    if hits.is_empty() {
+        return;
+    }
+
+    let event =
+        IncomingEvent::tmux_keywords(pane.session.clone(), hits, registration.channel.clone())
+            .with_mention(registration.mention.clone())
+            .with_format(registration.format.clone());
+    if let Err(error) =
+        dispatch_event(router, discord, &event, registration.mention.as_deref()).await
+    {
+        eprintln!("clawhip monitor tmux keyword dispatch failed: {error}");
     }
 }
 
@@ -784,32 +867,6 @@ async fn run_command(binary: &str, args: &[&str]) -> Result<String> {
     }
 }
 
-fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) -> Vec<KeywordHit> {
-    if keywords.is_empty() {
-        return Vec::new();
-    }
-    let previous_lines: HashSet<&str> = previous.lines().collect();
-    current
-        .lines()
-        .filter(|line| !previous_lines.contains(*line))
-        .flat_map(|line| {
-            keywords.iter().filter_map(move |keyword| {
-                if line
-                    .to_ascii_lowercase()
-                    .contains(&keyword.to_ascii_lowercase())
-                {
-                    Some(KeywordHit {
-                        keyword: keyword.clone(),
-                        line: line.to_string(),
-                    })
-                } else {
-                    None
-                }
-            })
-        })
-        .collect()
-}
-
 fn content_hash(content: &str) -> u64 {
     let mut hasher = DefaultHasher::new();
     content.hash(&mut hasher);
@@ -848,11 +905,6 @@ fn parse_github_repo(remote: &str) -> Option<String> {
     None
 }
 
-struct KeywordHit {
-    keyword: String,
-    line: String,
-}
-
 #[derive(Deserialize)]
 struct GitHubIssue {
     number: u64,
@@ -882,6 +934,7 @@ struct GitHubPullRequest {
 mod tests {
     use super::*;
     use crate::config::{AppConfig, DefaultsConfig, RouteRule};
+    use crate::keyword_window::KeywordHit;
     use crate::router::Router;
 
     #[test]
@@ -1025,4 +1078,70 @@ mod tests {
         );
         assert_eq!(hits.len(), 2);
     }
+
+    #[tokio::test]
+    async fn flush_pending_keyword_hits_aggregates_unique_hits() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let discord = Arc::new(DiscordClient::from_config(Arc::new(AppConfig::default())).unwrap());
+        let registration = RegisteredTmuxSession {
+            session: "issue-24".into(),
+            channel: Some("alerts".into()),
+            mention: None,
+            keywords: vec!["error".into(), "complete".into()],
+            keyword_window_secs: 30,
+            stale_minutes: 10,
+            format: Some(MessageFormat::Compact),
+            active_wrapper_monitor: false,
+        };
+        let start = Instant::now();
+        let mut pane = TmuxPaneState {
+            session: "issue-24".into(),
+            pane_name: "0.0".into(),
+            snapshot: String::new(),
+            content_hash: 0,
+            last_change: start,
+            last_stale_notification: None,
+            pending_keyword_hits: Some({
+                let mut pending = PendingKeywordHits::new(start);
+                pending.push(vec![
+                    KeywordHit {
+                        keyword: "error".into(),
+                        line: "error: failed".into(),
+                    },
+                    KeywordHit {
+                        keyword: "error".into(),
+                        line: "error: failed".into(),
+                    },
+                    KeywordHit {
+                        keyword: "complete".into(),
+                        line: "complete".into(),
+                    },
+                ]);
+                pending
+            }),
+        };
+
+        flush_pending_keyword_hits(
+            &mut pane,
+            &registration,
+            &router,
+            discord.as_ref(),
+            start + Duration::from_secs(30),
+            false,
+        )
+        .await;
+
+        assert!(pane.pending_keyword_hits.is_none());
+    }
+}
+
+fn default_keyword_window_secs() -> u64 {
+    30
 }

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -10,6 +10,7 @@ use crate::cli::{TmuxNewArgs, TmuxWatchArgs, TmuxWrapperFormat};
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
 use crate::events::IncomingEvent;
+use crate::keyword_window::{PendingKeywordHits, collect_keyword_hits};
 use crate::monitor::RegisteredTmuxSession;
 
 pub async fn run(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
@@ -41,6 +42,7 @@ struct TmuxMonitorArgs {
     channel: Option<String>,
     mention: Option<String>,
     keywords: Vec<String>,
+    keyword_window_secs: u64,
     stale_minutes: u64,
     format: Option<TmuxWrapperFormat>,
 }
@@ -52,6 +54,7 @@ impl From<&TmuxNewArgs> for TmuxMonitorArgs {
             channel: value.channel.clone(),
             mention: value.mention.clone(),
             keywords: value.keywords.clone(),
+            keyword_window_secs: default_keyword_window_secs(),
             stale_minutes: value.stale_minutes,
             format: value.format,
         }
@@ -65,6 +68,7 @@ impl From<&TmuxWatchArgs> for TmuxMonitorArgs {
             channel: value.channel.clone(),
             mention: value.mention.clone(),
             keywords: value.keywords.clone(),
+            keyword_window_secs: default_keyword_window_secs(),
             stale_minutes: value.stale_minutes,
             format: value.format,
         }
@@ -81,6 +85,7 @@ async fn register_and_start_monitor(
         channel: args.channel.clone(),
         mention: args.mention.clone(),
         keywords: args.keywords.clone(),
+        keyword_window_secs: args.keyword_window_secs,
         stale_minutes: args.stale_minutes,
         format: args.format.map(Into::into),
         active_wrapper_monitor: true,
@@ -101,6 +106,7 @@ struct PaneState {
     snapshot: String,
     last_change: Instant,
     last_stale_notification: Option<Instant>,
+    pending_keyword_hits: Option<PendingKeywordHits>,
 }
 
 #[derive(Clone)]
@@ -111,16 +117,11 @@ struct PaneSnapshot {
     content: String,
 }
 
-#[derive(Clone)]
-struct KeywordHit {
-    keyword: String,
-    line: String,
-}
-
 async fn monitor_session(args: TmuxMonitorArgs, client: DaemonClient) -> Result<()> {
     let mut state: HashMap<String, PaneState> = HashMap::new();
     let poll_interval = Duration::from_secs(1);
     let stale_after = Duration::from_secs(args.stale_minutes.max(1) * 60);
+    let keyword_window = Duration::from_secs(args.keyword_window_secs.max(1));
     let keywords = args
         .keywords
         .iter()
@@ -130,6 +131,15 @@ async fn monitor_session(args: TmuxMonitorArgs, client: DaemonClient) -> Result<
 
     loop {
         if !session_exists(&args.session).await? {
+            flush_removed_panes(
+                &mut state,
+                &HashSet::new(),
+                &args,
+                &client,
+                Instant::now(),
+                true,
+            )
+            .await?;
             break;
         }
 
@@ -154,21 +164,28 @@ async fn monitor_session(args: TmuxMonitorArgs, client: DaemonClient) -> Result<
                             snapshot: pane.content,
                             last_change: now,
                             last_stale_notification: None,
+                            pending_keyword_hits: None,
                         },
                     );
                 }
                 Some(existing) => {
+                    flush_pending_keyword_hits(
+                        existing,
+                        &args,
+                        &client,
+                        now,
+                        keyword_window,
+                        false,
+                    )
+                    .await?;
                     if existing.content_hash != hash {
                         let hits =
                             collect_keyword_hits(&existing.snapshot, &pane.content, &keywords);
-                        for hit in hits {
-                            let event = tmux_keyword_event(
-                                &args,
-                                pane.session.clone(),
-                                hit.keyword,
-                                hit.line,
-                            );
-                            client.send_event(&event).await?;
+                        if !hits.is_empty() {
+                            existing
+                                .pending_keyword_hits
+                                .get_or_insert_with(|| PendingKeywordHits::new(now))
+                                .push(hits);
                         }
 
                         existing.session = pane.session;
@@ -196,6 +213,7 @@ async fn monitor_session(args: TmuxMonitorArgs, client: DaemonClient) -> Result<
             }
         }
 
+        flush_removed_panes(&mut state, &active, &args, &client, now, true).await?;
         state.retain(|pane_id, _| active.contains(pane_id));
         sleep(poll_interval).await;
     }
@@ -206,10 +224,9 @@ async fn monitor_session(args: TmuxMonitorArgs, client: DaemonClient) -> Result<
 fn tmux_keyword_event(
     args: &TmuxMonitorArgs,
     session: String,
-    keyword: String,
-    line: String,
+    hits: Vec<(String, String)>,
 ) -> IncomingEvent {
-    let mut event = IncomingEvent::tmux_keyword(session, keyword, line, args.channel.clone());
+    let mut event = IncomingEvent::tmux_keywords(session, hits, args.channel.clone());
     event.format = args.format.map(Into::into);
     event.mention = args.mention.clone();
     event
@@ -231,6 +248,68 @@ fn tmux_stale_event(
     event.format = args.format.map(Into::into);
     event.mention = args.mention.clone();
     event
+}
+
+async fn flush_pending_keyword_hits(
+    pane: &mut PaneState,
+    args: &TmuxMonitorArgs,
+    client: &DaemonClient,
+    now: Instant,
+    keyword_window: Duration,
+    force: bool,
+) -> Result<()> {
+    let should_flush = pane
+        .pending_keyword_hits
+        .as_ref()
+        .map(|pending| force || pending.ready_to_flush(now, keyword_window))
+        .unwrap_or(false);
+    if !should_flush {
+        return Ok(());
+    }
+
+    let Some(pending) = pane.pending_keyword_hits.take() else {
+        return Ok(());
+    };
+    let hits = pending
+        .into_hits()
+        .into_iter()
+        .map(|hit| (hit.keyword, hit.line))
+        .collect::<Vec<_>>();
+    if hits.is_empty() {
+        return Ok(());
+    }
+
+    let event = tmux_keyword_event(args, pane.session.clone(), hits);
+    client.send_event(&event).await
+}
+
+async fn flush_removed_panes(
+    state: &mut HashMap<String, PaneState>,
+    active: &HashSet<String>,
+    args: &TmuxMonitorArgs,
+    client: &DaemonClient,
+    now: Instant,
+    force: bool,
+) -> Result<()> {
+    let keys_to_remove = state
+        .keys()
+        .filter(|pane_id| !active.contains(*pane_id))
+        .cloned()
+        .collect::<Vec<_>>();
+    for pane_id in keys_to_remove {
+        if let Some(mut pane) = state.remove(&pane_id) {
+            flush_pending_keyword_hits(
+                &mut pane,
+                args,
+                client,
+                now,
+                Duration::from_secs(args.keyword_window_secs.max(1)),
+                force,
+            )
+            .await?;
+        }
+    }
+    Ok(())
 }
 
 async fn launch_session(args: &TmuxNewArgs) -> Result<()> {
@@ -474,32 +553,6 @@ async fn snapshot_session(session: &str) -> Result<Vec<PaneSnapshot>> {
     Ok(panes)
 }
 
-fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) -> Vec<KeywordHit> {
-    if keywords.is_empty() {
-        return Vec::new();
-    }
-    let previous_lines: HashSet<&str> = previous.lines().collect();
-    current
-        .lines()
-        .filter(|line| !previous_lines.contains(*line))
-        .flat_map(|line| {
-            keywords.iter().filter_map(move |keyword| {
-                if line
-                    .to_ascii_lowercase()
-                    .contains(&keyword.to_ascii_lowercase())
-                {
-                    Some(KeywordHit {
-                        keyword: keyword.clone(),
-                        line: line.to_string(),
-                    })
-                } else {
-                    None
-                }
-            })
-        })
-        .collect()
-}
-
 fn content_hash(content: &str) -> u64 {
     let mut hasher = DefaultHasher::new();
     content.hash(&mut hasher);
@@ -523,6 +576,7 @@ fn tmux_bin() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::keyword_window::KeywordHit;
 
     #[test]
     fn keyword_hits_only_emit_for_new_lines() {
@@ -637,6 +691,7 @@ PR created #7",
         assert_eq!(monitor_args.channel.as_deref(), Some("alerts"));
         assert_eq!(monitor_args.mention.as_deref(), Some("<@123>"));
         assert_eq!(monitor_args.keywords, vec!["error", "complete"]);
+        assert_eq!(monitor_args.keyword_window_secs, 30);
         assert_eq!(monitor_args.stale_minutes, 15);
         assert!(matches!(
             monitor_args.format,
@@ -651,11 +706,16 @@ PR created #7",
             channel: Some("alerts".into()),
             mention: Some("<@123>".into()),
             keywords: vec!["error".into()],
+            keyword_window_secs: 30,
             stale_minutes: 15,
             format: Some(TmuxWrapperFormat::Alert),
         };
 
-        let event = tmux_keyword_event(&args, "issue-24".into(), "error".into(), "boom".into());
+        let event = tmux_keyword_event(
+            &args,
+            "issue-24".into(),
+            vec![("error".into(), "boom".into())],
+        );
 
         assert_eq!(event.channel.as_deref(), Some("alerts"));
         assert_eq!(event.mention.as_deref(), Some("<@123>"));
@@ -675,6 +735,7 @@ PR created #7",
             channel: Some("alerts".into()),
             mention: Some("<@123>".into()),
             keywords: vec!["error".into()],
+            keyword_window_secs: 30,
             stale_minutes: 15,
             format: Some(TmuxWrapperFormat::Inline),
         };
@@ -727,4 +788,60 @@ PR created #7",
             ]
         );
     }
+
+    #[test]
+    fn flush_pending_keyword_hits_clears_window_after_send_attempt() {
+        let args = TmuxMonitorArgs {
+            session: "issue-24".into(),
+            channel: Some("alerts".into()),
+            mention: None,
+            keywords: vec!["error".into(), "complete".into()],
+            keyword_window_secs: 30,
+            stale_minutes: 15,
+            format: Some(TmuxWrapperFormat::Compact),
+        };
+        let config = AppConfig::default();
+        let client = DaemonClient::from_config(&config);
+        let start = Instant::now();
+        let mut pane = PaneState {
+            session: "issue-24".into(),
+            pane_name: "0.0".into(),
+            content_hash: 0,
+            snapshot: String::new(),
+            last_change: start,
+            last_stale_notification: None,
+            pending_keyword_hits: Some({
+                let mut pending = PendingKeywordHits::new(start);
+                pending.push(vec![
+                    KeywordHit {
+                        keyword: "error".into(),
+                        line: "boom".into(),
+                    },
+                    KeywordHit {
+                        keyword: "error".into(),
+                        line: "boom".into(),
+                    },
+                ]);
+                pending
+            }),
+        };
+
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(flush_pending_keyword_hits(
+                &mut pane,
+                &args,
+                &client,
+                start + Duration::from_secs(30),
+                Duration::from_secs(30),
+                false,
+            ));
+
+        assert!(result.is_err());
+        assert!(pane.pending_keyword_hits.is_none());
+    }
+}
+
+fn default_keyword_window_secs() -> u64 {
+    30
 }


### PR DESCRIPTION
## Summary
- add a configurable `keyword_window_secs` tmux monitor setting with a 30s default
- batch tmux keyword hits into a single message per window and dedup repeated keyword+line pairs
- reuse the same batching behavior in the tmux wrapper monitor path and add tests for aggregation/dedup

## Testing
- cargo clippy -- -D warnings
- cargo test