### PR TITLE
Fix post-install GitHub star action

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ Release artifacts are generated for these Rust target triples: `x86_64-unknown-l
 
 `install.sh` now tries the latest prebuilt release first and falls back to `cargo install --path . --force` when a matching release asset is unavailable. If Cargo is needed for the fallback path but not installed, the script prints Rustup setup instructions. When `--systemd` is used, the installed binary is also copied to `/usr/local/bin/clawhip` so the bundled service unit can start it.
 
-In interactive terminals, both the repo-local installer and `clawhip install` may offer an optional post-install `gh repo star Yeachan-Heo/clawhip` prompt. It never runs automatically, is skipped when `gh` is missing or unauthenticated, and can be disabled with `./install.sh --skip-star-prompt`, `clawhip install --skip-star-prompt`, or `CLAWHIP_SKIP_STAR_PROMPT=1`.
+In interactive terminals, both the repo-local installer and `clawhip install` may offer an optional post-install GitHub star prompt via authenticated `gh api` access. It never runs automatically, is skipped when `gh` is missing or unauthenticated, and can be disabled with `./install.sh --skip-star-prompt`, `clawhip install --skip-star-prompt`, or `CLAWHIP_SKIP_STAR_PROMPT=1`.
 
 ### Runtime lifecycle commands
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,10 +14,10 @@ Use this repo as:
 
 ## Prerequisites
 
-⭐ If you want to support clawhip, star this repository. The interactive repo-local installer and `clawhip install` can offer an optional post-install `gh repo star` prompt when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
+⭐ If you want to support clawhip, star this repository. The interactive repo-local installer and `clawhip install` can offer an optional post-install GitHub star prompt via authenticated `gh api` access when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
 
 ```bash
-gh repo star Yeachan-Heo/clawhip
+gh api --method PUT /user/starred/Yeachan-Heo/clawhip --silent
 ```
 
 ## Primary install flow

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,10 @@ can_use_github_cli_for_star() {
   command -v gh >/dev/null 2>&1 && gh auth status &>/dev/null
 }
 
+star_repo_with_gh() {
+  gh api --method PUT "/user/starred/${GITHUB_REPO}" --silent &>/dev/null
+}
+
 prompt_to_star_repo() {
   local response
   printf '[clawhip] Would you like to star %s on GitHub with gh? [y/N]: ' "$GITHUB_REPO"
@@ -72,7 +76,7 @@ prompt_to_star_repo() {
 
   case "$response" in
     [yY]|[yY][eE][sS])
-      if gh repo star "${GITHUB_REPO}" 2>/dev/null; then
+      if star_repo_with_gh; then
         log "thanks for starring ${GITHUB_REPO}"
       else
         log "unable to star ${GITHUB_REPO} with gh; continuing without it"

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -158,7 +158,7 @@ where
 
     match response.trim() {
         "y" | "Y" | "yes" | "Yes" | "YES" => {
-            if gh_command_succeeds(&["repo", "star", GITHUB_REPO]) {
+            if gh_star_repo_succeeds_with(&mut gh_command_succeeds) {
                 writeln!(output, "[clawhip] thanks for starring {GITHUB_REPO}")?;
             } else {
                 writeln!(
@@ -181,6 +181,14 @@ fn star_prompt_disabled(skip_star_prompt: bool, env_skip_star_prompt: Option<&st
 
 fn is_truthy(value: &str) -> bool {
     matches!(value, "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON")
+}
+
+fn gh_star_repo_succeeds_with<F>(gh_command_succeeds: &mut F) -> bool
+where
+    F: FnMut(&[&str]) -> bool,
+{
+    let endpoint = format!("/user/starred/{GITHUB_REPO}");
+    gh_command_succeeds(&["api", "--method", "PUT", endpoint.as_str(), "--silent"])
 }
 
 fn gh_command_succeeds(args: &[&str]) -> bool {
@@ -330,9 +338,11 @@ mod tests {
             vec![
                 vec![String::from("auth"), String::from("status")],
                 vec![
-                    String::from("repo"),
-                    String::from("star"),
-                    String::from(GITHUB_REPO),
+                    String::from("api"),
+                    String::from("--method"),
+                    String::from("PUT"),
+                    String::from(format!("/user/starred/{GITHUB_REPO}")),
+                    String::from("--silent"),
                 ],
             ]
         );
@@ -349,7 +359,11 @@ mod tests {
 
         maybe_prompt_to_star_repo_with(false, None, true, &mut input, &mut output, |args| {
             gh_calls.push(args.iter().map(|arg| (*arg).to_string()).collect());
-            !matches!(args, ["repo", "star", GITHUB_REPO])
+            !matches!(
+                args,
+                ["api", "--method", "PUT", endpoint, "--silent"]
+                    if *endpoint == format!("/user/starred/{GITHUB_REPO}")
+            )
         })
         .expect("star failure should not fail install");
 
@@ -358,9 +372,11 @@ mod tests {
             vec![
                 vec![String::from("auth"), String::from("status")],
                 vec![
-                    String::from("repo"),
-                    String::from("star"),
-                    String::from(GITHUB_REPO),
+                    String::from("api"),
+                    String::from("--method"),
+                    String::from("PUT"),
+                    String::from(format!("/user/starred/{GITHUB_REPO}")),
+                    String::from("--silent"),
                 ],
             ]
         );

--- a/tests/install_star_prompt.rs
+++ b/tests/install_star_prompt.rs
@@ -28,7 +28,7 @@ case "${1:-} ${2:-}" in
   "auth status")
     exit "${GH_AUTH_EXIT_CODE:-0}"
     ;;
-  "repo star")
+  "api --method")
     exit "${GH_STAR_EXIT_CODE:-0}"
     ;;
 esac
@@ -151,7 +151,10 @@ EOF_INPUT
 
     assert!(output.status.success(), "script failed: {output:?}");
     let gh_log = fs::read_to_string(temp.path().join("gh.log")).expect("gh log");
-    assert_eq!(gh_log.trim(), "repo star Yeachan-Heo/clawhip");
+    assert_eq!(
+        gh_log.trim(),
+        "api --method PUT /user/starred/Yeachan-Heo/clawhip --silent"
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("thanks for starring"),


### PR DESCRIPTION
## Summary
- replace the unsupported `gh repo star` install-time action with the authenticated `gh api --method PUT /user/starred/{owner}/{repo}` path
- keep the existing prompt gating and fail-soft behavior in both the shell installer and `clawhip install`
- update the star prompt docs and coverage for the new CLI call

## Verification
- `cargo test --test install_star_prompt`
- `cargo test lifecycle::tests`
- `bash -n install.sh`
- manual interactive verification: `source install.sh; maybe_prompt_to_star_repo` and answered `y`, which completed with `thanks for starring Yeachan-Heo/clawhip`

Closes #71