### PR TITLE
feat: add native OMX hook ingress and SDK bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ Built-in starter plugins:
 - `plugins/codex/`
 - `plugins/claude-code/`
 
+Native OMX hook-forwarding assets are bundled separately under:
+
+- `integrations/omx/`
+
 List installed plugins with:
 
 ```bash
@@ -436,6 +440,8 @@ Accepted upstream inputs:
 - legacy wrapper emits like `agent.started` / `agent.finished` / `agent.failed`
 - OMC command/HTTP payloads with `signal.routeKey`
 - OMX hook payloads with `context.normalized_event`
+- native OMX hook-envelope CLI ingress via `clawhip omx hook`
+- native OMX hook-envelope POSTs to `POST /api/omx/hook`
 
 Canonical normalized events:
 - `session.started`
@@ -475,8 +481,12 @@ Route guidance:
 - `agent.*` remains supported for clawhip-local wrapper compatibility
 - `agent.started|blocked|finished|failed` and `session.started|blocked|finished|failed` cross-match in routing for backward compatibility
 - prefer route filters like `tool`, `repo_name`, `session_name`, `issue_number`, and `branch` over brittle message parsing
+- for OMX hook plugins, prefer forwarding the frozen v1 envelope to `POST /api/omx/hook` instead of translating it into a generic `/event` payload
+
+Native OMX bridge assets live in [`integrations/omx/`](integrations/omx/).
 
 See [`docs/native-event-contract.md`](docs/native-event-contract.md) for the full normalization/deprecation notes.
+See [`integrations/omx/README.md`](integrations/omx/README.md) for the OMX-native SDK/helper surface.
 
 ### 8. Agent lifecycle preset family
 
@@ -784,6 +794,7 @@ clawhip send ...        # thin client custom event
 clawhip github ...      # thin client GitHub event
 clawhip git ...         # thin client git event
 clawhip agent ...       # thin client agent lifecycle event
+clawhip omx hook ...    # native OMX hook-envelope thin client
 clawhip tmux ...        # thin client / wrapper surface
 clawhip plugin list     # list installed/bundled shell-hook plugins
 ```

--- a/docs/event-contract-v1.md
+++ b/docs/event-contract-v1.md
@@ -48,10 +48,19 @@ Upstream OMX hook payloads must use these hyphenated `normalized_event` values:
 - `handoff-needed`
 
 > Note: underscore spellings such as `retry_needed`, `pr_created`, `test_started`, `test_finished`, `test_failed`, and `handoff_needed` appear in issue prose but are **not** the frozen wire-format contract.
+>
+> Raw OMX hook events such as `pre-tool-use` / `post-tool-use` are also **not** frozen v1 canonical events. If OMX wants clawhip routing for a tool operation, it must map that operation onto one of the supported normalized events above and carry tool details as metadata.
 
 ## OMX hook envelope format
 
 clawhip accepts OMX hook envelope JSON with `schema_version = "1"`.
