### PR TITLE
Issue #150: add explicit in-place config reload path

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -499,6 +499,8 @@ pub enum ConfigCommand {
     Interactive,
     Show,
     Path,
+    /// Ask the running daemon to hot-reload routes/defaults/cron from disk.
+    Reload,
 }
 
 #[cfg(test)]
@@ -963,5 +965,16 @@ mod tests {
 
         assert!(systemd);
         assert!(skip_star_prompt);
+    }
+
+    #[test]
+    fn parses_config_reload_subcommand() {
+        let cli = Cli::parse_from(["clawhip", "config", "reload"]);
+
+        let Commands::Config { command } = cli.command.expect("config command") else {
+            panic!("expected config command");
+        };
+
+        assert!(matches!(command, Some(ConfigCommand::Reload)));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,6 +65,10 @@ impl DaemonClient {
         }
     }
 
+    pub async fn reload_config(&self) -> Result<Value> {
+        self.post_json("/api/config/reload", &Value::Null).await
+    }
+
     async fn post_json<T: Serialize>(&self, path: &str, payload: &T) -> Result<Value> {
         let response = self
             .http

--- a/src/config.rs
+++ b/src/config.rs
@@ -530,6 +530,12 @@ impl AppConfig {
         Ok(toml::to_string_pretty(self)?)
     }
 
+    pub fn apply_hot_reload_from(&mut self, updated: &Self) {
+        self.defaults = updated.defaults.clone();
+        self.routes = updated.routes.clone();
+        self.cron = updated.cron.clone();
+    }
+
     pub fn save(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
@@ -1444,5 +1450,54 @@ poll_interval_secs = 9
         let config = AppConfig::load_or_default(&path).unwrap();
         assert!(config.monitors.workspace.is_empty());
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn hot_reload_updates_only_routes_defaults_and_cron() {
+        let mut current = AppConfig::default();
+        current.daemon.base_url = "http://127.0.0.1:25294".into();
+        current.defaults.channel = Some("before".into());
+        current.monitors.git.repos.push(GitRepoMonitor {
+            path: ".".into(),
+            name: Some("repo".into()),
+            channel: Some("git".into()),
+            ..GitRepoMonitor::default()
+        });
+
+        let mut updated = AppConfig::default();
+        updated.daemon.base_url = "http://127.0.0.1:29999".into();
+        updated.defaults.channel = Some("after".into());
+        updated.routes.push(RouteRule {
+            event: "custom".into(),
+            filter: BTreeMap::new(),
+            sink: default_sink_name(),
+            channel: Some("ops".into()),
+            webhook: None,
+            slack_webhook: None,
+            mention: None,
+            allow_dynamic_tokens: false,
+            format: None,
+            template: None,
+        });
+        updated.cron.jobs.push(CronJob {
+            id: "dev-followup".into(),
+            schedule: "* * * * *".into(),
+            timezone: "UTC".into(),
+            enabled: true,
+            channel: Some("ops".into()),
+            mention: None,
+            format: Some(MessageFormat::Alert),
+            kind: CronJobKind::CustomMessage {
+                message: "check open PRs".into(),
+            },
+        });
+
+        current.apply_hot_reload_from(&updated);
+
+        assert_eq!(current.defaults.channel.as_deref(), Some("after"));
+        assert_eq!(current.routes.len(), 1);
+        assert_eq!(current.cron.jobs.len(), 1);
+        assert_eq!(current.daemon.base_url, "http://127.0.0.1:25294");
+        assert_eq!(current.monitors.git.repos.len(), 1);
     }
 }

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use time::{OffsetDateTime, Weekday};
-use tokio::sync::mpsc;
-use tokio::time::{MissedTickBehavior, interval};
+use tokio::sync::{mpsc, watch};
+use tokio::time::sleep;
 
 use crate::Result;
 use crate::client::DaemonClient;
@@ -17,13 +17,35 @@ use crate::events::IncomingEvent;
 use crate::source::Source;
 
 pub struct CronSource {
-    config: Arc<AppConfig>,
+    config: ConfigHandle,
     state_path: PathBuf,
+}
+
+enum ConfigHandle {
+    Static(Arc<AppConfig>),
+    Dynamic(watch::Receiver<Arc<AppConfig>>),
 }
 
 impl CronSource {
     pub fn new(config: Arc<AppConfig>, state_path: PathBuf) -> Self {
-        Self { config, state_path }
+        Self {
+            config: ConfigHandle::Static(config),
+            state_path,
+        }
+    }
+
+    pub fn from_receiver(config: watch::Receiver<Arc<AppConfig>>, state_path: PathBuf) -> Self {
+        Self {
+            config: ConfigHandle::Dynamic(config),
+            state_path,
+        }
+    }
+
+    fn current_config(&self) -> Arc<AppConfig> {
+        match &self.config {
+            ConfigHandle::Static(config) => config.clone(),
+            ConfigHandle::Dynamic(config) => config.borrow().clone(),
+        }
     }
 }
 
@@ -34,22 +56,76 @@ impl Source for CronSource {
     }
 
     async fn run(&self, tx: mpsc::Sender<IncomingEvent>) -> Result<()> {
-        if self.config.cron.jobs.is_empty() {
-            return Ok(());
-        }
-
+        let mut config_rx = match &self.config {
+            ConfigHandle::Static(_) => None,
+            ConfigHandle::Dynamic(config) => Some(config.clone()),
+        };
+        let mut config = self.current_config();
         let mut scheduler =
-            CronScheduler::new_with_state_path(self.config.as_ref(), self.state_path.clone())?;
-        let mut tick = interval(Duration::from_secs(
-            self.config.cron.poll_interval_secs.max(1),
-        ));
-        tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            CronScheduler::new_with_state_path(config.as_ref(), self.state_path.clone())?;
+        let mut current_signature = cron_signature(config.as_ref());
 
         loop {
-            tick.tick().await;
+            refresh_scheduler_if_needed(
+                &mut scheduler,
+                &mut current_signature,
+                config.as_ref(),
+                &self.state_path,
+            )?;
+
+            if scheduler.is_empty() {
+                let Some(receiver) = config_rx.as_mut() else {
+                    return Ok(());
+                };
+                if receiver.changed().await.is_err() {
+                    return Ok(());
+                }
+                config = receiver.borrow_and_update().clone();
+                continue;
+            }
+
             scheduler.emit_due(&tx, OffsetDateTime::now_utc()).await?;
+
+            let poll_interval = Duration::from_secs(config.cron.poll_interval_secs.max(1));
+            if let Some(receiver) = config_rx.as_mut() {
+                tokio::select! {
+                    _ = sleep(poll_interval) => {
+                        config = receiver.borrow().clone();
+                    }
+                    changed = receiver.changed() => {
+                        if changed.is_err() {
+                            return Ok(());
+                        }
+                        config = receiver.borrow_and_update().clone();
+                    }
+                }
+            } else {
+                sleep(poll_interval).await;
+            }
         }
     }
+}
+
+fn cron_signature(config: &AppConfig) -> String {
+    format!(
+        "{}:{}",
+        config.cron.poll_interval_secs,
+        toml::to_string(&config.cron).unwrap_or_default()
+    )
+}
+
+fn refresh_scheduler_if_needed(
+    scheduler: &mut CronScheduler,
+    current_signature: &mut String,
+    config: &AppConfig,
+    state_path: &Path,
+) -> Result<()> {
+    let next_signature = cron_signature(config);
+    if next_signature != *current_signature {
+        *scheduler = CronScheduler::new_with_state_path(config, state_path.to_path_buf())?;
+        *current_signature = next_signature;
+    }
+    Ok(())
 }
 
 #[async_trait::async_trait]
