### PR TITLE
feat: freeze native event contract v1

### DIFF
--- a/docs/event-contract-v1.md
+++ b/docs/event-contract-v1.md
@@ -1,0 +1,167 @@
+# Event Contract v1
+
+This document freezes clawhip's v1 native event contract for OMC/OMX integrations.
+
+## Status
+
+- **Schema version:** `1`
+- **Stability:** stable
+- **Compatibility policy:** v1 allows backward-compatible additive fields only. Existing field meanings, event names, and required metadata semantics are frozen.
+
+## Canonical event family
+
+clawhip routes native operational events on the `session.*` family:
+
+- `session.started`
+- `session.blocked`
+- `session.finished`
+- `session.failed`
+- `session.retry-needed`
+- `session.pr-created`
+- `session.test-started`
+- `session.test-finished`
+- `session.test-failed`
+- `session.handoff-needed`
+
+For backward compatibility, clawhip still accepts:
+
+- `agent.started`
+- `agent.blocked`
+- `agent.finished`
+- `agent.failed`
+
+Those legacy events cross-match with the corresponding first four `session.*` events.
+
+## Frozen normalized_event names
+
+Upstream OMX hook payloads must use these hyphenated `normalized_event` values:
+
+- `started`
+- `blocked`
+- `finished`
+- `failed`
+- `retry-needed`
+- `pr-created`
+- `test-started`
+- `test-finished`
+- `test-failed`
+- `handoff-needed`
+
+> Note: underscore spellings such as `retry_needed`, `pr_created`, `test_started`, `test_finished`, `test_failed`, and `handoff_needed` appear in issue prose but are **not** the frozen wire-format contract.
+
+## OMX hook envelope format
+
+clawhip accepts OMX hook envelope JSON with `schema_version = "1"`.
+
+```json
+{
+  "schema_version": "1",
+  "event": "notify",
+  "timestamp": "2026-03-31T09:00:00Z",
+  "channel": "alerts",
+  "mention": "@ops",
+  "context": {
+    "normalized_event": "test-failed",
+    "agent_name": "omx",
+    "session_name": "issue-65-event-contract",
+    "session_id": "sess-65",
+    "project": "clawhip",
+    "repo_path": "/repo/clawhip",
+    "branch": "feat/issue-65-event-contract",
+    "issue_number": 65,
+    "pr_number": 72,
+    "pr_url": "https://github.com/Yeachan-Heo/clawhip/pull/72",
+    "command": "cargo test",
+    "tool_name": "Bash",
+    "status": "failed",
+    "summary": "tests failed",
+    "error_summary": "1 test failed"
+  }
+}
+```
+
+### Envelope fields
+
+Top-level fields:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `schema_version` | yes | Must be the string `"1"`. |
+| `event` | no | May be a generic upstream event name such as `notify`; clawhip resolves the canonical route from `context.normalized_event`. |
+| `timestamp` | no | Preserved by normalization as `event_timestamp` when present. |
+| `channel` | no | Optional channel hint. |
+| `mention` | no | Optional fallback mention if not supplied in `context`. |
+| `context` | yes | Native routing and metadata payload. |
+
+Context fields:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `normalized_event` | yes | One of the 10 frozen names above. |
+| `agent_name` | yes | Native source/agent label, e.g. `omx`. |
+| `status` | yes | Human-meaningful status for the event. |
+| `session_name` | event-specific | Strongly recommended for all session events; required for stable routing summaries. |
+| `session_id` | no | Optional correlation/session identifier. |
+| `project` | no | Compatibility field for existing agent routes. |
+| `repo_path` | event-specific | Required whenever the repo/worktree is known. |
+| `branch` | event-specific | Required whenever the branch is known. |
+| `issue_number` | no | Include when known. |
+| `pr_number` | no | Include when known. |
+| `pr_url` | no | Include when known. |
+| `command` | no | Optional command context. |
+| `tool_name` | no | Optional tool context. |
+| `summary` | no | Short human-readable summary. |
+| `error_summary` | failure-specific | Required for failed or blocked states when an actionable error exists. |
+
+## Required metadata by normalized_event
+
+| normalized_event | Required metadata |
+| --- | --- |
+| `started` | `agent_name`, `status`, `session_name` |
+| `blocked` | `agent_name`, `status`, `session_name` |
+| `finished` | `agent_name`, `status`, `session_name` |
+| `failed` | `agent_name`, `status`, `session_name`, `error_summary` when failure details exist |
+| `retry-needed` | `agent_name`, `status`, `session_name`, `summary` or `error_summary` |
+| `pr-created` | `agent_name`, `status`, `session_name`, `pr_number` or `pr_url` |
+| `test-started` | `agent_name`, `status`, `session_name`, `command` or `tool_name` when known |
+| `test-finished` | `agent_name`, `status`, `session_name` |
+| `test-failed` | `agent_name`, `status`, `session_name`, `error_summary` |
+| `handoff-needed` | `agent_name`, `status`, `session_name`, `summary` |
+
+## Context field surface clawhip models natively
+
+clawhip's native Rust event surface models these context fields on `AgentEvent`:
+
+- `agent_name`
+- `session_name`
+- `status`
+- `normalized_event`
+- `session_id`
+- `project`
+- `repo_path`
+- `branch`
+- `issue_number`
+- `pr_number`
+- `pr_url`
+- `command`
+- `tool_name`
+- `elapsed_secs`
+- `summary`
+- `error_summary`
+- `error_message`
+- `mention`
+
+Fields remain optional in Rust unless legacy compatibility or the wire format requires them universally.
+
+## Backward compatibility
+
+- The original four typed variants remain stable: started, blocked, finished, failed.
+- Legacy `agent.*` inputs continue to deserialize into those same four variants.
+- Canonical `session.started|blocked|finished|failed` also map to those four variants.
+- The additional six canonical events are modeled as distinct typed variants.
+- Unknown out-of-contract events continue to degrade safely to `Custom`.
+
+## Relationship to the older native contract note
+
+`docs/native-event-contract.md` remains a higher-level migration and routing note.
+This document is the frozen v1 source of truth for event names, envelope format, metadata fields, and versioning policy.

