### PR TITLE
feat: route-scoped action layer with tmux.send-keys support

### DIFF
--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,0 +1,27 @@
+pub mod tmux;
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use crate::config::ActionSpec;
+use crate::events::IncomingEvent;
+
+#[derive(Debug, Clone)]
+pub enum ActionOutcome {
+    Success(String),
+    Failed(String),
+}
+
+#[async_trait]
+pub trait Action: Send + Sync {
+    #[allow(dead_code)]
+    fn name(&self) -> &str;
+    async fn execute(&self, spec: &ActionSpec, event: &IncomingEvent) -> ActionOutcome;
+}
+
+pub fn default_actions() -> HashMap<String, Box<dyn Action>> {
+    let mut actions: HashMap<String, Box<dyn Action>> = HashMap::new();
+    actions.insert("tmux.send-keys".into(), Box::new(tmux::TmuxSendKeysAction));
+    actions
+}

--- a/src/action/tmux.rs
+++ b/src/action/tmux.rs
@@ -1,0 +1,87 @@
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+
+use crate::config::ActionSpec;
+use crate::events::IncomingEvent;
+use crate::tmux_ops;
+
+use super::{Action, ActionOutcome};
+
+pub struct TmuxSendKeysAction;
+
+#[async_trait]
+impl Action for TmuxSendKeysAction {
+    fn name(&self) -> &str {
+        "tmux.send-keys"
+    }
+
+    async fn execute(&self, spec: &ActionSpec, event: &IncomingEvent) -> ActionOutcome {
+        let context = event.template_context();
+
+        let target = spec
+            .target
+            .as_deref()
+            .map(|t| resolve_template(t, &context))
+            .or_else(|| {
+                event
+                    .payload
+                    .get("session")
+                    .and_then(|v| v.as_str())
+                    .map(ToString::to_string)
+            });
+
+        let Some(target) = target.filter(|t| !t.is_empty()) else {
+            return ActionOutcome::Failed("no target session for tmux.send-keys".into());
+        };
+
+        let keys = spec.keys.as_deref().unwrap_or("continue");
+
+        if let Err(error) = tmux_ops::send_literal_keys(&target, keys).await {
+            return ActionOutcome::Failed(format!("send-keys literal to '{target}': {error}"));
+        }
+
+        if let Err(error) = tmux_ops::send_key(&target, "Enter").await {
+            return ActionOutcome::Failed(format!("send-keys Enter to '{target}': {error}"));
+        }
+
+        ActionOutcome::Success(format!("sent '{keys}' + Enter to tmux session '{target}'"))
+    }
+}
+
+fn resolve_template(template: &str, context: &BTreeMap<String, String>) -> String {
+    let mut result = template.to_string();
+    for (key, value) in context {
+        result = result.replace(&format!("{{{key}}}"), value);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_template_substitutes_known_keys() {
+        let mut context = BTreeMap::new();
+        context.insert("session".into(), "issue-24".into());
+        context.insert("pane".into(), "0.0".into());
+
+        assert_eq!(
+            resolve_template("{session}:{pane}", &context),
+            "issue-24:0.0"
+        );
+    }
+
+    #[test]
+    fn resolve_template_leaves_unknown_keys_as_is() {
+        let context = BTreeMap::new();
+        assert_eq!(resolve_template("{unknown}", &context), "{unknown}");
+    }
+
+    #[test]
+    fn resolve_template_handles_empty_template() {
+        let context = BTreeMap::new();
+        assert_eq!(resolve_template("", &context), "");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,14 @@ impl Default for DefaultsConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActionSpec {
+    #[serde(rename = "type")]
+    pub action_type: String,
+    pub target: Option<String>,
+    pub keys: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouteRule {
     pub event: String,
@@ -107,6 +115,8 @@ pub struct RouteRule {
     pub allow_dynamic_tokens: bool,
     pub format: Option<MessageFormat>,
     pub template: Option<String>,
+    #[serde(default)]
+    pub action: Option<ActionSpec>,
 }
 
 impl Default for RouteRule {
@@ -122,6 +132,7 @@ impl Default for RouteRule {
             allow_dynamic_tokens: false,
             format: None,
             template: None,
+            action: None,
         }
     }
 }
@@ -517,6 +528,19 @@ impl AppConfig {
                 }
                 _ => unreachable!(),
             }
+
+            if let Some(action) = &route.action {
+                const SUPPORTED_ACTIONS: &[&str] = &["tmux.send-keys"];
+                if !SUPPORTED_ACTIONS.contains(&action.action_type.as_str()) {
+                    return Err(format!(
+                        "route #{} ({}) uses unsupported action type '{}'",
+                        index + 1,
+                        route.event,
+                        action.action_type
+                    )
+                    .into());
+                }
+            }
         }
 
         if self.effective_token().is_none() && !self.has_webhook_routes() {
@@ -558,6 +582,7 @@ impl AppConfig {
             allow_dynamic_tokens: false,
             format: None,
             template: None,
+            action: None,
         });
     }
 
@@ -938,5 +963,75 @@ mod tests {
     fn tmux_session_monitor_defaults_keyword_window_to_thirty_seconds() {
         let session = TmuxSessionMonitor::default();
         assert_eq!(session.keyword_window_secs, 30);
+    }
+
+    #[test]
+    fn route_action_parses_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"
+[[routes]]
+event = "tmux.stale"
+sink = "discord"
+webhook = "https://discord.com/api/webhooks/123/abc"
+
+[routes.action]
+type = "tmux.send-keys"
+target = "{session}"
+keys = "continue"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_default(&path).unwrap();
+
+        assert_eq!(config.routes.len(), 1);
+        let action = config.routes[0].action.as_ref().unwrap();
+        assert_eq!(action.action_type, "tmux.send-keys");
+        assert_eq!(action.target.as_deref(), Some("{session}"));
+        assert_eq!(action.keys.as_deref(), Some("continue"));
+    }
+
+    #[test]
+    fn route_action_defaults_to_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"
+[[routes]]
+event = "tmux.keyword"
+sink = "discord"
+webhook = "https://discord.com/api/webhooks/123/abc"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_default(&path).unwrap();
+
+        assert_eq!(config.routes.len(), 1);
+        assert!(config.routes[0].action.is_none());
+    }
+
+    #[test]
+    fn route_action_rejects_unsupported_type() {
+        let config = AppConfig {
+            routes: vec![RouteRule {
+                event: "tmux.stale".into(),
+                webhook: Some("https://discord.com/api/webhooks/123/abc".into()),
+                action: Some(ActionSpec {
+                    action_type: "unsupported.type".into(),
+                    target: None,
+                    keys: None,
+                }),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("unsupported action type"));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -49,8 +49,9 @@ pub async fn run(config: Arc<AppConfig>, port_override: Option<u16>) -> Result<(
     let tmux_registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
     let (tx, rx) = mpsc::channel(EVENT_QUEUE_CAPACITY);
 
+    let actions = crate::action::default_actions();
     tokio::spawn(async move {
-        let mut dispatcher = Dispatcher::new(rx, router, renderer, sinks);
+        let mut dispatcher = Dispatcher::new(rx, router, renderer, sinks, actions);
         if let Err(error) = dispatcher.run().await {
             eprintln!("clawhip dispatcher stopped: {error}");
         }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 use tokio::sync::mpsc;
 
 use crate::Result;
+use crate::action::{Action, ActionOutcome};
 use crate::core::timer_wheel::{DelayedEntry, TimerWheel};
 use crate::events::IncomingEvent;
 use crate::render::Renderer;
@@ -20,6 +21,7 @@ pub struct Dispatcher {
     router: Router,
     renderer: Box<dyn Renderer>,
     sinks: HashMap<String, Box<dyn Sink>>,
+    actions: HashMap<String, Box<dyn Action>>,
     ci_batcher: GitHubCiBatcher,
     batch_tick: Duration,
 }
@@ -30,12 +32,14 @@ impl Dispatcher {
         router: Router,
         renderer: Box<dyn Renderer>,
         sinks: HashMap<String, Box<dyn Sink>>,
+        actions: HashMap<String, Box<dyn Action>>,
     ) -> Self {
         Self {
             rx,
             router,
             renderer,
             sinks,
+            actions,
             ci_batcher: GitHubCiBatcher::new(DEFAULT_CI_BATCH_WINDOW),
             batch_tick: DEFAULT_BATCH_TICK,
         }
@@ -108,6 +112,23 @@ impl Dispatcher {
         };
 
         for delivery in deliveries {
+            if let Some(ref action_spec) = delivery.action {
+                if let Some(action) = self.actions.get(action_spec.action_type.as_str()) {
+                    match action.execute(action_spec, &event).await {
+                        ActionOutcome::Success(msg) => {
+                            eprintln!("clawhip action ok: {msg}");
+                        }
+                        ActionOutcome::Failed(msg) => {
+                            eprintln!("clawhip action failed: {msg}");
+                        }
+                    }
+                } else {
+                    eprintln!(
+                        "clawhip dispatcher unknown action type '{}'",
+                        action_spec.action_type
+                    );
+                }
+            }
             let Some(sink) = self.sinks.get(delivery.sink.as_str()) else {
                 eprintln!(
                     "clawhip dispatcher missing sink '{}' for target {:?}",
@@ -476,7 +497,7 @@ mod tests {
             Box::new(DiscordSink::from_config(Arc::new(AppConfig::default())).unwrap()),
         );
         sinks.insert("slack".into(), Box::new(SlackSink::default()));
-        Dispatcher::new(rx, router, Box::new(DefaultRenderer), sinks)
+        Dispatcher::new(rx, router, Box::new(DefaultRenderer), sinks, HashMap::new())
     }
 
     #[tokio::test]
@@ -526,6 +547,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: Some("first".into()),
+                    action: None,
                 },
                 RouteRule {
                     event: "tmux.keyword".into(),
@@ -538,6 +560,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: Some("second".into()),
+                    action: None,
                 },
             ],
             ..AppConfig::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod action;
 mod cli;
 mod client;
 mod config;
@@ -17,6 +18,7 @@ mod router;
 mod sink;
 mod slack;
 mod source;
+mod tmux_ops;
 mod tmux_wrapper;
 
 use std::sync::Arc;

--- a/src/router.rs
+++ b/src/router.rs
@@ -13,6 +13,8 @@ use crate::sink::Sink;
 use crate::sink::SinkMessage;
 use crate::sink::SinkTarget;
 
+use crate::config::ActionSpec;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedDelivery {
     pub sink: String,
@@ -21,6 +23,7 @@ pub struct ResolvedDelivery {
     pub mention: Option<String>,
     pub template: Option<String>,
     pub allow_dynamic_tokens: bool,
+    pub action: Option<ActionSpec>,
 }
 
 pub struct Router {
@@ -111,6 +114,7 @@ impl Router {
                 .clone()
                 .or_else(|| route.and_then(|route| route.template.clone())),
             allow_dynamic_tokens: self.allow_dynamic_tokens_for(event, route),
+            action: route.and_then(|route| route.action.clone()),
         })
     }
 
@@ -324,6 +328,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
                     template: None,
+                    action: None,
                 },
                 RouteRule {
                     event: "tmux.*".into(),
@@ -336,6 +341,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Compact),
                     template: Some("duplicate: {line}".into()),
+                    action: None,
                 },
             ],
             ..AppConfig::default()
@@ -388,6 +394,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -449,6 +456,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: Some("first".into()),
+                    action: None,
                 },
                 RouteRule {
                     event: "tmux.keyword".into(),
@@ -461,6 +469,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: Some("second".into()),
+                    action: None,
                 },
             ],
             ..AppConfig::default()
@@ -504,6 +513,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -538,6 +548,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -569,6 +580,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
                     template: None,
+                    action: None,
                 },
                 RouteRule {
                     event: "tmux.*".into(),
@@ -583,6 +595,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
                     template: None,
+                    action: None,
                 },
             ],
             ..AppConfig::default()
