### PR TITLE
feat(github): emit CI status events to routes

### DIFF
--- a/src/event/body.rs
+++ b/src/event/body.rs
@@ -53,9 +53,11 @@ pub struct GitHubPRStatusEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitHubCIEvent {
     pub repo: String,
+    pub number: Option<u64>,
     pub branch: Option<String>,
     pub sha: Option<String>,
     pub status: Option<String>,
+    pub conclusion: Option<String>,
     pub url: Option<String>,
     pub workflow: Option<String>,
     pub message: Option<String>,

--- a/src/event/compat.rs
+++ b/src/event/compat.rs
@@ -58,9 +58,11 @@ fn body_for(kind: &str, payload: &Value) -> Result<EventBody> {
         "github.pr-status-changed" => github_pr_body(payload),
         "github.ci-failed" => Ok(EventBody::GitHubCIFailed(GitHubCIEvent {
             repo: string_field(payload, "repo")?,
+            number: payload.get("number").and_then(Value::as_u64),
             branch: optional_string_field(payload, "branch"),
             sha: optional_string_field(payload, "sha"),
             status: optional_string_field(payload, "status"),
+            conclusion: optional_string_field(payload, "conclusion"),
             url: optional_string_field(payload, "url"),
             workflow: optional_string_field(payload, "workflow"),
             message: optional_string_field(payload, "message"),
@@ -385,6 +387,40 @@ mod tests {
                 assert_eq!(body.payload.unwrap()["extra"], json!(true));
             }
             other => panic!("expected custom body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn keeps_github_ci_failed_route_compatibility_fields() {
+        let event = IncomingEvent::github_ci(
+            "github.ci-failed",
+            "clawhip".into(),
+            Some(58),
+            "CI / test".into(),
+            "completed".into(),
+            Some("failure".into()),
+            "abcdef1234567890".into(),
+            "https://github.com/Yeachan-Heo/clawhip/actions/runs/1".into(),
+            Some("feat/branch".into()),
+            Some("alerts".into()),
+        );
+
+        let envelope = from_incoming_event(&event).unwrap();
+        assert_eq!(envelope.metadata.channel_hint.as_deref(), Some("alerts"));
+        match envelope.body {
+            EventBody::GitHubCIFailed(body) => {
+                assert_eq!(body.repo, "clawhip");
+                assert_eq!(body.number, Some(58));
+                assert_eq!(body.workflow.as_deref(), Some("CI / test"));
+                assert_eq!(body.status.as_deref(), Some("completed"));
+                assert_eq!(body.conclusion.as_deref(), Some("failure"));
+                assert_eq!(body.sha.as_deref(), Some("abcdef1234567890"));
+                assert_eq!(
+                    body.url.as_deref(),
+                    Some("https://github.com/Yeachan-Heo/clawhip/actions/runs/1")
+                );
+            }
+            other => panic!("expected GitHubCIFailed body, got {other:?}"),
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -411,6 +411,45 @@ impl IncomingEvent {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn github_ci(
+        kind: &str,
+        repo: String,
+        number: Option<u64>,
+        workflow: String,
+        status: String,
+        conclusion: Option<String>,
+        sha: String,
+        url: String,
+        branch: Option<String>,
+        channel: Option<String>,
+    ) -> Self {
+        let mut payload = Map::new();
+        payload.insert("repo".to_string(), json!(repo));
+        payload.insert("workflow".to_string(), json!(workflow));
+        payload.insert("status".to_string(), json!(status));
+        payload.insert("sha".to_string(), json!(sha));
+        payload.insert("url".to_string(), json!(url));
+        if let Some(number) = number {
+            payload.insert("number".to_string(), json!(number));
+        }
+        if let Some(conclusion) = conclusion {
+            payload.insert("conclusion".to_string(), json!(conclusion));
+        }
+        if let Some(branch) = branch {
+            payload.insert("branch".to_string(), json!(branch));
+        }
+
+        Self {
+            kind: kind.to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: Value::Object(payload),
+        }
+    }
+
     pub fn tmux_keyword(
         session: String,
         keyword: String,
@@ -802,6 +841,57 @@ mod tests {
                 "summary": "after test run",
                 "error_message": "build failed"
             })
+        );
+    }
+
+    #[test]
+    fn renders_github_ci_failed_in_compact_and_alert_formats() {
+        let event = IncomingEvent::github_ci(
+            "github.ci-failed",
+            "clawhip".into(),
+            Some(58),
+            "CI / test".into(),
+            "completed".into(),
+            Some("failure".into()),
+            "abcdef1234567890".into(),
+            "https://github.com/Yeachan-Heo/clawhip/actions/runs/1".into(),
+            Some("feat/branch".into()),
+            Some("alerts".into()),
+        );
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "CI failed · clawhip#58 · CI / test · failure · abcdef1 · https://github.com/Yeachan-Heo/clawhip/actions/runs/1"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Alert).unwrap(),
+            "🚨 CI failed · clawhip#58 · CI / test · failure · abcdef1 · https://github.com/Yeachan-Heo/clawhip/actions/runs/1"
+        );
+        assert_eq!(event.channel.as_deref(), Some("alerts"));
+    }
+
+    #[test]
+    fn renders_github_ci_started_with_status_details() {
+        let event = IncomingEvent::github_ci(
+            "github.ci-started",
+            "clawhip".into(),
+            Some(58),
+            "CI / test".into(),
+            "in_progress".into(),
+            None,
+            "abcdef1234567890".into(),
+            "https://github.com/Yeachan-Heo/clawhip/actions/runs/1".into(),
+            None,
+            None,
+        );
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "CI started · clawhip#58 · CI / test · in_progress · abcdef1 · https://github.com/Yeachan-Heo/clawhip/actions/runs/1"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Alert).unwrap(),
+            "🚨 CI started · clawhip#58 · CI / test · in_progress · abcdef1 · https://github.com/Yeachan-Heo/clawhip/actions/runs/1"
         );
     }
 

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -193,6 +193,38 @@ impl Renderer for DefaultRenderer {
                 serde_json::to_string_pretty(payload)?
             }
 
+            (
+                "github.ci-started"
+                | "github.ci-failed"
+                | "github.ci-passed"
+                | "github.ci-cancelled",
+                MessageFormat::Compact,
+            ) => render_github_ci(payload, event.canonical_kind(), true)?,
+            (
+                "github.ci-started"
+                | "github.ci-failed"
+                | "github.ci-passed"
+                | "github.ci-cancelled",
+                MessageFormat::Alert,
+            ) => format!(
+                "🚨 {}",
+                render_github_ci(payload, event.canonical_kind(), true)?
+            ),
+            (
+                "github.ci-started"
+                | "github.ci-failed"
+                | "github.ci-passed"
+                | "github.ci-cancelled",
+                MessageFormat::Inline,
+            ) => render_github_ci(payload, event.canonical_kind(), false)?,
+            (
+                "github.ci-started"
+                | "github.ci-failed"
+                | "github.ci-passed"
+                | "github.ci-cancelled",
+                MessageFormat::Raw,
+            ) => serde_json::to_string_pretty(payload)?,
+
             ("tmux.keyword", MessageFormat::Compact) => format!(
                 "tmux:{} matched '{}' => {}",
                 string_field(payload, "session")?,
@@ -316,6 +348,49 @@ fn agent_inline_suffix(payload: &Value) -> String {
     } else {
         format!(" · {}", parts.join(" · "))
     }
+}
+
+fn render_github_ci(payload: &Value, kind: &str, include_url: bool) -> Result<String> {
+    let workflow = string_field(payload, "workflow")?;
+    let state = optional_string_field(payload, "conclusion")
+        .or_else(|| optional_string_field(payload, "status"))
+        .ok_or_else(|| "missing GitHub CI state".to_string())?;
+    let sha = short_sha(&string_field(payload, "sha")?);
+    let mut parts = vec![
+        format!("CI {}", github_ci_action(kind)),
+        github_ci_target(payload)?,
+        workflow,
+        state,
+        sha,
+    ];
+
+    if include_url {
+        parts.push(string_field(payload, "url")?);
+    }
+
+    Ok(parts.join(" · "))
+}
+
+fn github_ci_action(kind: &str) -> &'static str {
+    match kind {
+        "github.ci-started" => "started",
+        "github.ci-failed" => "failed",
+        "github.ci-passed" => "passed",
+        "github.ci-cancelled" => "cancelled",
+        _ => "updated",
+    }
+}
+
+fn github_ci_target(payload: &Value) -> Result<String> {
+    let repo = string_field(payload, "repo")?;
+    Ok(match optional_u64_field(payload, "number") {
+        Some(number) => format!("{repo}#{number}"),
+        None => repo,
+    })
+}
+
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
 }
 
 fn render_aggregated_git_commit(payload: &Value, format: &MessageFormat) -> Result<Option<String>> {

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -58,6 +58,7 @@ impl Source for GitHubSource {
 struct GitHubRepoState {
     issues: HashMap<u64, IssueSnapshot>,
     prs: HashMap<u64, PullRequestSnapshot>,
+    ci: HashMap<String, GitHubCISnapshot>,
 }
 
 #[derive(Clone)]
@@ -72,6 +73,36 @@ struct PullRequestSnapshot {
     title: String,
     status: String,
     url: String,
+    head_branch: String,
+    head_sha: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct GitHubCISnapshot {
+    pr_number: Option<u64>,
+    workflow: String,
+    status: String,
+    conclusion: Option<String>,
+    sha: String,
+    url: String,
+    branch: Option<String>,
+}
+
+impl GitHubCISnapshot {
+    fn dedupe_key(&self) -> String {
+        format!(
+            "{}:{}:{}",
+            self.pr_number
+                .map(|number| number.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            self.sha,
+            self.workflow
+        )
+    }
+
+    fn event_kind(&self) -> &'static str {
+        classify_ci_event_kind(&self.status, self.conclusion.as_deref())
+    }
 }
 
 async fn poll_github(
@@ -99,8 +130,10 @@ async fn poll_github(
         let previous = state.get(&repo.path);
         let issues = poll_issues(config, github_client, repo, &snapshot, previous, tx).await?;
         let prs = poll_pull_requests(config, github_client, repo, &snapshot, previous, tx).await?;
+        let ci =
+            poll_ci_statuses(config, github_client, repo, &snapshot, previous, &prs, tx).await?;
 
-        state.insert(repo.path.clone(), GitHubRepoState { issues, prs });
+        state.insert(repo.path.clone(), GitHubRepoState { issues, prs, ci });
     }
 
     Ok(())
@@ -204,6 +237,59 @@ async fn poll_pull_requests(
     }
 }
 
+async fn poll_ci_statuses(
+    config: &AppConfig,
+    github_client: Option<&reqwest::Client>,
+    repo: &GitRepoMonitor,
+    snapshot: &GitSnapshot,
+    previous: Option<&GitHubRepoState>,
+    prs: &HashMap<u64, PullRequestSnapshot>,
+    tx: &mpsc::Sender<IncomingEvent>,
+) -> Result<HashMap<String, GitHubCISnapshot>> {
+    if !repo.emit_pr_status {
+        return Ok(previous.map(|entry| entry.ci.clone()).unwrap_or_default());
+    }
+
+    let Some(client) = github_client else {
+        return Ok(previous.map(|entry| entry.ci.clone()).unwrap_or_default());
+    };
+
+    let open_prs = prs
+        .iter()
+        .filter(|(_, pr)| pr.status == "open")
+        .map(|(number, pr)| (*number, pr))
+        .collect::<Vec<_>>();
+    if open_prs.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    match fetch_ci_statuses(
+        client,
+        &config.monitors.github_api_base,
+        repo,
+        snapshot,
+        &open_prs,
+    )
+    .await
+    {
+        Ok(ci) => {
+            let empty = HashMap::new();
+            let previous_ci = previous.map(|entry| &entry.ci).unwrap_or(&empty);
+            for event in collect_ci_events(repo, &snapshot.repo_name, previous_ci, &ci) {
+                send_event(tx, event).await?;
+            }
+            Ok(ci)
+        }
+        Err(error) => {
+            eprintln!(
+                "clawhip source GitHub CI polling failed for {}: {error}",
+                repo.path
+            );
+            Ok(previous.map(|entry| entry.ci.clone()).unwrap_or_default())
+        }
+    }
+}
+
 async fn send_event(tx: &mpsc::Sender<IncomingEvent>, event: IncomingEvent) -> Result<()> {
     tx.send(event)
         .await
@@ -258,6 +344,53 @@ fn collect_issue_events(
             }
         }
     }
+    events
+}
+
+fn collect_ci_events(
+    repo: &GitRepoMonitor,
+    repo_name: &str,
+    previous: &HashMap<String, GitHubCISnapshot>,
+    current: &HashMap<String, GitHubCISnapshot>,
+) -> Vec<IncomingEvent> {
+    let mut events = Vec::new();
+    for (key, ci) in current {
+        let changed = previous
+            .get(key)
+            .map(|old| old.status != ci.status || old.conclusion != ci.conclusion)
+            .unwrap_or(true);
+        if !changed {
+            continue;
+        }
+
+        events.push(
+            IncomingEvent::github_ci(
+                ci.event_kind(),
+                repo_name.to_string(),
+                ci.pr_number,
+                ci.workflow.clone(),
+                ci.status.clone(),
+                ci.conclusion.clone(),
+                ci.sha.clone(),
+                ci.url.clone(),
+                ci.branch.clone(),
+                repo.channel.clone(),
+            )
+            .with_mention(repo.mention.clone())
+            .with_format(repo.format.clone()),
+        );
+    }
+
+    events.sort_by(|left, right| {
+        left.payload["workflow"]
+            .as_str()
+            .cmp(&right.payload["workflow"].as_str())
+            .then_with(|| {
+                left.payload["number"]
+                    .as_u64()
+                    .cmp(&right.payload["number"].as_u64())
+            })
+    });
     events
 }
 
@@ -341,8 +474,71 @@ async fn fetch_pull_requests(
                     title: pull.title,
                     status,
                     url: pull.html_url,
+                    head_branch: pull.head.reference,
+                    head_sha: pull.head.sha,
                 },
             )
