### PR TITLE
docs: make native launcher the default session path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,40 +43,38 @@ clawhip pairs well with coding session tools that run in tmux:
 
 ### [OMX (oh-my-codex)](https://github.com/Yeachan-Heo/oh-my-codex)
 
-OpenAI Codex wrapper with auto-monitoring. Launch monitored coding sessions:
+OpenAI Codex wrapper with native clawhip session launch. Launch monitored coding sessions with the native launcher first:
 
 ```bash
-clawhip tmux new -s issue-123 \
-  --channel YOUR_CHANNEL_ID \
+clawhip omx launch \
+  --session clawhip-issue-123-fix-routing \
+  --workdir ~/Workspace/clawhip.worktrees/clawhip-issue-123-fix-routing \
   --mention "<@your-user-id>" \
-  --keywords "error,PR created,complete" \
-  -- 'source ~/.zshrc && omx --madmax'
-
-# or attach monitoring to an existing tmux session
-clawhip tmux watch -s issue-123 \
-  --channel YOUR_CHANNEL_ID \
-  --mention "<@your-user-id>" \
-  --keywords "error,PR created,complete"
+  --skip-hook-check \
+  "$ralph Fix issue #123 and open a PR to dev"
 
 # inspect active daemon-known watches later
 clawhip tmux list
 ```
 
+Use `clawhip tmux new` / `clawhip tmux watch` only as fallback or launcher-debugging paths.
 See [`skills/omx/`](skills/omx/) for ready-to-use scripts.
 Native OMC/OMX routing now prefers the normalized [`session.*` contract](docs/native-event-contract.md); legacy `agent.*` wrapper emits remain supported for compatibility.
 
 ### [OMC (oh-my-claudecode)](https://github.com/Yeachan-Heo/oh-my-claudecode)
 
-Claude Code wrapper with auto-monitoring. Launch monitored coding sessions:
+Claude Code wrapper with native clawhip session launch:
 
 ```bash
-clawhip tmux new -s issue-456 \
-  --channel YOUR_CHANNEL_ID \
+clawhip omc \
+  --session clawhip-issue-456-build-feature \
+  --workdir ~/Workspace/clawhip.worktrees/clawhip-issue-456-build-feature \
   --mention "<@your-user-id>" \
-  --keywords "error,PR created,complete" \
-  -- 'source ~/.zshrc && omc --openclaw --madmax'
+  --skip-hook-check \
+  "Implement issue #456 and open a PR to dev"
 ```
 
+Use `clawhip tmux new` only when manually recovering or debugging launcher behavior.
 See [`skills/omc/`](skills/omc/) for ready-to-use scripts.
 Direct Slack/Discord notifications inside OMC/OMX should be treated as deprecated; emit native events and let clawhip own routing, mention policy, and formatting.
 
@@ -546,12 +544,30 @@ Verification:
 - let real tmux session idle past threshold
 - confirm final Discord body in target channel
 
-### 11. tmux wrapper / watch preset
+### 11. Native session launch + tmux fallback
 
-Input:
+Preferred input:
+```bash
+clawhip omx launch \
+  --session <project-issue-session-name> \
+  --workdir <verified-worktree-path> \
+  --mention '<@id>' \
+  --skip-hook-check \
+  "$ralph prompt here"
+
+clawhip omc \
+  --session <project-issue-session-name> \
+  --workdir <verified-worktree-path> \
+  --mention '<@id>' \
+  --skip-hook-check \
+  "implementation prompt here"
+
+clawhip tmux list
+```
+
+Fallback/debug input:
 ```bash
 clawhip tmux new -s <session> \
-  --channel <id> \
   --mention '<@id>' \
   --keywords 'error,PR created,FAILED,complete' \
   --stale-minutes 10 \
@@ -563,30 +579,30 @@ clawhip tmux new -s <session> \
   -- command args
 
 clawhip tmux watch -s <existing-session> \
-  --channel <id> \
   --mention '<@id>' \
   --keywords 'error,PR created,FAILED,complete' \
   --stale-minutes 10 \
   --format alert \
   --retry-enter true
-
-clawhip tmux list
 ```
 
 Behavior:
-- `tmux new` creates a tmux session using the user's default shell (or `--shell` override)
-- `tmux new` sends the requested command into the session, retrying Enter for TUI apps by default with exponential backoff (`--retry-enter=false` disables it, `--retry-enter-count` / `--retry-enter-delay-ms` tune retries)
-- when `tmux new` omits `--channel`, clawhip reuses the first matching Discord route channel for the session name before falling back to `defaults.channel`
-- `tmux watch` attaches monitoring to an already-running tmux session
-- both commands register the session with the daemon and emit an audit log line with launch options, timestamp, and parent-process provenance
+- native `omx launch` / `omc` should be the normal path for coding sessions
+- native launch emits project metadata and registers tmux monitoring automatically
+- `tmux new` / `tmux watch` are fallback paths for debugging or manual recovery
 - `tmux list` shows active daemon-known watches with source, registration timestamp, and parent-process info
-- daemon monitors keyword/stale events
-- final delivery goes through daemon routing
+- final delivery still goes through daemon routing
+
+Routing note:
+- session names are labels for operators, not routing authority
+- project metadata should be the source of truth for routing
+- broad prefix monitors like `clawhip*` are dangerous because they can overlap with launcher-registered watches and create stale/keyword noise
 
 Verification:
-- run wrapper or watch an existing session
-- emit keyword in pane
-- confirm Discord message body and mention
+- launch a native OMC/OMX session
+- verify the tmux pane is actually alive
+- confirm routed delivery in Discord
+- if alert text conflicts with pane reality, trust the pane and inspect monitor registrations
 
 ### 12. install lifecycle preset
 

--- a/docs/live-verification.md
+++ b/docs/live-verification.md
@@ -109,13 +109,13 @@ curl -sS -X POST http://127.0.0.1:25294/api/omx/hook \
 
 Operational flow:
 
-1. Use a monitored tmux session name that matches the route filter.
-2. Print a configured keyword (`error`, `FAILED`, `PR created`, etc).
-3. Confirm the keyword notification in Discord.
-4. Leave the session idle beyond the stale threshold.
-5. Confirm the stale notification in Discord.
-6. Launch a session via `clawhip tmux new ...`.
-7. Confirm wrapper registration + keyword/stale delivery.
+1. Launch a native session via `clawhip omx launch ...` or `clawhip omc ...`.
+2. Verify the pane is actually alive before trusting any `agent.started` message.
+3. Confirm routed delivery in Discord.
+4. Print a configured keyword (`error`, `FAILED`, `PR created`, etc) only when intentionally testing keyword behavior.
+5. Leave the session idle beyond the stale threshold only when intentionally testing stale behavior.
+6. Inspect `clawhip tmux list` to confirm exactly which watch registrations exist.
+7. If alert text disagrees with pane reality, treat it as monitor noise and debug registration overlap / stale math before assuming session failure.
 
 ## Helper script
 

--- a/docs/native-event-contract.md
+++ b/docs/native-event-contract.md
@@ -117,6 +117,14 @@ When upstream provides it, clawhip normalizes these fields onto the top-level pa
 
 ## Routing guidance
 
+Project metadata should be the routing authority.
+
+- Treat `project` / normalized `repo_name` as the source of truth for project-level routing.
+- Treat `session_name` as an operator label, not the authoritative project classifier.
+- Do not encode long-term routing doctrine around session-prefix glob hacks like `clawhip-*` when the launcher already knows the real project.
+- If routing behavior depends on prefix today, that is a compatibility bug to remove, not a convention to preserve.
+- Avoid overlapping broad tmux config monitors with launcher-registered per-session watches; duplicated watch layers can cause conflicting stale windows, ghost watches, and noisy keyword alerts.
+
 Recommended route filters:
 
 ```toml


### PR DESCRIPTION
## Summary
- make native  /  the documented default for coding sessions
- clarify that project metadata should be the routing authority, not session-prefix hacks
- document tmux wrapper commands as fallback/debug paths and call out monitor overlap pitfalls

## Testing
- not run (docs/config guidance only)