@@ -620,6 +633,7 @@ mod tests {
                 allow_dynamic_tokens: true,
                 format: None,
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -647,6 +661,7 @@ mod tests {
                 allow_dynamic_tokens: true,
                 format: None,
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -676,6 +691,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -709,6 +725,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -742,6 +759,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -779,6 +797,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -824,6 +843,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -886,6 +906,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -931,6 +952,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -988,6 +1010,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -1035,6 +1058,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: None,
+                    action: None,
                 },
                 RouteRule {
                     event: "github.*".into(),
@@ -1049,6 +1073,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: None,
+                    action: None,
                 },
             ],
             ..AppConfig::default()
@@ -1077,6 +1102,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };
@@ -1116,6 +1142,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -790,6 +790,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
                 template: None,
+                action: None,
             }],
             ..AppConfig::default()
         };

--- a/src/tmux_ops.rs
+++ b/src/tmux_ops.rs
@@ -1,0 +1,39 @@
+use tokio::process::Command;
+
+use crate::Result;
+use crate::source::tmux::tmux_bin;
+
+/// Send literal text to a tmux session/pane target via `send-keys -l`.
+pub async fn send_literal_keys(target: &str, text: &str) -> Result<()> {
+    let output = Command::new(tmux_bin())
+        .arg("send-keys")
+        .arg("-t")
+        .arg(target)
+        .arg("-l")
+        .arg(text)
+        .output()
+        .await?;
+    if !output.status.success() {
+        return Err(tmux_stderr(&output.stderr).into());
+    }
+    Ok(())
+}
+
+/// Send a named key (e.g. "Enter") to a tmux session/pane target.
+pub async fn send_key(target: &str, key: &str) -> Result<()> {
+    let output = Command::new(tmux_bin())
+        .arg("send-keys")
+        .arg("-t")
+        .arg(target)
+        .arg(key)
+        .output()
+        .await?;
+    if !output.status.success() {
+        return Err(tmux_stderr(&output.stderr).into());
+    }
+    Ok(())
+}
+
+fn tmux_stderr(stderr: &[u8]) -> String {
+    String::from_utf8_lossy(stderr).trim().to_string()
+}


