### PR TITLE
Fix clawhip install star prompt parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 name = "clawhip"
 version = "0.3.1"
 dependencies = [
+ "anyhow",
  "async-trait",
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["discord", "notifications", "tmux", "github", "devops"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
+anyhow = "1"
 async-trait = "0.1"
 axum = "0.8"
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/Yeachan-Heo/clawhip/stargazers"><img src="https://img.shields.io/github/stars/Yeachan-Heo/clawhip?style=social" alt="GitHub stars" /></a>
 </p>
 
-> **⭐ Optional support:** the interactive repo-local installer can offer to star this repo after a successful install when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
+> **⭐ Optional support:** the interactive repo-local install paths (`./install.sh` and `clawhip install` from a clone) can offer to star this repo after a successful install when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
 
 clawhip is a daemon-first Discord notification router with a typed event pipeline, extracted sources, and a clean renderer/sink split.
 
@@ -542,6 +542,7 @@ Behavior:
 - install binary from git clone
 - ensure config dir exists
 - optional systemd install
+- optional post-install GitHub star prompt on interactive local installs
 - update rebuilds/reinstalls and optionally restarts daemon
 - uninstall removes runtime artifacts
 
@@ -683,17 +684,20 @@ Release artifacts are generated for these Rust target triples: `x86_64-unknown-l
 
 `install.sh` now tries the latest prebuilt release first and falls back to `cargo install --path . --force` when a matching release asset is unavailable. If Cargo is needed for the fallback path but not installed, the script prints Rustup setup instructions. When `--systemd` is used, the installed binary is also copied to `/usr/local/bin/clawhip` so the bundled service unit can start it.
 
-In interactive terminals, the repo-local installer may also offer an optional post-install `gh repo star Yeachan-Heo/clawhip` prompt. It never runs automatically, is skipped when `gh` is missing or unauthenticated, and can be disabled with `./install.sh --skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1 ./install.sh`.
+In interactive terminals, both the repo-local installer and `clawhip install` may offer an optional post-install `gh repo star Yeachan-Heo/clawhip` prompt. It never runs automatically, is skipped when `gh` is missing or unauthenticated, and can be disabled with `./install.sh --skip-star-prompt`, `clawhip install --skip-star-prompt`, or `CLAWHIP_SKIP_STAR_PROMPT=1`.
 
 ### Runtime lifecycle commands
 
 ```bash
 clawhip install
 clawhip install --systemd
+clawhip install --skip-star-prompt
 clawhip update --restart
 clawhip uninstall
 clawhip uninstall --remove-systemd --remove-config
 ```
+
+`clawhip install` now matches the repo-local installer's optional GitHub star prompt behavior: it only appears in interactive terminals, is skipped when `gh` is missing or unauthenticated, never stars automatically, and can be disabled with `clawhip install --skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1 clawhip install`.
 
 ## systemd contract
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,7 +14,7 @@ Use this repo as:
 
 ## Prerequisites
 
-⭐ If you want to support clawhip, star this repository. The interactive repo-local installer can offer an optional post-install `gh repo star` prompt when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
+⭐ If you want to support clawhip, star this repository. The interactive repo-local installer and `clawhip install` can offer an optional post-install `gh repo star` prompt when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
 
 ```bash
 gh repo star Yeachan-Heo/clawhip
@@ -68,10 +68,12 @@ clawhip tmux watch -s <existing-session> --channel <id> --mention '<@id>' --keyw
 ```bash
 clawhip install
 clawhip install --systemd
+clawhip install --skip-star-prompt
 clawhip update --restart
 clawhip uninstall --remove-systemd --remove-config
 ./install.sh
 ./install.sh --systemd
+./install.sh --skip-star-prompt
 ```
 
 ## Discord bot token (recommended setup)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,8 +78,12 @@ pub enum Commands {
     },
     /// Install clawhip from the current git clone.
     Install {
+        /// Install and start the bundled systemd service.
         #[arg(long, default_value_t = false)]
         systemd: bool,
+        /// Disable the optional post-install GitHub star prompt.
+        #[arg(long, default_value_t = false)]
+        skip_star_prompt: bool,
     },
     /// Update clawhip from the current git clone.
     Update {
@@ -680,5 +684,21 @@ mod tests {
         };
 
         assert!(matches!(command, PluginCommands::List));
+    }
+
+    #[test]
+    fn parses_install_subcommand_with_skip_star_prompt() {
+        let cli = Cli::parse_from(["clawhip", "install", "--systemd", "--skip-star-prompt"]);
+
+        let Commands::Install {
+            systemd,
+            skip_star_prompt,
+        } = cli.command.expect("install command")
+        else {
+            panic!("expected install command");
+        };
+
+        assert!(systemd);
+        assert!(skip_star_prompt);
     }
 }

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -1,11 +1,17 @@
 use std::env;
 use std::fs;
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, anyhow};
 
 use crate::{Result, plugins};
 
