### PR TITLE
Prevent cron from dying on empty startup state

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -425,7 +425,26 @@ fn load_scheduler_state(path: &Path) -> Result<CronSchedulerState> {
         return Ok(CronSchedulerState::default());
     }
 
-    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+    let raw = fs::read_to_string(path)?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        eprintln!(
+            "clawhip cron state '{}' is empty; starting with fresh scheduler state",
+            path.display()
+        );
+        return Ok(CronSchedulerState::default());
+    }
+
+    match serde_json::from_str(trimmed) {
+        Ok(state) => Ok(state),
+        Err(error) => {
+            eprintln!(
+                "clawhip cron state '{}' is invalid JSON ({error}); starting with fresh scheduler state",
+                path.display()
+            );
+            Ok(CronSchedulerState::default())
+        }
+    }
 }
 
 fn save_scheduler_state(path: &Path, state: &CronSchedulerState) -> Result<()> {
@@ -537,6 +556,32 @@ mod tests {
 
         let events = emitter.events.lock().expect("events lock");
         assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn scheduler_starts_with_empty_state_file() {
+        let dir = tempdir().expect("tempdir");
+        let state_path = dir.path().join("cron-state.json");
+        let config = sample_config("*/10 * * * *");
+        fs::write(&state_path, "").expect("write empty state");
+
+        let scheduler =
+            CronScheduler::new_with_state_path(&config, state_path).expect("scheduler starts");
+
+        assert_eq!(scheduler.last_processed_minute, None);
+    }
+
+    #[test]
+    fn scheduler_starts_with_invalid_state_file() {
+        let dir = tempdir().expect("tempdir");
+        let state_path = dir.path().join("cron-state.json");
+        let config = sample_config("*/10 * * * *");
+        fs::write(&state_path, "{not-json").expect("write invalid state");
+
+        let scheduler =
+            CronScheduler::new_with_state_path(&config, state_path).expect("scheduler starts");
+
+        assert_eq!(scheduler.last_processed_minute, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat empty or invalid `cron-state.json` as fresh scheduler state instead of killing the cron source at startup
- log the exact state-file path when cron recovers from bad persisted state
- add regression coverage for empty and invalid cron state startup cases

## Reproduction
I reproduced issue #130 locally with an empty state file next to the active config:
- config: `/tmp/clawhip-issue130-ynzmh66i/config.toml`
- state: `/tmp/clawhip-issue130-ynzmh66i/cron-state.json`
- startup path: `main::real_main -> daemon::run -> spawn_source(CronSource) -> CronSource::run -> CronScheduler::new_with_state_path -> CronScheduler::new_internal -> load_scheduler_state`

Before this change, that empty state file produced:
- `clawhip source 'cron' starting`
- `clawhip source 'cron' stopped: EOF while parsing a value at line 1 column 0`

After this change, startup logs a path-bearing warning and keeps the cron source alive.

## Verification
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1`
- `cargo test dispatch::tests::dispatcher_sends_bypass_events_immediately_while_routine_delivery_waits -- --nocapture`
- local daemon start/restart smoke with empty `cron-state.json` plus `/health` checks on `127.0.0.1:25301`

## Notes
- default parallel `cargo test` remains intermittently flaky in existing dispatch webhook timing tests in this workspace; sequential test execution passed cleanly.

Fixes #130.
