### PR TITLE
Polish native OMC/OMX event contract unification

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,9 +426,12 @@ Normalized metadata (when upstream provides it):
 - `command`
 - `tool_name`
 - `test_runner`
+- `status`
 - `summary`
 - `error_message`
 - `event_timestamp`
+- `raw_event`
+- `contract_event`
 
 Route guidance:
 - prefer `session.*` for new native OMC/OMX routes

--- a/docs/native-event-contract.md
+++ b/docs/native-event-contract.md
@@ -69,6 +69,8 @@ When upstream provides it, clawhip normalizes these fields onto the top-level pa
 
 - `tool` is normalized to `omc` or `omx` when clawhip can infer it.
 - `status` is backfilled for legacy `agent.*` emits so generic `clawhip emit agent.finished --agent omx ...` remains valid.
+- OMC `context.projectName` backfills both compatibility `project` and canonical `repo_name`.
+- OMC `context.projectPath` backfills `repo_path` and `worktree_path` when no more specific path fields are present.
 - `issue_number` may be inferred from session/worktree/branch names like `issue-65` when upstream did not send it explicitly.
 - `pr_number` may be inferred from `pr_url`.
 - `raw_event` is retained only when clawhip had to rename the incoming event.

--- a/src/events.rs
+++ b/src/events.rs
@@ -679,10 +679,25 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
             "/context/session_name",
         ],
     );
