### PR TITLE
docs: add filesystem-offloaded memory pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ Operational notes:
 - use plain operational language like "check open PRs/issues", "review blockers", and "continue stalled work"
 - this keeps scheduling outside the agent loop: cron handles timing, clawhip handles delivery, Discord handles the handoff
 
+## Filesystem-offloaded memory pattern
+
+clawhip now documents a Claw OS-style memory pattern where `MEMORY.md` is the hot pointer/index layer and detailed memory lives in structured filesystem shards under `memory/`.
+
+Use this when you want:
+
+- a small, fast memory surface for agents
+- durable project/channel/daily memory in files
+- explicit read/write routing instead of one giant note
+- ongoing memory refactoring as part of operations
+
+Start here:
+
+- [docs/memory-offload-architecture.md](docs/memory-offload-architecture.md)
+- [docs/memory-offload-guide.md](docs/memory-offload-guide.md)
+- [docs/examples/MEMORY.example.md](docs/examples/MEMORY.example.md)
+- [skills/memory-offload/SKILL.md](skills/memory-offload/SKILL.md)
+
 ## Plugin architecture
 
 clawhip now includes a simple `plugins/` directory for tool-specific shell bridges.

--- a/SKILL.md
+++ b/SKILL.md
@@ -137,6 +137,21 @@ Allowed dynamic tokens:
 - `{now}`
 - `{iso_time}`
 
+## Filesystem-offloaded memory pattern
+
+When using clawhip as part of a broader Claw OS workflow, treat memory as an offloaded filesystem tree:
+
+- `MEMORY.md` = small pointer/index/current-beliefs layer
+- `memory/` = detailed project/channel/daily/handoff memory
+- update root memory only when the map or current summary changes
+
+Read before adopting this pattern:
+
+- `docs/memory-offload-architecture.md`
+- `docs/memory-offload-guide.md`
+- `docs/examples/MEMORY.example.md`
+- `skills/memory-offload/SKILL.md`
+
 ## Verification surface
 
 Use the live operational runbook:

--- a/docs/examples/MEMORY.example.md
+++ b/docs/examples/MEMORY.example.md
@@ -1,0 +1,29 @@
+# MEMORY.md — pointer/index layer
+
+## Current beliefs
+
+- Current priority: stabilize project work, keep memory retrieval cheap, and offload detail into filesystem shards.
+- Root memory is for summaries, pointers, and write obligations only.
+- Detailed logs belong in `memory/`.
+
+## Quick file map
+
+- Project status: `memory/projects/clawhip.md`
+- Today's execution log: `memory/daily/2026-03-10.md`
+- Channel-specific state: `memory/channels/example-channel.md`
+- Durable rules and lessons: `memory/topics/rules.md`, `memory/topics/lessons.md`
+- Full subtree guide: `memory/README.md`
+
+## Read this when...
+
+- You need current repo status -> read `memory/projects/clawhip.md`
+- You need latest execution context -> read today's file in `memory/daily/`
+- You are acting in one channel/lane -> read that file in `memory/channels/`
+- You are changing workflow policy -> read `memory/topics/rules.md`
+
+## Write obligations
+
+- Daily progress goes to today's daily file.
+- Channel-specific detail goes to that channel file.
+- Durable lessons get promoted into `memory/topics/lessons.md`.
+- `MEMORY.md` only changes when the pointer map or current beliefs change.

--- a/docs/examples/memory/README.example.md
+++ b/docs/examples/memory/README.example.md
@@ -1,0 +1,24 @@
+# memory/README.md — retrieval guide
+
+## File map
+
+- `daily/YYYY-MM-DD.md` -> chronological work log
+- `channels/<channel>.md` -> per-channel state and commitments
+- `projects/<project>.md` -> repo/project-specific status
+- `topics/rules.md` -> durable operating rules
+- `topics/lessons.md` -> reusable lessons
+- `handoffs/YYYY-MM-DD-<slug>.md` -> bounded handoffs
+- `archive/YYYY-MM/` -> cold history
+
+## Read by situation
+
+- Need latest execution context -> latest `daily/` file
+- Need canonical project state -> matching file in `projects/`
+- Need one lane's background -> matching file in `channels/`
+- Need policy or norms -> `topics/rules.md`
+
+## Naming rules
+
+- Use stable slugs for channels and projects.
+- Use one active daily-file convention.
+- Archive inactive time slices instead of bloating hot files.

