### PR TITLE
Add Slack webhook sink routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,34 @@ event = "tmux.keyword"
 webhook = "https://discord.com/api/webhooks/..."
 ```
 
+## Slack webhook setup
+
+Slack webhook routes work without a bot token.
+
+1. In Slack, open the app settings for your workspace and enable **Incoming Webhooks**
+2. Add a new webhook to the channel you want clawhip to notify
+3. Copy the generated `https://hooks.slack.com/services/...` URL into a route
+
+Route examples:
+
+```toml
+[[routes]]
+event = "git.commit"
+filter = { repo = "my-app" }
+slack_webhook = "https://hooks.slack.com/services/T.../B.../xxx"
+format = "compact"
+
+[[routes]]
+event = "tmux.keyword"
+sink = "slack"
+webhook = "https://hooks.slack.com/services/T.../B.../yyy"
+format = "alert"
+```
+
 ## System model
 
 ```text
-[input] -> [clawhip daemon :25294] -> [route/filter/preset render] -> [Discord REST delivery]
+[input] -> [clawhip daemon :25294] -> [route/filter/preset render] -> [Discord/Slack sink delivery]
 ```
 
 Input sources:
@@ -510,7 +534,7 @@ allow_dynamic_tokens = false
 Resolution rules:
 1. event family match
 2. payload filter match