+        })
+        .collect())
+}
+
+async fn fetch_ci_statuses(
+    client: &reqwest::Client,
+    api_base: &str,
+    repo: &GitRepoMonitor,
+    snapshot: &GitSnapshot,
+    open_prs: &[(u64, &PullRequestSnapshot)],
+) -> Result<HashMap<String, GitHubCISnapshot>> {
+    let github_repo = snapshot
+        .github_repo
+        .clone()
+        .ok_or_else(|| format!("no GitHub repo configured or inferred for {}", repo.path))?;
+    let mut check_runs = HashMap::new();
+
+    for (number, pr) in open_prs {
+        for check_run in fetch_check_runs(client, api_base, &github_repo, *number, pr).await? {
+            check_runs.insert(check_run.dedupe_key(), check_run);
+        }
+    }
+
+    Ok(check_runs)
+}
+
+async fn fetch_check_runs(
+    client: &reqwest::Client,
+    api_base: &str,
+    github_repo: &str,
+    pr_number: u64,
+    pr: &PullRequestSnapshot,
+) -> Result<Vec<GitHubCISnapshot>> {
+    let response = client
+        .get(format!(
+            "{}/repos/{}/commits/{}/check-runs",
+            api_base.trim_end_matches('/'),
+            github_repo,
+            pr.head_sha
+        ))
+        .query(&[("per_page", "100")])
+        .send()
+        .await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("GitHub API request failed with {status}: {body}").into());
+    }
+
+    let runs: GitHubCheckRunsResponse = response.json().await?;
+    Ok(runs
+        .check_runs
+        .into_iter()
+        .map(|check_run| GitHubCISnapshot {
+            pr_number: Some(pr_number),
+            workflow: check_run.name,
+            status: check_run.status,
+            conclusion: check_run.conclusion,
+            sha: check_run.head_sha,
+            url: check_run.details_url.unwrap_or_else(|| pr.url.clone()),
+            branch: Some(pr.head_branch.clone()),
         })
         .collect())
 }
