### PR TITLE
fix: allow stale_minutes=0 to disable stale detection

### DIFF
--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -587,7 +587,10 @@ fn insert_resolved_session(
 }
 
 fn should_emit_stale(pane: &TmuxPaneState, now: Instant, stale_minutes: u64) -> bool {
-    let stale_after = Duration::from_secs(stale_minutes.max(1) * 60);
+    if stale_minutes == 0 {
+        return false;
+    }
+    let stale_after = Duration::from_secs(stale_minutes * 60);
     now.duration_since(pane.last_change) >= stale_after
         && pane
             .last_stale_notification
@@ -1549,5 +1552,34 @@ error: failed";
             Some("specific-alerts")
         );
         assert_eq!(resolved["abc-prod"].keywords, vec!["panic"]);
+    }
+
+
+    #[test]
+    fn stale_minutes_zero_disables_stale_detection() {
+        let pane = TmuxPaneState {
+            session: "test".into(),
+            pane_name: "0.0".into(),
+            snapshot: String::new(),
+            content_hash: 0,
+            last_change: Instant::now() - Duration::from_secs(3600),
+            last_stale_notification: None,
+        };
+        // stale_minutes=0 should never emit, even after 1 hour idle
+        assert!(!should_emit_stale(&pane, Instant::now(), 0));
+    }
+
+    #[test]
+    fn stale_minutes_nonzero_still_emits() {
+        let pane = TmuxPaneState {
+            session: "test".into(),
+            pane_name: "0.0".into(),
+            snapshot: String::new(),
+            content_hash: 0,
+            last_change: Instant::now() - Duration::from_secs(3600),
+            last_stale_notification: None,
+        };
+        // stale_minutes=1 should emit after 1 hour idle
+        assert!(should_emit_stale(&pane, Instant::now(), 1));
     }
 }


### PR DESCRIPTION
## Problem

When monitoring long-running daemon processes (e.g. Discord bots, background agents) inside tmux sessions, `stale_minutes=0` should disable stale detection — but currently it doesn't.

The `should_emit_stale` function uses `.max(1)`, which forces a minimum of 1 minute:

```rust
let stale_after = Duration::from_secs(stale_minutes.max(1) * 60);
```

This means daemon processes that are idle by design (waiting for incoming messages) trigger stale alerts every minute, flooding the notification channel.

## Use Case

We run NanoClaw (Discord/Telegram bot agent) inside clawhip-monitored tmux sessions. The bot sits idle until a message arrives — this is normal behavior, not a stale session.

We want keyword monitoring (`error`, `crash`, `FATAL`) without stale alerts:

```toml
[[monitors.tmux.sessions]]
session = "nanoclaw"
stale_minutes = 0
keywords = ["error", "crash", "FATAL"]
```

## Root Cause

`.max(1)` was likely added to prevent `Duration::from_secs(0)` from triggering instant stale alerts when a user accidentally sets `stale_minutes=0`. This is a reasonable safeguard — but it also prevents intentional opt-out.

## Fix

Treat `stale_minutes=0` as an explicit opt-out instead of clamping to 1:

```rust
fn should_emit_stale(..., stale_minutes: u64) -> bool {
    if stale_minutes == 0 {
        return false;
    }
    let stale_after = Duration::from_secs(stale_minutes * 60);
    // ...
}
```

**Behavior change:**
- `stale_minutes=0` → stale detection disabled (new)
- `stale_minutes=1+` → works exactly as before (unchanged)
- Default (`10`) → unchanged

## Testing

Verified locally with two tmux sessions:
- `stale_minutes=0` → no stale alert after 5+ minutes ✅
- `stale_minutes=1` → stale alert after 1 minute ✅