### PR TITLE
fix: honor route channels for tmux session startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ clawhip tmux watch -s <existing-session> \
 Behavior:
 - `tmux new` creates a tmux session using the user's default shell (or `--shell` override)
 - `tmux new` sends the requested command into the session, retrying Enter for TUI apps by default with exponential backoff (`--retry-enter=false` disables it, `--retry-enter-count` / `--retry-enter-delay-ms` tune retries)
+- when `tmux new` omits `--channel`, clawhip reuses the first matching Discord route channel for the session name before falling back to `defaults.channel`
 - `tmux watch` attaches monitoring to an already-running tmux session
 - both commands register the session with the daemon
 - daemon monitors keyword/stale events

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use serde_json::json;
+
 use crate::Result;
 use crate::config::{AppConfig, RouteRule, default_sink_name};
 use crate::dynamic_tokens;
@@ -174,21 +176,10 @@ impl Router {
 
     fn routes_for<'a>(&'a self, event: &IncomingEvent) -> Vec<&'a RouteRule> {
         let context = event.template_context();
-        let candidates = route_candidates(event.canonical_kind());
         self.config
             .routes
             .iter()
-            .filter(|route| {
-                candidates
-                    .iter()
-                    .any(|candidate| glob_match(&route.event, candidate))
-                    && route.filter.iter().all(|(key, expected)| {
-                        context
-                            .get(key)
-                            .map(|actual| glob_match(expected, actual))
-                            .unwrap_or(false)
-                    })
-            })
+            .filter(|route| route_matches(route, event.canonical_kind(), &context))
             .collect()
     }
 
@@ -234,6 +225,43 @@ impl Router {
     }
 }
 