-3. route channel / format / template / mention applied
+3. route sink / target / format / template / mention applied
 4. default fallback used if route fields absent
 
 ## Dynamic token contract

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,8 @@ pub struct AppConfig {
 pub struct ProvidersConfig {
     #[serde(default)]
     pub discord: DiscordConfig,
+    #[serde(default)]
+    pub slack: SlackConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -38,6 +40,9 @@ pub struct DiscordConfig {
     #[serde(alias = "default_channel")]
     pub legacy_default_channel: Option<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SlackConfig {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonConfig {
@@ -57,7 +62,7 @@ impl DiscordConfig {
 
 impl ProvidersConfig {
     fn is_empty(&self) -> bool {
-        self.discord.is_empty()
+        self.discord.is_empty() && self.slack.is_empty()
     }
 }
 
@@ -96,6 +101,7 @@ pub struct RouteRule {
     pub sink: String,
     pub channel: Option<String>,
     pub webhook: Option<String>,
+    pub slack_webhook: Option<String>,
     pub mention: Option<String>,
     #[serde(default)]
     pub allow_dynamic_tokens: bool,
@@ -111,11 +117,47 @@ impl Default for RouteRule {
             sink: default_sink_name(),
             channel: None,
             webhook: None,
+            slack_webhook: None,
             mention: None,
             allow_dynamic_tokens: false,
             format: None,
             template: None,
         }
+    }
+}
+
+impl SlackConfig {
+    fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+impl RouteRule {
+    pub fn effective_sink(&self) -> &str {
+        let sink = self.sink.trim();
+        if self.slack_webhook_target().is_some() && (sink.is_empty() || sink == "discord") {
+            "slack"
+        } else if sink.is_empty() {
+            "discord"
+        } else {
+            sink
+        }
+    }
+
+    pub fn discord_webhook_target(&self) -> Option<&str> {
+        (self.effective_sink() == "discord")
+            .then(|| non_empty_trimmed(self.webhook.as_deref()))
+            .flatten()
+    }
+
+    pub fn slack_webhook_target(&self) -> Option<&str> {
+        non_empty_trimmed(self.slack_webhook.as_deref()).or_else(|| {
+            (self.sink.trim() == "slack").then(|| non_empty_trimmed(self.webhook.as_deref()))?
+        })
+    }
+
+    fn has_any_webhook_target(&self) -> bool {
+        self.discord_webhook_target().is_some() || self.slack_webhook_target().is_some()
     }
 }
 
@@ -303,6 +345,13 @@ fn normalize_secret(value: Option<String>) -> Option<String> {
     })
 }
 
+fn non_empty_trimmed(value: Option<&str>) -> Option<&str> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
 fn discord_token_from_env_with<F>(mut get_env: F) -> Option<String>
 where
     F: FnMut(&str) -> Option<String>,
@@ -398,7 +447,7 @@ impl AppConfig {
     pub fn webhook_route_count(&self) -> usize {
         self.routes
             .iter()
-            .filter(|route| normalize_secret(route.webhook.clone()).is_some())
+            .filter(|route| route.has_any_webhook_target())
             .count()
     }
 
@@ -408,29 +457,65 @@ impl AppConfig {
 
     pub fn validate(&self) -> Result<()> {
         for (index, route) in self.routes.iter().enumerate() {
+            let sink = route.effective_sink();
             let has_channel = normalize_secret(route.channel.clone()).is_some();
-            let has_webhook = normalize_secret(route.webhook.clone()).is_some();
-            if route.sink.trim().is_empty() {
+            let has_discord_webhook = route.discord_webhook_target().is_some();
+            let has_slack_webhook = route.slack_webhook_target().is_some();
+            if route.sink.trim().is_empty() && !has_slack_webhook {
                 return Err(
                     format!("route #{} ({}) must set a sink", index + 1, route.event).into(),
                 );
             }
-            if route.sink != default_sink_name() {
+            if !matches!(sink, "discord" | "slack") {
                 return Err(format!(
                     "route #{} ({}) uses unsupported sink '{}'",
                     index + 1,
                     route.event,
-                    route.sink
+                    sink
                 )
                 .into());
             }
-            if has_channel && has_webhook {
-                return Err(format!(
-                    "route #{} ({}) cannot set both channel and webhook",
-                    index + 1,
-                    route.event
-                )
-                .into());
+
+            match sink {
+                "discord" => {
+                    if has_channel && has_discord_webhook {
+                        return Err(format!(
+                            "route #{} ({}) cannot set both channel and webhook",
+                            index + 1,
+                            route.event
+                        )
+                        .into());
+                    }
+                }
+                "slack" => {
+                    if has_channel {
+                        return Err(format!(
+                            "route #{} ({}) cannot set channel when sink = \"slack\"",
+                            index + 1,
+                            route.event
+                        )
+                        .into());
+                    }
+                    if normalize_secret(route.webhook.clone()).is_some()
+                        && normalize_secret(route.slack_webhook.clone()).is_some()
+                    {
+                        return Err(format!(
+                            "route #{} ({}) cannot set both webhook and slack_webhook for Slack delivery",
+                            index + 1,
+                            route.event
+                        )
+                        .into());
+                    }
+                    if !has_slack_webhook {
+                        return Err(format!(
+                            "route #{} ({}) must set webhook or slack_webhook when sink = \"slack\"",
+                            index + 1,
+                            route.event
+                        )
+                        .into());
+                    }
+                }
+                _ => unreachable!(),
             }
         }
 
@@ -468,6 +553,7 @@ impl AppConfig {
             sink: default_sink_name(),
             channel: None,
             webhook: Some(webhook),
+            slack_webhook: None,
             mention: None,
             allow_dynamic_tokens: false,
             format: None,
@@ -575,6 +661,7 @@ impl AppConfig {
             route.sink = normalize_text(Some(route.sink.clone())).unwrap_or_else(default_sink_name);
             route.channel = normalize_text(route.channel.clone());
             route.webhook = normalize_text(route.webhook.clone());
+            route.slack_webhook = normalize_text(route.slack_webhook.clone());
             route.mention = normalize_text(route.mention.clone());
             route.template = normalize_text(route.template.clone());
         }
@@ -595,7 +682,7 @@ impl AppConfig {
     fn routes_with_webhooks(&self) -> usize {
         self.routes
             .iter()
-            .filter(|route| normalize_text(route.webhook.clone()).is_some())
+            .filter(|route| route.has_any_webhook_target())
             .count()
     }
 }
@@ -760,6 +847,21 @@ mod tests {
     }
 
     #[test]
+    fn slack_webhook_route_satisfies_delivery_validation_without_bot_token() {
+        let config = AppConfig {
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                slack_webhook: Some("https://hooks.slack.com/services/T/B/abc".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        assert!(config.validate().is_ok());
+        assert_eq!(config.webhook_route_count(), 1);
+    }
+
+    #[test]
     fn route_cannot_set_channel_and_webhook() {
         let config = AppConfig {
             providers: ProvidersConfig {
@@ -767,12 +869,14 @@ mod tests {
                     bot_token: Some("token".into()),
                     legacy_default_channel: None,
                 },
+                slack: SlackConfig::default(),
             },
             routes: vec![RouteRule {
                 event: "tmux.keyword".into(),
                 sink: default_sink_name(),
                 channel: Some("123".into()),
                 webhook: Some("https://discord.com/api/webhooks/123/abc".into()),
+                slack_webhook: None,
                 ..RouteRule::default()
             }],
             ..AppConfig::default()
@@ -780,6 +884,39 @@ mod tests {
 
         let error = config.validate().unwrap_err().to_string();
         assert!(error.contains("cannot set both channel and webhook"));
+    }
+
+    #[test]
+    fn slack_route_cannot_set_channel() {
+        let config = AppConfig {
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                sink: "slack".into(),
+                channel: Some("123".into()),
+                webhook: Some("https://hooks.slack.com/services/T/B/abc".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("cannot set channel when sink = \"slack\""));
+    }
+
+    #[test]
+    fn slack_route_can_use_generic_webhook_field() {
+        let config = AppConfig {
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                sink: "slack".into(),
+                webhook: Some("https://hooks.slack.com/services/T/B/abc".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        assert!(config.validate().is_ok());
+        assert_eq!(config.webhook_route_count(), 1);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -18,7 +18,7 @@ use crate::event::compat::from_incoming_event;
 use crate::events::{IncomingEvent, normalize_event};
 use crate::render::{DefaultRenderer, Renderer};
 use crate::router::Router;
-use crate::sink::{DiscordSink, Sink};
+use crate::sink::{DiscordSink, Sink, SlackSink};
 use crate::source::{
     GitHubSource, GitSource, RegisteredTmuxSession, SharedTmuxRegistry, Source, TmuxSource,
 };
@@ -43,6 +43,7 @@ pub async fn run(config: Arc<AppConfig>, port_override: Option<u16>) -> Result<(
         "discord".into(),
         Box::new(DiscordSink::from_config(config.clone())?),
     );
+    sinks.insert("slack".into(), Box::new(SlackSink::default()));
     let renderer: Box<dyn Renderer> = Box::new(DefaultRenderer);
     let router = Router::new(config.clone());
     let tmux_registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 
 use crate::Result;
 use crate::config::AppConfig;
-use crate::sink::SinkTarget;
+use crate::sink::{SinkMessage, SinkTarget};
 
 #[derive(Clone)]
 pub struct DiscordClient {
@@ -43,11 +43,16 @@ impl DiscordClient {
         })
     }
 
-    pub async fn send(&self, target: &SinkTarget, content: &str) -> Result<()> {
+    pub async fn send(&self, target: &SinkTarget, message: &SinkMessage) -> Result<()> {
         match target {
-            SinkTarget::DiscordChannel(channel_id) => self.send_message(channel_id, content).await,
+            SinkTarget::DiscordChannel(channel_id) => {
+                self.send_message(channel_id, &message.content).await
+            }
             SinkTarget::DiscordWebhook(webhook_url) => {
-                self.send_webhook(webhook_url, content).await
+                self.send_webhook(webhook_url, &message.content).await
+            }
+            SinkTarget::SlackWebhook(_) => {
+                Err("cannot send Slack webhook via Discord client".into())
             }
         }
     }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -6,7 +6,7 @@ use crate::Result;
 use crate::events::IncomingEvent;
 use crate::render::Renderer;
 use crate::router::Router;
-use crate::sink::Sink;
+use crate::sink::{Sink, SinkMessage};
 
 pub struct Dispatcher {
     rx: mpsc::Receiver<IncomingEvent>,
@@ -69,7 +69,13 @@ impl Dispatcher {
                     }
                 };
 
-                if let Err(error) = sink.send(&delivery.target, &content).await {
+                let message = SinkMessage {
+                    event_kind: event.canonical_kind().to_string(),
+                    format: delivery.format.clone(),
+                    content,
+                };
+
+                if let Err(error) = sink.send(&delivery.target, &message).await {
                     eprintln!(
                         "clawhip dispatcher delivery failed to {}/ {:?}: {error}",
                         delivery.sink, delivery.target
@@ -90,7 +96,7 @@ mod tests {
     use super::*;
     use crate::config::{AppConfig, RouteRule};
     use crate::render::DefaultRenderer;
-    use crate::sink::DiscordSink;
+    use crate::sink::{DiscordSink, SlackSink};
 
     fn test_dispatcher(rx: mpsc::Receiver<IncomingEvent>, router: Router) -> Dispatcher {
         let mut sinks: HashMap<String, Box<dyn Sink>> = HashMap::new();
@@ -98,6 +104,7 @@ mod tests {
             "discord".into(),
             Box::new(DiscordSink::from_config(Arc::new(AppConfig::default())).unwrap()),
         );
+        sinks.insert("slack".into(), Box::new(SlackSink::default()));
         Dispatcher::new(rx, router, Box::new(DefaultRenderer), sinks)
     }
 
@@ -143,6 +150,7 @@ mod tests {
                     filter: Default::default(),
                     channel: None,
                     webhook: Some(failing_webhook),
+                    slack_webhook: None,
                     mention: None,
                     allow_dynamic_tokens: false,
                     format: None,
@@ -154,6 +162,7 @@ mod tests {
                     filter: Default::default(),
                     channel: None,
                     webhook: Some(successful_webhook),
+                    slack_webhook: None,
                     mention: None,
                     allow_dynamic_tokens: false,
                     format: None,
@@ -188,5 +197,57 @@ mod tests {
             .unwrap();
         assert!(failing_request.contains("\"content\":\"first\""));
         assert!(successful_request.contains("\"content\":\"second\""));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_sends_to_slack_webhook() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::time::{Duration, timeout};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0_u8; 4096];
+            let n = stream.read(&mut buf).await.unwrap();
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            let response = "HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok";
+            stream.write_all(response.as_bytes()).await.unwrap();
+            req
+        });
+
+        let config = AppConfig {
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                slack_webhook: Some(format!("http://{addr}/webhook")),
+                format: Some(crate::events::MessageFormat::Alert),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let (tx, rx) = mpsc::channel(1);
+        let router = Router::new(Arc::new(config));
+        let mut dispatcher = test_dispatcher(rx, router);
+        let task = tokio::spawn(async move { dispatcher.run().await.unwrap() });
+
+        tx.send(IncomingEvent::tmux_keyword(
+            "issue-28".into(),
+            "error".into(),
+            "boom".into(),
+            None,
+        ))
+        .await
+        .unwrap();
+        drop(tx);
+
+        task.await.unwrap();
+        let request = timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            request.contains("\"text\":\"🚨 tmux session issue-28 hit keyword 'error': boom\"")
+        );
+        assert!(request.contains("\"blocks\""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod plugins;
 mod render;
 mod router;
 mod sink;
+mod slack;
 mod source;
 mod tmux_wrapper;
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -9,6 +9,8 @@ use crate::render::DefaultRenderer;
 use crate::render::Renderer;
 #[cfg(test)]
 use crate::sink::Sink;
+#[cfg(test)]
+use crate::sink::SinkMessage;
 use crate::sink::SinkTarget;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,7 +40,12 @@ impl Router {
         let renderer = DefaultRenderer;
         for delivery in self.resolve(event).await? {
             let content = self.render_delivery(event, &delivery, &renderer).await?;
-            if let Err(error) = sink.send(&delivery.target, &content).await {
+            let message = SinkMessage {
+                event_kind: event.canonical_kind().to_string(),
+                format: delivery.format.clone(),
+                content,
+            };
+            if let Err(error) = sink.send(&delivery.target, &message).await {
                 eprintln!(
                     "clawhip router delivery failed to {:?}: {error}",
                     delivery.target
@@ -81,8 +88,7 @@ impl Router {
         route: Option<&RouteRule>,
     ) -> Result<ResolvedDelivery> {
         let sink = route
-            .map(|route| route.sink.trim())
-            .filter(|sink| !sink.is_empty())
+            .map(RouteRule::effective_sink)
             .map(ToString::to_string)
             .unwrap_or_else(default_sink_name);
         let target = self.target_for(event, route, &sink)?;
@@ -143,8 +149,8 @@ impl Router {
             .await?;
         match delivery.target {
             SinkTarget::DiscordChannel(channel) => Ok((channel, delivery.format, content)),
-            SinkTarget::DiscordWebhook(_) => {
-                Err("matched route uses a Discord webhook instead of a channel".into())
+            SinkTarget::DiscordWebhook(_) | SinkTarget::SlackWebhook(_) => {
+                Err("matched route uses a webhook instead of a channel".into())
             }
         }
     }
@@ -191,30 +197,39 @@ impl Router {
         route: Option<&RouteRule>,
         sink: &str,
     ) -> Result<SinkTarget> {
-        if sink != default_sink_name() {
-            return Err(format!(
-                "unsupported sink '{sink}' for event {}",
+        match sink {
+            "discord" => {
+                if let Some(webhook) = route.and_then(RouteRule::discord_webhook_target) {
+                    return Ok(SinkTarget::DiscordWebhook(webhook.to_string()));
+                }
+
+                let channel = event
+                    .channel
+                    .clone()
+                    .or_else(|| route.and_then(|route| route.channel.clone()))
+                    .or_else(|| self.config.defaults.channel.clone())
+                    .ok_or_else(|| {
+                        format!("no channel configured for event {}", event.canonical_kind())
+                    })?;
+
+                Ok(SinkTarget::DiscordChannel(channel))
+            }
+            "slack" => route
+                .and_then(RouteRule::slack_webhook_target)
+                .map(|webhook| SinkTarget::SlackWebhook(webhook.to_string()))
+                .ok_or_else(|| {
+                    format!(
+                        "no Slack webhook configured for event {}",
+                        event.canonical_kind()
+                    )
+                    .into()
+                }),
+            other => Err(format!(
+                "unsupported sink '{other}' for event {}",
                 event.canonical_kind()
             )
-            .into());
+            .into()),
         }
-
-        if let Some(webhook) = route
-            .and_then(|route| route.webhook.as_deref())
-            .map(str::trim)
-            .filter(|webhook| !webhook.is_empty())
-        {
-            return Ok(SinkTarget::DiscordWebhook(webhook.to_string()));
-        }
-
-        let channel = event
-            .channel
-            .clone()
-            .or_else(|| route.and_then(|route| route.channel.clone()))
-            .or_else(|| self.config.defaults.channel.clone())
-            .ok_or_else(|| format!("no channel configured for event {}", event.canonical_kind()))?;
-
-        Ok(SinkTarget::DiscordChannel(channel))
     }
 }
 
@@ -274,7 +289,7 @@ mod tests {
     use super::*;
     use crate::config::{DefaultsConfig, RouteRule};
     use crate::render::DefaultRenderer;
-    use crate::sink::DiscordSink;
+    use crate::sink::{DiscordSink, SlackSink};
 
     #[tokio::test]
     async fn resolve_returns_all_matching_deliveries_in_route_order() {
@@ -290,6 +305,7 @@ mod tests {
                     filter: Default::default(),
                     channel: Some("ops".into()),
                     webhook: None,
+                    slack_webhook: None,
                     mention: Some("@ops".into()),
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
@@ -301,6 +317,7 @@ mod tests {
                     filter: Default::default(),
                     channel: Some("eng".into()),
                     webhook: None,
+                    slack_webhook: None,
                     mention: Some("@eng".into()),
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Compact),
@@ -352,6 +369,7 @@ mod tests {
                 filter: Default::default(),
                 channel: Some("github".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: None,
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
@@ -412,6 +430,7 @@ mod tests {
                     filter: Default::default(),
                     channel: None,
                     webhook: Some(failing_webhook),
+                    slack_webhook: None,
                     mention: None,
                     allow_dynamic_tokens: false,
                     format: None,
@@ -423,6 +442,7 @@ mod tests {
                     filter: Default::default(),
                     channel: None,
                     webhook: Some(successful_webhook),
+                    slack_webhook: None,
                     mention: None,
                     allow_dynamic_tokens: false,
                     format: None,
@@ -465,6 +485,7 @@ mod tests {
                     .collect(),
                 channel: Some("route".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: None,
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
@@ -498,6 +519,7 @@ mod tests {
                 filter: Default::default(),
                 channel: Some("route".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: Some("<@1465264645320474637>".into()),
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
@@ -528,6 +550,7 @@ mod tests {
                         .collect(),
                     channel: Some("gh-route".into()),
                     webhook: None,
+                    slack_webhook: None,
                     mention: Some("<@botid>".into()),
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
@@ -541,6 +564,7 @@ mod tests {
                         .collect(),
                     channel: Some("tmux-route".into()),
                     webhook: None,
+                    slack_webhook: None,
                     mention: Some("<@botid>".into()),
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
@@ -577,6 +601,7 @@ mod tests {
                 filter: Default::default(),
                 channel: Some("dynamic-route".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: None,
                 allow_dynamic_tokens: true,
                 format: None,
@@ -603,6 +628,7 @@ mod tests {
                 filter: Default::default(),
                 channel: Some("dynamic-route".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: None,
                 allow_dynamic_tokens: true,
                 format: None,
@@ -631,6 +657,7 @@ mod tests {
                     .collect(),
                 channel: Some("tmux-route".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: None,
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
@@ -663,6 +690,7 @@ mod tests {
                 filter: Default::default(),
                 channel: Some("tmux-route".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: Some("<@route>".into()),
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
@@ -695,6 +723,7 @@ mod tests {
                     .collect(),
                 channel: Some("route-channel".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: Some("<@route>".into()),
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
@@ -731,6 +760,7 @@ mod tests {
                     .collect(),
                 channel: Some("route-channel".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: Some("<@route>".into()),
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
@@ -775,6 +805,7 @@ mod tests {
                     .collect(),
                 channel: Some("agent-route".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: None,
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
@@ -834,6 +865,7 @@ mod tests {
                         .collect(),
                     channel: Some("repo-a".into()),
                     webhook: None,
+                    slack_webhook: None,
                     mention: None,
                     allow_dynamic_tokens: false,
                     format: None,
@@ -847,6 +879,7 @@ mod tests {
                         .collect(),
                     channel: Some("repo-b".into()),
                     webhook: None,
+                    slack_webhook: None,
                     mention: None,
                     allow_dynamic_tokens: false,
                     format: None,
@@ -874,6 +907,7 @@ mod tests {
                 filter: Default::default(),
                 channel: None,
                 webhook: Some("https://discord.com/api/webhooks/123/abc".into()),
+                slack_webhook: None,
                 mention: None,
                 allow_dynamic_tokens: false,
                 format: None,
@@ -912,6 +946,7 @@ mod tests {
                 filter: Default::default(),
                 channel: None,
                 webhook: Some("https://discord.com/api/webhooks/123/abc".into()),
+                slack_webhook: None,
                 mention: None,
                 allow_dynamic_tokens: false,
                 format: None,
@@ -932,5 +967,107 @@ mod tests {
             delivery.target,
             SinkTarget::DiscordWebhook("https://discord.com/api/webhooks/123/abc".into())
         );
+    }
+
+    #[tokio::test]
+    async fn slack_webhook_route_is_used_as_delivery_target() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                slack_webhook: Some("https://hooks.slack.com/services/T/B/abc".into()),
+                format: Some(MessageFormat::Alert),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event =
+            IncomingEvent::tmux_keyword("issue-28".into(), "error".into(), "boom".into(), None);
+
+        let delivery = router.preview_delivery(&event).await.unwrap();
+        assert_eq!(delivery.sink, "slack");
+        assert_eq!(
+            delivery.target,
+            SinkTarget::SlackWebhook("https://hooks.slack.com/services/T/B/abc".into())
+        );
+        assert_eq!(
+            router
+                .render_delivery(&event, &delivery, &DefaultRenderer)
+                .await
+                .unwrap(),
+            "🚨 tmux session issue-28 hit keyword 'error': boom"
+        );
+    }
+
+    #[tokio::test]
+    async fn slack_sink_route_can_use_generic_webhook_field() {
+        let config = AppConfig {
+            routes: vec![RouteRule {
+                event: "custom".into(),
+                sink: "slack".into(),
+                webhook: Some("https://hooks.slack.com/services/T/B/generic".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let delivery = router
+            .preview_delivery(&IncomingEvent::custom(None, "hello".into()))
+            .await
+            .unwrap();
+
+        assert_eq!(delivery.sink, "slack");
+        assert_eq!(
+            delivery.target,
+            SinkTarget::SlackWebhook("https://hooks.slack.com/services/T/B/generic".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn slack_dispatch_posts_block_kit_payload() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::time::{Duration, timeout};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0_u8; 4096];
+            let n = stream.read(&mut buf).await.unwrap();
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            let response = "HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok";
+            stream.write_all(response.as_bytes()).await.unwrap();
+            req
+        });
+
+        let config = AppConfig {
+            routes: vec![RouteRule {
+                event: "custom".into(),
+                slack_webhook: Some(format!("http://{addr}/webhook")),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let slack = SlackSink::default();
+
+        router
+            .dispatch(
+                &IncomingEvent::custom(None, "hello from clawhip".into()),
+                &slack,
+            )
+            .await
+            .unwrap();
+
+        let request = timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(request.contains("\"text\":\"hello from clawhip\""));
+        assert!(request.contains("\"blocks\""));
     }
 }

--- a/src/sink/discord.rs
+++ b/src/sink/discord.rs
@@ -6,7 +6,7 @@ use crate::Result;
 use crate::config::AppConfig;
 use crate::discord::DiscordClient;
 
-use super::{Sink, SinkTarget};
+use super::{Sink, SinkMessage, SinkTarget};
 
 #[derive(Clone)]
 pub struct DiscordSink {
@@ -25,7 +25,7 @@ impl DiscordSink {
 
 #[async_trait]
 impl Sink for DiscordSink {
-    async fn send(&self, target: &SinkTarget, content: &str) -> Result<()> {
-        self.client.send(target, content).await
+    async fn send(&self, target: &SinkTarget, message: &SinkMessage) -> Result<()> {
+        self.client.send(target, message).await
     }
 }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -1,18 +1,29 @@
 pub mod discord;
+pub mod slack;
 
 use async_trait::async_trait;
 
 use crate::Result;
+use crate::events::MessageFormat;
 
 pub use discord::DiscordSink;
+pub use slack::SlackSink;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SinkTarget {
     DiscordChannel(String),
     DiscordWebhook(String),
+    SlackWebhook(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SinkMessage {
+    pub event_kind: String,
+    pub format: MessageFormat,
+    pub content: String,
 }
 
 #[async_trait]
 pub trait Sink: Send + Sync {
-    async fn send(&self, target: &SinkTarget, content: &str) -> Result<()>;
+    async fn send(&self, target: &SinkTarget, message: &SinkMessage) -> Result<()>;
 }

--- a/src/sink/slack.rs
+++ b/src/sink/slack.rs
@@ -1,0 +1,30 @@
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::slack::SlackClient;
+
+use super::{Sink, SinkMessage, SinkTarget};
+
+#[derive(Clone)]
+pub struct SlackSink {
+    client: SlackClient,
+}
+
+impl SlackSink {
+    pub fn new(client: SlackClient) -> Self {
+        Self { client }
+    }
+}
+
+impl Default for SlackSink {
+    fn default() -> Self {
+        Self::new(SlackClient::new())
+    }
+}
+
+#[async_trait]
+impl Sink for SlackSink {
+    async fn send(&self, target: &SinkTarget, message: &SinkMessage) -> Result<()> {
+        self.client.send(target, message).await
+    }
+}

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,0 +1,148 @@
+use serde_json::{Value, json};
+
+use crate::Result;
+use crate::events::MessageFormat;
+use crate::sink::{SinkMessage, SinkTarget};
+
+#[derive(Clone)]
+pub struct SlackClient {
+    webhook_client: reqwest::Client,
+}
+
+impl SlackClient {
+    pub fn new() -> Self {
+        Self {
+            webhook_client: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn send(&self, target: &SinkTarget, message: &SinkMessage) -> Result<()> {
+        match target {
+            SinkTarget::SlackWebhook(webhook_url) => self.send_webhook(webhook_url, message).await,
+            SinkTarget::DiscordChannel(_) | SinkTarget::DiscordWebhook(_) => {
+                Err("cannot send Discord target via Slack client".into())
+            }
+        }
+    }
+
+    pub async fn send_webhook(&self, webhook_url: &str, message: &SinkMessage) -> Result<()> {
+        let response = self
+            .webhook_client
+            .post(webhook_url)
+            .json(&webhook_payload(message))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Err(format!("Slack webhook request failed with {status}: {body}").into())
+    }
+}
+
+impl Default for SlackClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn webhook_payload(message: &SinkMessage) -> Value {
+    let mut payload = json!({
+        "text": message.content,
+    });
+
+    if matches!(
+        message.format,
+        MessageFormat::Compact | MessageFormat::Alert
+    ) {
+        payload["blocks"] = json!(slack_blocks(message));
+    }
+
+    payload
+}
+
+fn slack_blocks(message: &SinkMessage) -> Vec<Value> {
+    let label = match message.format {
+        MessageFormat::Alert => ":rotating_light: *Alert*",
+        _ => ":speech_balloon: *Notification*",
+    };
+
+    vec![
+        json!({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": label,
+            }
+        }),
+        json!({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": message.content,
+            }
+        }),
+        json!({
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": format!("event `{}` · format `{}`", message.event_kind, message.format.as_str()),
+                }
+            ]
+        }),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_payload_includes_block_kit_sections() {
+        let payload = webhook_payload(&SinkMessage {
+            event_kind: "tmux.keyword".into(),
+            format: MessageFormat::Compact,
+            content: "tmux:ops matched 'error' => boom".into(),
+        });
+
+        assert_eq!(
+            payload.get("text").and_then(Value::as_str),
+            Some("tmux:ops matched 'error' => boom")
+        );
+        let blocks = payload
+            .get("blocks")
+            .and_then(Value::as_array)
+            .expect("blocks");
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(
+            blocks[0]["text"]["text"].as_str(),
+            Some(":speech_balloon: *Notification*")
+        );
+    }
+
+    #[test]
+    fn alert_payload_uses_alert_label() {
+        let payload = webhook_payload(&SinkMessage {
+            event_kind: "github.ci-failed".into(),
+            format: MessageFormat::Alert,
+            content: "🚨 deploy <failed> & paging".into(),
+        });
+
+        let blocks = payload
+            .get("blocks")
+            .and_then(Value::as_array)
+            .expect("blocks");
+        assert_eq!(
+            blocks[0]["text"]["text"].as_str(),
+            Some(":rotating_light: *Alert*")
+        );
+        assert_eq!(
+            blocks[1]["text"]["text"].as_str(),
+            Some("🚨 deploy <failed> & paging")
+        );
+    }
+}

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -668,6 +668,7 @@ mod tests {
                     .collect(),
                 channel: Some("route-channel".into()),
                 webhook: None,
+                slack_webhook: None,
                 mention: Some("<@1465264645320474637>".into()),
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),


### PR DESCRIPTION
## Summary
- add Slack webhook routing alongside Discord in the sink/router pipeline
- support `slack_webhook` route config plus `sink = "slack"` + generic `webhook` for the new sink architecture
- add Slack webhook delivery with compact/alert Block Kit payloads and README setup docs

## Testing
- cargo build
- cargo test
- cargo clippy -- -D warnings

## Notes
- preserves existing Discord route/channel/webhook behavior for backward compatibility
- issue body also mentions a dedicated `clawhip send --test --slack` verification command; this PR focuses on the routing/sink/docs scope requested for issue #28

Refs #28