--- a/docs/examples/memory/channels/example-channel.md
+++ b/docs/examples/memory/channels/example-channel.md
@@ -1,0 +1,18 @@
+# example-channel
+
+## Purpose
+
+Canonical memory for one conversation lane.
+
+## Keep here
+
+- channel-specific decisions
+- ongoing blockers
+- who owns next action
+- links/pointers to project files when needed
+
+## Keep elsewhere
+
+- generic project state -> `memory/projects/<project>.md`
+- daily execution transcript -> `memory/daily/YYYY-MM-DD.md`
+- durable cross-channel rules -> `memory/topics/rules.md`

--- a/docs/examples/memory/daily/2026-03-10.md
+++ b/docs/examples/memory/daily/2026-03-10.md
@@ -1,0 +1,18 @@
+# 2026-03-10
+
+## Summary
+
+- Worked on the memory offload pattern.
+- Extracted detailed notes into filesystem shards.
+- Kept root memory limited to pointers and current beliefs.
+
+## Events
+
+- new architecture/spec documented
+- guide written for agents/operators
+- examples added for pointer file and memory tree
+
+## Follow-up
+
+- continue moving monolithic sections into canonical shards
+- archive cold history when the active set grows too large

--- a/docs/examples/memory/projects/clawhip.md
+++ b/docs/examples/memory/projects/clawhip.md
@@ -1,0 +1,13 @@
+# clawhip
+
+## Current state
+
+- Canonical project shard for repo-specific status.
+- Use this file for active plans, blockers, and durable project context.
+
+## Keep here
+
+- project status
+- active priorities
+- blockers and follow-ups
+- links to handoffs and decisions

--- a/docs/examples/memory/topics/lessons.md
+++ b/docs/examples/memory/topics/lessons.md
@@ -1,0 +1,5 @@
+# lessons
+
+- Repeated workflows deserve stable files.
+- Daily logs and durable knowledge should not live in the same place.
+- Small pointer files scale better than giant narrative memory docs.

--- a/docs/examples/memory/topics/rules.md
+++ b/docs/examples/memory/topics/rules.md
@@ -1,0 +1,5 @@
+# rules
+
+- Root `MEMORY.md` stays short.
+- Detailed updates belong in canonical leaf shards.
+- Refactor memory when retrieval becomes noisy.

