### PR TITLE
stability: harden native recovery signals for issue 166

### DIFF
--- a/src/hooks/prompt_deliver.rs
+++ b/src/hooks/prompt_deliver.rs
@@ -11,6 +11,17 @@ const DEFAULT_TUI_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const DEFAULT_VERIFY_DELAY: Duration = Duration::from_millis(250);
 const PROMPT_CHARS: &[char] = &['$', '%', '>', '#', '❯', '›'];
+const MAX_VERIFY_KEYWORDS: usize = 6;
+const GENERIC_FALLBACK_PATTERNS: &[&str] = &[
+    "implement {feature}",
+    "summarize recent commits",
+    "explain this codebase",
+];
+const VERIFY_STOPWORDS: &[&str] = &[
+    "a", "an", "and", "the", "this", "that", "these", "those", "for", "from", "with", "into",
+    "about", "your", "you", "please", "task", "tasks", "issue", "issues", "review", "reviews",
+    "session", "sessions", "native", "clawhip", "omx", "omc", "fix", "now",
+];
 
 /// Configuration for prompt delivery to a tmux session.
 #[derive(Debug, Clone)]
@@ -88,21 +99,23 @@ async fn try_deliver(config: &PromptDeliverConfig, attempt: u32) -> Result<Deliv
 
     sleep(config.verify_delay).await;
 
-    let post_hash = capture_pane_hash(&config.session).await?;
+    let pane_content = capture_recent_pane(&config.session).await?;
+    let post_hash = content_hash(&pane_content);
     let content_changed = post_hash != pre_hash;