-pub fn install(systemd: bool) -> Result<()> {
+const GITHUB_REPO: &str = "Yeachan-Heo/clawhip";
+const SKIP_STAR_PROMPT_ENV: &str = "CLAWHIP_SKIP_STAR_PROMPT";
+
+pub fn install(systemd: bool, skip_star_prompt: bool) -> Result<()> {
     let repo_root = current_repo_root()?;
     run(Command::new("cargo")
         .arg("install")
@@ -16,6 +22,7 @@ pub fn install(systemd: bool) -> Result<()> {
     if systemd {
         install_systemd(&repo_root)?;
     }
+    maybe_prompt_to_star_repo(skip_star_prompt)?;
     println!("clawhip install complete");
     Ok(())
 }
@@ -67,7 +74,7 @@ fn current_repo_root() -> Result<PathBuf> {
     if dir.join("Cargo.toml").exists() && dir.join("src").exists() {
         Ok(dir)
     } else {
-        Err("run this command from the clawhip git clone root".into())
+        Err(anyhow!("run this command from the clawhip git clone root").into())
     }
 }
 
@@ -89,6 +96,100 @@ fn cargo_bin_dir() -> PathBuf {
             PathBuf::from(env::var("HOME").unwrap_or_else(|_| ".".into())).join(".cargo")
         })
         .join("bin")
+}
+
+fn maybe_prompt_to_star_repo(skip_star_prompt: bool) -> Result<()> {
+    let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut input = stdin.lock();
+    let mut output = stdout.lock();
+    let env_skip_star_prompt = env::var(SKIP_STAR_PROMPT_ENV).ok();
+
+    maybe_prompt_to_star_repo_with(
+        skip_star_prompt,
+        env_skip_star_prompt.as_deref(),
+        interactive,
+        &mut input,
+        &mut output,
+        gh_command_succeeds,
+    )
+}
+
+fn maybe_prompt_to_star_repo_with<R, W, F>(
+    skip_star_prompt: bool,
+    env_skip_star_prompt: Option<&str>,
+    interactive: bool,
+    input: &mut R,
+    output: &mut W,
+    mut gh_command_succeeds: F,
+) -> Result<()>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&[&str]) -> bool,
+{
+    if star_prompt_disabled(skip_star_prompt, env_skip_star_prompt) {
+        writeln!(
+            output,
+            "[clawhip] skipping GitHub star prompt (--skip-star-prompt or {SKIP_STAR_PROMPT_ENV})"
+        )?;
+        return Ok(());
+    }
+
+    if !interactive || !gh_command_succeeds(&["auth", "status"]) {
+        return Ok(());
+    }
+
+    writeln!(
+        output,
+        "[clawhip] optional: star {GITHUB_REPO} on GitHub to support the project"
+    )?;
+    write!(
+        output,
+        "[clawhip] Would you like to star {GITHUB_REPO} on GitHub with gh? [y/N]: "
+    )?;
+    output.flush()?;
+
+    let mut response = String::new();
+    if input.read_line(&mut response)? == 0 {
+        return Ok(());
+    }
+
+    match response.trim() {
+        "y" | "Y" | "yes" | "Yes" | "YES" => {
+            if gh_command_succeeds(&["repo", "star", GITHUB_REPO]) {
+                writeln!(output, "[clawhip] thanks for starring {GITHUB_REPO}")?;
+            } else {
+                writeln!(
+                    output,
+                    "[clawhip] unable to star {GITHUB_REPO} with gh; continuing without it"
+                )?;
+            }
+        }
+        _ => {
+            writeln!(output, "[clawhip] skipping GitHub star step")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn star_prompt_disabled(skip_star_prompt: bool, env_skip_star_prompt: Option<&str>) -> bool {
+    skip_star_prompt || env_skip_star_prompt.is_some_and(is_truthy)
+}
+
+fn is_truthy(value: &str) -> bool {
+    matches!(value, "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON")
+}
+
+fn gh_command_succeeds(args: &[&str]) -> bool {
+    Command::new("gh")
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
 }
 
 fn install_systemd(repo_root: &Path) -> Result<()> {
@@ -144,10 +245,126 @@ fn stop_systemd_if_present() -> Result<()> {
 }
 
 fn run(command: &mut Command) -> Result<()> {
-    let status = command.status()?;
+    let status = command
+        .status()
+        .with_context(|| format!("failed to run command: {command:?}"))?;
     if status.success() {
         Ok(())
     } else {
-        Err(format!("command failed with status {status}").into())
+        Err(anyhow!("command failed with status {status}: {command:?}").into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn skip_flag_or_env_disables_star_prompt() {
+        let mut output = Vec::new();
+        let mut input = Cursor::new(Vec::<u8>::new());
+        let mut gh_calls = Vec::<Vec<String>>::new();
+
+        maybe_prompt_to_star_repo_with(true, Some("1"), true, &mut input, &mut output, |args| {
+            gh_calls.push(args.iter().map(|arg| (*arg).to_string()).collect());
+            true
+        })
+        .expect("skip should succeed");
+
+        assert!(gh_calls.is_empty());
+        let stdout = String::from_utf8(output).expect("utf8 output");
+        assert!(stdout.contains("skipping GitHub star prompt"));
+    }
+
+    #[test]
+    fn skips_star_prompt_when_not_interactive() {
+        let mut output = Vec::new();
+        let mut input = Cursor::new(Vec::<u8>::new());
+        let mut gh_calls = Vec::<Vec<String>>::new();
+
+        maybe_prompt_to_star_repo_with(false, None, false, &mut input, &mut output, |args| {
+            gh_calls.push(args.iter().map(|arg| (*arg).to_string()).collect());
+            true
+        })
+        .expect("non-interactive install should succeed");
+
+        assert!(gh_calls.is_empty());
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn skips_prompt_when_gh_is_unauthenticated() {
+        let mut output = Vec::new();
+        let mut input = Cursor::new(Vec::<u8>::new());
+        let mut gh_calls = Vec::<Vec<String>>::new();
+
+        maybe_prompt_to_star_repo_with(false, None, true, &mut input, &mut output, |args| {
+            gh_calls.push(args.iter().map(|arg| (*arg).to_string()).collect());
+            !matches!(args, ["auth", "status"])
+        })
+        .expect("unauthenticated gh should skip cleanly");
+
+        assert_eq!(
+            gh_calls,
+            vec![vec![String::from("auth"), String::from("status")]]
+        );
+        let stdout = String::from_utf8(output).expect("utf8 output");
+        assert!(!stdout.contains("Would you like to star"));
+    }
+
+    #[test]
+    fn stars_repo_only_after_explicit_yes() {
+        let mut output = Vec::new();
+        let mut input = Cursor::new(b"y\n".to_vec());
+        let mut gh_calls = Vec::<Vec<String>>::new();
+
+        maybe_prompt_to_star_repo_with(false, None, true, &mut input, &mut output, |args| {
+            gh_calls.push(args.iter().map(|arg| (*arg).to_string()).collect());
+            true
+        })
+        .expect("yes path should succeed");
+
+        assert_eq!(
+            gh_calls,
+            vec![
+                vec![String::from("auth"), String::from("status")],
+                vec![
+                    String::from("repo"),
+                    String::from("star"),
+                    String::from(GITHUB_REPO),
+                ],
+            ]
+        );
+        let stdout = String::from_utf8(output).expect("utf8 output");
+        assert!(stdout.contains("Would you like to star"));
+        assert!(stdout.contains("thanks for starring"));
+    }
+
+    #[test]
+    fn star_failure_does_not_fail_the_install() {
+        let mut output = Vec::new();
+        let mut input = Cursor::new(b"yes\n".to_vec());
+        let mut gh_calls = Vec::<Vec<String>>::new();
+
+        maybe_prompt_to_star_repo_with(false, None, true, &mut input, &mut output, |args| {
+            gh_calls.push(args.iter().map(|arg| (*arg).to_string()).collect());
+            !matches!(args, ["repo", "star", GITHUB_REPO])
+        })
+        .expect("star failure should not fail install");
+
+        assert_eq!(
+            gh_calls,
+            vec![
+                vec![String::from("auth"), String::from("status")],
+                vec![
+                    String::from("repo"),
+                    String::from("star"),
+                    String::from(GITHUB_REPO),
+                ],
+            ]
+        );
+        let stdout = String::from_utf8(output).expect("utf8 output");
+        assert!(stdout.contains("continuing without it"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,10 @@ async fn real_main() -> Result<()> {
             };
             send_incoming_event(&client, event).await
         }
-        Commands::Install { systemd } => lifecycle::install(systemd),
+        Commands::Install {
+            systemd,
+            skip_star_prompt,
+        } => lifecycle::install(systemd, skip_star_prompt),
         Commands::Update { restart } => lifecycle::update(restart),
         Commands::Uninstall {
             remove_systemd,


### PR DESCRIPTION
## Summary
- add optional GitHub star prompt parity to `clawhip install`
- keep fail-soft behavior plus non-interactive and opt-out skips via `--skip-star-prompt` / `CLAWHIP_SKIP_STAR_PROMPT`
- align README and SKILL lifecycle docs with the CLI install path

Closes #69.

## Testing
- `cargo test`
- manual: `./target/debug/clawhip install --help`
- manual: interactive `./target/debug/clawhip install` with fake `gh` on `PATH` showed the prompt and skipped cleanly on `n`
- manual: `./target/debug/clawhip install --skip-star-prompt` skipped the prompt and never invoked `gh`