--- a/docs/memory-offload-architecture.md
+++ b/docs/memory-offload-architecture.md
@@ -1,0 +1,198 @@
+# Filesystem-Offloaded Memory Architecture
+
+This document defines the Claw OS-style memory pattern that clawhip recommends for filesystem-backed project memory: keep `MEMORY.md` small and high-signal, and offload detailed memory into structured filesystem documents.
+
+## Goal
+
+Use the filesystem as the durable memory substrate while keeping the root memory surface fast to load, easy to maintain, and safe for repeated agent use.
+
+In this pattern:
+
+- `MEMORY.md` is the hot pointer/index layer
+- `memory/` holds the detailed memory shards
+- agents read the minimum set of files needed for the current task
+- agents write detailed updates to leaf files, not back into a monolith
+- memory refactoring/offloading is ongoing maintenance, not a one-time cleanup
+
+This is the memory model that fits clawhip's broader direction as an OS-like runtime: small control surfaces, explicit routing, and durable state outside the hot path.
+
+## Design principles
+
+1. **Keep the hot layer small.** `MEMORY.md` should stay short enough to scan quickly.
+2. **Shard by stable retrieval paths.** Organize memory by entity, domain, or time instead of one narrative file.
+3. **Separate index from detail.** Index files answer where to read and write; leaf files hold the detail.
+4. **Prefer append at the edge.** Daily logs and entity files absorb detail so the root stays curated.
+5. **Refactor memory continuously.** When a section grows noisy, split it into a dedicated file and leave a pointer behind.
+6. **Protect private or sensitive state.** Not every shard should be loaded in every context.
+
+## Layer model
+
+### Layer 1: `MEMORY.md` (hot pointer layer)
+
+`MEMORY.md` should answer only high-value questions such as:
+
+- what is currently true
+- which files matter right now
+- where a new update should be written
+- what an agent must read before acting
+
+Recommended contents:
+
+- current beliefs / active focus
+- quick file map
+- scenario-based read guide
+- write obligations
+- recent refactors / moved files
+
+Avoid putting long transcripts, raw logs, or exhaustive histories here.
+
+### Layer 2: subtree indexes (routing layer)
+
+Subtree index files live under `memory/` and narrow retrieval further.
+
+Examples:
+
+- `memory/README.md`
+- `memory/channels/README.md`
+- `memory/projects/README.md`
+- `memory/agents/README.md`
+
+Their job is to answer:
+
+- which shard is canonical for a category
+- naming conventions
+- lookup rules and aliases
+- which files are active vs archived
+
+### Layer 3: leaf memory files (detail layer)
+
+Leaf files hold the durable detail.
+
+Common shard types:
+
+- **daily logs** — chronological activity and handoff notes
+- **channel memory** — one file per channel or conversation lane
+- **project memory** — repo-specific state, plans, blockers, decisions
+- **agent memory** — preferences, roles, working patterns, handoff expectations
+- **topic memory** — rules, lessons, ops, people, research, decisions
+- **archive files** — older daily or project material moved out of the hot set
+
+## Recommended directory layout
+
+A practical default layout:
+
+```text
+MEMORY.md
+memory/
+  README.md
+  daily/
+    YYYY-MM-DD.md
+  channels/
+    README.md
+    <channel-slug>.md
+  projects/
+    README.md
+    <project-slug>.md
+  agents/
+    README.md
+    <agent-slug>.md
+  topics/
+    README.md
+    rules.md
+    lessons.md
+    ops.md
+    people.md
+  decisions/
+    YYYY-MM-DD-<slug>.md
+  handoffs/
+    YYYY-MM-DD-<slug>.md
+  archive/
+    YYYY-MM/
+      YYYY-MM-DD.md
+  registry/
+    channel-registry.json
+    project-registry.json
+```
+
+Notes:
+
+- teams may use `memory/daily/YYYY-MM-DD.md` or `memory/YYYY-MM-DD.md`; standardize on one active convention
+- use registries only where alias/ID lookup is genuinely useful
+- avoid creating dozens of tiny folders before retrieval rules are clear
+
+## Read path
+
+Recommended read order:
+
+1. open `MEMORY.md`
+2. follow the scenario-based pointer to the relevant subtree index or leaf file
+3. read only the files needed for the task
+4. avoid bulk-loading the whole memory tree unless explicitly required
+
+Example:
+
+```text
+Need current repo status?
+-> MEMORY.md
+-> memory/projects/clawhip.md
+-> latest daily file if recent execution context matters
+```
+
+## Write path
+
+Recommended write order:
+
+1. decide the canonical target file
+2. write detail into the leaf file
+3. update `MEMORY.md` only if the pointer map or current beliefs changed
+4. archive or split a file when it becomes noisy
+
+Example event-driven routing:
+
+- new execution log -> today's daily file
+- channel-specific decision -> that channel file
+- durable workflow rule -> `memory/topics/rules.md`
+- reusable lesson -> `memory/topics/lessons.md`
+- long section extracted from root memory -> dedicated shard + short pointer in `MEMORY.md`
+
+## Offload/refactor rules
+
+Offload content out of `MEMORY.md` when any of these are true:
+
+- a section becomes mostly historical detail
+- the content belongs to one stable entity or topic
+- the content is needed only in specific workflows
+- the root file is getting slow or noisy to scan
+- the content is append-heavy and better suited to a log
+
+When offloading:
+
+1. create the destination file
+2. move or summarize the detailed content there
+3. replace the old root section with a one-line pointer and current takeaway
+4. add or update a subtree index if the new area will grow
+
+## Clawhip-as-OS fit
+
+clawhip already models the world as routed events, normalized contracts, and explicit sinks. The offloaded memory pattern applies the same operating idea to project state:
+
+- `MEMORY.md` behaves like a control-plane index
+- filesystem shards behave like durable state partitions
+- agent workflows route reads/writes to the right partition
+- archival keeps the hot surface operationally cheap
+
+That makes memory a first-class operating pattern instead of an accidental giant note.
+
+## Non-goals
+
+This pattern does **not** require clawhip to become a database, vector store, or embedded note service.
+
+It is a documentation and workflow architecture for filesystem-backed memory that agents and operators can adopt around clawhip.
+
+## Related docs
+
+- [Filesystem-Offloaded Memory Guide](memory-offload-guide.md)
+- [Example pointer file](examples/MEMORY.example.md)
+- [Example memory subtree index](examples/memory/README.example.md)
+- [Memory-offload skill guide](../skills/memory-offload/SKILL.md)
+- [Installable workflow skill](../skills/memory-offload/SKILL.md)

