### PR TITLE
Unify Discord channel resolution precedence

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -204,10 +204,9 @@ impl Router {
                     return Ok(SinkTarget::DiscordWebhook(webhook.to_string()));
                 }
 
-                let channel = event
-                    .channel
-                    .clone()
-                    .or_else(|| route.and_then(|route| route.channel.clone()))
+                let channel = route
+                    .and_then(|route| route.channel.clone())
+                    .or_else(|| event.channel.clone())
                     .or_else(|| self.config.defaults.channel.clone())
                     .ok_or_else(|| {
                         format!("no channel configured for event {}", event.canonical_kind())
@@ -1238,6 +1237,78 @@ mod tests {
         assert_eq!(
             delivery.target,
             SinkTarget::DiscordWebhook("https://discord.com/api/webhooks/123/abc".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn route_channel_takes_precedence_over_event_channel() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                sink: "discord".into(),
+                filter: Default::default(),
+                channel: Some("route-channel".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::tmux_keyword(
+            "issue-25".into(),
+            "error".into(),
+            "boom".into(),
+            Some("launcher-channel".into()),
+        );
+
+        let delivery = router.preview_delivery(&event).await.unwrap();
+        assert_eq!(
+            delivery.target,
+            SinkTarget::DiscordChannel("route-channel".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn event_channel_is_used_when_matching_route_has_no_channel() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                sink: "discord".into(),
+                filter: Default::default(),
+                channel: None,
+                webhook: None,
+                slack_webhook: None,
+                mention: Some("<@route>".into()),
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::tmux_keyword(
+            "issue-25".into(),
+            "error".into(),
+            "boom".into(),
+            Some("monitor-channel".into()),
+        );
+
+        let delivery = router.preview_delivery(&event).await.unwrap();
+        assert_eq!(
+            delivery.target,
+            SinkTarget::DiscordChannel("monitor-channel".into())
         );
     }
 

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -751,7 +751,7 @@ mod tests {
     use serde_json::json;
 
     #[tokio::test]
-    async fn new_issue_events_match_repo_filter_and_route_mention() {
+    async fn new_issue_events_apply_route_channel_and_mention_over_repo_monitor_channel() {
         let repo = GitRepoMonitor {
             path: "/tmp/clawhip".into(),
             name: Some("clawhip".into()),
@@ -797,7 +797,7 @@ mod tests {
         };
         let router = Router::new(Arc::new(config));
         let (channel, _, content) = router.preview(&events[0]).await.unwrap();
-        assert_eq!(channel, "dev-channel");
+        assert_eq!(channel, "route-channel");
         assert!(content.starts_with("<@1465264645320474637> "));
         assert!(content.contains("live issue"));
     }


### PR DESCRIPTION
## Summary
- make Discord route channels override source-provided event channels when a matching route specifies a target
- keep source-provided channels as the fallback before `defaults.channel` when the route has no channel
- add regression coverage for launcher-channel, monitor-channel, and GitHub repo-monitor routing cases

## Current vs new precedence
- before: webhook > event/monitor/launcher channel > route channel > defaults.channel
- after: webhook > route channel > event/monitor/launcher channel > defaults.channel

## Verification
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- reproducible case: `cargo test new_issue_events_apply_route_channel_and_mention_over_repo_monitor_channel`
- reproducible case: `cargo test route_channel_takes_precedence_over_event_channel`