### PR TITLE
Preserve stable ingress identifiers in clawhip normalization

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -132,18 +132,25 @@ async fn post_event(
     Json(event): Json<IncomingEvent>,
 ) -> impl IntoResponse {
     let event = normalize_event(event);
-    if let Err(error) = from_incoming_event(&event) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"ok": false, "error": error.to_string()})),
-        )
-            .into_response();
-    }
+    let envelope = match from_incoming_event(&event) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"ok": false, "error": error.to_string()})),
+            )
+                .into_response();
+        }
+    };
 
     match enqueue_event(&state.tx, event.clone()).await {
         Ok(()) => (
             StatusCode::ACCEPTED,
-            Json(json!({"ok": true, "type": event.kind})),
+            Json(json!({
+                "ok": true,
+                "type": event.kind,
+                "event_id": envelope.id.to_string(),
+            })),
         )
             .into_response(),
         Err(error) => (
@@ -291,6 +298,7 @@ async fn enqueue_event(tx: &mpsc::Sender<IncomingEvent>, event: IncomingEvent) -
 mod tests {
     use super::*;
     use crate::config::AppConfig;
+    use axum::body::to_bytes;
 
     #[test]
     fn health_payload_includes_version_and_token_source() {
@@ -308,5 +316,45 @@ mod tests {
         assert_eq!(payload["configured_git_monitors"], Value::from(1));
         assert_eq!(payload["configured_tmux_monitors"], Value::from(1));
         assert_eq!(payload["registered_tmux_sessions"], Value::from(3));
+    }
+
+    #[tokio::test]
+    async fn post_event_returns_event_id_and_preserves_normalized_metadata() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+        };
+        let event = IncomingEvent::agent_started(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("my-repo".into()),
+            None,
+            Some("booted".into()),
+            None,
+            None,
+        );
+
+        let response = post_event(State(state), Json(event)).await.into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response_json: Value = serde_json::from_slice(&body).unwrap();
+        let event_id = response_json["event_id"].as_str().unwrap();
+        assert!(!event_id.is_empty());
+        assert_eq!(response_json["type"], Value::from("agent.started"));
+
+        let queued = rx.recv().await.unwrap();
+        assert_eq!(queued.payload["event_id"], Value::from(event_id));
+        assert_eq!(queued.payload["correlation_id"], Value::from("sess-123"));
+        assert!(
+            queued
+                .payload
+                .get("first_seen_at")
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+        );
     }
 }

--- a/src/event/compat.rs
+++ b/src/event/compat.rs
@@ -24,7 +24,7 @@ impl TryFrom<&IncomingEvent> for EventEnvelope {
         let payload = &normalized.payload;
 
         Ok(Self {
-            id: Uuid::new_v4(),
+            id: event_id_for(&normalized).unwrap_or_else(Uuid::new_v4),
             timestamp: OffsetDateTime::now_utc(),
             source: source_for_kind(kind),
             body: body_for(kind, payload)?,
@@ -283,6 +283,14 @@ fn optional_string_field(payload: &Value, key: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
+fn event_id_for(event: &IncomingEvent) -> Option<Uuid> {
+    event
+        .payload
+        .get("event_id")
+        .and_then(Value::as_str)
+        .and_then(|value| Uuid::parse_str(value).ok())
+}
+
 fn u64_field(payload: &Value, key: &str) -> Result<u64> {
     payload
         .get(key)
@@ -430,5 +438,16 @@ mod tests {
             }
             other => panic!("expected GitHubCIFailed body, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn reuses_normalized_event_id_when_available() {
+        let event = crate::events::normalize_event(IncomingEvent::custom(None, "hello".into()));
+        let envelope = from_incoming_event(&event).unwrap();
+
+        assert_eq!(
+            envelope.id.to_string(),
+            event.payload["event_id"].as_str().unwrap()
+        );
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use uuid::Uuid;
 
 use crate::Result;
 use crate::render::{DefaultRenderer, Renderer};
@@ -650,6 +652,7 @@ fn map_native_signal(raw: &str) -> Option<&'static str> {
 }
 
 fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind: &str) {
+    let first_seen_at = now_rfc3339();
     let tool = infer_tool(payload);
     let session_name = first_string(
         payload,
@@ -745,6 +748,22 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
             .flatten()
     });
     let event_timestamp = first_string(payload, &["/event_timestamp", "/timestamp"]);
+    let event_id =
+        first_string(payload, &["/event_id"]).unwrap_or_else(|| Uuid::new_v4().to_string());
+    let correlation_id = first_string(payload, &["/correlation_id"])
+        .or_else(|| {
+            [
+                session_id.as_deref(),
+                session_name.as_deref(),
+                project.as_deref(),
+                repo_name.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .find(|value| !value.trim().is_empty())
+            .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| event_id.clone());
     let route_key = first_string(
         payload,
         &["/route_key", "/signal/routeKey", "/context/route_key"],
@@ -785,6 +804,9 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
         .or_insert_with(|| json!(canonical_kind));
 
     insert_string_if_missing(object, "tool", tool);
+    insert_string_if_missing(object, "event_id", Some(event_id));
+    insert_string_if_missing(object, "correlation_id", Some(correlation_id));
+    insert_string_if_missing(object, "first_seen_at", Some(first_seen_at));
     if (canonical_kind.starts_with("agent.") || canonical_kind.starts_with("session."))
         && object.get("agent_name").is_none()
         && let Some(tool) = object
@@ -814,6 +836,12 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
     insert_string_if_missing(object, "event_timestamp", event_timestamp);
     insert_string_if_missing(object, "route_key", route_key);
     insert_string_if_missing(object, "source", source);
+}
+
+fn now_rfc3339() -> String {
+    let now = OffsetDateTime::now_utc();
+    now.format(&Rfc3339)
+        .unwrap_or_else(|_| now.unix_timestamp().to_string())
 }
 
 fn infer_tool(payload: &Value) -> Option<String> {
@@ -1293,6 +1321,37 @@ mod tests {
         assert_eq!(event.payload["status"], json!("finished"));
         assert_eq!(event.payload["tool"], json!("omc"));
         assert_eq!(event.payload["agent_name"], json!("omc"));
+    }
+
+    #[test]
+    fn normalize_event_adds_ingress_metadata_and_exposes_it_in_template_context() {
+        let event = normalize_event(IncomingEvent::agent_started(
+            "worker-1".into(),
+            Some("sess-123".into()),
+            Some("my-repo".into()),
+            None,
+            Some("booted".into()),
+            None,
+            None,
+        ));
+        let context = event.template_context();
+
+        let event_id = event.payload["event_id"].as_str().unwrap();
+        assert!(!event_id.is_empty());
+        assert_eq!(event.payload["correlation_id"], json!("sess-123"));
+        assert!(
+            event
+                .payload
+                .get("first_seen_at")
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+        );
+        assert_eq!(context.get("event_id").map(String::as_str), Some(event_id));
+        assert_eq!(
+            context.get("correlation_id").map(String::as_str),
+            Some("sess-123")
+        );
+        assert!(context.get("first_seen_at").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add stable normalized ingress metadata: `event_id`, `correlation_id`, `first_seen_at`
- Preserve the ID through event compat conversion and return it from HTTP enqueue responses
- Add regression tests for normalization, compat ID reuse, and enqueue response payloads

## Verification
- `cargo test events::tests::normalize_event_adds_ingress_metadata_and_exposes_it_in_template_context`
- `cargo test event::compat::tests::reuses_normalized_event_id_when_available`
- `cargo test daemon::tests::post_event_returns_event_id_and_preserves_normalized_metadata`
- `cargo test`