### PR TITLE
feat: native release event support for GitHub release/tag announcements

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -292,6 +292,47 @@ async fn post_github(
                 None,
             )))
         }
+        "release" if matches!(action, "published" | "released" | "prereleased" | "edited") => {
+            let repo = payload
+                .pointer("/repository/full_name")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown/unknown")
+                .to_string();
+            let tag = payload
+                .pointer("/release/tag_name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let name = payload
+                .pointer("/release/name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let is_prerelease = payload
+                .pointer("/release/prerelease")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let url = payload
+                .pointer("/release/html_url")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let actor = payload
+                .pointer("/sender/login")
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+
+            Some(normalize_event(IncomingEvent::github_release(
+                action,
+                repo,
+                tag,
+                name,
+                is_prerelease,
+                url,
+                actor,
+                None,
+            )))
+        }
         "pull_request" => {
             let repo = payload
                 .pointer("/repository/full_name")

--- a/src/event/body.rs
+++ b/src/event/body.rs
@@ -64,6 +64,17 @@ pub struct GitHubCIEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitHubReleaseEvent {
+    pub repo: String,
+    pub tag: String,
+    pub name: String,
+    pub action: String,
+    pub is_prerelease: bool,
+    pub url: String,
+    pub actor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TmuxKeywordEvent {
     pub session: String,
     pub keyword: String,

--- a/src/event/compat.rs
+++ b/src/event/compat.rs
@@ -6,8 +6,8 @@ use crate::Result;
 use crate::event::{
     AgentEvent, CustomEvent, EventBody, EventEnvelope, EventMetadata, EventPriority,
     GitBranchChangedEvent, GitCommitAggregatedEvent, GitCommitEvent, GitHubCIEvent,
-    GitHubIssueEvent, GitHubPREvent, GitHubPRStatusEvent, TmuxKeywordAggregatedEvent,
-    TmuxKeywordEvent, TmuxStaleEvent, WorkspaceEvent,
+    GitHubIssueEvent, GitHubPREvent, GitHubPRStatusEvent, GitHubReleaseEvent,
+    TmuxKeywordAggregatedEvent, TmuxKeywordEvent, TmuxStaleEvent, WorkspaceEvent,
 };
 use crate::events::{IncomingEvent, normalize_event};
 
@@ -104,6 +104,9 @@ fn body_for(kind: &str, payload: &Value) -> Result<EventBody> {
         )?)),
         "github.issue-closed" => Ok(EventBody::GitHubIssueClosed(github_issue_event(payload)?)),
         "github.pr-status-changed" => github_pr_body(payload),
+        "github.release-published" => Ok(EventBody::GitHubReleasePublished(github_release_event(payload)?)),
+        "github.release-prereleased" => Ok(EventBody::GitHubReleasePrereleased(github_release_event(payload)?)),
+        "github.release-edited" => Ok(EventBody::GitHubReleaseEdited(github_release_event(payload)?)),
         "github.ci-failed" => Ok(EventBody::GitHubCIFailed(GitHubCIEvent {
             repo: string_field(payload, "repo")?,
             number: payload.get("number").and_then(Value::as_u64),
@@ -225,6 +228,21 @@ fn github_issue_event(payload: &Value) -> Result<GitHubIssueEvent> {
         number: u64_field(payload, "number")?,
         title: string_field(payload, "title")?,
         comments: payload.get("comments").and_then(Value::as_u64),
+    })
+}
+
+fn github_release_event(payload: &Value) -> Result<GitHubReleaseEvent> {
+    Ok(GitHubReleaseEvent {
+        repo: string_field(payload, "repo")?,
+        tag: string_field(payload, "tag")?,
+        name: optional_string_field(payload, "name").unwrap_or_default(),
+        action: optional_string_field(payload, "action").unwrap_or_else(|| "published".to_string()),
+        is_prerelease: payload
+            .get("is_prerelease")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        url: optional_string_field(payload, "url").unwrap_or_default(),
+        actor: optional_string_field(payload, "actor"),
     })
 }
 
@@ -401,6 +419,7 @@ fn priority_for(kind: &str, payload: &Value) -> EventPriority {
         | "session.handoff-needed"
         | "tmux.stale"
         | "workspace.session.blocked" => EventPriority::High,
+        "github.release-published" | "github.release-prereleased" => EventPriority::High,
         "github.pr-status-changed"
             if optional_string_field(payload, "new_status")
                 .map(|status| status == "merged" || status == "closed")
@@ -860,5 +879,80 @@ mod tests {
 
         let envelope = from_incoming_event(&event).unwrap();
         assert_eq!(envelope.metadata.priority, EventPriority::High);
+    }
+
+    #[test]
+    fn maps_github_release_published_event() {
+        let event = IncomingEvent::github_release(
+            "published",
+            "Yeachan-Heo/clawhip".into(),
+            "v0.6.0".into(),
+            "clawhip 0.6.0".into(),
+            false,
+            "https://github.com/Yeachan-Heo/clawhip/releases/tag/v0.6.0".into(),
+            Some("Yeachan-Heo".into()),
+            Some("releases".into()),
+        );
+
+        let envelope = from_incoming_event(&event).unwrap();
+        assert_eq!(envelope.source, "github");
+        assert_eq!(envelope.metadata.channel_hint.as_deref(), Some("releases"));
+        assert_eq!(envelope.metadata.priority, EventPriority::High);
+        match envelope.body {
+            EventBody::GitHubReleasePublished(body) => {
+                assert_eq!(body.repo, "Yeachan-Heo/clawhip");
+                assert_eq!(body.tag, "v0.6.0");
+                assert_eq!(body.name, "clawhip 0.6.0");
+                assert!(!body.is_prerelease);
+                assert_eq!(body.actor.as_deref(), Some("Yeachan-Heo"));
+            }
+            other => panic!("expected GitHubReleasePublished, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_github_release_prereleased_event() {
+        let event = IncomingEvent::github_release(
+            "prereleased",
+            "Yeachan-Heo/clawhip".into(),
+            "v0.6.0-rc.1".into(),
+            "clawhip 0.6.0-rc.1".into(),
+            true,
+            "https://github.com/Yeachan-Heo/clawhip/releases/tag/v0.6.0-rc.1".into(),
+            None,
+            None,
+        );
+
+        let envelope = from_incoming_event(&event).unwrap();
+        assert_eq!(envelope.metadata.priority, EventPriority::High);
+        match envelope.body {
+            EventBody::GitHubReleasePrereleased(body) => {
+                assert!(body.is_prerelease);
+                assert_eq!(body.tag, "v0.6.0-rc.1");
+                assert!(body.actor.is_none());
+            }
+            other => panic!("expected GitHubReleasePrereleased, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_github_release_edited_event() {
+        let event = IncomingEvent::github_release(
+            "edited",
+            "Yeachan-Heo/clawhip".into(),
+            "v0.5.4".into(),
+            "clawhip 0.5.4".into(),
+            false,
+            "https://github.com/Yeachan-Heo/clawhip/releases/tag/v0.5.4".into(),
+            Some("Yeachan-Heo".into()),
+            None,
+        );
+
+        let envelope = from_incoming_event(&event).unwrap();
+        assert_eq!(envelope.metadata.priority, EventPriority::Normal);
+        assert!(matches!(
+            envelope.body,
+            EventBody::GitHubReleaseEdited(_)
+        ));
     }
 }

--- a/src/event/compat.rs
+++ b/src/event/compat.rs
@@ -104,9 +104,15 @@ fn body_for(kind: &str, payload: &Value) -> Result<EventBody> {
         )?)),
         "github.issue-closed" => Ok(EventBody::GitHubIssueClosed(github_issue_event(payload)?)),
         "github.pr-status-changed" => github_pr_body(payload),
-        "github.release-published" => Ok(EventBody::GitHubReleasePublished(github_release_event(payload)?)),
-        "github.release-prereleased" => Ok(EventBody::GitHubReleasePrereleased(github_release_event(payload)?)),
-        "github.release-edited" => Ok(EventBody::GitHubReleaseEdited(github_release_event(payload)?)),
+        "github.release-published" => Ok(EventBody::GitHubReleasePublished(github_release_event(
+            payload,
+        )?)),
+        "github.release-prereleased" => Ok(EventBody::GitHubReleasePrereleased(
+            github_release_event(payload)?,
+        )),
+        "github.release-edited" => Ok(EventBody::GitHubReleaseEdited(github_release_event(
+            payload,
+        )?)),
         "github.ci-failed" => Ok(EventBody::GitHubCIFailed(GitHubCIEvent {
             repo: string_field(payload, "repo")?,
             number: payload.get("number").and_then(Value::as_u64),
@@ -950,9 +956,6 @@ mod tests {
 
         let envelope = from_incoming_event(&event).unwrap();
         assert_eq!(envelope.metadata.priority, EventPriority::Normal);
-        assert!(matches!(
-            envelope.body,
-            EventBody::GitHubReleaseEdited(_)
-        ));
+        assert!(matches!(envelope.body, EventBody::GitHubReleaseEdited(_)));
     }
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -3,7 +3,7 @@ pub mod compat;
 
 pub use body::{
     AgentEvent, CustomEvent, GitBranchChangedEvent, GitCommitAggregatedEvent, GitCommitEvent,
-    GitHubCIEvent, GitHubIssueEvent, GitHubPREvent, GitHubPRStatusEvent,
+    GitHubCIEvent, GitHubIssueEvent, GitHubPREvent, GitHubPRStatusEvent, GitHubReleaseEvent,
     TmuxKeywordAggregatedEvent, TmuxKeywordEvent, TmuxStaleEvent, WorkspaceEvent,
 };
 
@@ -33,6 +33,9 @@ pub enum EventBody {
     GitHubPRMerged(GitHubPREvent),
     GitHubPRStatusChanged(GitHubPRStatusEvent),
     GitHubCIFailed(GitHubCIEvent),
+    GitHubReleasePublished(GitHubReleaseEvent),
+    GitHubReleasePrereleased(GitHubReleaseEvent),
+    GitHubReleaseEdited(GitHubReleaseEvent),
     TmuxKeyword(TmuxKeywordEvent),
     TmuxKeywordAggregated(TmuxKeywordAggregatedEvent),
     TmuxStale(TmuxStaleEvent),

--- a/src/events.rs
+++ b/src/events.rs
@@ -464,6 +464,43 @@ impl IncomingEvent {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn github_release(
+        action: &str,
+        repo: String,
+        tag: String,
+        name: String,
+        is_prerelease: bool,
+        url: String,
+        actor: Option<String>,
+        channel: Option<String>,
+    ) -> Self {
+        let kind = match action {
+            "prereleased" => "github.release-prereleased",
+            "edited" => "github.release-edited",
+            _ => "github.release-published",
+        };
+        let mut payload = Map::new();
+        payload.insert("repo".to_string(), json!(repo));
+        payload.insert("tag".to_string(), json!(tag));
+        payload.insert("name".to_string(), json!(name));
+        payload.insert("action".to_string(), json!(action));
+        payload.insert("is_prerelease".to_string(), json!(is_prerelease));
+        payload.insert("url".to_string(), json!(url));
+        if let Some(actor) = actor {
+            payload.insert("actor".to_string(), json!(actor));
+        }
+
+        Self {
+            kind: kind.to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: Value::Object(payload),
+        }
+    }
+
     pub fn tmux_keyword(
         session: String,
         keyword: String,

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -233,6 +233,43 @@ impl Renderer for DefaultRenderer {
                 MessageFormat::Raw,
             ) => serde_json::to_string_pretty(payload)?,
 
+            (
+                "github.release-published"
+                | "github.release-prereleased"
+                | "github.release-edited",
+                MessageFormat::Compact,
+            ) => render_github_release(payload, event.canonical_kind())?,
+            (
+                "github.release-published"
+                | "github.release-prereleased"
+                | "github.release-edited",
+                MessageFormat::Alert,
+            ) => format!(
+                "🚨 {}",
+                render_github_release(payload, event.canonical_kind())?
+            ),
+            (
+                "github.release-published"
+                | "github.release-prereleased"
+                | "github.release-edited",
+                MessageFormat::Inline,
+            ) => {
+                let tag = string_field(payload, "tag")?;
+                let repo = string_field(payload, "repo")?;
+                let prerelease = payload
+                    .get("is_prerelease")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let suffix = if prerelease { " (pre)" } else { "" };
+                format!("[release] {repo} {tag}{suffix}")
+            }
+            (
+                "github.release-published"
+                | "github.release-prereleased"
+                | "github.release-edited",
+                MessageFormat::Raw,
+            ) => serde_json::to_string_pretty(payload)?,
+
             ("tmux.keyword", MessageFormat::Compact) => format!(
                 "tmux:{} matched '{}' => {}",
                 string_field(payload, "session")?,
@@ -585,6 +622,38 @@ fn github_ci_target(payload: &Value) -> Result<String> {
     })
 }
 
+fn render_github_release(payload: &Value, kind: &str) -> Result<String> {
+    let repo = string_field(payload, "repo")?;
+    let tag = string_field(payload, "tag")?;
+    let name = optional_string_field(payload, "name").unwrap_or_default();
+    let url = optional_string_field(payload, "url").unwrap_or_default();
+    let prerelease = payload
+        .get("is_prerelease")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let action_label = match kind {
+        "github.release-prereleased" => "prereleased",
+        "github.release-edited" => "edited",
+        _ => "published",
+    };
+
+    let pre_flag = if prerelease { " (prerelease)" } else { "" };
+    let name_part = if name.is_empty() || name == tag {
+        String::new()
+    } else {
+        format!(" \"{name}\"")
+    };
+
+    let mut parts = vec![format!(
+        "release {action_label} · {repo} {tag}{pre_flag}{name_part}"
+    )];
+    if !url.is_empty() {
+        parts.push(url);
+    }
+    Ok(parts.join(" · "))
+}
+
 fn short_sha(sha: &str) -> String {
     sha.chars().take(7).collect()
 }
@@ -817,5 +886,86 @@ mod tests {
             .render(&event, &MessageFormat::Compact)
             .unwrap();
         assert_eq!(rendered, "git:repo@main 1234567 ship it");
+    }
+
+    #[test]
+    fn renders_release_published_compact() {
+        let event = IncomingEvent::github_release(
+            "published",
+            "Yeachan-Heo/clawhip".into(),
+            "v0.6.0".into(),
+            "clawhip 0.6.0".into(),
+            false,
+            "https://github.com/Yeachan-Heo/clawhip/releases/tag/v0.6.0".into(),
+            Some("Yeachan-Heo".into()),
+            None,
+        );
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Compact)
+            .unwrap();
+        assert!(rendered.contains("release published"));
+        assert!(rendered.contains("Yeachan-Heo/clawhip"));
+        assert!(rendered.contains("v0.6.0"));
+        assert!(rendered.contains("clawhip 0.6.0"));
+    }
+
+    #[test]
+    fn renders_release_prerelease_compact_with_flag() {
+        let event = IncomingEvent::github_release(
+            "prereleased",
+            "Yeachan-Heo/clawhip".into(),
+            "v0.6.0-rc.1".into(),
+            "v0.6.0-rc.1".into(),
+            true,
+            "https://github.com/Yeachan-Heo/clawhip/releases/tag/v0.6.0-rc.1".into(),
+            None,
+            None,
+        );
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Compact)
+            .unwrap();
+        assert!(rendered.contains("prereleased"));
+        assert!(rendered.contains("(prerelease)"));
+    }
+
+    #[test]
+    fn renders_release_inline_format() {
+        let event = IncomingEvent::github_release(
+            "published",
+            "Yeachan-Heo/clawhip".into(),
+            "v0.6.0".into(),
+            "clawhip 0.6.0".into(),
+            false,
+            "https://github.com/Yeachan-Heo/clawhip/releases/tag/v0.6.0".into(),
+            None,
+            None,
+        );
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Inline)
+            .unwrap();
+        assert_eq!(rendered, "[release] Yeachan-Heo/clawhip v0.6.0");
+    }
+
+    #[test]
+    fn renders_release_alert_format() {
+        let event = IncomingEvent::github_release(
+            "published",
+            "Yeachan-Heo/clawhip".into(),
+            "v0.6.0".into(),
+            "clawhip 0.6.0".into(),
+            false,
+            "https://github.com/Yeachan-Heo/clawhip/releases/tag/v0.6.0".into(),
+            None,
+            None,
+        );
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Alert)
+            .unwrap();
+        assert!(rendered.starts_with("🚨"));
+        assert!(rendered.contains("release published"));
     }
 }

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -234,24 +234,18 @@ impl Renderer for DefaultRenderer {
             ) => serde_json::to_string_pretty(payload)?,
 
             (
-                "github.release-published"
-                | "github.release-prereleased"
-                | "github.release-edited",
+                "github.release-published" | "github.release-prereleased" | "github.release-edited",
                 MessageFormat::Compact,
             ) => render_github_release(payload, event.canonical_kind())?,
             (
-                "github.release-published"
-                | "github.release-prereleased"
-                | "github.release-edited",
+                "github.release-published" | "github.release-prereleased" | "github.release-edited",
                 MessageFormat::Alert,
             ) => format!(
                 "🚨 {}",
                 render_github_release(payload, event.canonical_kind())?
             ),
             (
-                "github.release-published"
-                | "github.release-prereleased"
-                | "github.release-edited",
+                "github.release-published" | "github.release-prereleased" | "github.release-edited",
                 MessageFormat::Inline,
             ) => {
                 let tag = string_field(payload, "tag")?;
@@ -264,9 +258,7 @@ impl Renderer for DefaultRenderer {
                 format!("[release] {repo} {tag}{suffix}")
             }
             (
-                "github.release-published"
-                | "github.release-prereleased"
-                | "github.release-edited",
+                "github.release-published" | "github.release-prereleased" | "github.release-edited",
                 MessageFormat::Raw,
             ) => serde_json::to_string_pretty(payload)?,
 


### PR DESCRIPTION
## Summary
- Add first-class `GitHubReleaseEvent` type with `published`, `prereleased`, and `edited` variants
- Handle GitHub `release` webhook events (published/released/prereleased/edited actions)
- Render release events in compact/alert/inline/raw formats with prerelease flag support
- Route release-published and release-prereleased as high-priority events
- Expose stable template fields: repo, tag, name, action, is_prerelease, url, actor

## Test plan
- [x] `cargo test` — 286 tests passing (281 unit + 5 integration)
- [x] `cargo clippy` — clean, no warnings
- [x] Compat tests verify published/prereleased/edited map to correct EventBody variants
- [x] Compat tests verify priority routing (published=High, edited=Normal)
- [x] Renderer tests verify compact, alert, inline formats including prerelease flag

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>