@@ -388,6 +584,40 @@ struct GitHubPullRequest {
     state: String,
     html_url: String,
     merged_at: Option<String>,
+    head: GitHubPullRequestHead,
+}
+
+#[derive(Deserialize)]
+struct GitHubPullRequestHead {
+    #[serde(rename = "ref")]
+    reference: String,
+    sha: String,
+}
+
+#[derive(Deserialize)]
+struct GitHubCheckRunsResponse {
+    check_runs: Vec<GitHubCheckRun>,
+}
+
+#[derive(Deserialize)]
+struct GitHubCheckRun {
+    name: String,
+    status: String,
+    conclusion: Option<String>,
+    details_url: Option<String>,
+    head_sha: String,
+}
+
+fn classify_ci_event_kind(status: &str, conclusion: Option<&str>) -> &'static str {
+    if status != "completed" {
+        return "github.ci-started";
+    }
+
+    match conclusion {
+        Some("success" | "neutral" | "skipped") => "github.ci-passed",
+        Some("cancelled") => "github.ci-cancelled",
+        _ => "github.ci-failed",
+    }
 }
 
 #[cfg(test)]
@@ -399,6 +629,7 @@ mod tests {
     use crate::config::{DefaultsConfig, RouteRule};
     use crate::events::MessageFormat;
     use crate::router::Router;
+    use serde_json::json;
 
     #[tokio::test]
     async fn new_issue_events_match_repo_filter_and_route_mention() {
@@ -489,6 +720,133 @@ mod tests {
                 .iter()
                 .any(|event| event.canonical_kind() == "github.issue-closed")
         );
+    }
+
+    fn ci_snapshot(
+        pr_number: u64,
+        workflow: &str,
+        status: &str,
+        conclusion: Option<&str>,
+    ) -> GitHubCISnapshot {
+        GitHubCISnapshot {
+            pr_number: Some(pr_number),
+            workflow: workflow.into(),
+            status: status.into(),
+            conclusion: conclusion.map(ToString::to_string),
+            sha: "abcdef1234567890".into(),
+            url: "https://github.com/Yeachan-Heo/clawhip/actions/runs/1".into(),
+            branch: Some("feat/github-ci-events".into()),
+        }
+    }
+
+    #[test]
+    fn initial_ci_detection_emits_started_event_with_route_metadata() {
+        let repo = GitRepoMonitor {
+            path: "/tmp/clawhip".into(),
+            name: Some("clawhip".into()),
+            channel: Some("dev-channel".into()),
+            mention: Some("<@123>".into()),
+            format: Some(MessageFormat::Alert),
+            ..GitRepoMonitor::default()
+        };
+        let previous = HashMap::new();
+        let current_ci = ci_snapshot(58, "CI / test", "in_progress", None);
+        let current = [(current_ci.dedupe_key(), current_ci)]
+            .into_iter()
+            .collect();
+
+        let events = collect_ci_events(&repo, "clawhip", &previous, &current);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-started");
+        assert_eq!(events[0].channel.as_deref(), Some("dev-channel"));
+        assert_eq!(events[0].mention.as_deref(), Some("<@123>"));
+        assert_eq!(events[0].format, Some(MessageFormat::Alert));
+        assert_eq!(events[0].payload["repo"], json!("clawhip"));
+        assert_eq!(events[0].payload["number"], json!(58));
+        assert_eq!(events[0].payload["workflow"], json!("CI / test"));
+        assert_eq!(events[0].payload["status"], json!("in_progress"));
+        assert_eq!(events[0].payload["sha"], json!("abcdef1234567890"));
+        assert_eq!(
+            events[0].payload["url"],
+            json!("https://github.com/Yeachan-Heo/clawhip/actions/runs/1")
+        );
+    }
+
+    #[test]
+    fn unchanged_ci_state_is_suppressed() {
+        let repo = GitRepoMonitor {
+            path: "/tmp/clawhip".into(),
+            ..GitRepoMonitor::default()
+        };
+        let ci = ci_snapshot(58, "CI / test", "in_progress", None);
+        let previous = [(ci.dedupe_key(), ci.clone())].into_iter().collect();
+        let current = [(ci.dedupe_key(), ci)].into_iter().collect();
+
+        let events = collect_ci_events(&repo, "clawhip", &previous, &current);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn ci_state_transition_to_failed_emits_failed_event() {
+        let repo = GitRepoMonitor {
+            path: "/tmp/clawhip".into(),
+            ..GitRepoMonitor::default()
+        };
+        let previous_ci = ci_snapshot(58, "CI / test", "in_progress", None);
+        let current_ci = ci_snapshot(58, "CI / test", "completed", Some("failure"));
+        let previous = [(previous_ci.dedupe_key(), previous_ci)]
+            .into_iter()
+            .collect();
+        let current = [(current_ci.dedupe_key(), current_ci)]
+            .into_iter()
+            .collect();
+
+        let events = collect_ci_events(&repo, "clawhip", &previous, &current);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-failed");
+        assert_eq!(events[0].payload["workflow"], json!("CI / test"));
+        assert_eq!(events[0].payload["status"], json!("completed"));
+        assert_eq!(events[0].payload["conclusion"], json!("failure"));
+    }
+
+    #[test]
+    fn ci_state_transition_to_passed_emits_passed_event() {
+        let repo = GitRepoMonitor {
+            path: "/tmp/clawhip".into(),
+            ..GitRepoMonitor::default()
+        };
+        let previous_ci = ci_snapshot(58, "CI / test", "in_progress", None);
+        let current_ci = ci_snapshot(58, "CI / test", "completed", Some("success"));
+        let previous = [(previous_ci.dedupe_key(), previous_ci)]
+            .into_iter()
+            .collect();
+        let current = [(current_ci.dedupe_key(), current_ci)]
+            .into_iter()
+            .collect();
+
+        let events = collect_ci_events(&repo, "clawhip", &previous, &current);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-passed");
+    }
+
+    #[test]
+    fn ci_state_transition_to_cancelled_emits_cancelled_event() {
+        let repo = GitRepoMonitor {
+            path: "/tmp/clawhip".into(),
+            ..GitRepoMonitor::default()
+        };
+        let previous_ci = ci_snapshot(58, "CI / test", "in_progress", None);
+        let current_ci = ci_snapshot(58, "CI / test", "completed", Some("cancelled"));
+        let previous = [(previous_ci.dedupe_key(), previous_ci)]
+            .into_iter()
+            .collect();
+        let current = [(current_ci.dedupe_key(), current_ci)]
+            .into_iter()
+            .collect();
+
+        let events = collect_ci_events(&repo, "clawhip", &previous, &current);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-cancelled");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- poll GitHub check runs for open PR heads and emit normalized CI lifecycle events
- suppress duplicate notifications unless the check state changes while preserving github.ci-failed compatibility
- render compact/alert Discord messages with repo, PR, check name, state, sha, and URL

## Testing
- cargo clippy -- -D warnings
- cargo test

Closes #58