+
+Recommended native daemon ingress for this envelope:
+
+- `POST /api/omx/hook`
+- `POST /omx/hook`
+
+This lets native OMX integrations forward the frozen v1 envelope directly without translating it into clawhip's generic `/event` payload shape first.
 
 ```json
 {

--- a/docs/live-verification.md
+++ b/docs/live-verification.md
@@ -67,6 +67,39 @@ Operational flow:
 4. Confirm clawhip normalizes it into the expected `session.*` route family.
 5. Post one representative OMX payload carrying `context.normalized_event` to `/event`.
 6. Confirm the rendered message stays low-noise and includes normalized metadata like repo/session/issue/PR when present.
+7. Pipe the same OMX payload through the native OMX CLI ingress and confirm acceptance:
+
+```bash
+printf '%s\n' '{
+  "schema_version": "1",
+  "event": "session-start",
+  "timestamp": "2026-04-01T22:00:00Z",
+  "context": {
+    "normalized_event": "started",
+    "agent_name": "omx",
+    "session_name": "issue-65-native-sdk",
+    "status": "started"
+  }
+}' | clawhip omx hook
+```
+
+8. Post the same OMX payload to the native OMX daemon ingress and confirm acceptance:
+
+```bash
+curl -sS -X POST http://127.0.0.1:25294/api/omx/hook \
+  -H 'content-type: application/json' \
+  -d '{
+    "schema_version": "1",
+    "event": "session-start",
+    "timestamp": "2026-04-01T22:00:00Z",
+    "context": {
+      "normalized_event": "started",
+      "agent_name": "omx",
+      "session_name": "issue-65-native-sdk",
+      "status": "started"
+    }
+  }'
+```
 
 ### tmux presets
 

--- a/docs/native-event-contract.md
+++ b/docs/native-event-contract.md
@@ -39,9 +39,13 @@ clawhip normalizes already-merged OMC/OMX payloads from these upstream surfaces:
 
 - OMC payloads that include `signal.routeKey`
 - OMX payloads that include `context.normalized_event`
+- native OMX hook-envelope CLI ingress via `clawhip omx hook`
+- native OMX hook-envelope POSTs to clawhip's `/api/omx/hook` / `/omx/hook` ingress
 - legacy local `clawhip emit agent.* ...` wrapper emits from `skills/omc/create.sh` and `skills/omx/create.sh`
 
 Not every upstream raw event becomes a canonical session event. Low-signal/raw hook events should stay as secondary/debug inputs. New routes should target `session.*`.
+
+In particular, raw OMX hook events such as `pre-tool-use` / `post-tool-use` are not clawhip v1 canonical route keys. When OMX wants clawhip-native routing for tool activity, it should map the activity onto an existing v1 event family (`session.failed`, `session.test-*`, `session.pr-created`, etc.) and keep tool details in metadata like `command`, `tool_name`, and `error_summary`.
 
 ## Normalized metadata
 
@@ -77,6 +81,7 @@ When upstream provides it, clawhip normalizes these fields onto the top-level pa
 - `pr_number` may be inferred from `pr_url`.
 - `raw_event` is retained only when clawhip had to rename the incoming event.
 - `contract_event` is the canonical normalized event after clawhip ingestion.
+- raw OMX tool events such as `pre-tool-use` / `post-tool-use` are not new clawhip v1 canonical events; map them to the frozen `session.*` family via metadata when they represent PR/test/failure/handoff semantics.
 
 ## Upstream-to-canonical mapping
 
@@ -151,7 +156,8 @@ Direct platform notifications from inside OMC/OMX are deprecated for clawhip-int
 Preferred model:
 
 1. OMC/OMX emit native operational events
-2. clawhip normalizes them
-3. clawhip owns channel routing, mentions, formatting, and webhook delivery
+2. clawhip ingests them directly (for OMX, `clawhip omx hook` and `/api/omx/hook` are the native ingress surfaces)
+3. clawhip normalizes them
+4. clawhip owns channel routing, mentions, formatting, and webhook delivery
 
 That keeps notification policy in one place and avoids duplicate/noisy Discord or Slack messages.

--- a/integrations/omx/README.md
+++ b/integrations/omx/README.md
@@ -1,0 +1,90 @@
+# clawhip × OMX native hook bridge
+
+This directory ships a clawhip-side OMX integration that forwards native OMX hook envelopes to the clawhip daemon without making OMX users hand-roll generic `IncomingEvent` HTTP payloads.
+
+## What is included
+
+- `clawhip-sdk.mjs` — small OMX-facing client that hides clawhip discovery + transport details
+- `clawhip-hook.mjs` — sample `.omx/hooks/*.mjs` plugin that forwards contract-compliant events to clawhip
+- `install-hook.sh` — copies the sample hook + SDK into an OMX workspace
+
+## Transport and discovery order
+
+The SDK chooses the lightest transport that preserves native semantics:
+
+1. **CLI transport** — preferred when `clawhip` is available (`CLAWHIP_BIN` or `PATH`)
+   - sends the raw v1 envelope to `clawhip omx hook`
+2. **HTTP transport** — fallback when a daemon URL is discoverable
+   - checks `CLAWHIP_OMX_DAEMON_URL`
+   - then `CLAWHIP_DAEMON_URL`
+   - then `CLAWHIP_CONFIG` / `~/.clawhip/config.toml`
+   - finally falls back to `http://127.0.0.1:25294`
+
+Override the transport explicitly with:
+
+```bash
+export CLAWHIP_OMX_TRANSPORT=cli   # or http
+```
+
+## Install into an OMX workspace
+
+```bash
+./integrations/omx/install-hook.sh /path/to/repo/.omx/hooks
+```
+
+Then validate inside that OMX workspace:
+
+```bash
+omx hooks validate
+omx hooks test
+```
+
+If you already have a serialized v1 hook envelope, clawhip also exposes a matching thin client:
+
+```bash
+clawhip omx hook --file payload.json
+# or
+cat payload.json | clawhip omx hook
+```
+
+## Contract boundary notes
+
+The SDK only forwards the frozen v1 `normalized_event` surface:
+
+- `started`
+- `blocked`
+- `finished`
+- `failed`
+- `retry-needed`
+- `pr-created`
+- `test-started`
+- `test-finished`
+- `test-failed`
+- `handoff-needed`
+
+`tool.use` is intentionally **not** a new v1 canonical event. Use `tool_name`, `command`, and `error_summary` metadata on one of the frozen events instead.
+
+## Manual usage
+
+```js
+import { createClawhipOmxClient } from './clawhip-sdk.mjs';
+
+const client = await createClawhipOmxClient();
+await client.emitSessionStarted({
+  context: {
+    session_name: 'issue-65-native-sdk',
+    repo_path: '/repo/clawhip',
+    branch: 'feat/issue-65-native-sdk',
+    status: 'started',
+  },
+});
+```
+
+Or forward an existing OMX hook event from a plugin:
+
+```js
+export async function onHookEvent(event, sdk) {
+  const client = await createClawhipOmxClient();
+  return await client.emitFromHookEvent(event);
+}
+```

--- a/integrations/omx/clawhip-hook.mjs
+++ b/integrations/omx/clawhip-hook.mjs
@@ -1,0 +1,26 @@
+import { createClawhipOmxClient } from './clawhip-sdk.mjs';
+
+const clientPromise = createClawhipOmxClient();
+
+export async function onHookEvent(event, sdk) {
+  const client = await clientPromise;
+  const sessionState = await sdk.omx.session.read();
+
+  const result = await client.emitFromHookEvent(event, {
+    context: {
+      agent_name: 'omx',
+      ...(sessionState?.session_id && !event?.session_id ? { session_id: sessionState.session_id } : {}),
+      ...(sessionState?.cwd && !event?.context?.worktree_path ? { worktree_path: sessionState.cwd } : {}),
+    },
+  });
+
+  if (result?.skipped) {
+    await sdk.log.info('clawhip OMX hook skipped non-contract event', {
+      event: event?.event,
+      normalized_event: event?.context?.normalized_event ?? null,
+      reason: result.reason,
+    });
+  }
+
+  return result;
+}

--- a/integrations/omx/clawhip-sdk.mjs
+++ b/integrations/omx/clawhip-sdk.mjs
@@ -1,0 +1,356 @@
+import { spawn } from 'node:child_process';
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const CONTRACT_EVENTS = new Set([
+  'started',
+  'blocked',
+  'finished',
+  'failed',
+  'retry-needed',
+  'pr-created',
+  'test-started',
+  'test-finished',
+  'test-failed',
+  'handoff-needed',
+]);
+
+const DEFAULT_CLAWHIP_BIN = 'clawhip';
+const DEFAULT_DAEMON_URL = 'http://127.0.0.1:25294';
+
+function trimString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeUrl(url) {
+  return trimString(url).replace(/\/$/, '');
+}
+
+function pickFirstString(...values) {
+  for (const value of values) {
+    const trimmed = trimString(value);
+    if (trimmed) return trimmed;
+  }
+  return '';
+}
+
+export function isSupportedNormalizedEvent(value) {
+  return CONTRACT_EVENTS.has(trimString(value));
+}
+
+export function canForwardHookEvent(event) {
+  return isSupportedNormalizedEvent(event?.context?.normalized_event);
+}
+
+function assertSupportedNormalizedEvent(value) {
+  const normalizedEvent = trimString(value);
+  if (!isSupportedNormalizedEvent(normalizedEvent)) {
+    throw new Error(
+      `unsupported clawhip OMX normalized_event: ${normalizedEvent || '<empty>'}`,
+    );
+  }
+  return normalizedEvent;
+}
+
+function buildContext(context = {}, normalizedEvent) {
+  const merged = {
+    agent_name: 'omx',
+    ...context,
+    normalized_event: normalizedEvent,
+  };
+  return Object.fromEntries(
+    Object.entries(merged).filter(([, value]) => value !== undefined && value !== null && value !== ''),
+  );
+}
+
+export function buildHookEnvelope({
+  normalizedEvent,
+  event = 'notify',
+  source = 'native',
+  timestamp = new Date().toISOString(),
+  context = {},
+  sessionId,
+  threadId,
+  turnId,
+  mode,
+  channel,
+  mention,
+} = {}) {
+  const canonical = assertSupportedNormalizedEvent(normalizedEvent);
+  const envelope = {
+    schema_version: '1',
+    event,
+    timestamp,
+    source,
+    context: buildContext(context, canonical),
+  };
+
+  const topLevel = {
+    session_id: sessionId,
+    thread_id: threadId,
+    turn_id: turnId,
+    mode,
+    channel,
+    mention,
+  };
+
+  for (const [key, value] of Object.entries(topLevel)) {
+    if (value !== undefined && value !== null && value !== '') {
+      envelope[key] = value;
+    }
+  }
+
+  return envelope;
+}
+
+async function commandAvailable(bin) {
+  return await new Promise((resolve) => {
+    const child = spawn(bin, ['--version'], { stdio: 'ignore' });
+    child.on('error', () => resolve(false));
+    child.on('close', (code) => resolve(code === 0));
+  });
+}
+
+async function readClawhipConfig(env) {
+  const configPath = pickFirstString(env.CLAWHIP_CONFIG) || join(homedir(), '.clawhip', 'config.toml');
+  try {
+    await access(configPath, constants.R_OK);
+    return await readFile(configPath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function daemonSection(toml) {
+  const lines = String(toml).split(/\r?\n/);
+  const collected = [];
+  let inDaemon = false;
+
+  for (const line of lines) {
+    const trimmed = trimString(line);
+    if (/^\[[^\]]+\]$/.test(trimmed)) {
+      if (inDaemon) break;
+      inDaemon = trimmed === '[daemon]';
+      continue;
+    }
+    if (inDaemon) {
+      collected.push(line);
+    }
+  }
+
+  return collected.join('\n');
+}
+
+function quotedValue(section, key) {
+  const match = section.match(new RegExp(`^\\s*${key}\\s*=\\s*"([^"]+)"\\s*$`, 'm'));
+  return match ? trimString(match[1]) : '';
+}
+
+function numericValue(section, key) {
+  const match = section.match(new RegExp(`^\\s*${key}\\s*=\\s*(\\d+)\\s*$`, 'm'));
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+async function discoverDaemonUrl(env) {
+  const explicit = normalizeUrl(pickFirstString(env.CLAWHIP_OMX_DAEMON_URL, env.CLAWHIP_DAEMON_URL));
+  if (explicit) {
+    return { url: explicit, source: env.CLAWHIP_OMX_DAEMON_URL ? 'env:CLAWHIP_OMX_DAEMON_URL' : 'env:CLAWHIP_DAEMON_URL' };
+  }
+
+  const configToml = await readClawhipConfig(env);
+  if (configToml) {
+    const daemon = daemonSection(configToml);
+    const baseUrl = normalizeUrl(quotedValue(daemon, 'base_url'));
+    if (baseUrl) {
+      return { url: baseUrl, source: 'config:daemon.base_url' };
+    }
+    const port = numericValue(daemon, 'port');
+    if (port) {
+      return { url: `http://127.0.0.1:${port}`, source: 'config:daemon.port' };
+    }
+  }
+
+  return { url: DEFAULT_DAEMON_URL, source: 'default' };
+}
+
+export async function discoverClawhip(options = {}) {
+  const env = options.env ?? process.env;
+  const preferredTransport = trimString(env.CLAWHIP_OMX_TRANSPORT || env.CLAWHIP_TRANSPORT).toLowerCase();
+  const explicitBin = trimString(env.CLAWHIP_BIN);
+
+  if (preferredTransport !== 'http') {
+    if (explicitBin) {
+      return { transport: 'cli', bin: explicitBin, source: 'env:CLAWHIP_BIN' };
+    }
+    if (preferredTransport !== 'http' && (await commandAvailable(DEFAULT_CLAWHIP_BIN))) {
+      return { transport: 'cli', bin: DEFAULT_CLAWHIP_BIN, source: 'path' };
+    }
+  }
+
+  const daemon = await discoverDaemonUrl(env);
+  return { transport: 'http', url: daemon.url, source: daemon.source };
+}
+
+function normalizeEnvelope(envelope) {
+  if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) {
+    throw new Error('clawhip OMX envelope must be an object');
+  }
+
+  const normalizedEvent = assertSupportedNormalizedEvent(
+    envelope.context?.normalized_event ?? envelope.normalized_event,
+  );
+
+  return {
+    schema_version: trimString(envelope.schema_version) || '1',
+    event: trimString(envelope.event) || 'notify',
+    timestamp: trimString(envelope.timestamp) || new Date().toISOString(),
+    source: trimString(envelope.source) || 'native',
+    ...Object.fromEntries(
+      Object.entries(envelope).filter(([key]) => !['schema_version', 'event', 'timestamp', 'source', 'context'].includes(key)),
+    ),
+    context: buildContext(envelope.context ?? {}, normalizedEvent),
+  };
+}
+
+async function emitViaCli(bin, envelope) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(bin, ['omx', 'hook'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ ok: true, transport: 'cli', stdout: trimString(stdout) || null, stderr: trimString(stderr) || null });
+      } else {
+        reject(new Error(`clawhip CLI transport failed with exit ${code}: ${trimString(stderr) || trimString(stdout) || 'unknown error'}`));
+      }
+    });
+
+    child.stdin.end(`${JSON.stringify(envelope)}\n`);
+  });
+}
+
+async function emitViaHttp(url, envelope) {
+  const response = await fetch(`${normalizeUrl(url)}/api/omx/hook`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(envelope),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(
+      `clawhip HTTP transport failed (${response.status}): ${payload.error || response.statusText}`,
+    );
+  }
+
+  return { ok: true, transport: 'http', payload };
+}
+
+export async function createClawhipOmxClient(options = {}) {
+  const discovery = await discoverClawhip(options);
+
+  async function emitEnvelope(envelope) {
+    const normalized = normalizeEnvelope(envelope);
+    if (discovery.transport === 'cli') {
+      return await emitViaCli(discovery.bin, normalized);
+    }
+    return await emitViaHttp(discovery.url, normalized);
+  }
+
+  async function emitNormalizedEvent({ normalizedEvent, context = {}, ...rest } = {}) {
+    return await emitEnvelope(buildHookEnvelope({ normalizedEvent, context, ...rest }));
+  }
+
+  return {
+    discovery,
+    emitEnvelope,
+    emitNormalizedEvent,
+    emitSessionStarted: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'started', ...args }),
+    emitSessionBlocked: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'blocked', ...args }),
+    emitSessionFinished: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'finished', ...args }),
+    emitSessionFailed: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'failed', ...args }),
+    emitRetryNeeded: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'retry-needed', ...args }),
+    emitPrCreated: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'pr-created', ...args }),
+    emitTestStarted: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'test-started', ...args }),
+    emitTestFinished: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'test-finished', ...args }),
+    emitTestFailed: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'test-failed', ...args }),
+    emitTestResult: ({ success = true, ok = true, ...args } = {}) =>
+      emitNormalizedEvent({
+        normalizedEvent: success === false || ok === false ? 'test-failed' : 'test-finished',
+        ...args,
+      }),
+    emitHandoffNeeded: (args = {}) => emitNormalizedEvent({ normalizedEvent: 'handoff-needed', ...args }),
+    emitToolUse: ({ normalizedEvent = '', context = {}, toolName, command, ...rest } = {}) => {
+      const mapped = pickFirstString(normalizedEvent);
+      if (!mapped) {
+        throw new Error(
+          'tool.use is not a canonical clawhip v1 event; provide a canonical normalizedEvent such as test-started, test-failed, pr-created, failed, or handoff-needed',
+        );
+      }
+      return emitNormalizedEvent({
+        normalizedEvent: mapped,
+        context: {
+          ...context,
+          ...(toolName ? { tool_name: toolName } : {}),
+          ...(command ? { command } : {}),
+        },
+        ...rest,
+      });
+    },
+    emitError: ({ normalizedEvent = 'failed', context = {}, errorSummary, ...rest } = {}) =>
+      emitNormalizedEvent({
+        normalizedEvent,
+        context: {
+          ...context,
+          ...(errorSummary ? { error_summary: errorSummary } : {}),
+        },
+        ...rest,
+      }),
+    emitFromHookEvent: async (event, overrides = {}) => {
+      const normalizedEvent = pickFirstString(
+        overrides.normalizedEvent,
+        overrides.context?.normalized_event,
+        event?.context?.normalized_event,
+      );
+
+      if (!normalizedEvent) {
+        return { ok: true, skipped: true, reason: 'missing_normalized_event' };
+      }
+      if (!isSupportedNormalizedEvent(normalizedEvent)) {
+        return {
+          ok: true,
+          skipped: true,
+          reason: 'unsupported_normalized_event',
+          normalized_event: normalizedEvent,
+        };
+      }
+
+      return await emitEnvelope({
+        ...event,
+        ...overrides,
+        schema_version: '1',
+        context: {
+          agent_name: 'omx',
+          ...(event?.context ?? {}),
+          ...(overrides.context ?? {}),
+          normalized_event: normalizedEvent,
+        },
+      });
+    },
+  };
+}

--- a/integrations/omx/install-hook.sh
+++ b/integrations/omx/install-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="${1:-$PWD/.omx/hooks}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$TARGET_DIR"
+install -m 0644 "$SCRIPT_DIR/clawhip-sdk.mjs" "$TARGET_DIR/clawhip-sdk.mjs"
+install -m 0644 "$SCRIPT_DIR/clawhip-hook.mjs" "$TARGET_DIR/clawhip.mjs"
+
+echo "Installed clawhip OMX hook bridge into $TARGET_DIR"
+echo "Next: validate with 'omx hooks validate' and test with 'omx hooks test' from your OMX workspace."

--- a/skills/omx/SKILL.md
+++ b/skills/omx/SKILL.md
@@ -1,11 +1,12 @@
 # clawhip × OMX (oh-my-codex)
 
-Launch [OMX](https://github.com/Yeachan-Heo/oh-my-codex) coding sessions with automatic Discord notifications via clawhip.
+Launch [OMX](https://github.com/Yeachan-Heo/oh-my-codex) coding sessions with native clawhip event routing and automatic Discord notifications.
 
 ## What you get
 
-- Legacy-compatible `agent.started`, `agent.finished`, and `agent.failed` wrapper emits via `clawhip emit`
+- Native lifecycle emits via `clawhip omx hook`
 - clawhip-side normalization of richer native OMC/OMX events into the canonical `session.*` routing contract
+- Native OMX hook bridge assets in `integrations/omx/` for first-class OMX plugin forwarding
 - Session keyword alerts (error, PR created, complete, etc.)
 - Stale session detection (no output for N minutes)
 - All notifications routed to the correct Discord channel
@@ -36,7 +37,9 @@ Launch [OMX](https://github.com/Yeachan-Heo/oh-my-codex) coding sessions with au
 ./create.sh issue-123 ~/my-project/worktrees/issue-123 "Fix the bug in src/main.rs and create a PR to dev" 1234567890 "<@user-id>"
 ```
 
-`create.sh` now emits lifecycle notifications directly from the OMX shell session, so you no longer need a separate lifecycle watcher command. If you pass a prompt, the script waits 10 seconds for the TUI to initialize, then sends the prompt via `tmux send-keys -l` before pressing Enter.
+`create.sh` now emits native clawhip v1 hook envelopes directly from the OMX shell session via `clawhip omx hook`, so you no longer need a separate lifecycle watcher command. If you pass a prompt, the script waits 10 seconds for the TUI to initialize, then sends the prompt via `tmux send-keys -l` before pressing Enter.
+
+For a first-class `.omx/hooks/*.mjs` bridge, see [`integrations/omx/`](../../integrations/omx/).
 
 ### Send a prompt
 

--- a/skills/omx/create.sh
+++ b/skills/omx/create.sh
@@ -44,34 +44,86 @@ ARGS=(
 [ -n "$CHANNEL" ] && ARGS+=(--channel "$CHANNEL")
 [ -n "$MENTION" ] && ARGS+=(--mention "$MENTION")
 
-EMIT_ARGS=()
-[ -n "$CHANNEL" ] && EMIT_ARGS+=(--channel "$CHANNEL")
-[ -n "$MENTION" ] && EMIT_ARGS+=(--mention "$MENTION")
-EMIT_SUFFIX=""
-if [ ${#EMIT_ARGS[@]} -gt 0 ]; then
-  printf -v EMIT_SUFFIX ' %q' "${EMIT_ARGS[@]}"
-fi
-
 quote() {
   printf '%q' "$1"
 }
 
-# Build the OMX command with native clawhip lifecycle emits
+# Build the OMX command with native clawhip hook-envelope lifecycle emits.
 OMX_CMD=$(cat <<EOF
 source ~/.zshrc
 START_TS=\$(date +%s)
+REPO_ROOT=\$(git -C $(quote "$WORKDIR") rev-parse --show-toplevel 2>/dev/null || printf %s $(quote "$WORKDIR"))
+BRANCH=\$(git -C $(quote "$WORKDIR") rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+emit_omx_event() {
+  local raw_event="\$1"
+  local normalized_event="\$2"
+  local status="\$3"
+  local summary="\${4:-}"
+  local error_summary="\${5:-}"
+  local elapsed="\${6:-}"
+  CLAWHIP_EVENT="\$raw_event" \\
+  CLAWHIP_NORMALIZED_EVENT="\$normalized_event" \\
+  CLAWHIP_STATUS="\$status" \\
+  CLAWHIP_SUMMARY="\$summary" \\
+  CLAWHIP_ERROR_SUMMARY="\$error_summary" \\
+  CLAWHIP_ELAPSED="\$elapsed" \\
+  CLAWHIP_SESSION=$(quote "$SESSION") \\
+  CLAWHIP_PROJECT=$(quote "$PROJECT") \\
+  CLAWHIP_REPO_PATH="\$REPO_ROOT" \\
+  CLAWHIP_WORKTREE_PATH=$(quote "$WORKDIR") \\
+  CLAWHIP_BRANCH="\$BRANCH" \\
+  CLAWHIP_CHANNEL=$(quote "$CHANNEL") \\
+  CLAWHIP_MENTION=$(quote "$MENTION") \\
+  node <<'NODE' | clawhip omx hook || true
+const clean = (value) => (typeof value === 'string' ? value.trim() : '');
+const number = (value) => {
+  const parsed = Number.parseInt(clean(value), 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+const payload = {
+  schema_version: '1',
+  event: clean(process.env.CLAWHIP_EVENT) || 'notify',
+  timestamp: new Date().toISOString(),
+  source: 'native',
+  context: {
+    normalized_event: clean(process.env.CLAWHIP_NORMALIZED_EVENT),
+    agent_name: 'omx',
+    session_name: clean(process.env.CLAWHIP_SESSION),
+    status: clean(process.env.CLAWHIP_STATUS),
+    project: clean(process.env.CLAWHIP_PROJECT),
+    repo_path: clean(process.env.CLAWHIP_REPO_PATH),
+    worktree_path: clean(process.env.CLAWHIP_WORKTREE_PATH),
+    branch: clean(process.env.CLAWHIP_BRANCH),
+  },
+  session_id: clean(process.env.CLAWHIP_SESSION),
+};
+const issueNumber = number(process.env.CLAWHIP_SESSION.match(/issue-(\\d+)/)?.[1] ?? '');
+if (issueNumber !== undefined) payload.context.issue_number = issueNumber;
+const summary = clean(process.env.CLAWHIP_SUMMARY);
+if (summary) payload.context.summary = summary;
+const errorSummary = clean(process.env.CLAWHIP_ERROR_SUMMARY);
+if (errorSummary) payload.context.error_summary = errorSummary;
+const elapsed = number(process.env.CLAWHIP_ELAPSED);
+if (elapsed !== undefined) payload.context.elapsed_secs = elapsed;
+const channel = clean(process.env.CLAWHIP_CHANNEL);
+if (channel) payload.channel = channel;
+const mention = clean(process.env.CLAWHIP_MENTION);
+if (mention) payload.mention = mention;
+process.stdout.write(JSON.stringify(payload));
+NODE
+}
 cleanup() {
   local exit_code=\$?
   local elapsed=\$(( \$(date +%s) - START_TS ))
   if [ "\$exit_code" -eq 0 ]; then
-    clawhip emit agent.finished --agent omx --session $(quote "$SESSION") --project $(quote "$PROJECT") --elapsed "\$elapsed"$EMIT_SUFFIX || true
+    emit_omx_event session-end finished finished "session finished" "" "\$elapsed"
   else
-    clawhip emit agent.failed --agent omx --session $(quote "$SESSION") --project $(quote "$PROJECT") --elapsed "\$elapsed" --error "exit \$exit_code"$EMIT_SUFFIX || true
+    emit_omx_event session-end failed failed "session failed" "exit \$exit_code" "\$elapsed"
   fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM
-clawhip emit agent.started --agent omx --session $(quote "$SESSION") --project $(quote "$PROJECT")$EMIT_SUFFIX || true
+emit_omx_event session-start started started "session started"
 ${OMX_ENV:+$OMX_ENV }omx $OMX_FLAGS
 EOF
 )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
+use std::io::Read;
 use std::path::PathBuf;
 
-use serde_json::Value;
-
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use serde_json::Value;
 
 use crate::events::MessageFormat;
 
@@ -75,6 +75,11 @@ pub enum Commands {
     Tmux {
         #[command(subcommand)]
         command: TmuxCommands,
+    },
+    /// Send native OMX hook-envelope events to the local daemon.
+    Omx {
+        #[command(subcommand)]
+        command: OmxCommands,
     },
     /// Install clawhip from the current git clone.
     Install {
@@ -279,6 +284,53 @@ pub struct AgentFailedArgs {
 #[derive(Debug, Clone, Subcommand)]
 pub enum PluginCommands {
     List,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum OmxCommands {
+    /// Forward an OMX v1 hook envelope to clawhip.
+    Hook(OmxHookArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct OmxHookArgs {
+    /// Provide the hook-envelope JSON inline.
+    #[arg(long)]
+    pub payload: Option<String>,
+    /// Read hook-envelope JSON from a file. Use "-" or omit to read stdin.
+    #[arg(long)]
+    pub file: Option<PathBuf>,
+}
+
+#[cfg_attr(test, allow(dead_code))]
+impl OmxHookArgs {
+    pub fn read_payload(&self, stdin: &mut dyn Read) -> crate::Result<serde_json::Value> {
+        match (&self.payload, &self.file) {
+            (Some(_), Some(_)) => {
+                Err("provide either --payload or --file for clawhip omx hook, not both".into())
+            }
+            (Some(payload), None) => Ok(serde_json::from_str(payload)?),
+            (None, Some(path)) => {
+                if path.as_os_str() == "-" {
+                    return Self::read_payload_from_stdin(stdin);
+                }
+                Ok(serde_json::from_str(&std::fs::read_to_string(path)?)?)
+            }
+            (None, None) => Self::read_payload_from_stdin(stdin),
+        }
+    }
+
+    fn read_payload_from_stdin(stdin: &mut dyn Read) -> crate::Result<serde_json::Value> {
+        let mut buffer = String::new();
+        stdin.read_to_string(&mut buffer)?;
+        let trimmed = buffer.trim();
+        if trimmed.is_empty() {
+            return Err(
+                "clawhip omx hook expects a JSON payload via stdin, --payload, or --file".into(),
+            );
+        }
+        Ok(serde_json::from_str(trimmed)?)
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -738,6 +790,60 @@ mod tests {
         };
 
         assert!(matches!(command, PluginCommands::List));
+    }
+
+    #[test]
+    fn parses_omx_hook_subcommand() {
+        let cli = Cli::parse_from(["clawhip", "omx", "hook", "--file", "payload.json"]);
+
+        let Commands::Omx { command } = cli.command.expect("omx command") else {
+            panic!("expected omx command");
+        };
+
+        let OmxCommands::Hook(args) = command;
+
+        assert_eq!(
+            args.file.as_deref(),
+            Some(PathBuf::from("payload.json").as_path())
+        );
+    }
+
+    #[test]
+    fn omx_hook_args_read_payload_from_inline_json() {
+        let args = OmxHookArgs {
+            payload: Some(
+                r#"{"schema_version":"1","context":{"normalized_event":"started"}}"#.into(),
+            ),
+            file: None,
+        };
+
+        let payload = args
+            .read_payload(&mut std::io::Cursor::new(Vec::<u8>::new()))
+            .expect("inline json payload");
+
+        assert_eq!(payload["schema_version"], serde_json::json!("1"));
+        assert_eq!(
+            payload["context"]["normalized_event"],
+            serde_json::json!("started")
+        );
+    }
+
+    #[test]
+    fn omx_hook_args_reject_empty_input() {
+        let args = OmxHookArgs {
+            payload: None,
+            file: None,
+        };
+
+        let error = args
+            .read_payload(&mut std::io::Cursor::new(Vec::<u8>::new()))
+            .expect_err("empty stdin should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("clawhip omx hook expects a JSON payload")
+        );
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,6 +25,10 @@ impl DaemonClient {
         self.post_json("/event", event).await.map(|_| ())
     }
 
+    pub async fn send_omx_hook(&self, envelope: &Value) -> Result<Value> {
+        self.post_json("/api/omx/hook", envelope).await
+    }
+
     pub async fn register_tmux(&self, registration: &RegisteredTmuxSession) -> Result<()> {
         self.post_json("/api/tmux/register", registration)
             .await

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,7 @@ use crate::Result;
 use crate::VERSION;
 use crate::config::AppConfig;
 use crate::dispatch::Dispatcher;
-use crate::event::compat::from_incoming_event;
+use crate::event::compat::{from_incoming_event, incoming_event_from_omx_hook_envelope_json};
 use crate::events::{IncomingEvent, normalize_event};
 use crate::render::{DefaultRenderer, Renderer};
 use crate::router::Router;
@@ -71,6 +71,8 @@ pub async fn run(config: Arc<AppConfig>, port_override: Option<u16>) -> Result<(
         .route("/event", post(post_event))
         .route("/api/event", post(post_event))
         .route("/events", post(post_event))
+        .route("/omx/hook", post(post_omx_hook))
+        .route("/api/omx/hook", post(post_omx_hook))
         .route("/api/tmux/register", post(register_tmux))
         .route("/github", post(post_github));
     let port = port_override.unwrap_or(config.daemon.port);
@@ -135,7 +137,28 @@ async fn post_event(
     State(state): State<AppState>,
     Json(event): Json<IncomingEvent>,
 ) -> impl IntoResponse {
-    let event = normalize_event(event);
+    accept_event(&state, normalize_event(event)).await
+}
+
+async fn post_omx_hook(
+    State(state): State<AppState>,
+    Json(payload): Json<Value>,
+) -> impl IntoResponse {
+    let event = match incoming_event_from_omx_hook_envelope_json(&payload) {
+        Ok(event) => normalize_event(event),
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"ok": false, "error": error.to_string()})),
+            )
+                .into_response();
+        }
+    };
+
+    accept_event(&state, event).await
+}
+
+async fn accept_event(state: &AppState, event: IncomingEvent) -> axum::response::Response {
     let envelope = match from_incoming_event(&event) {
         Ok(envelope) => envelope,
         Err(error) => {
@@ -361,6 +384,82 @@ mod tests {
                 .get("first_seen_at")
                 .and_then(Value::as_str)
                 .is_some_and(|value| !value.is_empty())
+        );
+    }
+
+    #[tokio::test]
+    async fn post_omx_hook_accepts_native_hook_envelope_and_queues_normalized_event() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+        };
+        let payload = json!({
+            "schema_version": "1",
+            "event": "session-start",
+            "timestamp": "2026-04-01T22:00:00Z",
+            "context": {
+                "normalized_event": "started",
+                "agent_name": "omx",
+                "session_name": "issue-65-native-sdk",
+                "status": "started",
+                "repo_path": "/repo/clawhip",
+                "branch": "feat/issue-65-native-sdk"
+            }
+        });
+
+        let response = post_omx_hook(State(state), Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response_json: Value = serde_json::from_slice(&body).unwrap();
+        let event_id = response_json["event_id"].as_str().unwrap();
+        assert!(!event_id.is_empty());
+        assert_eq!(response_json["type"], Value::from("session.started"));
+
+        let queued = rx.recv().await.unwrap();
+        assert_eq!(queued.kind, "session.started");
+        assert_eq!(queued.payload["tool"], Value::from("omx"));
+        assert_eq!(
+            queued.payload["session_name"],
+            Value::from("issue-65-native-sdk")
+        );
+        assert_eq!(queued.payload["event_id"], Value::from(event_id));
+    }
+
+    #[tokio::test]
+    async fn post_omx_hook_rejects_missing_normalized_event() {
+        let (tx, _rx) = mpsc::channel(1);
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+        };
+        let payload = json!({
+            "schema_version": "1",
+            "event": "session-start",
+            "context": {
+                "agent_name": "omx",
+                "status": "started"
+            }
+        });
+
+        let response = post_omx_hook(State(state), Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response_json: Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            response_json["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("context.normalized_event"))
         );
     }
 }

--- a/src/event/compat.rs
+++ b/src/event/compat.rs
@@ -17,6 +17,11 @@ pub fn from_incoming_event(event: &IncomingEvent) -> Result<EventEnvelope> {
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub fn from_omx_hook_envelope_json(payload: &Value) -> Result<EventEnvelope> {
+    let incoming = incoming_event_from_omx_hook_envelope_json(payload)?;
+    from_incoming_event(&incoming)
+}
+
+pub fn incoming_event_from_omx_hook_envelope_json(payload: &Value) -> Result<IncomingEvent> {
     let schema_version = payload
         .get("schema_version")
         .and_then(Value::as_str)
@@ -55,7 +60,7 @@ pub fn from_omx_hook_envelope_json(payload: &Value) -> Result<EventEnvelope> {
         payload: payload.clone(),
     };
 
-    from_incoming_event(&incoming)
+    Ok(incoming)
 }
 
 impl TryFrom<&IncomingEvent> for EventEnvelope {
@@ -718,6 +723,32 @@ mod tests {
             }
             other => panic!("expected AgentTestFailed body, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn converts_omx_hook_envelope_into_incoming_event() {
+        let event = incoming_event_from_omx_hook_envelope_json(&json!({
+            "schema_version": "1",
+            "event": "notify",
+            "channel": "alerts",
+            "mention": "@ops",
+            "context": {
+                "normalized_event": "pr-created",
+                "agent_name": "omx",
+                "status": "pr-created",
+                "session_name": "issue-65",
+                "pr_number": 91
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(event.kind, "notify");
+        assert_eq!(event.channel.as_deref(), Some("alerts"));
+        assert_eq!(event.mention.as_deref(), Some("@ops"));
+        assert_eq!(
+            event.payload["context"]["normalized_event"],
+            json!("pr-created")
+        );
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -755,6 +755,7 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
                 .and_then(infer_test_runner)
                 .map(ToString::to_string)
         });
+    let elapsed_secs = first_u64(payload, &["/elapsed_secs", "/context/elapsed_secs"]);
     let status = first_string(payload, &["/status", "/context/status", "/signal/phase"])
         .or_else(|| event_status_from_kind(canonical_kind).map(ToString::to_string));
     let summary = first_string(
@@ -873,6 +874,7 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
     insert_string_if_missing(object, "command", command);
     insert_string_if_missing(object, "tool_name", tool_name);
     insert_string_if_missing(object, "test_runner", test_runner);
+    insert_u64_if_missing(object, "elapsed_secs", elapsed_secs);
     insert_string_if_missing(object, "status", status);
     insert_string_if_missing(object, "summary", summary);
     insert_string_if_missing(object, "error_message", error_message);
@@ -1416,6 +1418,7 @@ mod tests {
                     "worktree_path": "/repo/clawhip-worktrees/issue-65",
                     "branch": "feat/issue-65-native-event-contract-polish",
                     "issue_number": 65,
+                    "elapsed_secs": 42,
                     "error_summary": "cargo test failed"
                 }
             }),
@@ -1429,6 +1432,7 @@ mod tests {
         );
         assert_eq!(event.payload["repo_name"], json!("clawhip"));
         assert_eq!(event.payload["issue_number"], json!(65));
+        assert_eq!(event.payload["elapsed_secs"], json!(42));
         assert_eq!(event.payload["error_message"], json!("cargo test failed"));
         assert_eq!(
             event.payload["event_timestamp"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use clap::Parser;
 
 use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, GitCommands, GithubCommands, MemoryCommands,
-    PluginCommands, TmuxCommands,
+    OmxCommands, PluginCommands, TmuxCommands,
 };
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
@@ -204,6 +204,15 @@ async fn real_main() -> Result<()> {
             }
             TmuxCommands::New(args) => tmux_wrapper::run(args, config.as_ref()).await,
             TmuxCommands::Watch(args) => tmux_wrapper::watch(args, config.as_ref()).await,
+        },
+        Commands::Omx { command } => match command {
+            OmxCommands::Hook(args) => {
+                let client = DaemonClient::from_config(config.as_ref());
+                let payload = args.read_payload(&mut std::io::stdin())?;
+                let response = client.send_omx_hook(&payload).await?;
+                println!("{}", serde_json::to_string(&response)?);
+                Ok(())
+            }
         },
         Commands::Config { command } => match command.unwrap_or(ConfigCommand::Interactive) {
             ConfigCommand::Interactive => {


### PR DESCRIPTION
## Summary
- add first-class OMX hook-envelope ingress to clawhip via `clawhip omx hook` and `/api/omx/hook`
- bundle OMX-facing bridge assets under `integrations/omx/` and upgrade the OMX session launcher to emit native v1 envelopes
- document the native ingress/discovery flow and extend verification coverage while preserving v1 contract compatibility

## Testing
- cargo test --quiet
- cargo clippy --all-targets --all-features -- -D warnings
- node --check integrations/omx/clawhip-sdk.mjs
- node --check integrations/omx/clawhip-hook.mjs
- bash -n skills/omx/create.sh integrations/omx/install-hook.sh
- git diff --check

Related: #65