@@ -153,6 +229,10 @@ impl CronScheduler {
             last_processed_minute,
             state_path,
         })
+    }
+
+    fn is_empty(&self) -> bool {
+        self.jobs.is_empty()
     }
 
     async fn emit_due<E>(&mut self, emitter: &E, now: OffsetDateTime) -> Result<Vec<String>>
@@ -455,11 +535,10 @@ fn save_scheduler_state(path: &Path, state: &CronSchedulerState) -> Result<()> {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use tempfile::tempdir;
-    use time::{Date, Month, PrimitiveDateTime, Time};
-
     use crate::config::{CronConfig, DefaultsConfig};
     use crate::events::MessageFormat;
+    use tempfile::tempdir;
+    use time::{Date, Month, PrimitiveDateTime, Time};
 
     use super::*;
 
@@ -552,6 +631,33 @@ mod tests {
 
         let events = emitter.events.lock().expect("events lock");
         assert_eq!(events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn cron_refresh_rebuilds_scheduler_for_reloaded_config() {
+        let dir = tempdir().expect("tempdir");
+        let state_path = dir.path().join("cron-state.json");
+        let emitter = RecordingEmitter::default();
+        let mut scheduler =
+            CronScheduler::new_with_state_path(&AppConfig::default(), state_path.clone())
+                .expect("initial scheduler");
+        let mut signature = cron_signature(&AppConfig::default());
+        let reloaded = sample_config("* * * * *");
+
+        refresh_scheduler_if_needed(&mut scheduler, &mut signature, &reloaded, &state_path)
+            .expect("refresh scheduler");
+        scheduler
+            .emit_due(&emitter, dt(2026, Month::April, 2, 8, 20, 3))
+            .await
+            .expect("emit reloaded job");
+
+        let events = emitter.events.lock().expect("events lock");
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+
+        assert_eq!(event.kind, "custom");
+        assert_eq!(event.channel.as_deref(), Some("ops"));
+        assert_eq!(event.payload["cron_job_id"], json!("dev-followup"));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,7 +9,8 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router as AxumRouter};
 use serde_json::{Value, json};
-use tokio::sync::{RwLock, mpsc};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use tokio::sync::{RwLock, mpsc, watch};
 
 use crate::Result;
 use crate::VERSION;
@@ -27,18 +28,28 @@ use crate::source::{
 };
 
 const EVENT_QUEUE_CAPACITY: usize = 256;
+const HOT_RELOAD_SECTIONS: [&str; 3] = ["routes", "defaults", "cron"];
 
 #[derive(Clone)]
 struct AppState {
-    config: Arc<AppConfig>,
+    config: watch::Sender<Arc<AppConfig>>,
+    config_path: PathBuf,
+    reload_status: Arc<RwLock<ReloadStatus>>,
     port: u16,
     tx: mpsc::Sender<IncomingEvent>,
     tmux_registry: SharedTmuxRegistry,
 }
 
+#[derive(Debug, Clone, Default)]
+struct ReloadStatus {
+    generation: u64,
+    last_reloaded_at: Option<String>,
+}
+
 pub async fn run(
     config: Arc<AppConfig>,
     port_override: Option<u16>,
+    config_path: PathBuf,
     cron_state_path: PathBuf,
 ) -> Result<()> {
     config.validate()?;
@@ -52,7 +63,9 @@ pub async fn run(
     );
     sinks.insert("slack".into(), Box::new(SlackSink::default()));
     let renderer: Box<dyn Renderer> = Box::new(DefaultRenderer);
-    let router = Router::new(config.clone());
+    let (config_tx, config_rx) = watch::channel(config.clone());
+    let router = Router::from_receiver(config_rx);
+    let reload_status = Arc::new(RwLock::new(ReloadStatus::default()));
     let tmux_registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
     let (tx, rx) = mpsc::channel(EVENT_QUEUE_CAPACITY);
 
@@ -78,11 +91,15 @@ pub async fn run(
         tx.clone(),
     );
     spawn_source(WorkspaceSource::new(config.clone()), tx.clone());
-    spawn_source(CronSource::new(config.clone(), cron_state_path), tx.clone());
+    spawn_source(
+        CronSource::from_receiver(config_tx.subscribe(), cron_state_path),
+        tx.clone(),
+    );
 
     let app = AxumRouter::new()
         .route("/health", get(health))
         .route("/api/status", get(status))
+        .route("/api/config/reload", post(reload_config))
         .route("/event", post(post_event))
         .route("/api/event", post(post_event))
         .route("/events", post(post_event))
@@ -94,7 +111,9 @@ pub async fn run(
     let port = port_override.unwrap_or(config.daemon.port);
 
     let app = app.with_state(AppState {
-        config: config.clone(),
+        config: config_tx,
+        config_path,
+        reload_status,
         port,
         tx,
         tmux_registry,
@@ -149,14 +168,22 @@ fn source_failure_alert_event(source_name: &str, error_message: &str) -> Incomin
 
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let registered = state.tmux_registry.read().await.len();
+    let reload_status = state.reload_status.read().await.clone();
+    let config = state.config.borrow().clone();
     Json(health_payload(
-        state.config.as_ref(),
+        config.as_ref(),
         state.port,
         registered,
+        &reload_status,
     ))
 }
 
-fn health_payload(config: &AppConfig, port: u16, registered_tmux_sessions: usize) -> Value {
+fn health_payload(
+    config: &AppConfig,
+    port: u16,
+    registered_tmux_sessions: usize,
+    reload_status: &ReloadStatus,
+) -> Value {
     json!({
         "ok": true,
         "version": VERSION,
@@ -169,11 +196,64 @@ fn health_payload(config: &AppConfig, port: u16, registered_tmux_sessions: usize
         "configured_workspace_monitors": config.monitors.workspace.len(),
         "configured_cron_jobs": config.cron.jobs.len(),
         "registered_tmux_sessions": registered_tmux_sessions,
+        "config_reload_generation": reload_status.generation,
+        "last_config_reload_at": reload_status.last_reloaded_at,
+        "hot_reload_sections": HOT_RELOAD_SECTIONS,
     })
 }
 
 async fn status(State(state): State<AppState>) -> impl IntoResponse {
     health(State(state)).await
+}
+
+async fn reload_config(State(state): State<AppState>) -> impl IntoResponse {
+    let loaded = match AppConfig::load_or_default(&state.config_path) {
+        Ok(config) => config,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"ok": false, "error": error.to_string()})),
+            )
+                .into_response();
+        }
+    };
+
+    let current = state.config.borrow().clone();
+    let mut merged = current.as_ref().clone();
+    merged.apply_hot_reload_from(&loaded);
+
+    if let Err(error) = merged.validate() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"ok": false, "error": error.to_string()})),
+        )
+            .into_response();
+    }
+
+    let reloaded_at = now_rfc3339();
+    let generation = {
+        let mut reload_status = state.reload_status.write().await;
+        reload_status.generation += 1;
+        reload_status.last_reloaded_at = Some(reloaded_at.clone());
+        reload_status.generation
+    };
+
+    state.config.send_replace(Arc::new(merged.clone()));
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "config_reload_generation": generation,
+            "last_config_reload_at": reloaded_at,
+            "hot_reload_sections": HOT_RELOAD_SECTIONS,
+            "default_channel": merged.defaults.channel,
+            "default_format": merged.defaults.format.as_str(),
+            "configured_routes": merged.routes.len(),
+            "configured_cron_jobs": merged.cron.jobs.len(),
+        })),
+    )
+        .into_response()
 }
 
 async fn post_event(
@@ -248,7 +328,8 @@ async fn register_tmux(
 }
 
 async fn list_tmux(State(state): State<AppState>) -> impl IntoResponse {
-    match list_active_tmux_registrations(state.config.as_ref(), &state.tmux_registry).await {
+    let config = state.config.borrow().clone();
+    match list_active_tmux_registrations(config.as_ref(), &state.tmux_registry).await {
         Ok(registrations) => (StatusCode::OK, Json(json!(registrations))).into_response(),
         Err(error) => (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -375,6 +456,12 @@ async fn enqueue_event(tx: &mpsc::Sender<IncomingEvent>, event: IncomingEvent) -
         .map_err(|error| format!("event queue unavailable: {error}").into())
 }
 
+fn now_rfc3339() -> String {
+    let now = OffsetDateTime::now_utc();
+    now.format(&Rfc3339)
+        .unwrap_or_else(|_| now.unix_timestamp().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -386,8 +473,21 @@ mod tests {
     use crate::source::tmux::{ParentProcessInfo, RegistrationSource};
     use axum::body::to_bytes;
     use std::fs;
+    use std::path::PathBuf;
     use tempfile::tempdir;
     use tokio::time::{Duration, timeout};
+
+    fn test_state(config: AppConfig, tx: mpsc::Sender<IncomingEvent>) -> AppState {
+        let (config_tx, _config_rx) = watch::channel(Arc::new(config));
+        AppState {
+            config: config_tx,
+            config_path: PathBuf::from("config.toml"),
+            reload_status: Arc::new(RwLock::new(ReloadStatus::default())),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
 
     #[test]
     fn health_payload_includes_version_and_token_source() {
@@ -397,7 +497,7 @@ mod tests {
         config.monitors.tmux.sessions.push(Default::default());
         config.monitors.workspace.push(Default::default());
 
-        let payload = health_payload(&config, 25294, 3);
+        let payload = health_payload(&config, 25294, 3, &ReloadStatus::default());
 
         assert_eq!(payload["ok"], Value::Bool(true));
         assert_eq!(payload["version"], Value::String(VERSION.to_string()));
@@ -407,6 +507,7 @@ mod tests {
         assert_eq!(payload["configured_tmux_monitors"], Value::from(1));
         assert_eq!(payload["configured_workspace_monitors"], Value::from(1));
         assert_eq!(payload["registered_tmux_sessions"], Value::from(3));
+        assert_eq!(payload["config_reload_generation"], Value::from(0));
     }
 
     #[tokio::test]
@@ -485,12 +586,7 @@ mod tests {
     #[tokio::test]
     async fn post_event_returns_event_id_and_preserves_normalized_metadata() {
         let (tx, mut rx) = mpsc::channel(1);
-        let state = AppState {
-            config: Arc::new(AppConfig::default()),
-            port: 25294,
-            tx,
-            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
-        };
+        let state = test_state(AppConfig::default(), tx);
         let event = IncomingEvent::agent_started(
             "worker-1".into(),
             Some("sess-123".into()),
@@ -525,12 +621,7 @@ mod tests {
     #[tokio::test]
     async fn post_omx_hook_accepts_native_hook_envelope_and_queues_normalized_event() {
         let (tx, mut rx) = mpsc::channel(1);
-        let state = AppState {
-            config: Arc::new(AppConfig::default()),
-            port: 25294,
-            tx,
-            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
-        };
+        let state = test_state(AppConfig::default(), tx);
         let payload = json!({
             "schema_version": "1",
             "event": "session-start",
@@ -569,12 +660,7 @@ mod tests {
     #[tokio::test]
     async fn post_omx_hook_rejects_missing_normalized_event() {
         let (tx, _rx) = mpsc::channel(1);
-        let state = AppState {
-            config: Arc::new(AppConfig::default()),
-            port: 25294,
-            tx,
-            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
-        };
+        let state = test_state(AppConfig::default(), tx);
         let payload = json!({
             "schema_version": "1",
             "event": "session-start",
@@ -621,12 +707,8 @@ mod tests {
                 active_wrapper_monitor: true,
             },
         );
-        let state = AppState {
-            config: Arc::new(AppConfig::default()),
-            port: 25294,
-            tx,
-            tmux_registry: registry,
-        };
+        let mut state = test_state(AppConfig::default(), tx);
+        state.tmux_registry = registry;
 
         let response = list_tmux(State(state)).await.into_response();
         assert_eq!(response.status(), StatusCode::OK);
@@ -649,5 +731,84 @@ mod tests {
             registrations[0]["parent_process"]["name"],
             Value::from("codex")
         );
+    }
+
+    #[tokio::test]
+    async fn reload_config_applies_only_reloadable_sections_from_disk() {
+        let dir = tempdir().expect("tempdir");
+        let config_path = dir.path().join("config.toml");
+        let (tx, _rx) = mpsc::channel(1);
+
+        let mut initial = AppConfig::default();
+        initial.providers.discord.bot_token = Some("config-token".into());
+        initial.defaults.channel = Some("before".into());
+        initial.daemon.base_url = "http://127.0.0.1:25294".into();
+        initial.monitors.git.repos.push(Default::default());
+
+        let mut updated = AppConfig::default();
+        updated.defaults.channel = Some("after".into());
+        updated.daemon.base_url = "http://127.0.0.1:29999".into();
+        updated.routes.push(crate::config::RouteRule {
+            event: "custom".into(),
+            filter: Default::default(),
+            sink: crate::config::default_sink_name(),
+            channel: Some("ops".into()),
+            webhook: None,
+            slack_webhook: None,
+            mention: None,
+            allow_dynamic_tokens: false,
+            format: Some(MessageFormat::Alert),
+            template: None,
+        });
+        updated.cron.jobs.push(CronJob {
+            id: "dev-followup".into(),
+            schedule: "* * * * *".into(),
+            timezone: "UTC".into(),
+            enabled: true,
+            channel: Some("ops".into()),
+            mention: None,
+            format: Some(MessageFormat::Alert),
+            kind: CronJobKind::CustomMessage {
+                message: "check open PRs".into(),
+            },
+        });
+        updated.save(&config_path).expect("save config");
+
+        let mut state = test_state(initial.clone(), tx);
+        state.config_path = config_path;
+
+        let response = reload_config(State(state.clone())).await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response_json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(response_json["configured_routes"], Value::from(1));
+        assert_eq!(response_json["configured_cron_jobs"], Value::from(1));
+        assert_eq!(response_json["config_reload_generation"], Value::from(1));
+
+        let reloaded = state.config.borrow().clone();
+        assert_eq!(reloaded.defaults.channel.as_deref(), Some("after"));
+        assert_eq!(reloaded.routes.len(), 1);
+        assert_eq!(reloaded.cron.jobs.len(), 1);
+        assert_eq!(reloaded.daemon.base_url, initial.daemon.base_url);
+        assert_eq!(
+            reloaded.monitors.git.repos.len(),
+            initial.monitors.git.repos.len()
+        );
+
+        let router = Router::from_receiver(state.config.subscribe());
+        let delivery = router
+            .preview_delivery(&IncomingEvent::custom(None, "check open PRs".into()))
+            .await
+            .expect("delivery");
+        assert_eq!(delivery.target, SinkTarget::DiscordChannel("ops".into()));
+
+        let health = health(State(state)).await.into_response();
+        let body = to_bytes(health.into_body(), usize::MAX).await.unwrap();
+        let health_json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(health_json["configured_cron_jobs"], Value::from(1));
+        assert_eq!(health_json["configured_git_monitors"], Value::from(1));
+        assert_eq!(health_json["config_reload_generation"], Value::from(1));
+        assert!(health_json["last_config_reload_at"].is_string());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,9 @@ async fn real_main() -> Result<()> {
     let cron_state_path = crate::cron::default_state_path(&config_path);
 
     match cli.command.unwrap_or(Commands::Start { port: None }) {
-        Commands::Start { port } => daemon::run(config, port, cron_state_path).await,
+        Commands::Start { port } => {
+            daemon::run(config, port, config_path.clone(), cron_state_path).await
+        }
         Commands::Status => {
             let client = DaemonClient::from_config(config.as_ref());
             let health = client.health().await?;
@@ -240,6 +242,12 @@ async fn real_main() -> Result<()> {
             }
             ConfigCommand::Path => {
                 println!("{}", config_path.display());
+                Ok(())
+            }
+            ConfigCommand::Reload => {
+                let client = DaemonClient::from_config(config.as_ref());
+                let response = client.reload_config().await?;
+                println!("{}", serde_json::to_string_pretty(&response)?);
                 Ok(())
             }
         },

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use serde_json::json;
+use tokio::sync::watch;
 
 use crate::Result;
 use crate::config::{AppConfig, RouteRule, default_sink_name};
@@ -26,12 +27,25 @@ pub struct ResolvedDelivery {
 }
 
 pub struct Router {
-    config: Arc<AppConfig>,
+    config: ConfigHandle,
+}
+
+enum ConfigHandle {
+    Static(Arc<AppConfig>),
+    Dynamic(watch::Receiver<Arc<AppConfig>>),
 }
 
 impl Router {
     pub fn new(config: Arc<AppConfig>) -> Self {
-        Self { config }
+        Self {
+            config: ConfigHandle::Static(config),
+        }
+    }
+
+    pub fn from_receiver(config: watch::Receiver<Arc<AppConfig>>) -> Self {
+        Self {
+            config: ConfigHandle::Dynamic(config),
+        }
     }
 
     #[cfg(test)]
@@ -60,7 +74,8 @@ impl Router {
     }
 
     pub async fn resolve(&self, event: &IncomingEvent) -> Result<Vec<ResolvedDelivery>> {
-        let routes = self.routes_for(event);
+        let config = self.current_config();
+        let routes = self.routes_for(config.as_ref(), event);
         let routes = if routes.is_empty() {
             vec![None]
         } else {
@@ -69,7 +84,7 @@ impl Router {
         let mut deliveries = Vec::with_capacity(routes.len());
 
         for route in routes {
-            deliveries.push(self.resolve_delivery(event, route)?);
+            deliveries.push(self.resolve_delivery(config.as_ref(), event, route)?);
         }
 
         Ok(deliveries)
@@ -87,6 +102,7 @@ impl Router {
 
     fn resolve_delivery(
         &self,
+        config: &AppConfig,
         event: &IncomingEvent,
         route: Option<&RouteRule>,
     ) -> Result<ResolvedDelivery> {
@@ -94,12 +110,12 @@ impl Router {
             .map(RouteRule::effective_sink)
             .map(ToString::to_string)
             .unwrap_or_else(default_sink_name);
-        let target = self.target_for(event, route, &sink)?;
+        let target = self.target_for(config, event, route, &sink)?;
         let format = event
             .format
             .clone()
             .or_else(|| route.and_then(|route| route.format.clone()))
-            .unwrap_or_else(|| self.config.defaults.format.clone());
+            .unwrap_or_else(|| config.defaults.format.clone());
 
         Ok(ResolvedDelivery {
             sink,
@@ -112,7 +128,7 @@ impl Router {
                 .template
                 .clone()
                 .or_else(|| route.and_then(|route| route.template.clone())),
-            allow_dynamic_tokens: self.allow_dynamic_tokens_for(event, route),
+            allow_dynamic_tokens: self.allow_dynamic_tokens_for(config, event, route),
         })
     }
 
@@ -167,7 +183,12 @@ impl Router {
         }
     }
 
-    fn allow_dynamic_tokens_for(&self, event: &IncomingEvent, route: Option<&RouteRule>) -> bool {
+    fn allow_dynamic_tokens_for(
+        &self,
+        config: &AppConfig,
+        event: &IncomingEvent,
+        route: Option<&RouteRule>,
+    ) -> bool {
         if let Some(route) = route {
             return route.allow_dynamic_tokens;
         }
@@ -175,7 +196,7 @@ impl Router {
         if event.canonical_kind() == "custom"
             && let Some(channel) = event.channel.as_deref()
         {
-            return self.config.routes.iter().any(|route| {
+            return config.routes.iter().any(|route| {
                 route.allow_dynamic_tokens && route.channel.as_deref() == Some(channel)
             });
         }
@@ -183,9 +204,9 @@ impl Router {
         false
     }
 
-    fn routes_for<'a>(&'a self, event: &IncomingEvent) -> Vec<&'a RouteRule> {
+    fn routes_for<'a>(&self, config: &'a AppConfig, event: &IncomingEvent) -> Vec<&'a RouteRule> {
         let context = event.template_context();
-        self.config
+        config
             .routes
             .iter()
             .filter(|route| route_matches(route, event.canonical_kind(), &context))
@@ -194,6 +215,7 @@ impl Router {
 
     fn target_for(
         &self,
+        config: &AppConfig,
         event: &IncomingEvent,
         route: Option<&RouteRule>,
         sink: &str,
@@ -212,12 +234,12 @@ impl Router {
                         .channel
                         .clone()
                         .or_else(|| route.and_then(|route| route.channel.clone()))
-                        .or_else(|| self.config.defaults.channel.clone())
+                        .or_else(|| config.defaults.channel.clone())
                 } else {
                     route
                         .and_then(|route| route.channel.clone())
                         .or_else(|| event.channel.clone())
-                        .or_else(|| self.config.defaults.channel.clone())
+                        .or_else(|| config.defaults.channel.clone())
                 }
                 .ok_or_else(|| {
                     format!("no channel configured for event {}", event.canonical_kind())
@@ -240,6 +262,13 @@ impl Router {
                 event.canonical_kind()
             )
             .into()),
+        }
+    }
+
+    fn current_config(&self) -> Arc<AppConfig> {
+        match &self.config {
+            ConfigHandle::Static(config) => config.clone(),
+            ConfigHandle::Dynamic(config) => config.borrow().clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `clawhip config reload` and daemon `/api/config/reload` support for in-place reloads
- hot-swap only `routes`, `defaults`, and `cron` config while preserving daemon/monitor settings
- expose reload generation/timestamp in health/status and add focused reload coverage

## Testing
- `cargo fmt --all`
- `cargo test parses_config_reload_subcommand -- --nocapture`
- `cargo test cron_refresh_rebuilds_scheduler_for_reloaded_config -- --nocapture`
- `cargo test reload_config_applies_only_reloadable_sections_from_disk -- --nocapture`
- `cargo test`

## Risk summary
- moderate: routing/default delivery behavior now reads live config snapshots instead of startup-only config
- moderate: cron reload rebuilds scheduler state on config changes, so follow-up slices should treat monitor/daemon config as non-reloadable until explicitly implemented
- low: CLI/API surface is additive and keeps full-restart behavior available