--- a/docs/native-event-contract.md
+++ b/docs/native-event-contract.md
@@ -1,5 +1,7 @@
 # Native OMC / OMX Event Contract
 
+> Frozen contract reference: see [docs/event-contract-v1.md](event-contract-v1.md) for the stable v1 wire-format specification. This document remains the higher-level routing and migration guide.
+
 This document is the clawhip-side normalization contract for native OMC/OMX operational events.
 
 ## Goal

--- a/src/event/body.rs
+++ b/src/event/body.rs
@@ -88,11 +88,21 @@ pub struct TmuxStaleEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentEvent {
     pub agent_name: String,
+    pub session_name: Option<String>,
     pub status: String,
+    pub normalized_event: Option<String>,
     pub session_id: Option<String>,
     pub project: Option<String>,
+    pub repo_path: Option<String>,
+    pub branch: Option<String>,
+    pub issue_number: Option<u64>,
+    pub pr_number: Option<u64>,
+    pub pr_url: Option<String>,
+    pub command: Option<String>,
+    pub tool_name: Option<String>,
     pub elapsed_secs: Option<u64>,
     pub summary: Option<String>,
+    pub error_summary: Option<String>,
     pub error_message: Option<String>,
     pub mention: Option<String>,
 }

--- a/src/event/compat.rs
+++ b/src/event/compat.rs
@@ -15,6 +15,49 @@ pub fn from_incoming_event(event: &IncomingEvent) -> Result<EventEnvelope> {
     EventEnvelope::try_from(event)
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn from_omx_hook_envelope_json(payload: &Value) -> Result<EventEnvelope> {
+    let schema_version = payload
+        .get("schema_version")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "missing string field 'schema_version'".to_string())?;
+
+    if schema_version != "1" {
+        return Err(format!("unsupported schema_version '{schema_version}'").into());
+    }
+
+    let normalized_event = payload
+        .pointer("/context/normalized_event")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "missing string field 'context.normalized_event'".to_string())?;
+
+    let kind = payload
+        .get("event")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| normalized_event.to_string());
+
+    let incoming = IncomingEvent {
+        kind,
+        channel: optional_string_field(payload, "channel"),
+        mention: optional_string_field(payload, "mention").or_else(|| {
+            payload
+                .pointer("/context/mention")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+        }),
+        format: None,
+        template: None,
+        payload: payload.clone(),
+    };
+
+    from_incoming_event(&incoming)
+}
+
 impl TryFrom<&IncomingEvent> for EventEnvelope {
     type Error = crate::DynError;
 
@@ -80,6 +123,12 @@ fn body_for(kind: &str, payload: &Value) -> Result<EventBody> {
             Ok(EventBody::AgentFinished(agent_event(payload)?))
         }
         "agent.failed" | "session.failed" => Ok(EventBody::AgentFailed(agent_event(payload)?)),
+        "session.retry-needed" => Ok(EventBody::AgentRetryNeeded(agent_event(payload)?)),
+        "session.pr-created" => Ok(EventBody::AgentPRCreated(agent_event(payload)?)),
+        "session.test-started" => Ok(EventBody::AgentTestStarted(agent_event(payload)?)),
+        "session.test-finished" => Ok(EventBody::AgentTestFinished(agent_event(payload)?)),
+        "session.test-failed" => Ok(EventBody::AgentTestFailed(agent_event(payload)?)),
+        "session.handoff-needed" => Ok(EventBody::AgentHandoffNeeded(agent_event(payload)?)),
         _ => Ok(EventBody::Custom(CustomEvent {
             kind: kind.to_string(),
             message: optional_string_field(payload, "message").unwrap_or_else(|| kind.to_string()),
@@ -228,13 +277,39 @@ fn tmux_keyword_body(payload: &Value) -> Result<EventBody> {
 fn agent_event(payload: &Value) -> Result<AgentEvent> {
     Ok(AgentEvent {
         agent_name: string_field(payload, "agent_name")?,
+        session_name: optional_string_field(payload, "session_name"),
         status: string_field(payload, "status")?,
+        normalized_event: optional_string_field(payload, "normalized_event").or_else(|| {
+            payload
+                .pointer("/context/normalized_event")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+        }),
         session_id: optional_string_field(payload, "session_id"),
         project: optional_string_field(payload, "project"),
+        repo_path: optional_string_field(payload, "repo_path"),
+        branch: optional_string_field(payload, "branch"),
+        issue_number: payload.get("issue_number").and_then(Value::as_u64),
+        pr_number: payload.get("pr_number").and_then(Value::as_u64),
+        pr_url: optional_string_field(payload, "pr_url"),
+        command: optional_string_field(payload, "command"),
+        tool_name: optional_string_field(payload, "tool_name"),
         elapsed_secs: payload.get("elapsed_secs").and_then(Value::as_u64),
         summary: optional_string_field(payload, "summary"),
-        error_message: optional_string_field(payload, "error_message"),
-        mention: optional_string_field(payload, "mention"),
+        error_summary: optional_string_field(payload, "error_summary")
+            .or_else(|| optional_string_field(payload, "error_message")),
+        error_message: optional_string_field(payload, "error_message")
+            .or_else(|| optional_string_field(payload, "error_summary")),
+        mention: optional_string_field(payload, "mention").or_else(|| {
+            payload
+                .pointer("/context/mention")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+        }),
     })
 }
 
@@ -441,6 +516,165 @@ mod tests {
     }
 
     #[test]
+    fn maps_all_canonical_session_events_to_typed_agent_variants() {
+        let cases = [
+            (
+                "session.started",
+                EventBody::AgentStarted(sample_agent_event("started")),
+            ),
+            (
+                "session.blocked",
+                EventBody::AgentBlocked(sample_agent_event("blocked")),
+            ),
+            (
+                "session.finished",
+                EventBody::AgentFinished(sample_agent_event("finished")),
+            ),
+            (
+                "session.failed",
+                EventBody::AgentFailed(sample_agent_event("failed")),
+            ),
+            (
+                "session.retry-needed",
+                EventBody::AgentRetryNeeded(sample_agent_event("retry-needed")),
+            ),
+            (
+                "session.pr-created",
+                EventBody::AgentPRCreated(sample_agent_event("pr-created")),
+            ),
+            (
+                "session.test-started",
+                EventBody::AgentTestStarted(sample_agent_event("test-started")),
+            ),
+            (
+                "session.test-finished",
+                EventBody::AgentTestFinished(sample_agent_event("test-finished")),
+            ),
+            (
+                "session.test-failed",
+                EventBody::AgentTestFailed(sample_agent_event("test-failed")),
+            ),
+            (
+                "session.handoff-needed",
+                EventBody::AgentHandoffNeeded(sample_agent_event("handoff-needed")),
+            ),
+        ];
+
+        for (kind, expected) in cases {
+            let event = IncomingEvent {
+                kind: kind.into(),
+                channel: None,
+                mention: None,
+                format: None,
+                template: None,
+                payload: sample_agent_payload(expected_normalized_event(&expected)),
+            };
+
+            let envelope = from_incoming_event(&event).unwrap();
+            assert_eq!(envelope.body, expected, "unexpected body for {kind}");
+        }
+    }
+
+    #[test]
+    fn keeps_legacy_agent_variants_backward_compatible() {
+        let event = IncomingEvent {
+            kind: "agent.finished".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: sample_agent_payload("finished"),
+        };
+
+        let envelope = from_incoming_event(&event).unwrap();
+        assert!(matches!(envelope.body, EventBody::AgentFinished(_)));
+    }
+
+    #[test]
+    fn deserializes_omx_hook_envelope_schema_v1_with_all_context_fields() {
+        let envelope = from_omx_hook_envelope_json(&json!({
+            "schema_version": "1",
+            "event": "notify",
+            "timestamp": "2026-03-31T09:00:00Z",
+            "context": {
+                "normalized_event": "test-failed",
+                "agent_name": "omx",
+                "session_name": "issue-65-event-contract",
+                "session_id": "sess-65",
+                "project": "clawhip",
+                "repo_path": "/repo/clawhip",
+                "branch": "feat/issue-65-event-contract",
+                "issue_number": 65,
+                "pr_number": 72,
+                "pr_url": "https://github.com/Yeachan-Heo/clawhip/pull/72",
+                "command": "cargo test",
+                "tool_name": "Bash",
+                "status": "failed",
+                "summary": "tests failed",
+                "error_summary": "1 test failed",
+                "mention": "@ops"
+            }
+        }))
+        .unwrap();
+
+        match envelope.body {
+            EventBody::AgentTestFailed(body) => {
+                assert_eq!(body.agent_name, "omx");
+                assert_eq!(
+                    body.session_name.as_deref(),
+                    Some("issue-65-event-contract")
+                );
+                assert_eq!(body.session_id.as_deref(), Some("sess-65"));
+                assert_eq!(body.project.as_deref(), Some("clawhip"));
+                assert_eq!(body.repo_path.as_deref(), Some("/repo/clawhip"));
+                assert_eq!(body.branch.as_deref(), Some("feat/issue-65-event-contract"));
+                assert_eq!(body.issue_number, Some(65));
+                assert_eq!(body.pr_number, Some(72));
+                assert_eq!(
+                    body.pr_url.as_deref(),
+                    Some("https://github.com/Yeachan-Heo/clawhip/pull/72")
+                );
+                assert_eq!(body.command.as_deref(), Some("cargo test"));
+                assert_eq!(body.tool_name.as_deref(), Some("Bash"));
+                assert_eq!(body.status, "failed");
+                assert_eq!(body.summary.as_deref(), Some("tests failed"));
+                assert_eq!(body.error_summary.as_deref(), Some("1 test failed"));
+                assert_eq!(body.error_message.as_deref(), Some("1 test failed"));
+                assert_eq!(body.normalized_event.as_deref(), Some("test-failed"));
+                assert_eq!(body.mention.as_deref(), Some("@ops"));
+            }
+            other => panic!("expected AgentTestFailed body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_omx_hook_envelope_without_normalized_event() {
+        let error = from_omx_hook_envelope_json(&json!({
+            "schema_version": "1",
+            "event": "notify",
+            "context": {
+                "agent_name": "omx"
+            }
+        }))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("context.normalized_event"));
+    }
+
+    #[test]
+    fn rejects_unsupported_omx_hook_schema_version() {
+        let error = from_omx_hook_envelope_json(&json!({
+            "schema_version": "2",
+            "context": {
+                "normalized_event": "started"
+            }
+        }))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("unsupported schema_version"));
+    }
+
+    #[test]
     fn reuses_normalized_event_id_when_available() {
         let event = crate::events::normalize_event(IncomingEvent::custom(None, "hello".into()));
         let envelope = from_incoming_event(&event).unwrap();
@@ -449,5 +683,66 @@ mod tests {
             envelope.id.to_string(),
             event.payload["event_id"].as_str().unwrap()
         );
+    }
+
+    fn sample_agent_payload(normalized_event: &str) -> Value {
+        json!({
+            "agent_name": "omx",
+            "session_name": "issue-65",
+            "status": normalized_event,
+            "normalized_event": normalized_event,
+            "session_id": "sess-65",
+            "project": "clawhip",
+            "repo_path": "/repo/clawhip",
+            "branch": "feat/issue-65",
+            "issue_number": 65,
+            "pr_number": 72,
+            "pr_url": "https://github.com/Yeachan-Heo/clawhip/pull/72",
+            "command": "cargo test",
+            "tool_name": "Bash",
+            "elapsed_secs": 42,
+            "summary": "summary",
+            "error_summary": "error summary",
+            "mention": "@ops"
+        })
+    }
+
+    fn sample_agent_event(normalized_event: &str) -> AgentEvent {
+        AgentEvent {
+            agent_name: "omx".into(),
+            session_name: Some("issue-65".into()),
+            status: normalized_event.into(),
+            normalized_event: Some(normalized_event.into()),
+            session_id: Some("sess-65".into()),
+            project: Some("clawhip".into()),
+            repo_path: Some("/repo/clawhip".into()),
+            branch: Some("feat/issue-65".into()),
+            issue_number: Some(65),
+            pr_number: Some(72),
+            pr_url: Some("https://github.com/Yeachan-Heo/clawhip/pull/72".into()),
+            command: Some("cargo test".into()),
+            tool_name: Some("Bash".into()),
+            elapsed_secs: Some(42),
+            summary: Some("summary".into()),
+            error_summary: Some("error summary".into()),
+            error_message: Some("error summary".into()),
+            mention: Some("@ops".into()),
+        }
+    }
+
+    fn expected_normalized_event(body: &EventBody) -> &'static str {
+        match body {
+            EventBody::AgentStarted(_) => "started",
+            EventBody::AgentBlocked(_) => "blocked",
+            EventBody::AgentFinished(_) => "finished",
+            EventBody::AgentFailed(_) => "failed",
+            EventBody::AgentRetryNeeded(_) => "retry-needed",
+            EventBody::AgentPRCreated(_) => "pr-created",
+            EventBody::AgentTestStarted(_) => "test-started",
+            EventBody::AgentTestFinished(_) => "test-finished",
+            EventBody::AgentTestFailed(_) => "test-failed",
+            EventBody::AgentHandoffNeeded(_) => "handoff-needed",
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -40,6 +40,12 @@ pub enum EventBody {
     AgentBlocked(AgentEvent),
     AgentFinished(AgentEvent),
     AgentFailed(AgentEvent),
+    AgentRetryNeeded(AgentEvent),
+    AgentPRCreated(AgentEvent),
+    AgentTestStarted(AgentEvent),
+    AgentTestFinished(AgentEvent),
+    AgentTestFailed(AgentEvent),
+    AgentHandoffNeeded(AgentEvent),
     Custom(CustomEvent),
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -752,6 +752,7 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
             "/summary",
             "/signal/summary",
             "/reason",
+            "/context/summary",
             "/context/contextSummary",
             "/context/reason",
             "/context/question",


### PR DESCRIPTION
## Summary
- freeze the clawhip native event contract in docs/event-contract-v1.md
- expand typed native agent/session events to cover all 10 canonical normalized events
- add OMX schema_version=1 hook envelope deserialization and acceptance tests

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

Closes #65