--- a/docs/memory-offload-guide.md
+++ b/docs/memory-offload-guide.md
@@ -1,0 +1,180 @@
+# Filesystem-Offloaded Memory Guide
+
+This guide shows how agents and operators should use the offloaded memory pattern in practice.
+
+For the architecture/spec, see [Filesystem-Offloaded Memory Architecture](memory-offload-architecture.md).
+
+## Operating rule
+
+Treat `MEMORY.md` as the fast pointer layer, not the place where all detail accumulates.
+
+A good default policy is:
+
+- read `MEMORY.md` first
+- jump to the smallest relevant shard
+- write detail into leaf files
+- update root pointers only when the map or current beliefs change
+
+## What goes where
+
+### Put in `MEMORY.md`
+
+- active focus
+- short current-state summary
+- mandatory read paths for common situations
+- write obligations
+- links/pointers to canonical files
+- recently moved or split sections
+
+### Put in `memory/` leaf files
+
+- detailed notes
+- chronological logs
+- channel-specific context
+- project-specific state
+- lessons, decisions, and operating rules
+- handoff detail
+- raw or semi-raw material that is too large for the hot layer
+
+## Practical agent workflow
+
+### Before acting
+
+1. Read `MEMORY.md`.
+2. Follow the scenario pointer for the current task.
+3. Load only the relevant project/channel/topic/daily shard.
+4. If no canonical target exists, create one in the correct subtree.
+
+### While working
+
+- append execution detail to the leaf shard that owns it
+- keep root updates short and intentional
+- if you discover a repeated retrieval path, add it to an index
+- if a shard starts mixing unrelated topics, split it
+
+### After working
+
+- write detailed outcome to the canonical shard
+- update `MEMORY.md` with only the new current belief or pointer change
+- move stale time-based material to `archive/` when needed
+
+## Recommended write-routing rules
+
+Use rules like these:
+
+| If the update is about... | Write to... |
+|---|---|
+| what happened today | `memory/daily/YYYY-MM-DD.md` |
+| one Discord/Slack/channel lane | `memory/channels/<channel>.md` |
+| one project/repo | `memory/projects/<project>.md` |
+| one agent/operator profile | `memory/agents/<agent>.md` |
+| reusable lessons | `memory/topics/lessons.md` |
+| durable policies/rules | `memory/topics/rules.md` |
+| one handoff | `memory/handoffs/YYYY-MM-DD-<slug>.md` |
+| older inactive history | `memory/archive/...` |
+
+## Migration: monolithic `MEMORY.md` -> offloaded memory
+
+A safe migration path:
+
+### 1. Freeze the role of `MEMORY.md`
+
+Rewrite the file so it becomes:
+
+- current beliefs
+- file map
+- scenario-based read guide
+- write obligations
+
+Do **not** keep adding detailed narrative after this step.
+
+### 2. Identify high-growth sections
+
+Typical sections to extract first:
+
+- daily logs
+- per-project sections
+- per-channel sections
+- long decision histories
+- raw handoff dumps
+- reusable rules/lessons hidden inside narrative blocks
+
+### 3. Create the first shards
+
+Start with the highest-leverage set:
+
+```text
+memory/README.md
+memory/daily/
+memory/projects/
+memory/channels/
+memory/topics/
+memory/archive/
+```
+
+You do not need every subtree on day one.
+
+### 4. Move detail, leave pointers
+
+For each extracted section:
+
+- move the detailed content into the new shard
+- replace it in `MEMORY.md` with:
+  - a short summary
+  - the canonical file path
+  - when to read it
+
+### 5. Add write obligations
+
+Make the system self-maintaining by stating rules such as:
+
+- daily activity must go to today's daily file
+- channel-specific context must go to the channel file
+- durable lessons must be lifted into `topics/lessons.md`
+- root memory must only hold summaries and pointers
+
+### 6. Archive aggressively
+
+Once a daily or project shard is no longer hot:
+
+- compress it into a monthly archive bucket, or
+- leave a short status summary and move the history out
+
+## Refactor triggers
+
+Refactor memory when:
+
+- `MEMORY.md` stops being skimmable
+- the same topic keeps expanding in the root file
+- agents repeatedly read too much irrelevant context
+- a file serves more than one clear owner
+- retrieval depends on remembering ad hoc prose instead of stable paths
+
+## Example starter set
+
+Concrete example files in this repo:
+
+- [docs/examples/MEMORY.example.md](examples/MEMORY.example.md)
+- [docs/examples/memory/README.example.md](examples/memory/README.example.md)
+- [docs/examples/memory/channels/example-channel.md](examples/memory/channels/example-channel.md)
+- [docs/examples/memory/daily/2026-03-10.md](examples/memory/daily/2026-03-10.md)
+- [skills/memory-offload/SKILL.md](../skills/memory-offload/SKILL.md)
+- [docs/examples/memory/projects/clawhip.md](examples/memory/projects/clawhip.md)
+- [docs/examples/memory/topics/rules.md](examples/memory/topics/rules.md)
+- [docs/examples/memory/topics/lessons.md](examples/memory/topics/lessons.md)
+
+## Cautions
+
+- Do not turn the new tree into a second monolith.
+- Do not create shards without clear read/write ownership.
+- Do not expose sensitive memory in shared or automatically loaded files.
+- Do not keep parallel daily-file conventions forever; pick one and normalize.
+- Do not copy private production memory into public examples; abstract the pattern.
+
+## Quick checklist
+
+- Is `MEMORY.md` short and high-signal?
+- Does every common workflow have a canonical file?
+- Are daily logs separated from durable rules/lessons?
+- Are archive rules clear?
+- Can an agent tell where to write without guessing?

