### PR TITLE
Add optional post-install GitHub star prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/Yeachan-Heo/clawhip/stargazers"><img src="https://img.shields.io/github/stars/Yeachan-Heo/clawhip?style=social" alt="GitHub stars" /></a>
 </p>
 
-> **⭐ Star this repo before using clawhip.** The installer will star it automatically if you have `gh` CLI authenticated.
+> **⭐ Optional support:** the interactive repo-local installer can offer to star this repo after a successful install when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
 
 clawhip is a daemon-first Discord notification router with a typed event pipeline, extracted sources, and a clean renderer/sink split.
 
@@ -682,6 +682,8 @@ Release artifacts are generated for these Rust target triples: `x86_64-unknown-l
 ```
 
 `install.sh` now tries the latest prebuilt release first and falls back to `cargo install --path . --force` when a matching release asset is unavailable. If Cargo is needed for the fallback path but not installed, the script prints Rustup setup instructions. When `--systemd` is used, the installed binary is also copied to `/usr/local/bin/clawhip` so the bundled service unit can start it.
+
+In interactive terminals, the repo-local installer may also offer an optional post-install `gh repo star Yeachan-Heo/clawhip` prompt. It never runs automatically, is skipped when `gh` is missing or unauthenticated, and can be disabled with `./install.sh --skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1 ./install.sh`.
 
 ### Runtime lifecycle commands
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,7 +14,7 @@ Use this repo as:
 
 ## Prerequisites
 
