### PR TITLE
feat: polish native OMC/OMX event contract routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ clawhip tmux watch -s issue-123 \
 ```
 
 See [`skills/omx/`](skills/omx/) for ready-to-use scripts.
+Native OMC/OMX routing now prefers the normalized [`session.*` contract](docs/native-event-contract.md); legacy `agent.*` wrapper emits remain supported for compatibility.
 
 ### [OMC (oh-my-claudecode)](https://github.com/Yeachan-Heo/oh-my-claudecode)
 
@@ -74,6 +75,7 @@ clawhip tmux new -s issue-456 \
 ```
 
 See [`skills/omc/`](skills/omc/) for ready-to-use scripts.
+Direct Slack/Discord notifications inside OMC/OMX should be treated as deprecated; emit native events and let clawhip own routing, mention policy, and formatting.
 
 ## Recipes
 
@@ -389,7 +391,54 @@ Verification:
 - create real empty commit in monitored repo
 - confirm final Discord body contains commit summary and mention
 
-### 7. Agent lifecycle preset family
+### 7. Native OMC / OMX session contract
+
+Canonical native routing for OMC/OMX uses `session.*` events after clawhip normalization.
+
+Accepted upstream inputs:
+- legacy wrapper emits like `agent.started` / `agent.finished` / `agent.failed`
+- OMC command/HTTP payloads with `signal.routeKey`
+- OMX hook payloads with `context.normalized_event`
+
+Canonical normalized events:
+- `session.started`
+- `session.blocked`
+- `session.finished`
+- `session.failed`
+- `session.retry-needed`
+- `session.pr-created`
+- `session.test-started`
+- `session.test-finished`
+- `session.test-failed`
+- `session.handoff-needed`
+
+Normalized metadata (when upstream provides it):
+- `tool`
+- `session_name`
+- `session_id`
+- `repo_name`
+- `repo_path`
+- `worktree_path`
+- `branch`
+- `issue_number`
+- `pr_number`
+- `pr_url`
+- `command`
+- `tool_name`
+- `test_runner`
+- `summary`
+- `error_message`
+- `event_timestamp`
+
+Route guidance:
+- prefer `session.*` for new native OMC/OMX routes
+- `agent.*` remains supported for clawhip-local wrapper compatibility
+- `agent.started|blocked|finished|failed` and `session.started|blocked|finished|failed` cross-match in routing for backward compatibility
+- prefer route filters like `tool`, `repo_name`, `session_name`, `issue_number`, and `branch` over brittle message parsing
+
+See [`docs/native-event-contract.md`](docs/native-event-contract.md) for the full normalization/deprecation notes.
+
+### 8. Agent lifecycle preset family
 
 Input:
 ```bash
@@ -411,7 +460,7 @@ Verification:
 - confirm final Discord body contains agent name and lifecycle state
 - confirm `agent.*` route rules match each event type
 
-### 8. tmux keyword preset
+### 9. tmux keyword preset
 
 Input:
 - built-in tmux monitor detects configured keyword
@@ -426,7 +475,7 @@ Verification:
 - print configured keyword in real monitored tmux session
 - confirm final Discord body in target channel
 
-### 9. tmux stale preset
+### 10. tmux stale preset
 
 Input:
 - built-in tmux stale detection
@@ -441,7 +490,7 @@ Verification:
 - let real tmux session idle past threshold
 - confirm final Discord body in target channel
 
-### 10. tmux wrapper / watch preset
+### 11. tmux wrapper / watch preset
 
 Input:
 ```bash
@@ -479,7 +528,7 @@ Verification:
 - emit keyword in pane
 - confirm Discord message body and mention
 
