### PR TITLE
feat: add automatic worktree commit monitoring for configured repos

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -560,6 +560,22 @@ impl IncomingEvent {
         self
     }
 
+    pub fn with_repo_context(
+        mut self,
+        repo_path: Option<String>,
+        worktree_path: Option<String>,
+    ) -> Self {
+        if let Some(payload) = self.payload.as_object_mut() {
+            if let Some(repo_path) = repo_path.filter(|value| !value.trim().is_empty()) {
+                payload.insert("repo_path".to_string(), json!(repo_path));
+            }
+            if let Some(worktree_path) = worktree_path.filter(|value| !value.trim().is_empty()) {
+                payload.insert("worktree_path".to_string(), json!(worktree_path));
+            }
+        }
+        self
+    }
+
     pub fn canonical_kind(&self) -> &str {
         match self.kind.as_str() {
             "issue-opened" => "github.issue-opened",
@@ -1083,6 +1099,27 @@ mod tests {
         .with_mention(Some("<@123>".into()));
 
         assert_eq!(event.mention.as_deref(), Some("<@123>"));
+    }
+
+    #[test]
+    fn with_repo_context_sets_repo_and_worktree_paths() {
+        let event = IncomingEvent::git_commit(
+            "repo".into(),
+            "main".into(),
+            "1234567890abcdef".into(),
+            "ship it".into(),
+            None,
+        )
+        .with_repo_context(
+            Some("/repo/root".into()),
+            Some("/repo/root/.worktrees/issue-115".into()),
+        );
+
+        assert_eq!(event.payload["repo_path"], json!("/repo/root"));
+        assert_eq!(
+            event.payload["worktree_path"],
+            json!("/repo/root/.worktrees/issue-115")
+        );
     }
 
     #[test]

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde_json::Value;
 
 use crate::Result;
@@ -133,40 +135,40 @@ impl Renderer for DefaultRenderer {
 
             ("git.commit", MessageFormat::Compact) => format!(
                 "git:{}@{} {} {}",
-                string_field(payload, "repo")?,
+                git_repo_label(payload)?,
                 string_field(payload, "branch")?,
                 string_field(payload, "short_commit")?,
                 string_field(payload, "summary")?
             ),
             ("git.commit", MessageFormat::Alert) => format!(
                 "🚨 new commit in {}@{}: {} {}",
-                string_field(payload, "repo")?,
+                git_repo_label(payload)?,
                 string_field(payload, "branch")?,
                 string_field(payload, "short_commit")?,
                 string_field(payload, "summary")?
             ),
             ("git.commit", MessageFormat::Inline) => format!(
                 "[git] {} {}",
-                string_field(payload, "repo")?,
+                git_repo_label(payload)?,
                 string_field(payload, "summary")?
             ),
             ("git.commit", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
 
             ("git.branch-changed", MessageFormat::Compact) => format!(
                 "git:{} branch changed {} -> {}",
-                string_field(payload, "repo")?,
+                git_repo_label(payload)?,
                 string_field(payload, "old_branch")?,
                 string_field(payload, "new_branch")?
             ),
             ("git.branch-changed", MessageFormat::Alert) => format!(
                 "🚨 git repo {} branch changed {} -> {}",
-                string_field(payload, "repo")?,
+                git_repo_label(payload)?,
                 string_field(payload, "old_branch")?,
                 string_field(payload, "new_branch")?
             ),
             ("git.branch-changed", MessageFormat::Inline) => format!(
                 "[git:{}] {} -> {}",
-                string_field(payload, "repo")?,
+                git_repo_label(payload)?,
                 string_field(payload, "old_branch")?,
                 string_field(payload, "new_branch")?
             ),
@@ -587,6 +589,30 @@ fn short_sha(sha: &str) -> String {
     sha.chars().take(7).collect()
 }
 
+fn git_repo_label(payload: &Value) -> Result<String> {
+    let repo = string_field(payload, "repo")?;
+    Ok(match worktree_display_name(payload) {
+        Some(worktree) => format!("{repo}[wt:{worktree}]"),
+        None => repo,
+    })
+}
+
+fn worktree_display_name(payload: &Value) -> Option<String> {
+    let worktree_path = optional_string_field(payload, "worktree_path")?;
+    let repo_path = optional_string_field(payload, "repo_path");
+    if repo_path.as_deref() == Some(worktree_path.as_str()) {
+        return None;
+    }
+
+    Path::new(&worktree_path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or(Some(worktree_path))
+}
+
 fn render_aggregated_git_commit(payload: &Value, format: &MessageFormat) -> Result<Option<String>> {
     let Some(commits) = payload.get("commits").and_then(Value::as_array) else {
         return Ok(None);
@@ -595,7 +621,7 @@ fn render_aggregated_git_commit(payload: &Value, format: &MessageFormat) -> Resu
         return Ok(None);
     }
 
-    let repo = string_field(payload, "repo")?;
+    let repo = git_repo_label(payload)?;
     let branch = string_field(payload, "branch")?;
     let summaries = commits
         .iter()
@@ -754,5 +780,42 @@ mod tests {
             .unwrap();
         assert!(rendered.contains("repo-a"));
         assert!(rendered.contains("workspace skill state changed"));
+    }
+
+    #[test]
+    fn renders_git_commit_with_worktree_suffix_when_distinct() {
+        let event = IncomingEvent::git_commit(
+            "repo".into(),
+            "main".into(),
+            "1234567890abcdef".into(),
+            "ship it".into(),
+            None,
+        )
+        .with_repo_context(
+            Some("/repo/root".into()),
+            Some("/repo/root/.worktrees/issue-115".into()),
+        );
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Compact)
+            .unwrap();
+        assert_eq!(rendered, "git:repo[wt:issue-115]@main 1234567 ship it");
+    }
+
+    #[test]
+    fn does_not_render_worktree_suffix_for_primary_repo_path() {
+        let event = IncomingEvent::git_commit(
+            "repo".into(),
+            "main".into(),
+            "1234567890abcdef".into(),
+            "ship it".into(),
+            None,
+        )
+        .with_repo_context(Some("/repo/root".into()), Some("/repo/root".into()));
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Compact)
+            .unwrap();
+        assert_eq!(rendered, "git:repo@main 1234567 ship it");
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -574,6 +574,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn preview_matches_git_routes_on_worktree_path() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "git.commit".into(),
+                sink: "discord".into(),
+                filter: [("worktree_path".to_string(), "*/issue-115".to_string())]
+                    .into_iter()
+                    .collect(),
+                channel: Some("worktrees".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: Some(MessageFormat::Compact),
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::git_commit(
+            "clawhip".into(),
+            "feat/issue-115".into(),
+            "1234567890abcdef".into(),
+            "ship it".into(),
+            None,
+        )
+        .with_repo_context(
+            Some("/repo/clawhip".into()),
+            Some("/repo/.worktrees/issue-115".into()),
+        );
+
+        let (channel, format, content) = router.preview(&event).await.unwrap();
+        assert_eq!(channel, "worktrees");
+        assert_eq!(format, MessageFormat::Compact);
+        assert_eq!(
+            content,
+            "git:clawhip[wt:issue-115]@feat/issue-115 1234567 ship it"
+        );
+    }
+
+    #[tokio::test]
     async fn route_level_mention_is_prepended_for_custom() {
         let config = AppConfig {
             defaults: DefaultsConfig {

--- a/src/source/git.rs
+++ b/src/source/git.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -47,6 +47,13 @@ struct GitRepoState {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+struct MonitoredGitPath {
+    state_key: String,
+    repo_path: String,
+    worktree_path: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct CommitEntry {
     pub(crate) sha: String,
     pub(crate) summary: String,
@@ -55,6 +62,8 @@ pub(crate) struct CommitEntry {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct GitSnapshot {
     pub(crate) repo_name: String,
+    pub(crate) repo_path: String,
+    pub(crate) worktree_path: String,
     pub(crate) branch: String,
     pub(crate) head: String,
     pub(crate) commits: Vec<CommitEntry>,
@@ -66,67 +75,141 @@ async fn poll_git(
     tx: &mpsc::Sender<IncomingEvent>,
     state: &mut HashMap<String, GitRepoState>,
 ) -> Result<()> {
+    let mut active_keys = HashSet::new();
+
     for repo in &config.monitors.git.repos {
-        match snapshot_git_repo(repo).await {
-            Ok(snapshot) => {
-                if let Some(previous) = state.get(&repo.path) {
-                    if repo.emit_branch_changes && previous.branch != snapshot.branch {
-                        send_event(
-                            tx,
-                            IncomingEvent::git_branch_changed(
-                                snapshot.repo_name.clone(),
-                                previous.branch.clone(),
-                                snapshot.branch.clone(),
-                                repo.channel.clone(),
+        let monitored_paths = discover_monitored_git_paths(repo)
+            .await
+            .unwrap_or_else(|error| {
+                eprintln!(
+                    "clawhip source git worktree discovery failed for {}: {error}",
+                    repo.path
+                );
+                vec![MonitoredGitPath {
+                    state_key: repo.path.clone(),
+                    repo_path: repo.path.clone(),
+                    worktree_path: repo.path.clone(),
+                }]
+            });
+
+        for monitored in monitored_paths {
+            active_keys.insert(monitored.state_key.clone());
+
+            match snapshot_git_worktree(repo, &monitored).await {
+                Ok(snapshot) => {
+                    if let Some(previous) = state.get(&monitored.state_key) {
+                        if repo.emit_branch_changes && previous.branch != snapshot.branch {
+                            send_event(
+                                tx,
+                                IncomingEvent::git_branch_changed(
+                                    snapshot.repo_name.clone(),
+                                    previous.branch.clone(),
+                                    snapshot.branch.clone(),
+                                    repo.channel.clone(),
+                                )
+                                .with_repo_context(
+                                    Some(snapshot.repo_path.clone()),
+                                    Some(snapshot.worktree_path.clone()),
+                                )
+                                .with_mention(repo.mention.clone())
+                                .with_format(repo.format.clone()),
                             )
-                            .with_mention(repo.mention.clone())
-                            .with_format(repo.format.clone()),
-                        )
-                        .await?;
-                    }
-                    if repo.emit_commits && previous.head != snapshot.head {
-                        let commits = list_new_commits(repo, &previous.head, &snapshot.head)
+                            .await?;
+                        }
+                        if repo.emit_commits && previous.head != snapshot.head {
+                            let commits = list_new_commits_for_path(
+                                &snapshot.worktree_path,
+                                &previous.head,
+                                &snapshot.head,
+                            )
                             .await
                             .ok()
                             .filter(|entries| !entries.is_empty())
                             .unwrap_or_else(|| snapshot.commits.clone());
-                        let events = IncomingEvent::git_commit_events(
-                            snapshot.repo_name.clone(),
-                            snapshot.branch.clone(),
-                            commits
-                                .into_iter()
-                                .map(|commit| (commit.sha, commit.summary))
-                                .collect(),
-                            repo.channel.clone(),
-                        );
-                        for event in events {
-                            send_event(
-                                tx,
-                                event
-                                    .with_mention(repo.mention.clone())
-                                    .with_format(repo.format.clone()),
-                            )
-                            .await?;
+                            let events = IncomingEvent::git_commit_events(
+                                snapshot.repo_name.clone(),
+                                snapshot.branch.clone(),
+                                commits
+                                    .into_iter()
+                                    .map(|commit| (commit.sha, commit.summary))
+                                    .collect(),
+                                repo.channel.clone(),
+                            );
+                            for event in events {
+                                send_event(
+                                    tx,
+                                    event
+                                        .with_repo_context(
+                                            Some(snapshot.repo_path.clone()),
+                                            Some(snapshot.worktree_path.clone()),
+                                        )
+                                        .with_mention(repo.mention.clone())
+                                        .with_format(repo.format.clone()),
+                                )
+                                .await?;
+                            }
                         }
                     }
-                }
 
-                state.insert(
-                    repo.path.clone(),
-                    GitRepoState {
-                        branch: snapshot.branch,
-                        head: snapshot.head,
-                    },
-                );
+                    state.insert(
+                        monitored.state_key.clone(),
+                        GitRepoState {
+                            branch: snapshot.branch,
+                            head: snapshot.head,
+                        },
+                    );
+                }
+                Err(error) => eprintln!(
+                    "clawhip source git snapshot failed for {}: {error}",
+                    monitored.worktree_path
+                ),
             }
-            Err(error) => eprintln!(
-                "clawhip source git snapshot failed for {}: {error}",
-                repo.path
-            ),
         }
     }
 
+    state.retain(|key, _| active_keys.contains(key));
+
     Ok(())
+}
+
+async fn discover_monitored_git_paths(repo: &GitRepoMonitor) -> Result<Vec<MonitoredGitPath>> {
+    let output = run_command(
+        &git_bin(),
+        &["-C", &repo.path, "worktree", "list", "--porcelain"],
+    )
+    .await?;
+
+    let mut seen = HashSet::new();
+    let mut monitored = Vec::new();
+    for worktree_path in parse_worktree_list(&output) {
+        if seen.insert(worktree_path.clone()) {
+            monitored.push(MonitoredGitPath {
+                state_key: worktree_path.clone(),
+                repo_path: repo.path.clone(),
+                worktree_path,
+            });
+        }
+    }
+
+    if monitored.is_empty() {
+        monitored.push(MonitoredGitPath {
+            state_key: repo.path.clone(),
+            repo_path: repo.path.clone(),
+            worktree_path: repo.path.clone(),
+        });
+    }
+
+    Ok(monitored)
+}
+
+fn parse_worktree_list(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(ToString::to_string)
+        .collect()
 }
 
 async fn send_event(tx: &mpsc::Sender<IncomingEvent>, event: IncomingEvent) -> Result<()> {
@@ -136,18 +219,47 @@ async fn send_event(tx: &mpsc::Sender<IncomingEvent>, event: IncomingEvent) -> R
 }
 
 pub(crate) async fn snapshot_git_repo(repo: &GitRepoMonitor) -> Result<GitSnapshot> {
-    let head = run_command(&git_bin(), &["-C", &repo.path, "rev-parse", "HEAD"]).await?;
-    let branch = run_command(
+    snapshot_git_worktree(
+        repo,
+        &MonitoredGitPath {
+            state_key: repo.path.clone(),
+            repo_path: repo.path.clone(),
+            worktree_path: repo.path.clone(),
+        },
+    )
+    .await
+}
+
+async fn snapshot_git_worktree(
+    repo: &GitRepoMonitor,
+    monitored: &MonitoredGitPath,
+) -> Result<GitSnapshot> {
+    let head = run_command(
         &git_bin(),
-        &["-C", &repo.path, "rev-parse", "--abbrev-ref", "HEAD"],
+        &["-C", &monitored.worktree_path, "rev-parse", "HEAD"],
     )
     .await?;
-    let summary = run_command(&git_bin(), &["-C", &repo.path, "log", "-1", "--pretty=%s"]).await?;
+    let branch = run_command(
+        &git_bin(),
+        &[
+            "-C",
+            &monitored.worktree_path,
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+        ],
+    )
+    .await?;
+    let summary = run_command(
+        &git_bin(),
+        &["-C", &monitored.worktree_path, "log", "-1", "--pretty=%s"],
+    )
+    .await?;
     let remote_url = run_command(
         &git_bin(),
         &[
             "-C",
-            &repo.path,
+            &monitored.worktree_path,
             "config",
             "--get",
             &format!("remote.{}.url", repo.remote),
@@ -158,6 +270,8 @@ pub(crate) async fn snapshot_git_repo(repo: &GitRepoMonitor) -> Result<GitSnapsh
 
     Ok(GitSnapshot {
         repo_name: repo_display_name(repo),
+        repo_path: monitored.repo_path.clone(),
+        worktree_path: monitored.worktree_path.clone(),
         branch,
         head: head.clone(),
         commits: vec![CommitEntry { sha: head, summary }],
@@ -168,16 +282,12 @@ pub(crate) async fn snapshot_git_repo(repo: &GitRepoMonitor) -> Result<GitSnapsh
     })
 }
 
-pub(crate) async fn list_new_commits(
-    repo: &GitRepoMonitor,
-    old: &str,
-    new: &str,
-) -> Result<Vec<CommitEntry>> {
+async fn list_new_commits_for_path(path: &str, old: &str, new: &str) -> Result<Vec<CommitEntry>> {
     let output = run_command(
         &git_bin(),
         &[
             "-C",
-            &repo.path,
+            path,
             "log",
             "--reverse",
             "--pretty=%H%x1f%s",
@@ -244,6 +354,7 @@ pub(crate) fn parse_github_repo(remote: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn parses_github_repo_urls() {
@@ -255,5 +366,100 @@ mod tests {
             parse_github_repo("https://github.com/bellman/clawhip.git"),
             Some("bellman/clawhip".to_string())
         );
+    }
+
+    #[test]
+    fn parses_worktree_list_output() {
+        let output = "worktree /repo/root\nHEAD abc\nbranch refs/heads/main\n\nworktree /repo/.worktrees/issue-115\nHEAD def\nbranch refs/heads/feat/issue-115\n";
+        assert_eq!(
+            parse_worktree_list(output),
+            vec![
+                "/repo/root".to_string(),
+                "/repo/.worktrees/issue-115".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_git_emits_branch_and_commit_events_for_linked_worktree() {
+        let sandbox = TempDir::new().unwrap();
+        let root = sandbox.path().join("repo");
+        let worktree = sandbox.path().join("repo-issue-115");
+        init_repo(&root).await;
+        git(
+            &root,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feat/issue-115",
+                path_str(&worktree),
+            ],
+        )
+        .await;
+
+        let repo = GitRepoMonitor {
+            path: path_str(&root).to_string(),
+            name: Some("clawhip".into()),
+            ..GitRepoMonitor::default()
+        };
+        let config = AppConfig {
+            monitors: crate::config::MonitorConfig {
+                git: crate::config::GitMonitorConfig { repos: vec![repo] },
+                ..crate::config::MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut state = HashMap::new();
+
+        poll_git(&config, &tx, &mut state).await.unwrap();
+        assert!(rx.try_recv().is_err());
+
+        git(&worktree, &["checkout", "-b", "feat/issue-115-v2"]).await;
+        poll_git(&config, &tx, &mut state).await.unwrap();
+        let branch_event = rx.try_recv().unwrap();
+        assert_eq!(branch_event.kind, "git.branch-changed");
+        assert_eq!(branch_event.payload["repo"], "clawhip");
+        assert_eq!(branch_event.payload["repo_path"], path_str(&root));
+        assert_eq!(branch_event.payload["worktree_path"], path_str(&worktree));
+        assert_eq!(branch_event.payload["old_branch"], "feat/issue-115");
+        assert_eq!(branch_event.payload["new_branch"], "feat/issue-115-v2");
+        assert!(rx.try_recv().is_err());
+
+        std::fs::write(worktree.join("worktree.txt"), "hello from worktree\n").unwrap();
+        git(&worktree, &["add", "worktree.txt"]).await;
+        git(&worktree, &["commit", "-m", "worktree commit"]).await;
+
+        poll_git(&config, &tx, &mut state).await.unwrap();
+        let commit_event = rx.try_recv().unwrap();
+        assert_eq!(commit_event.kind, "git.commit");
+        assert_eq!(commit_event.payload["repo"], "clawhip");
+        assert_eq!(commit_event.payload["repo_path"], path_str(&root));
+        assert_eq!(commit_event.payload["worktree_path"], path_str(&worktree));
+        assert_eq!(commit_event.payload["branch"], "feat/issue-115-v2");
+        assert_eq!(commit_event.payload["summary"], "worktree commit");
+        assert!(rx.try_recv().is_err());
+    }
+
+    async fn init_repo(root: &Path) {
+        std::fs::create_dir_all(root).unwrap();
+        git(root, &["init"]).await;
+        git(root, &["config", "user.name", "Test User"]).await;
+        git(root, &["config", "user.email", "test@example.com"]).await;
+        std::fs::write(root.join("README.md"), "seed\n").unwrap();
+        git(root, &["add", "README.md"]).await;
+        git(root, &["commit", "-m", "initial commit"]).await;
+    }
+
+    async fn git(root: &Path, args: &[&str]) {
+        let mut command_args = vec!["-C", path_str(root)];
+        command_args.extend_from_slice(args);
+        run_command(&git_bin(), &command_args).await.unwrap();
+    }
+
+    fn path_str(path: &Path) -> &str {
+        path.to_str().unwrap()
     }
 }

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -131,6 +131,8 @@ async fn snapshot_github_repo(repo: &GitRepoMonitor) -> Result<GitSnapshot> {
                 );
                 Ok(GitSnapshot {
                     repo_name: repo_display_name(repo),
+                    repo_path: repo.path.clone(),
+                    worktree_path: repo.path.clone(),
                     branch: String::new(),
                     head: String::new(),
                     commits: Vec::new(),


### PR DESCRIPTION
## Summary
- discover linked worktrees for each configured git monitor via `git worktree list --porcelain`
- poll each observed repo/worktree path and emit existing `git.commit` / `git.branch-changed` events on HEAD or ref changes
- attach `repo_path` and `worktree_path` metadata so routes can target worktree activity and renderers can label worktree-originated events
- add focused tests for worktree discovery, polling, renderer behavior, and router filtering

## Verification
- `cargo test`

Refs #115