-⭐ **You must star this repository to use clawhip.** The installer does this automatically if `gh` CLI is authenticated, but please ensure the repo is starred before proceeding.
+⭐ If you want to support clawhip, star this repository. The interactive repo-local installer can offer an optional post-install `gh repo star` prompt when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
 
 ```bash
 gh repo star Yeachan-Heo/clawhip

--- a/install.sh
+++ b/install.sh
@@ -7,24 +7,99 @@ INSTALLER_URL="${CLAWHIP_INSTALLER_URL:-https://github.com/${GITHUB_REPO}/releas
 CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
 export CARGO_HOME
 SYSTEMD=0
-for arg in "$@"; do
-  case "$arg" in
-    --systemd) SYSTEMD=1 ;;
-    *) echo "unknown arg: $arg" >&2; exit 1 ;;
-  esac
-done
+SKIP_STAR_PROMPT=0
+
+usage() {
+  cat <<'EOF'
+Usage: ./install.sh [--systemd] [--skip-star-prompt]
+
+Options:
+  --systemd            Install and start the bundled systemd service.
+  --skip-star-prompt   Disable the optional post-install GitHub star prompt.
+  -h, --help           Show this help text.
+
+Environment:
+  CLAWHIP_SKIP_STAR_PROMPT=1
+      Disable the optional post-install GitHub star prompt.
+EOF
+}
+
+parse_args() {
+  for arg in "$@"; do
+    case "$arg" in
+      --systemd) SYSTEMD=1 ;;
+      --skip-star-prompt) SKIP_STAR_PROMPT=1 ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "unknown arg: $arg" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+}
 
 log() {
   echo "[clawhip] $*"
 }
 
-star_repo() {
-  if command -v gh >/dev/null 2>&1; then
-    if gh auth status &>/dev/null; then
-      log "⭐ Starring ${GITHUB_REPO} — thanks for the support!"
-      gh repo star "${GITHUB_REPO}" 2>/dev/null || true
-    fi
+is_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+star_prompt_disabled() {
+  is_truthy "${CLAWHIP_SKIP_STAR_PROMPT:-}" || is_truthy "${SKIP_STAR_PROMPT:-}"
+}
+
+is_interactive_install() {
+  [[ -t 0 && -t 1 ]]
+}
+
+can_use_github_cli_for_star() {
+  command -v gh >/dev/null 2>&1 && gh auth status &>/dev/null
+}
+
+prompt_to_star_repo() {
+  local response
+  printf '[clawhip] Would you like to star %s on GitHub with gh? [y/N]: ' "$GITHUB_REPO"
+  read -r response || return 0
+
+  case "$response" in
+    [yY]|[yY][eE][sS])
+      if gh repo star "${GITHUB_REPO}" 2>/dev/null; then
+        log "thanks for starring ${GITHUB_REPO}"
+      else
+        log "unable to star ${GITHUB_REPO} with gh; continuing without it"
+      fi
+      ;;
+    *)
+      log "skipping GitHub star step"
+      ;;
+  esac
+}
+
+maybe_prompt_to_star_repo() {
+  if star_prompt_disabled; then
+    log "skipping GitHub star prompt (--skip-star-prompt or CLAWHIP_SKIP_STAR_PROMPT)"
+    return 0
   fi
+
+  if ! is_interactive_install; then
+    return 0
+  fi
+
+  if ! can_use_github_cli_for_star; then
+    return 0
+  fi
+
+  log "optional: star ${GITHUB_REPO} on GitHub to support the project"
+  prompt_to_star_repo
 }
 
 install_prebuilt_binary() {
@@ -138,30 +213,38 @@ install_systemd_binary() {
   sudo install -m 755 "$binary_path" /usr/local/bin/clawhip
 }
 
-log "install flow: star -> prebuilt binary -> cargo fallback -> SKILL attach -> config scaffold -> daemon start -> live verification"
-log "repo root: $REPO_ROOT"
+main() {
+  parse_args "$@"
 
-star_repo
+  log "install flow: prebuilt binary -> cargo fallback -> SKILL attach -> config scaffold -> optional post-install GitHub star prompt -> verification"
+  log "repo root: $REPO_ROOT"
 
-if install_prebuilt_binary; then
-  log "prebuilt binary installed successfully"
-else
-  install_from_source
+  if install_prebuilt_binary; then
+    log "prebuilt binary installed successfully"
+  else
+    install_from_source
+  fi
+
+  mkdir -p "$HOME/.clawhip"
+  log "ensured config dir $HOME/.clawhip"
+  sync_plugins
+  log "next: read SKILL.md and attach the skill surface"
+  setup_quick_start
+
+  if [[ "$SYSTEMD" == "1" ]]; then
+    install_systemd_binary
+    sudo cp deploy/clawhip.service /etc/systemd/system/clawhip.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now clawhip
+    log "systemd unit installed and started"
+  fi
+
+  maybe_prompt_to_star_repo
+
+  log "recommended verification: scripts/live-verify-default-presets.sh <mode>"
+  log "install complete"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-
-mkdir -p "$HOME/.clawhip"
-log "ensured config dir $HOME/.clawhip"
-sync_plugins
-log "next: read SKILL.md and attach the skill surface"
-setup_quick_start
-
-if [[ "$SYSTEMD" == "1" ]]; then
-  install_systemd_binary
-  sudo cp deploy/clawhip.service /etc/systemd/system/clawhip.service
-  sudo systemctl daemon-reload
-  sudo systemctl enable --now clawhip
-  log "systemd unit installed and started"
-fi
-
-log "recommended verification: scripts/live-verify-default-presets.sh <mode>"
-log "install complete"

--- a/tests/install_star_prompt.rs
+++ b/tests/install_star_prompt.rs
@@ -1,0 +1,183 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn install_script() -> PathBuf {
+    repo_root().join("install.sh")
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write file");
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod");
+}
+
+fn fake_gh_script() -> &'static str {
+    r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_LOG"
+case "${1:-} ${2:-}" in
+  "auth status")
+    exit "${GH_AUTH_EXIT_CODE:-0}"
+    ;;
+  "repo star")
+    exit "${GH_STAR_EXIT_CODE:-0}"
+    ;;
+esac
+"#
+}
+
+fn run_shell(temp: &TempDir, script_body: &str, extra_env: &[(&str, &str)]) -> Output {
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+    write_executable(&bin_dir.join("gh"), fake_gh_script());
+
+    let script_path = temp.path().join("runner.sh");
+    let script = format!(
+        "#!/usr/bin/env bash\nset -euo pipefail\nsource \"{}\"\n{}\n",
+        install_script().display(),
+        script_body
+    );
+    write_executable(&script_path, &script);
+
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let mut command = Command::new("bash");
+    command.arg(script_path);
+    command.env("PATH", format!("{}:{}", bin_dir.display(), existing_path));
+    command.env("GH_LOG", temp.path().join("gh.log"));
+    command.env("HOME", temp.path().join("home"));
+    command.env("CARGO_HOME", temp.path().join("cargo"));
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    command.output().expect("run shell script")
+}
+
+#[test]
+fn skips_star_prompt_when_not_interactive() {
+    let temp = TempDir::new().expect("tempdir");
+    let output = run_shell(
+        &temp,
+        r#"
+can_use_github_cli_for_star() {
+  echo invoked >> "$HOME/can-use.log"
+  return 0
+}
+maybe_prompt_to_star_repo
+"#,
+        &[],
+    );
+
+    assert!(output.status.success(), "script failed: {output:?}");
+    assert!(!temp.path().join("home/can-use.log").exists());
+    assert!(!temp.path().join("gh.log").exists());
+}
+
+#[test]
+fn skip_flag_or_env_disables_star_prompt() {
+    let temp = TempDir::new().expect("tempdir");
+    let output = run_shell(
+        &temp,
+        r#"
+SKIP_STAR_PROMPT=1
+is_interactive_install() {
+  return 0
+}
+can_use_github_cli_for_star() {
+  echo invoked >> "$HOME/can-use.log"
+  return 0
+}
+maybe_prompt_to_star_repo <<'EOF_INPUT'
+y
+EOF_INPUT
+"#,
+        &[],
+    );
+
+    assert!(output.status.success(), "script failed: {output:?}");
+    assert!(!temp.path().join("home/can-use.log").exists());
+    assert!(!temp.path().join("gh.log").exists());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("skipping GitHub star prompt"),
+        "stdout was: {stdout}"
+    );
+}
+
+#[test]
+fn skips_prompt_when_gh_is_unauthenticated() {
+    let temp = TempDir::new().expect("tempdir");
+    let output = run_shell(
+        &temp,
+        r#"
+is_interactive_install() {
+  return 0
+}
+maybe_prompt_to_star_repo
+"#,
+        &[("GH_AUTH_EXIT_CODE", "1")],
+    );
+
+    assert!(output.status.success(), "script failed: {output:?}");
+    let gh_log = fs::read_to_string(temp.path().join("gh.log")).expect("gh log");
+    assert_eq!(gh_log.trim(), "auth status");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Would you like to star"),
+        "stdout was: {stdout}"
+    );
+}
+
+#[test]
+fn stars_repo_only_after_explicit_yes() {
+    let temp = TempDir::new().expect("tempdir");
+    let output = run_shell(
+        &temp,
+        r#"
+prompt_to_star_repo <<'EOF_INPUT'
+y
+EOF_INPUT
+"#,
+        &[],
+    );
+
+    assert!(output.status.success(), "script failed: {output:?}");
+    let gh_log = fs::read_to_string(temp.path().join("gh.log")).expect("gh log");
+    assert_eq!(gh_log.trim(), "repo star Yeachan-Heo/clawhip");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("thanks for starring"),
+        "stdout was: {stdout}"
+    );
+}
+
+#[test]
+fn star_failure_does_not_fail_the_script() {
+    let temp = TempDir::new().expect("tempdir");
+    let output = run_shell(
+        &temp,
+        r#"
+prompt_to_star_repo <<'EOF_INPUT'
+yes
+EOF_INPUT
+echo after-prompt
+"#,
+        &[("GH_STAR_EXIT_CODE", "1")],
+    );
+
+    assert!(output.status.success(), "script failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("continuing without it"),
+        "stdout was: {stdout}"
+    );
+    assert!(stdout.contains("after-prompt"), "stdout was: {stdout}");
+}


### PR DESCRIPTION
## Summary
- add an optional post-install GitHub star prompt to `install.sh`
- keep it interactive-only, opt-outable, and fail-soft when `gh` is missing or unauthenticated
- document the behavior and add installer tests covering prompt/skip/fail-soft cases

## Testing
- bash -n install.sh
- cargo test

Closes #66