-    let project = first_string(payload, &["/project", "/projectName", "/project_name"]);
+    let project = first_string(
+        payload,
+        &[
+            "/project",
+            "/projectName",
+            "/project_name",
+            "/context/project",
+            "/context/projectName",
+            "/context/project_name",
+        ],
+    );
     let repo_name = first_string(
         payload,
-        &["/repo_name", "/context/repo_name", "/projectName"],
+        &[
+            "/repo_name",
+            "/context/repo_name",
+            "/projectName",
+            "/context/projectName",
+        ],
     )
     .or_else(|| {
         first_string(payload, &["/repo_path", "/context/repo_path"]).and_then(|path| {
@@ -694,11 +709,21 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
     });
     let repo_path = first_string(
         payload,
-        &["/repo_path", "/context/repo_path", "/projectPath"],
+        &[
+            "/repo_path",
+            "/context/repo_path",
+            "/projectPath",
+            "/context/projectPath",
+        ],
     );
     let worktree_path = first_string(
         payload,
-        &["/worktree_path", "/context/worktree_path", "/projectPath"],
+        &[
+            "/worktree_path",
+            "/context/worktree_path",
+            "/projectPath",
+            "/context/projectPath",
+        ],
     );
     let branch = first_string(payload, &["/branch", "/context/branch"]);
     let command = first_string(
@@ -763,7 +788,13 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
             .find_map(extract_issue_number)
         });
     let mut pr_number = first_u64(payload, &["/pr_number", "/context/pr_number"]);
-    let pr_url = first_string(payload, &["/pr_url", "/context/pr_url", "/signal/prUrl"]);
+    let pr_url =
+        first_string(payload, &["/pr_url", "/context/pr_url", "/signal/prUrl"]).or_else(|| {
+            summary
+                .as_ref()
+                .filter(|value| extract_pr_number_from_url(value).is_some())
+                .cloned()
+        });
     if pr_number.is_none() {
         pr_number = pr_url.as_deref().and_then(extract_pr_number_from_url);
     }
@@ -1331,6 +1362,119 @@ mod tests {
         assert_eq!(
             event.payload["event_timestamp"],
             json!("2026-03-09T18:07:07.000Z")
+        );
+    }
+
+    #[test]
+    fn normalize_event_maps_omc_signal_route_key_into_session_event() {
+        let event = normalize_event(IncomingEvent {
+            kind: "post-tool-use".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "timestamp": "2026-03-09T18:01:58.000Z",
+                "signal": {
+                    "routeKey": "pull-request.created",
+                    "phase": "finished",
+                    "summary": "https://github.com/Yeachan-Heo/clawhip/pull/67"
+                },
+                "context": {
+                    "sessionId": "issue-65",
+                    "projectPath": "/repo/clawhip-worktrees/issue-65",
+                    "projectName": "clawhip"
+                }
+            }),
+        });
+
+        assert_eq!(event.kind, "session.pr-created");
+        assert_eq!(event.payload["tool"], json!("omc"));
+        assert_eq!(event.payload["session_id"], json!("issue-65"));
+        assert_eq!(event.payload["project"], json!("clawhip"));
+        assert_eq!(event.payload["repo_name"], json!("clawhip"));
+        assert_eq!(
+            event.payload["repo_path"],
+            json!("/repo/clawhip-worktrees/issue-65")
+        );
+        assert_eq!(
+            event.payload["worktree_path"],
+            json!("/repo/clawhip-worktrees/issue-65")
+        );
+        assert_eq!(event.payload["pr_number"], json!(67));
+        assert_eq!(
+            event.payload["pr_url"],
+            json!("https://github.com/Yeachan-Heo/clawhip/pull/67")
+        );
+        assert_eq!(event.payload["status"], json!("finished"));
+    }
+
+    #[test]
+    fn normalize_event_maps_omc_native_contract_into_session_event() {
+        let event = normalize_event(IncomingEvent {
+            kind: "post-tool-use".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "timestamp": "2026-03-09T18:01:58.000Z",
+                "signal": {
+                    "routeKey": "pull-request.created",
+                    "toolName": "Bash",
+                    "command": "gh pr create",
+                    "summary": "https://github.com/Yeachan-Heo/clawhip/pull/71"
+                },
+                "context": {
+                    "sessionId": "issue-65",
+                    "projectPath": "/repo/clawhip",
+                    "projectName": "clawhip"
+                }
+            }),
+        });
+
+        assert_eq!(event.kind, "session.pr-created");
+        assert_eq!(event.payload["tool"], json!("omc"));
+        assert_eq!(event.payload["session_id"], json!("issue-65"));
+        assert_eq!(event.payload["project"], json!("clawhip"));
+        assert_eq!(event.payload["repo_name"], json!("clawhip"));
+        assert_eq!(event.payload["repo_path"], json!("/repo/clawhip"));
+        assert_eq!(event.payload["worktree_path"], json!("/repo/clawhip"));
+        assert_eq!(event.payload["tool_name"], json!("Bash"));
+        assert_eq!(event.payload["command"], json!("gh pr create"));
+        assert_eq!(
+            event.payload["summary"],
+            json!("https://github.com/Yeachan-Heo/clawhip/pull/71")
+        );
+        assert_eq!(event.payload["pr_number"], json!(71));
+    }
+
+    #[test]
+    fn renders_omc_pr_created_event_using_contract_label() {
+        let event = normalize_event(IncomingEvent {
+            kind: "post-tool-use".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "timestamp": "2026-03-09T18:01:58.000Z",
+                "signal": {
+                    "routeKey": "pull-request.created",
+                    "phase": "finished",
+                    "summary": "https://github.com/Yeachan-Heo/clawhip/pull/67"
+                },
+                "context": {
+                    "sessionId": "issue-65",
+                    "projectPath": "/repo/clawhip-worktrees/issue-65",
+                    "projectName": "clawhip"
+                }
+            }),
+        });
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "omc issue-65 pr-created (repo=clawhip, issue=#65, pr=#67, summary=https://github.com/Yeachan-Heo/clawhip/pull/67)"
         );
     }
 

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -379,11 +379,16 @@ fn session_subject(payload: &Value) -> String {
 }
 
 fn session_status_label(kind: &str, payload: &Value) -> String {
-    optional_string_field(payload, "status").unwrap_or_else(|| {
-        kind.strip_prefix("session.")
-            .unwrap_or(kind)
-            .replace('-', " ")
-    })
+    match kind {
+        "session.started" | "session.blocked" | "session.finished" | "session.failed" => {
+            optional_string_field(payload, "status").unwrap_or_else(|| {
+                kind.strip_prefix("session.")
+                    .unwrap_or(kind)
+                    .replace('-', " ")
+            })
+        }
+        _ => kind.strip_prefix("session.").unwrap_or(kind).to_string(),
+    }
 }
 
 fn session_detail_suffix(payload: &Value) -> String {

--- a/src/router.rs
+++ b/src/router.rs
@@ -863,6 +863,108 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn legacy_agent_events_match_session_routes() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "session.*".into(),
+                sink: "discord".into(),
+                filter: [
+                    ("tool".to_string(), "omx".to_string()),
+                    ("project".to_string(), "clawhip".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+                channel: Some("session-route".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: Some(MessageFormat::Compact),
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = normalize_event(IncomingEvent::agent_finished(
+            "omx".into(),
+            Some("issue-65".into()),
+            Some("clawhip".into()),
+            Some(42),
+            Some("PR created".into()),
+            None,
+            None,
+        ));
+
+        let (channel, format, content) = router.preview(&event).await.unwrap();
+
+        assert_eq!(channel, "session-route");
+        assert_eq!(format, MessageFormat::Compact);
+        assert!(content.contains("agent omx"));
+        assert!(content.contains("finished"));
+    }
+
+    #[tokio::test]
+    async fn native_omc_session_events_match_session_routes() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "session.*".into(),
+                sink: "discord".into(),
+                filter: [
+                    ("tool".to_string(), "omc".to_string()),
+                    ("repo_name".to_string(), "clawhip".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+                channel: Some("session-route".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: Some(MessageFormat::Compact),
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = normalize_event(IncomingEvent {
+            kind: "post-tool-use".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "timestamp": "2026-03-09T18:01:58.000Z",
+                "signal": {
+                    "routeKey": "pull-request.created",
+                    "phase": "finished",
+                    "summary": "https://github.com/Yeachan-Heo/clawhip/pull/67"
+                },
+                "context": {
+                    "sessionId": "issue-65",
+                    "projectPath": "/repo/clawhip-worktrees/issue-65",
+                    "projectName": "clawhip"
+                }
+            }),
+        });
+
+        let (channel, format, content) = router.preview(&event).await.unwrap();
+
+        assert_eq!(channel, "session-route");
+        assert_eq!(format, MessageFormat::Compact);
+        assert!(content.contains("omc issue-65 pr-created"));
+        assert!(content.contains("repo=clawhip"));
+        assert!(content.contains("pr=#67"));
+    }
+
+    #[tokio::test]
     async fn session_lifecycle_events_match_existing_agent_routes() {
         let config = AppConfig {
             defaults: DefaultsConfig {


### PR DESCRIPTION
## Summary
- finish native OMC context normalization for project/path metadata and PR URL/number inference
- keep canonical session rendering semantic for contract events like `session.pr-created`
- add router and normalization coverage for legacy agent/session compatibility and native OMC routing

## Testing
- cargo test normalize_event_maps_omc -- --nocapture
- cargo test normalize_event_maps_omx_native_contract_into_session_event -- --nocapture
- cargo test renders_omc_pr_created_event_using_contract_label -- --nocapture
- cargo test renders_session_contract_events_in_low_noise_formats -- --nocapture
- cargo test legacy_agent_events_match_session_routes -- --nocapture
- cargo test native_omc_session_events_match_session_routes -- --nocapture
- cargo test session_lifecycle_events_match_existing_agent_routes -- --nocapture

Refs #65