--- a/skills/memory-offload/SKILL.md
+++ b/skills/memory-offload/SKILL.md
@@ -1,0 +1,51 @@
+# clawhip × filesystem-offloaded memory
+
+Use this skill when you want a Claw OS-style memory system where `MEMORY.md` stays small and points into a structured `memory/` tree.
+
+## What you get
+
+- a clear role for `MEMORY.md` as pointer/index/current-beliefs layer
+- a practical read/write workflow for agents
+- guidance for sharding memory by time, channel, project, topic, and handoff
+- migration guidance away from monolithic memory files
+
+## Read order
+
+1. Read `MEMORY.md` first.
+2. Follow the pointer to the smallest relevant shard.
+3. Read subtree indexes only when needed.
+4. Avoid loading the whole memory tree by default.
+
+## Write order
+
+1. Write detailed updates to the canonical leaf shard.
+2. Update `MEMORY.md` only when the pointer map or current beliefs changed.
+3. If a section grows noisy, split it into a dedicated file.
+4. Archive cold history to keep the hot path small.
+
+## Default shard map
+
+- `memory/daily/YYYY-MM-DD.md` -> chronological execution log
+- `memory/channels/<channel>.md` -> one lane/channel
+- `memory/projects/<project>.md` -> project/repo state
+- `memory/agents/<agent>.md` -> agent/operator profile
+- `memory/topics/rules.md` -> durable operating rules
+- `memory/topics/lessons.md` -> reusable lessons
+- `memory/handoffs/YYYY-MM-DD-<slug>.md` -> bounded handoffs
+- `memory/archive/YYYY-MM/` -> cold history
+
+## Offload triggers
+
+Offload when:
+
+- `MEMORY.md` stops being easy to scan
+- one topic dominates the root file
+- detail is only relevant to one entity or workflow
+- logs or history start crowding out current beliefs
+
+## Start here
+
+- `docs/memory-offload-architecture.md`
+- `docs/memory-offload-guide.md`
+- `docs/examples/MEMORY.example.md`
+- `docs/examples/memory/README.example.md`


### PR DESCRIPTION
## Summary
- add a filesystem-offloaded memory architecture/spec for clawhip's Claw OS direction
- add a practical guide, concrete example MEMORY/memory tree files, and a dedicated memory-offload skill
- link the new pattern from the main README and root SKILL surface

## Testing
- verified all new/updated markdown links resolve locally
- no code/tests changed (docs-only PR)

Closes #73