+pub(crate) fn resolve_tmux_session_channel(
+    config: &AppConfig,
+    session_name: &str,
+) -> Option<String> {
+    let tmux_event =
+        IncomingEvent::tmux_keyword(session_name.to_string(), String::new(), String::new(), None);
+    let tmux_context = tmux_event.template_context();
+    let session_event = IncomingEvent {
+        kind: "session.started".to_string(),
+        channel: None,
+        mention: None,
+        format: None,
+        template: None,
+        payload: json!({
+            "session_name": session_name,
+            "session": session_name,
+            "tool": "tmux",
+        }),
+    };
+    let session_context = session_event.template_context();
+
+    for route in &config.routes {
+        let matches_tmux = route_matches(route, tmux_event.canonical_kind(), &tmux_context);
+        let matches_session =
+            route_matches(route, session_event.canonical_kind(), &session_context);
+        if !(matches_tmux || matches_session) || route.effective_sink() != "discord" {
+            continue;
+        }
+
+        if let Some(channel) = route_channel(route) {
+            return Some(channel.to_string());
+        }
+    }
+
+    config.defaults.channel.clone()
+}
+
 fn route_candidates(kind: &str) -> Vec<&str> {
     match kind {
         "git.commit" => vec!["git.commit", "github.commit"],
@@ -254,6 +282,30 @@ fn route_candidates(kind: &str) -> Vec<&str> {
         }
         other => vec![other],
     }
+}
+
+fn route_matches(
+    route: &RouteRule,
+    canonical_kind: &str,
+    context: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    route_candidates(canonical_kind)
+        .iter()
+        .any(|candidate| glob_match(&route.event, candidate))
+        && route.filter.iter().all(|(key, expected)| {
+            context
+                .get(key)
+                .map(|actual| glob_match(expected, actual))
+                .unwrap_or(false)
+        })
+}
+
+fn route_channel(route: &RouteRule) -> Option<&str> {
+    route
+        .channel
+        .as_deref()
+        .map(str::trim)
+        .filter(|channel| !channel.is_empty())
 }
 
 fn glob_match(pattern: &str, value: &str) -> bool {
@@ -304,6 +356,7 @@ mod tests {
     use crate::render::DefaultRenderer;
     use crate::sink::{DiscordSink, SlackSink};
     use serde_json::json;
+    use std::collections::BTreeMap;
 
     #[tokio::test]
     async fn resolve_returns_all_matching_deliveries_in_route_order() {
@@ -1189,6 +1242,90 @@ mod tests {
         assert_eq!(
             delivery.target,
             SinkTarget::SlackWebhook("https://hooks.slack.com/services/T/B/generic".into())
+        );
+    }
+
+    #[test]
+    fn resolve_tmux_session_channel_prefers_matching_tmux_route() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.*".into(),
+                filter: BTreeMap::from([("session".into(), "xeroclaw-*".into())]),
+                sink: "discord".into(),
+                channel: Some("xeroclaw-dev".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+
+        assert_eq!(
+            resolve_tmux_session_channel(&config, "xeroclaw-42").as_deref(),
+            Some("xeroclaw-dev")
+        );
+    }
+
+    #[test]
+    fn resolve_tmux_session_channel_supports_session_routes() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "session.*".into(),
+                filter: BTreeMap::from([("session_name".into(), "xeroclaw-*".into())]),
+                sink: "discord".into(),
+                channel: Some("xeroclaw-dev".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+
+        assert_eq!(
+            resolve_tmux_session_channel(&config, "xeroclaw-42").as_deref(),
+            Some("xeroclaw-dev")
+        );
+    }
+
+    #[test]
+    fn resolve_tmux_session_channel_skips_webhooks_and_falls_back_to_defaults() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.*".into(),
+                filter: BTreeMap::from([("session".into(), "xeroclaw-*".into())]),
+                sink: "discord".into(),
+                channel: None,
+                webhook: Some("https://discord.com/api/webhooks/123/abc".into()),
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+
+        assert_eq!(
+            resolve_tmux_session_channel(&config, "xeroclaw-42").as_deref(),
+            Some("default")
         );
     }
 

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -7,13 +7,14 @@ use crate::Result;
 use crate::cli::{TmuxNewArgs, TmuxWatchArgs, TmuxWrapperFormat};
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
+use crate::router::resolve_tmux_session_channel;
 use crate::source::tmux::{
     RegisteredTmuxSession, content_hash, monitor_registered_session, session_exists, tmux_bin,
 };
 
 pub async fn run(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
     launch_session(&args).await?;
-    let monitor_args = TmuxMonitorArgs::from(&args);
+    let monitor_args = TmuxMonitorArgs::from_new_args(&args, config);
     let monitor = register_and_start_monitor(monitor_args, config).await?;
 
     if args.attach {
@@ -56,6 +57,16 @@ impl From<&TmuxNewArgs> for TmuxMonitorArgs {
             stale_minutes: value.stale_minutes,
             format: value.format,
         }
+    }
+}
+
+impl TmuxMonitorArgs {
+    fn from_new_args(value: &TmuxNewArgs, config: &AppConfig) -> Self {
+        let mut monitor_args = Self::from(value);
+        if monitor_args.channel.is_none() {
+            monitor_args.channel = resolve_tmux_session_channel(config, &value.session);
+        }
+        monitor_args
     }
 }
 
@@ -287,6 +298,8 @@ fn default_keyword_window_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{AppConfig, DefaultsConfig, RouteRule};
+    use std::collections::BTreeMap;
 
     #[test]
     fn build_command_to_send_preserves_shell_arguments_when_joining() {
@@ -391,6 +404,92 @@ mod tests {
             monitor_args.format,
             Some(TmuxWrapperFormat::Inline)
         ));
+    }
+
+    #[test]
+    fn new_args_auto_resolve_channel_from_routes() {
+        let args = TmuxNewArgs {
+            session: "xeroclaw-22".into(),
+            window_name: None,
+            cwd: None,
+            channel: None,
+            mention: None,
+            keywords: Vec::new(),
+            stale_minutes: 10,
+            format: None,
+            attach: false,
+            retry_enter: true,
+            retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
+            retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
+            shell: None,
+            command: vec!["codex".into()],
+        };
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: crate::events::MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.*".into(),
+                filter: BTreeMap::from([("session".into(), "xeroclaw-*".into())]),
+                sink: "discord".into(),
+                channel: Some("xeroclaw-dev".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+
+        let monitor_args = TmuxMonitorArgs::from_new_args(&args, &config);
+
+        assert_eq!(monitor_args.channel.as_deref(), Some("xeroclaw-dev"));
+    }
+
+    #[test]
+    fn new_args_keep_explicit_channel_over_route_resolution() {
+        let args = TmuxNewArgs {
+            session: "xeroclaw-22".into(),
+            window_name: None,
+            cwd: None,
+            channel: Some("manual".into()),
+            mention: None,
+            keywords: Vec::new(),
+            stale_minutes: 10,
+            format: None,
+            attach: false,
+            retry_enter: true,
+            retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
+            retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
+            shell: None,
+            command: vec!["codex".into()],
+        };
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: crate::events::MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.*".into(),
+                filter: BTreeMap::from([("session".into(), "xeroclaw-*".into())]),
+                sink: "discord".into(),
+                channel: Some("xeroclaw-dev".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+
+        let monitor_args = TmuxMonitorArgs::from_new_args(&args, &config);
+
+        assert_eq!(monitor_args.channel.as_deref(), Some("manual"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- auto-resolve tmux session channels from matching route config when `clawhip tmux new` omits `--channel`\n- reuse router matching semantics for both `tmux.*` and `session.*` session-name routes while skipping webhook-only matches\n- add regression tests and README coverage for the inferred channel behavior\n\n## Verification\n- cargo build\n- cargo test\n- git diff --check