-### 11. install lifecycle preset
+### 12. install lifecycle preset
 
 Input:
 ```bash
@@ -519,6 +568,18 @@ Verification:
 - `agent.finished`
 - `agent.failed`
 
+### Native session family
+- `session.started`
+- `session.blocked`
+- `session.finished`
+- `session.failed`
+- `session.retry-needed`
+- `session.pr-created`
+- `session.test-started`
+- `session.test-finished`
+- `session.test-failed`
+- `session.handoff-needed`
+
 ### tmux family
 - `tmux.keyword`
 - `tmux.stale`
@@ -540,6 +601,14 @@ filter = { repo = "clawhip" }
 sink = "discord"
 channel = "1480171113253175356"
 mention = "<@1465264645320474637>"
+format = "compact"
+allow_dynamic_tokens = false
+
+[[routes]]
+event = "session.*"
+filter = { tool = "omx", repo_name = "clawhip" }
+sink = "discord"
+channel = "1480171113253175356"
 format = "compact"
 allow_dynamic_tokens = false
 

--- a/docs/live-verification.md
+++ b/docs/live-verification.md
@@ -54,6 +54,20 @@ Operational flow:
 6. Confirm the merged status message arrives.
 7. Delete temporary branches if desired.
 
+### Native OMC / OMX contract
+
+- legacy wrapper `agent.*` emits
+- normalized `session.*` contract from OMC/OMX payloads
+
+Operational flow:
+
+1. Emit a legacy compatibility event such as `clawhip emit agent.finished --agent omx --session issue-65 --project clawhip --elapsed 42`.
+2. Confirm clawhip accepts it and renders a stable lifecycle message.
+3. Post one representative OMC payload carrying `signal.routeKey` to `/event`.
+4. Confirm clawhip normalizes it into the expected `session.*` route family.
+5. Post one representative OMX payload carrying `context.normalized_event` to `/event`.
+6. Confirm the rendered message stays low-noise and includes normalized metadata like repo/session/issue/PR when present.
+
 ### tmux presets
 
 - keyword detection

--- a/docs/native-event-contract.md
+++ b/docs/native-event-contract.md
@@ -1,0 +1,153 @@
+# Native OMC / OMX Event Contract
+
+This document is the clawhip-side normalization contract for native OMC/OMX operational events.
+
+## Goal
+
+clawhip should be the single routing and formatting layer.
+OMC/OMX should emit machine-readable native events, not send direct Slack/Discord notifications.
+
+## Canonical routing surface
+
+Prefer routing on these canonical clawhip events:
+
+- `session.started`
+- `session.blocked`
+- `session.finished`
+- `session.failed`
+- `session.retry-needed`
+- `session.pr-created`
+- `session.test-started`
+- `session.test-finished`
+- `session.test-failed`
+- `session.handoff-needed`
+
+For backward compatibility, clawhip still accepts legacy local wrapper emits:
+
+- `agent.started`
+- `agent.blocked`
+- `agent.finished`
+- `agent.failed`
+
+`agent.started|blocked|finished|failed` and `session.started|blocked|finished|failed` intentionally cross-match in routing so existing configs do not break.
+
+## Accepted upstream native inputs
+
+clawhip normalizes already-merged OMC/OMX payloads from these upstream surfaces:
+
+- OMC payloads that include `signal.routeKey`
+- OMX payloads that include `context.normalized_event`
+- legacy local `clawhip emit agent.* ...` wrapper emits from `skills/omc/create.sh` and `skills/omx/create.sh`
+
+Not every upstream raw event becomes a canonical session event. Low-signal/raw hook events should stay as secondary/debug inputs. New routes should target `session.*`.
+
+## Normalized metadata
+
+When upstream provides it, clawhip normalizes these fields onto the top-level payload:
+
+- `tool`
+- `session_name`
+- `session_id`
+- `repo_name`
+- `repo_path`
+- `worktree_path`
+- `branch`
+- `issue_number`
+- `pr_number`
+- `pr_url`
+- `command`
+- `tool_name`
+- `test_runner`
+- `status`
+- `summary`
+- `error_message`
+- `event_timestamp`
+- `raw_event`
+- `contract_event`
+
+### Notes
+
+- `tool` is normalized to `omc` or `omx` when clawhip can infer it.
+- `status` is backfilled for legacy `agent.*` emits so generic `clawhip emit agent.finished --agent omx ...` remains valid.
+- `issue_number` may be inferred from session/worktree/branch names like `issue-65` when upstream did not send it explicitly.
+- `pr_number` may be inferred from `pr_url`.
+- `raw_event` is retained only when clawhip had to rename the incoming event.
+- `contract_event` is the canonical normalized event after clawhip ingestion.
+
+## Upstream-to-canonical mapping
+
+### OMC-style route keys
+
+| Upstream signal | Canonical clawhip event |
+| --- | --- |
+| `session.started` | `session.started` |
+| `session.finished` | `session.finished` |
+| `session.idle` | `session.blocked` |
+| `question.requested` | `session.blocked` |
+| `test.started` | `session.test-started` |
+| `test.finished` | `session.test-finished` |
+| `test.failed` | `session.test-failed` |
+| `pull-request.created` | `session.pr-created` |
+| `pull-request.failed` | `session.failed` |
+| `tool.failed` | `session.failed` |
+
+### OMX-style normalized events
+
+| Upstream normalized event | Canonical clawhip event |
+| --- | --- |
+| `started` | `session.started` |
+| `blocked` | `session.blocked` |
+| `finished` | `session.finished` |
+| `failed` | `session.failed` |
+| `retry-needed` | `session.retry-needed` |
+| `pr-created` | `session.pr-created` |
+| `test-started` | `session.test-started` |
+| `test-finished` | `session.test-finished` |
+| `test-failed` | `session.test-failed` |
+| `handoff-needed` | `session.handoff-needed` |
+
+## Routing guidance
+
+Recommended route filters:
+
+```toml
+[[routes]]
+event = "session.*"
+filter = { tool = "omx", repo_name = "clawhip" }
+channel = "1480171113253175356"
+format = "compact"
+```
+
+Prefer filters on structured metadata such as:
+
+- `tool`
+- `repo_name`
+- `session_name`
+- `issue_number`
+- `pr_number`
+- `branch`
+
+Avoid routing on rendered message text.
+
+## Formatting guidance
+
+Default clawhip session formatting is intentionally low-noise:
+
+- compact: stable one-line status plus the most useful metadata
+- inline: dense channel-safe summaries for busy rooms
+- alert: same content with alert prefix for high-priority channels
+- raw: original normalized payload for debugging
+
+This contract is designed so real-world routing can stay stable even if OMC/OMX keep evolving their internal raw hook/event names.
+
+## Deprecation note
+
+Direct platform notifications from inside OMC/OMX are deprecated for clawhip-integrated setups.
+
+Preferred model:
+
+1. OMC/OMX emit native operational events
+2. clawhip normalizes them
+3. clawhip owns channel routing, mentions, formatting, and webhook delivery
+
+That keeps notification policy in one place and avoids duplicate/noisy Discord or Slack messages.

--- a/skills/omc/SKILL.md
+++ b/skills/omc/SKILL.md
@@ -4,10 +4,12 @@ Launch [OMC](https://github.com/Yeachan-Heo/oh-my-claudecode) coding sessions wi
 
 ## What you get
 
-- Native `agent.started`, `agent.finished`, and `agent.failed` lifecycle events via `clawhip emit`
+- Legacy-compatible `agent.started`, `agent.finished`, and `agent.failed` wrapper emits via `clawhip emit`
+- clawhip-side normalization of richer native OMC/OMX events into the canonical `session.*` routing contract
 - Session keyword alerts (error, PR created, complete, etc.)
 - Stale session detection (no output for N minutes)
 - All notifications routed to the correct Discord channel
+- Direct Slack/Discord notifications inside OMC/OMX should be treated as deprecated in clawhip-integrated setups
 
 ## Prerequisites
 

--- a/skills/omx/SKILL.md
+++ b/skills/omx/SKILL.md
@@ -4,10 +4,12 @@ Launch [OMX](https://github.com/Yeachan-Heo/oh-my-codex) coding sessions with au
 
 ## What you get
 
-- Native `agent.started`, `agent.finished`, and `agent.failed` lifecycle events via `clawhip emit`
+- Legacy-compatible `agent.started`, `agent.finished`, and `agent.failed` wrapper emits via `clawhip emit`
+- clawhip-side normalization of richer native OMC/OMX events into the canonical `session.*` routing contract
 - Session keyword alerts (error, PR created, complete, etc.)
 - Stale session detection (no output for N minutes)
 - All notifications routed to the correct Discord channel
+- Direct Slack/Discord notifications inside OMC/OMX should be treated as deprecated in clawhip-integrated setups
 
 ## Prerequisites
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -378,6 +378,7 @@ pub enum ConfigCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event::compat::from_incoming_event;
 
     #[test]
     fn parses_emit_subcommand_with_top_level_fields() {
@@ -455,6 +456,32 @@ mod tests {
                 .to_string()
                 .contains("emit fields must be provided as --key value pairs")
         );
+    }
+
+    #[test]
+    fn emit_agent_lifecycle_events_normalize_for_validation() {
+        let args = EmitArgs {
+            event_type: "agent.started".into(),
+            fields: vec![
+                "--agent".into(),
+                "omx".into(),
+                "--session".into(),
+                "issue-65".into(),
+                "--project".into(),
+                "clawhip".into(),
+            ],
+        };
+
+        let normalized = crate::events::normalize_event(args.into_event().expect("event"));
+        let typed = from_incoming_event(&normalized).expect("typed envelope");
+
+        assert_eq!(normalized.kind, "agent.started");
+        assert_eq!(
+            normalized.payload["status"],
+            Value::String("started".into())
+        );
+        assert_eq!(normalized.payload["tool"], Value::String("omx".into()));
+        assert_eq!(typed.metadata.priority, crate::event::EventPriority::Normal);
     }
 
     #[test]

--- a/src/event/compat.rs
+++ b/src/event/compat.rs
@@ -74,10 +74,12 @@ fn body_for(kind: &str, payload: &Value) -> Result<EventBody> {
             minutes: u64_field(payload, "minutes")?,
             last_line: string_field(payload, "last_line")?,
         })),
-        "agent.started" => Ok(EventBody::AgentStarted(agent_event(payload)?)),
-        "agent.blocked" => Ok(EventBody::AgentBlocked(agent_event(payload)?)),
-        "agent.finished" => Ok(EventBody::AgentFinished(agent_event(payload)?)),
-        "agent.failed" => Ok(EventBody::AgentFailed(agent_event(payload)?)),
+        "agent.started" | "session.started" => Ok(EventBody::AgentStarted(agent_event(payload)?)),
+        "agent.blocked" | "session.blocked" => Ok(EventBody::AgentBlocked(agent_event(payload)?)),
+        "agent.finished" | "session.finished" => {
+            Ok(EventBody::AgentFinished(agent_event(payload)?))
+        }
+        "agent.failed" | "session.failed" => Ok(EventBody::AgentFailed(agent_event(payload)?)),
         _ => Ok(EventBody::Custom(CustomEvent {
             kind: kind.to_string(),
             message: optional_string_field(payload, "message").unwrap_or_else(|| kind.to_string()),
@@ -238,8 +240,14 @@ fn agent_event(payload: &Value) -> Result<AgentEvent> {
 
 fn priority_for(kind: &str, payload: &Value) -> EventPriority {
     match kind {
-        "agent.failed" | "github.ci-failed" => EventPriority::Critical,
-        "agent.blocked" | "tmux.stale" => EventPriority::High,
+        "agent.failed" | "session.failed" | "session.test-failed" | "github.ci-failed" => {
+            EventPriority::Critical
+        }
+        "agent.blocked"
+        | "session.blocked"
+        | "session.retry-needed"
+        | "session.handoff-needed"
+        | "tmux.stale" => EventPriority::High,
         "github.pr-status-changed"
             if optional_string_field(payload, "new_status")
                 .map(|status| status == "merged" || status == "closed")

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
@@ -550,6 +551,16 @@ impl IncomingEvent {
         match self.kind.as_str() {
             "issue-opened" => "github.issue-opened",
             "git.pr-status-changed" => "github.pr-status-changed",
+            "session-start" | "started" => "session.started",
+            "session-idle" | "blocked" => "session.blocked",
+            "session-end" | "finished" => "session.finished",
+            "failed" => "session.failed",
+            "retry-needed" => "session.retry-needed",
+            "pr-created" => "session.pr-created",
+            "test-started" => "session.test-started",
+            "test-finished" => "session.test-finished",
+            "test-failed" => "session.test-failed",
+            "handoff-needed" => "session.handoff-needed",
             other => other,
         }
     }
@@ -577,11 +588,352 @@ pub fn render_template(template: &str, context: &BTreeMap<String, String>) -> St
 }
 
 pub fn normalize_event(mut event: IncomingEvent) -> IncomingEvent {
-    event.kind = event.canonical_kind().to_string();
     if !event.payload.is_object() {
         event.payload = json!({ "value": event.payload });
     }
+
+    let raw_kind = event.kind.clone();
+    let canonical_kind = canonical_event_kind(&event.kind, &event.payload);
+    normalize_native_metadata(&mut event.payload, &raw_kind, &canonical_kind);
+    event.kind = canonical_kind;
     event
+}
+
+fn canonical_event_kind(kind: &str, payload: &Value) -> String {
+    match kind {
+        "issue-opened" => "github.issue-opened".to_string(),
+        "git.pr-status-changed" => "github.pr-status-changed".to_string(),
+        other => native_contract_kind(other, payload).unwrap_or_else(|| other.to_string()),
+    }
+}
+
+fn native_contract_kind(kind: &str, payload: &Value) -> Option<String> {
+    if let Some(route_key) = first_string(
+        payload,
+        &["/signal/routeKey", "/route_key", "/context/route_key"],
+    ) && let Some(mapped) = map_native_signal(route_key.as_str())
+    {
+        return Some(mapped.to_string());
+    }
+
+    if let Some(normalized_event) =
+        first_string(payload, &["/context/normalized_event", "/normalized_event"])
+        && let Some(mapped) = map_native_signal(normalized_event.as_str())
+    {
+        return Some(mapped.to_string());
+    }
+
+    map_native_signal(kind).map(ToString::to_string)
+}
+
+fn map_native_signal(raw: &str) -> Option<&'static str> {
+    let normalized = raw.trim().replace('_', "-").to_ascii_lowercase();
+    match normalized.as_str() {
+        "session-start" | "started" | "session.started" => Some("session.started"),
+        "session-idle" | "blocked" | "session.blocked" | "session.idle" | "question.requested" => {
+            Some("session.blocked")
+        }
+        "session-end" | "finished" | "session.finished" => Some("session.finished"),
+        "failed" | "session.failed" | "tool.failed" | "pull-request.failed" => {
+            Some("session.failed")
+        }
+        "retry-needed" | "session.retry-needed" => Some("session.retry-needed"),
+        "pr-created" | "session.pr-created" | "pull-request.created" => Some("session.pr-created"),
+        "test-started" | "session.test-started" | "test.started" => Some("session.test-started"),
+        "test-finished" | "session.test-finished" | "test.finished" => {
+            Some("session.test-finished")
+        }
+        "test-failed" | "session.test-failed" | "test.failed" => Some("session.test-failed"),
+        "handoff-needed" | "session.handoff-needed" => Some("session.handoff-needed"),
+        _ => None,
+    }
+}
+
+fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind: &str) {
+    let tool = infer_tool(payload);
+    let session_name = first_string(
+        payload,
+        &[
+            "/session_name",
+            "/context/session_name",
+            "/session",
+            "/tmuxSession",
+            "/tmux_session",
+            "/context/tmuxSession",
+            "/context/tmux_session",
+            "/session_id",
+            "/sessionId",
+            "/context/session_id",
+            "/context/sessionId",
+        ],
+    );
+    let session_id = first_string(
+        payload,
+        &[
+            "/session_id",
+            "/sessionId",
+            "/context/session_id",
+            "/context/sessionId",
+            "/sessionId",
+            "/session_name",
+            "/context/session_name",
+        ],
+    );
+    let project = first_string(payload, &["/project", "/projectName", "/project_name"]);
+    let repo_name = first_string(
+        payload,
+        &["/repo_name", "/context/repo_name", "/projectName"],
+    )
+    .or_else(|| {
+        first_string(payload, &["/repo_path", "/context/repo_path"]).and_then(|path| {
+            Path::new(path.as_str())
+                .file_name()
+                .and_then(|value| value.to_str())
+                .map(ToString::to_string)
+        })
+    });
+    let repo_path = first_string(
+        payload,
+        &["/repo_path", "/context/repo_path", "/projectPath"],
+    );
+    let worktree_path = first_string(
+        payload,
+        &["/worktree_path", "/context/worktree_path", "/projectPath"],
+    );
+    let branch = first_string(payload, &["/branch", "/context/branch"]);
+    let command = first_string(
+        payload,
+        &["/command", "/context/command", "/signal/command"],
+    );
+    let tool_name = first_string(
+        payload,
+        &["/tool_name", "/context/tool_name", "/signal/toolName"],
+    );
+    let test_runner =
+        first_string(payload, &["/test_runner", "/signal/testRunner"]).or_else(|| {
+            command
+                .as_deref()
+                .and_then(infer_test_runner)
+                .map(ToString::to_string)
+        });
+    let status = first_string(payload, &["/status", "/context/status", "/signal/phase"])
+        .or_else(|| event_status_from_kind(canonical_kind).map(ToString::to_string));
+    let summary = first_string(
+        payload,
+        &[
+            "/summary",
+            "/signal/summary",
+            "/reason",
+            "/context/contextSummary",
+            "/context/reason",
+            "/context/question",
+        ],
+    );
+    let error_message = first_string(
+        payload,
+        &[
+            "/error_message",
+            "/error_summary",
+            "/context/error_summary",
+            "/context/error_message",
+        ],
+    )
+    .or_else(|| {
+        canonical_kind
+            .ends_with(".failed")
+            .then(|| summary.clone())
+            .flatten()
+    });
+    let event_timestamp = first_string(payload, &["/event_timestamp", "/timestamp"]);
+    let route_key = first_string(
+        payload,
+        &["/route_key", "/signal/routeKey", "/context/route_key"],
+    );
+    let source = first_string(payload, &["/source"]);
+    let mut issue_number =
+        first_u64(payload, &["/issue_number", "/context/issue_number"]).or_else(|| {
+            [
+                session_name.as_deref(),
+                branch.as_deref(),
+                worktree_path.as_deref(),
+                command.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .find_map(extract_issue_number)
+        });
+    let mut pr_number = first_u64(payload, &["/pr_number", "/context/pr_number"]);
+    let pr_url = first_string(payload, &["/pr_url", "/context/pr_url", "/signal/prUrl"]);
+    if pr_number.is_none() {
+        pr_number = pr_url.as_deref().and_then(extract_pr_number_from_url);
+    }
+    if issue_number.is_none() {
+        issue_number = pr_number;
+    }
+
+    let Some(object) = payload.as_object_mut() else {
+        return;
+    };
+
+    if raw_kind != canonical_kind {
+        object
+            .entry("raw_event".to_string())
+            .or_insert_with(|| json!(raw_kind));
+    }
+    object
+        .entry("contract_event".to_string())
+        .or_insert_with(|| json!(canonical_kind));
+
+    insert_string_if_missing(object, "tool", tool);
+    if (canonical_kind.starts_with("agent.") || canonical_kind.starts_with("session."))
+        && object.get("agent_name").is_none()
+        && let Some(tool) = object
+            .get("tool")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    {
+        object.insert("agent_name".to_string(), json!(tool));
+    }
+    insert_string_if_missing(object, "session_name", session_name);
+    insert_string_if_missing(object, "session_id", session_id);
+    insert_string_if_missing(object, "project", project);
+    insert_string_if_missing(object, "repo_name", repo_name);
+    insert_string_if_missing(object, "repo_path", repo_path);
+    insert_string_if_missing(object, "worktree_path", worktree_path);
+    insert_string_if_missing(object, "branch", branch);
+    insert_u64_if_missing(object, "issue_number", issue_number);
+    insert_u64_if_missing(object, "pr_number", pr_number);
+    insert_string_if_missing(object, "pr_url", pr_url);
+    insert_string_if_missing(object, "command", command);
+    insert_string_if_missing(object, "tool_name", tool_name);
+    insert_string_if_missing(object, "test_runner", test_runner);
+    insert_string_if_missing(object, "status", status);
+    insert_string_if_missing(object, "summary", summary);
+    insert_string_if_missing(object, "error_message", error_message);
+    insert_string_if_missing(object, "event_timestamp", event_timestamp);
+    insert_string_if_missing(object, "route_key", route_key);
+    insert_string_if_missing(object, "source", source);
+}
+
+fn infer_tool(payload: &Value) -> Option<String> {
+    if let Some(tool) = first_string(payload, &["/tool"]) {
+        return Some(tool);
+    }
+
+    match first_string(payload, &["/agent_name"])
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "omc" | "openclaw" => return Some("omc".to_string()),
+        "omx" => return Some("omx".to_string()),
+        _ => {}
+    }
+
+    if payload.pointer("/signal/routeKey").is_some() {
+        return Some("omc".to_string());
+    }
+    if payload.pointer("/context/normalized_event").is_some() {
+        return Some("omx".to_string());
+    }
+
+    None
+}
+
+fn infer_test_runner(command: &str) -> Option<&'static str> {
+    let command = command.to_ascii_lowercase();
+    if command.contains("cargo test") {
+        Some("cargo-test")
+    } else if command.contains("pytest") {
+        Some("pytest")
+    } else if command.contains("vitest") {
+        Some("vitest")
+    } else if command.contains("jest") {
+        Some("jest")
+    } else if command.contains("go test") {
+        Some("go-test")
+    } else if command.contains("npm test")
+        || command.contains("pnpm test")
+        || command.contains("yarn test")
+        || command.contains("bun test")
+    {
+        Some("package-test")
+    } else {
+        None
+    }
+}
+
+fn event_status_from_kind(kind: &str) -> Option<&'static str> {
+    match kind {
+        "agent.started" | "session.started" => Some("started"),
+        "agent.blocked" | "session.blocked" => Some("blocked"),
+        "agent.finished" | "session.finished" => Some("finished"),
+        "agent.failed" | "session.failed" => Some("failed"),
+        "session.retry-needed" => Some("retry-needed"),
+        "session.pr-created" => Some("pr-created"),
+        "session.test-started" => Some("test-started"),
+        "session.test-finished" => Some("test-finished"),
+        "session.test-failed" => Some("test-failed"),
+        "session.handoff-needed" => Some("handoff-needed"),
+        _ => None,
+    }
+}
+
+fn first_string(payload: &Value, pointers: &[&str]) -> Option<String> {
+    pointers.iter().find_map(|pointer| {
+        payload
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+    })
+}
+
+fn first_u64(payload: &Value, pointers: &[&str]) -> Option<u64> {
+    pointers
+        .iter()
+        .find_map(|pointer| payload.pointer(pointer).and_then(Value::as_u64))
+}
+
+fn insert_string_if_missing(object: &mut Map<String, Value>, key: &str, value: Option<String>) {
+    if object.get(key).is_none()
+        && let Some(value) = value
+    {
+        object.insert(key.to_string(), json!(value));
+    }
+}
+
+fn insert_u64_if_missing(object: &mut Map<String, Value>, key: &str, value: Option<u64>) {
+    if object.get(key).is_none()
+        && let Some(value) = value
+    {
+        object.insert(key.to_string(), json!(value));
+    }
+}
+
+fn extract_issue_number(text: &str) -> Option<u64> {
+    extract_number_after(text, "issue-")
+        .or_else(|| extract_number_after(text, "issue/"))
+        .or_else(|| extract_number_after(text, "issue#"))
+        .or_else(|| extract_number_after(text, "#"))
+}
+
+fn extract_pr_number_from_url(url: &str) -> Option<u64> {
+    url.split("/pull/").nth(1)?.split('/').next()?.parse().ok()
+}
+
+fn extract_number_after(text: &str, marker: &str) -> Option<u64> {
+    let text = text.to_ascii_lowercase();
+    let marker = marker.to_ascii_lowercase();
+    let start = text.find(marker.as_str())? + marker.len();
+    let digits = text[start..]
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
 }
 
 fn short_sha(commit: &str) -> String {
@@ -918,6 +1270,98 @@ mod tests {
         assert_eq!(
             event.render_default(&MessageFormat::Alert).unwrap(),
             "🚨 CI started · clawhip#58 · CI / test · in_progress · abcdef1 · https://github.com/Yeachan-Heo/clawhip/actions/runs/1"
+        );
+    }
+
+    #[test]
+    fn normalize_event_backfills_agent_emit_status_fields() {
+        let event = normalize_event(IncomingEvent {
+            kind: "agent.finished".into(),
+            channel: None,
+            mention: Some("<@123>".into()),
+            format: None,
+            template: None,
+            payload: json!({
+                "agent_name": "omc",
+                "session_id": "issue-65",
+                "project": "clawhip",
+                "elapsed_secs": 42
+            }),
+        });
+
+        assert_eq!(event.kind, "agent.finished");
+        assert_eq!(event.payload["status"], json!("finished"));
+        assert_eq!(event.payload["tool"], json!("omc"));
+        assert_eq!(event.payload["agent_name"], json!("omc"));
+    }
+
+    #[test]
+    fn normalize_event_maps_omx_native_contract_into_session_event() {
+        let event = normalize_event(IncomingEvent {
+            kind: "notify".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "event": "test-failed",
+                "timestamp": "2026-03-09T18:07:07.000Z",
+                "context": {
+                    "normalized_event": "test-failed",
+                    "session_name": "issue-65-native-event-contract-polish",
+                    "repo_name": "clawhip",
+                    "repo_path": "/repo/clawhip",
+                    "worktree_path": "/repo/clawhip-worktrees/issue-65",
+                    "branch": "feat/issue-65-native-event-contract-polish",
+                    "issue_number": 65,
+                    "error_summary": "cargo test failed"
+                }
+            }),
+        });
+
+        assert_eq!(event.kind, "session.test-failed");
+        assert_eq!(event.payload["tool"], json!("omx"));
+        assert_eq!(
+            event.payload["session_name"],
+            json!("issue-65-native-event-contract-polish")
+        );
+        assert_eq!(event.payload["repo_name"], json!("clawhip"));
+        assert_eq!(event.payload["issue_number"], json!(65));
+        assert_eq!(event.payload["error_message"], json!("cargo test failed"));
+        assert_eq!(
+            event.payload["event_timestamp"],
+            json!("2026-03-09T18:07:07.000Z")
+        );
+    }
+
+    #[test]
+    fn renders_session_contract_events_in_low_noise_formats() {
+        let event = normalize_event(IncomingEvent {
+            kind: "pr-created".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "context": {
+                    "normalized_event": "pr-created",
+                    "session_name": "issue-65",
+                    "repo_name": "clawhip",
+                    "branch": "feat/issue-65-native-event-contract-polish",
+                    "issue_number": 65,
+                    "pr_number": 71,
+                    "pr_url": "https://github.com/Yeachan-Heo/clawhip/pull/71"
+                }
+            }),
+        });
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "omx issue-65 pr-created (repo=clawhip, issue=#65, pr=#71, branch=feat/issue-65-native-event-contract-polish)"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Inline).unwrap(),
+            "[omx issue-65] pr-created · clawhip · issue #65 · PR #71 · feat/issue-65-native-event-contract-polish"
         );
     }
 

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -11,6 +11,9 @@ pub struct DefaultRenderer;
 impl Renderer for DefaultRenderer {
     fn render(&self, event: &IncomingEvent, format: &MessageFormat) -> Result<String> {
         let payload = &event.payload;
+        if event.canonical_kind().starts_with("session.") {
+            return render_session_event(event.canonical_kind(), payload, format);
+        }
         if event.canonical_kind() == "git.commit"
             && let Some(rendered) = render_aggregated_git_commit(payload, format)?
         {
@@ -336,6 +339,113 @@ fn agent_detail_suffix(payload: &Value) -> String {
 fn agent_inline_suffix(payload: &Value) -> String {
     let mut parts = agent_context_parts(payload);
 
+    if let Some(summary) = optional_string_field(payload, "summary") {
+        parts.push(summary);
+    }
+    if let Some(error_message) = optional_string_field(payload, "error_message") {
+        parts.push(format!("error: {error_message}"));
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" · {}", parts.join(" · "))
+    }
+}
+
+fn render_session_event(kind: &str, payload: &Value, format: &MessageFormat) -> Result<String> {
+    let label = session_subject(payload);
+    let status = session_status_label(kind, payload);
+    let detail = session_detail_suffix(payload);
+    let inline = session_inline_suffix(payload);
+    let prefix = agent_optional_mention_prefix(payload);
+
+    Ok(match format {
+        MessageFormat::Compact => format!("{prefix}{label} {status}{detail}"),
+        MessageFormat::Alert => format!("🚨 {prefix}{label} {status}{detail}"),
+        MessageFormat::Inline => format!("{prefix}[{label}] {status}{inline}"),
+        MessageFormat::Raw => serde_json::to_string_pretty(payload)?,
+    })
+}
+
+fn session_subject(payload: &Value) -> String {
+    let tool = optional_string_field(payload, "tool").unwrap_or_else(|| "session".to_string());
+    let session = optional_string_field(payload, "session_name")
+        .or_else(|| optional_string_field(payload, "session_id"));
+    match session {
+        Some(session) => format!("{tool} {session}"),
+        None => tool,
+    }
+}
+
+fn session_status_label(kind: &str, payload: &Value) -> String {
+    optional_string_field(payload, "status").unwrap_or_else(|| {
+        kind.strip_prefix("session.")
+            .unwrap_or(kind)
+            .replace('-', " ")
+    })
+}
+
+fn session_detail_suffix(payload: &Value) -> String {
+    let mut parts = Vec::new();
+
+    if let Some(repo_name) = optional_string_field(payload, "repo_name")
+        .or_else(|| optional_string_field(payload, "project"))
+    {
+        parts.push(format!("repo={repo_name}"));
+    }
+    if let Some(issue_number) = optional_u64_field(payload, "issue_number") {
+        parts.push(format!("issue=#{issue_number}"));
+    }
+    if let Some(pr_number) = optional_u64_field(payload, "pr_number") {
+        parts.push(format!("pr=#{pr_number}"));
+    }
+    if let Some(branch) = optional_string_field(payload, "branch") {
+        parts.push(format!("branch={branch}"));
+    }
+    if let Some(test_runner) = optional_string_field(payload, "test_runner") {
+        parts.push(format!("runner={test_runner}"));
+    }
+    if let Some(elapsed_secs) = optional_u64_field(payload, "elapsed_secs") {
+        parts.push(format!("elapsed={elapsed_secs}s"));
+    }
+    if let Some(summary) = optional_string_field(payload, "summary") {
+        parts.push(format!("summary={summary}"));
+    }
+    if let Some(error_message) = optional_string_field(payload, "error_message") {
+        parts.push(format!("error={error_message}"));
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join(", "))
+    }
+}
+
+fn session_inline_suffix(payload: &Value) -> String {
+    let mut parts = Vec::new();
+
+    if let Some(repo_name) = optional_string_field(payload, "repo_name")
+        .or_else(|| optional_string_field(payload, "project"))
+    {
+        parts.push(repo_name);
+    }
+    if let Some(issue_number) = optional_u64_field(payload, "issue_number") {
+        parts.push(format!("issue #{issue_number}"));
+    }
+    if let Some(pr_number) = optional_u64_field(payload, "pr_number") {
+        parts.push(format!("PR #{pr_number}"));
+    }
+    if let Some(branch) = optional_string_field(payload, "branch") {
+        parts.push(branch);
+    }
+    if let Some(test_runner) = optional_string_field(payload, "test_runner") {
+        parts.push(test_runner);
+    }
+    if let Some(elapsed_secs) = optional_u64_field(payload, "elapsed_secs") {
+        parts.push(format!("{elapsed_secs}s"));
+    }
     if let Some(summary) = optional_string_field(payload, "summary") {
         parts.push(summary);
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -238,7 +238,18 @@ fn route_candidates(kind: &str) -> Vec<&str> {
         "git.commit" => vec!["git.commit", "github.commit"],
         "git.branch-changed" => vec!["git.branch-changed", "github.branch-changed"],
         "agent.started" | "agent.blocked" | "agent.finished" | "agent.failed" => {
-            vec![kind, "agent.*"]
+            vec![kind, "agent.*", "session.*"]
+        }
+        "session.started" | "session.blocked" | "session.finished" | "session.failed" => {
+            vec![kind, "session.*", "agent.*"]
+        }
+        "session.retry-needed"
+        | "session.pr-created"
+        | "session.test-started"
+        | "session.test-finished"
+        | "session.test-failed"
+        | "session.handoff-needed" => {
+            vec![kind, "session.*"]
         }
         other => vec![other],
     }
@@ -288,8 +299,10 @@ fn glob_match(pattern: &str, value: &str) -> bool {
 mod tests {
     use super::*;
     use crate::config::{DefaultsConfig, RouteRule};
+    use crate::events::normalize_event;
     use crate::render::DefaultRenderer;
     use crate::sink::{DiscordSink, SlackSink};
+    use serde_json::json;
 
     #[tokio::test]
     async fn resolve_returns_all_matching_deliveries_in_route_order() {
@@ -847,6 +860,55 @@ mod tests {
         assert!(started_content.contains("started"));
         assert!(finished_content.contains("worker-1"));
         assert!(finished_content.contains("finished"));
+    }
+
+    #[tokio::test]
+    async fn session_lifecycle_events_match_existing_agent_routes() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "agent.*".into(),
+                sink: "discord".into(),
+                filter: [
+                    ("tool".to_string(), "omx".to_string()),
+                    ("repo_name".to_string(), "clawhip".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+                channel: Some("agent-route".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: Some(MessageFormat::Compact),
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = normalize_event(IncomingEvent {
+            kind: "finished".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "context": {
+                    "normalized_event": "finished",
+                    "session_name": "issue-65",
+                    "repo_name": "clawhip"
+                }
+            }),
+        });
+
+        let (channel, format, content) = router.preview(&event).await.unwrap();
+
+        assert_eq!(channel, "agent-route");
+        assert_eq!(format, MessageFormat::Compact);
+        assert!(content.contains("omx issue-65 finished"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- normalize already-merged OMC/OMX native payloads into a stable `session.*` clawhip routing contract
- keep legacy `agent.*` wrapper emits working by backfilling status/metadata and cross-matching agent/session routes
- add low-noise session formatting plus contract/deprecation docs for clawhip-owned routing

## Verification
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

Refs #65.