-
-    let keyword_verified = if config.verify_keywords.is_empty() {
-        true
-    } else {
-        verify_keywords(&config.session, &config.verify_keywords).await?
-    };
-
-    let verified = content_changed && keyword_verified;
+    let verified = content_changed
+        && verify_prompt_against_content(&config.prompt, &pane_content, &config.verify_keywords);
 
     if !content_changed {
         return Err(
             format!("attempt {attempt}: pane content unchanged after sending prompt").into(),
         );
+    }
+
+    if !verified {
+        return Err(format!(
+            "attempt {attempt}: pane content changed but did not reflect the requested task"
+        )
+        .into());
     }
 
     Ok(DeliveryResult {
@@ -163,6 +176,10 @@ async fn capture_last_line(session: &str) -> Result<String> {
 }
 
 async fn capture_pane_hash(session: &str) -> Result<u64> {
+    Ok(content_hash(&capture_recent_pane(session).await?))
+}
+
+async fn capture_recent_pane(session: &str) -> Result<String> {
     let output = Command::new(tmux_bin())
         .arg("capture-pane")
         .arg("-p")
@@ -175,7 +192,7 @@ async fn capture_pane_hash(session: &str) -> Result<u64> {
     if !output.status.success() {
         return Err(tmux_stderr(&output.stderr).into());
     }
-    Ok(content_hash(&String::from_utf8(output.stdout)?))
+    Ok(String::from_utf8(output.stdout)?)
 }
 
 async fn send_literal_keys(session: &str, text: &str) -> Result<()> {
@@ -207,22 +224,66 @@ async fn send_key(session: &str, key: &str) -> Result<()> {
     Ok(())
 }
 
-/// Check whether any of the verify keywords appear in the current pane content.
-async fn verify_keywords(session: &str, keywords: &[String]) -> Result<bool> {
-    let output = Command::new(tmux_bin())
-        .arg("capture-pane")
-        .arg("-p")
-        .arg("-t")
-        .arg(session)
-        .arg("-S")
-        .arg("-50")
-        .output()
-        .await?;
-    if !output.status.success() {
-        return Err(tmux_stderr(&output.stderr).into());
+pub fn derive_verify_keywords(prompt: &str) -> Vec<String> {
+    let mut keywords = Vec::new();
+
+    for token in prompt
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(|token| token.to_ascii_lowercase())
+    {
+        if VERIFY_STOPWORDS.contains(&token.as_str()) {
+            continue;
+        }
+        let is_numeric = token.chars().all(|ch| ch.is_ascii_digit());
+        if !(token.len() >= 4 || (is_numeric && token.len() >= 3)) {
+            continue;
+        }
+        if !keywords.contains(&token) {
+            keywords.push(token);
+        }
+        if keywords.len() >= MAX_VERIFY_KEYWORDS {
+            break;
+        }
     }
-    let content = String::from_utf8_lossy(&output.stdout);
-    Ok(keywords.iter().any(|kw| content.contains(kw.as_str())))
+
+    keywords
+}
+
+fn verify_prompt_against_content(prompt: &str, content: &str, verify_keywords: &[String]) -> bool {
+    if looks_like_generic_fallback(content) {
+        return false;
+    }
+
+    let effective_keywords = if verify_keywords.is_empty() {
+        derive_verify_keywords(prompt)
+    } else {
+        verify_keywords.to_vec()
+    };
+
+    if effective_keywords.is_empty() {
+        return true;
+    }
+
+    content_matches_keywords(content, &effective_keywords)
+}
+
+fn looks_like_generic_fallback(content: &str) -> bool {
+    let normalized = content.to_ascii_lowercase();
+    GENERIC_FALLBACK_PATTERNS
+        .iter()
+        .any(|pattern| normalized.contains(pattern))
+}
+
+fn content_matches_keywords(content: &str, keywords: &[String]) -> bool {
+    let normalized = content.to_ascii_lowercase();
+    let required_matches = keywords.len().min(2);
+    keywords
+        .iter()
+        .filter(|keyword| normalized.contains(keyword.as_str()))
+        .take(required_matches)
+        .count()
+        >= required_matches.max(1)
 }
 
 fn tmux_stderr(stderr: &[u8]) -> String {
@@ -269,5 +330,51 @@ mod tests {
         assert!(PROMPT_CHARS.contains(&'#'));
         assert!(PROMPT_CHARS.contains(&'❯'));
         assert!(PROMPT_CHARS.contains(&'›'));
+    }
+
+    #[test]
+    fn derive_verify_keywords_prefers_specific_task_terms() {
+        let keywords = derive_verify_keywords(
+            "Fix issue #166 now with minimal mergeable scope focused on live operational recovery",
+        );
+
+        assert_eq!(
+            keywords,
+            vec![
+                "166".to_string(),
+                "minimal".to_string(),
+                "mergeable".to_string(),
+                "scope".to_string(),
+                "focused".to_string(),
+                "live".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn verify_prompt_against_content_rejects_generic_fallbacks() {
+        let prompt =
+            "Fix issue #166 now with minimal mergeable scope focused on live operational recovery";
+        let content = "Implement {feature}\nSummarize recent commits\nExplain this codebase";
+
+        assert!(!verify_prompt_against_content(prompt, content, &[]));
+    }
+
+    #[test]
+    fn verify_prompt_against_content_requires_multiple_keyword_matches_when_available() {
+        let keywords = derive_verify_keywords(
+            "Fix issue #166 now with minimal mergeable scope focused on live operational recovery",
+        );
+
+        assert!(verify_prompt_against_content(
+            "",
+            "Working task: issue 166 live operational recovery is in progress",
+            &keywords,
+        ));
+        assert!(!verify_prompt_against_content(
+            "",
+            "Working task: issue 166",
+            &keywords,
+        ));
     }
 }

--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -1,6 +1,17 @@
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
+const LAUNCHER_NOISE_PATTERNS: &[&str] = &[
+    "clawhip emit agent.started",
+    "clawhip emit agent.finished",
+    "clawhip emit agent.failed",
+    "function else>",
+    "registered_at=",
+    "parent_pid=",
+    "parent_name=",
+    "--error \"exit $exit_code\"",
+];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeywordHit {
     pub keyword: String,
@@ -77,9 +88,9 @@ pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) 
 
 fn should_ignore_launcher_line(line: &str) -> bool {
     let trimmed = line.trim();
-    trimmed.contains("clawhip emit agent.started")
-        || trimmed.contains("clawhip emit agent.finished")
-        || trimmed.contains("clawhip emit agent.failed")
+    LAUNCHER_NOISE_PATTERNS
+        .iter()
+        .any(|pattern| trimmed.contains(pattern))
 }
 
 fn appended_lines<'a>(previous: &'a str, current: &'a str) -> Vec<&'a str> {
@@ -176,6 +187,40 @@ mod tests {
             vec![KeywordHit {
                 keyword: "error".into(),
                 line: "error: real failure".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn collect_keyword_hits_ignores_tmux_wrapper_audit_lines() {
+        let hits = collect_keyword_hits(
+            "boot",
+            "boot\nclawhip tmux cli-new start session=issue-166 channel=ops keywords=error mention=- stale_minutes=30 format=- registered_at=2026-04-07T09:58:00Z parent_pid=4242 parent_name=codex\nerror: real failure",
+            &["error".into()],
+        );
+
+        assert_eq!(
+            hits,
+            vec![KeywordHit {
+                keyword: "error".into(),
+                line: "error: real failure".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn collect_keyword_hits_ignores_wrapped_exit_error_boilerplate() {
+        let hits = collect_keyword_hits(
+            "boot",
+            "boot\n  --error \"exit $exit_code\" \\\nFAILED: actual application failure",
+            &["error".into(), "FAILED".into()],
+        );
+
+        assert_eq!(
+            hits,
+            vec![KeywordHit {
+                keyword: "FAILED".into(),
+                line: "FAILED: actual application failure".into(),
             }]
         );
     }

--- a/src/omc.rs
+++ b/src/omc.rs
@@ -7,14 +7,11 @@ use crate::config::AppConfig;
 use crate::tmux_wrapper;
 
 /// Default keywords monitored for OMC sessions.
-const DEFAULT_OMC_KEYWORDS: &[&str] = &[
-    "error",
-    "Error",
-    "FAILED",
-    "PR created",
-    "panic",
-    "complete",
-];
+///
+/// Disabled by default because wrapper/bootstrap text can create more alert noise
+/// than signal during normal native launches. Operators can still opt in via
+/// explicit --keywords or CLAWHIP_OMC_KEYWORDS.
+const DEFAULT_OMC_KEYWORDS: &[&str] = &[];
 
 /// Default stale timeout in minutes for OMC sessions.
 const DEFAULT_OMC_STALE_MINUTES: u64 = 30;
@@ -99,35 +96,21 @@ pub async fn run(args: OmcArgs, config: &AppConfig) -> Result<()> {
 
 /// Deliver a prompt to a tmux session via send-keys.
 async fn deliver_prompt(session: &str, prompt: &str) -> Result<()> {
-    use crate::source::tmux::tmux_bin;
-    use tokio::process::Command;
+    use crate::hooks::prompt_deliver::{PromptDeliverConfig, deliver, derive_verify_keywords};
 
-    let literal_output = Command::new(tmux_bin())
-        .arg("send-keys")
-        .arg("-t")
-        .arg(session)
-        .arg("-l")
-        .arg(prompt)
-        .output()
-        .await?;
-    if !literal_output.status.success() {
-        let stderr = String::from_utf8_lossy(&literal_output.stderr);
-        return Err(format!("tmux send-keys failed: {}", stderr.trim()).into());
+    let mut config = PromptDeliverConfig::new(session.to_string(), prompt.to_string());
+    config.verify_keywords = derive_verify_keywords(prompt);
+
+    let result = deliver(&config).await?;
+    if !result.verified {
+        return Err(format!("prompt delivery to '{session}' was not verified").into());
     }
 
-    let enter_output = Command::new(tmux_bin())
-        .arg("send-keys")
-        .arg("-t")
-        .arg(session)
-        .arg("Enter")
-        .output()
-        .await?;
-    if !enter_output.status.success() {
-        let stderr = String::from_utf8_lossy(&enter_output.stderr);
-        return Err(format!("tmux send-keys Enter failed: {}", stderr.trim()).into());
-    }
-
-    eprintln!("clawhip omc: prompt delivered to {session}");
+    eprintln!(
+        "clawhip omc: prompt delivered to {session} (attempts={}, verified_keywords={})",
+        result.attempts,
+        config.verify_keywords.len()
+    );
     Ok(())
 }
 

--- a/src/omx.rs
+++ b/src/omx.rs
@@ -7,14 +7,11 @@ use crate::config::AppConfig;
 use crate::tmux_wrapper;
 
 /// Default keywords monitored for OMX sessions.
-const DEFAULT_OMX_KEYWORDS: &[&str] = &[
-    "error",
-    "Error",
-    "FAILED",
-    "PR created",
-    "panic",
-    "complete",
-];
+///
+/// Disabled by default because wrapper/bootstrap text can create more alert noise
+/// than signal during normal native launches. Operators can still opt in via
+/// explicit --keywords or CLAWHIP_OMX_KEYWORDS.
+const DEFAULT_OMX_KEYWORDS: &[&str] = &[];
 
 /// Default stale timeout in minutes for OMX sessions.
 const DEFAULT_OMX_STALE_MINUTES: u64 = 30;
@@ -96,35 +93,21 @@ pub async fn run(args: OmxLaunchArgs, config: &AppConfig) -> Result<()> {
 
 /// Deliver a prompt to a tmux session via send-keys.
 async fn deliver_prompt(session: &str, prompt: &str) -> Result<()> {
-    use crate::source::tmux::tmux_bin;
-    use tokio::process::Command;
+    use crate::hooks::prompt_deliver::{PromptDeliverConfig, deliver, derive_verify_keywords};
 
-    let literal_output = Command::new(tmux_bin())
-        .arg("send-keys")
-        .arg("-t")
-        .arg(session)
-        .arg("-l")
-        .arg(prompt)
-        .output()
-        .await?;
-    if !literal_output.status.success() {
-        let stderr = String::from_utf8_lossy(&literal_output.stderr);
-        return Err(format!("tmux send-keys failed: {}", stderr.trim()).into());
+    let mut config = PromptDeliverConfig::new(session.to_string(), prompt.to_string());
+    config.verify_keywords = derive_verify_keywords(prompt);
+
+    let result = deliver(&config).await?;
+    if !result.verified {
+        return Err(format!("prompt delivery to '{session}' was not verified").into());
     }
 
-    let enter_output = Command::new(tmux_bin())
-        .arg("send-keys")
-        .arg("-t")
-        .arg(session)
-        .arg("Enter")
-        .output()
-        .await?;
-    if !enter_output.status.success() {
-        let stderr = String::from_utf8_lossy(&enter_output.stderr);
-        return Err(format!("tmux send-keys Enter failed: {}", stderr.trim()).into());
-    }
-
-    eprintln!("clawhip omx: prompt delivered to {session}");
+    eprintln!(
+        "clawhip omx: prompt delivered to {session} (attempts={}, verified_keywords={})",
+        result.attempts,
+        config.verify_keywords.len()
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- suppress tmux launcher/bootstrap false positives for native OMX/Claude recovery sessions
- reject generic fallback/default prompts when verifying OMX/OMC prompt delivery
- add regression tests for the noisy patterns and prompt-drift guard

## Testing
- cargo fmt
- cargo build
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

Closes #166