### PR DESCRIPTION
## Summary

Introduces an **Action trait** and wires it into the Dispatcher alongside notification delivery, enabling routes to trigger automated responses when events fire — not just notifications.

This PR implements only `tmux.send-keys`, the ["obvious 80% use case"](https://github.com/Yeachan-Heo/clawhip/issues/91#issuecomment-2767941143) for stale session recovery. When an agent stalls, clawhip can now automatically inject `continue` + Enter into the tmux session before notifying the human.

### Config example

```toml
[[routes]]
event = "tmux.stale"
sink = "discord"
webhook = "https://..."

[routes.action]
type = "tmux.send-keys"
target = "{session}"
keys = "continue"
```

### Design choices (per maintainer feedback on #91)

- **Route-scoped and opt-in** — existing configs are completely unaffected (backward-compatible)
- **No `shell` action type** — sandboxing design deferred per maintainer's concern
- **Independent of notification** — action failure does not block sink delivery (best-effort, matching existing Sink behavior)
- **Template variables** — `{session}`, `{pane}`, etc. resolved from event context in action args
- **Follows existing patterns** — `Action` trait mirrors the `Sink` trait; action registry mirrors sink registry

### Architecture

```
Source → Event → Router → Dispatcher
                              ├── Action (execute tmux.send-keys)  ← NEW
                              └── Sink (deliver notification)      ← existing
```

Action execution is a parallel branch at the Dispatcher level, composing with the existing `Source → Dispatcher → Router → Renderer → Sink` pipeline without modifying it.

### Changes

| File | Change |
|------|--------|
| `src/action/mod.rs` | `Action` trait, `ActionOutcome` enum, `default_actions()` registry |
| `src/action/tmux.rs` | `TmuxSendKeysAction` — sends literal keys + Enter to target tmux session |
| `src/tmux_ops.rs` | Shared tmux `send-keys` helpers (reusable by future action types) |
| `src/config.rs` | `ActionSpec` struct + `action` field on `RouteRule` + validation |
| `src/router.rs` | `action` field on `ResolvedDelivery`, resolved from route config |
| `src/dispatch.rs` | Action execution in `deliver_event()`, parallel to sink delivery |
| `src/daemon.rs` | Wire `default_actions()` into Dispatcher construction |

### What's NOT included (deferred to follow-up PRs)

- Escalation chain (`max_retries` → `tmux_kill_restart`)
- `shell` action type (needs sandboxing design)
- `webhook` action type
- Action outcome reflected in notification content (`[auto-recovered]` tag)

### Test plan

- [x] All 155 existing tests pass (0 regressions)
- [x] New test: `route_action_parses_from_toml` — verifies TOML config with action block
- [x] New test: `route_action_defaults_to_none` — verifies backward compatibility
- [x] New test: `route_action_rejects_unsupported_type` — verifies config validation
- [x] New test: `resolve_template_*` — verifies template variable substitution in action args

### Prior art

Validated in production: [ghostview-ralphthon](https://github.com/shaun0927/ghostview-ralphthon) — tmux hang detection + continue injection + session restart reduced human interventions from ~12/night to ~1/night.

Closes #91 (partial — escalation chain deferred)