### PR TITLE
fix: keep cron startup alive with empty or invalid persisted state

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -425,7 +425,22 @@ fn load_scheduler_state(path: &Path) -> Result<CronSchedulerState> {
         return Ok(CronSchedulerState::default());
     }
 
-    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+    let raw = fs::read_to_string(path)?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(CronSchedulerState::default());
+    }
+
+    match serde_json::from_str(trimmed) {
+        Ok(state) => Ok(state),
+        Err(error) => {
+            eprintln!(
+                "clawhip cron state '{}' is invalid; ignoring persisted state: {error}",
+                path.display()
+            );
+            Ok(CronSchedulerState::default())
+        }
+    }
 }
 
 fn save_scheduler_state(path: &Path, state: &CronSchedulerState) -> Result<()> {
@@ -537,6 +552,32 @@ mod tests {
 
         let events = emitter.events.lock().expect("events lock");
         assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn scheduler_startup_tolerates_empty_state_file() {
+        let dir = tempdir().expect("tempdir");
+        let state_path = dir.path().join("cron-state.json");
+        fs::write(&state_path, "").expect("write empty state");
+
+        let scheduler =
+            CronScheduler::new_with_state_path(&sample_config("*/10 * * * *"), state_path)
+                .expect("scheduler");
+
+        assert_eq!(scheduler.last_processed_minute, None);
+    }
+
+    #[test]
+    fn scheduler_startup_tolerates_invalid_state_file() {
+        let dir = tempdir().expect("tempdir");
+        let state_path = dir.path().join("cron-state.json");
+        fs::write(&state_path, "{not-json").expect("write invalid state");
+
+        let scheduler =
+            CronScheduler::new_with_state_path(&sample_config("*/10 * * * *"), state_path)
+                .expect("scheduler");
+
+        assert_eq!(scheduler.last_processed_minute, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make cron scheduler state loading fail open for empty or malformed `cron-state.json` contents
- log a warning for malformed persisted state and continue with a clean in-memory scheduler state
- add regression tests covering empty and invalid startup state files

## Repro / root cause
- reproduced issue #131 locally from this worktree by restarting the installed binary with a zero-byte `~/.clawhip/cron-state.json`
- exact failure path: `src/main.rs:59-62` -> `src/daemon.rs:80-81` -> `CronSource::run` -> `CronScheduler::new_with_state_path` / `new_internal` in `src/cron.rs:133-149` -> `load_scheduler_state` in `src/cron.rs:423-444`
- before this patch, `serde_json::from_str("")` raised `EOF while parsing a value at line 1 column 0`, which bubbled up and stopped the cron source during daemon startup

## Verification
- `cargo fmt --all --check`
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- real local install + restart smoke with empty `~/.clawhip/cron-state.json`: daemon stayed up, cron source did not stop, and the next poll rewrote a valid state file

Fixes #131