### PR TITLE
Fix metadata-first session/tmux routing

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -519,7 +519,7 @@ mod tests {
     use super::*;
     use crate::config::AppConfig;
     use crate::config::{CronJob, CronJobKind};
-    use crate::events::MessageFormat;
+    use crate::events::{MessageFormat, RoutingMetadata};
     use crate::router::Router;
     use crate::sink::SinkTarget;
     use crate::source::tmux::{ParentProcessInfo, RegistrationSource};
@@ -750,6 +750,7 @@ mod tests {
                 session: "issue-105".into(),
                 channel: Some("alerts".into()),
                 mention: Some("<@123>".into()),
+                routing: RoutingMetadata::default(),
                 keywords: vec!["error".into()],
                 keyword_window_secs: 30,
                 stale_minutes: 15,

--- a/src/events.rs
+++ b/src/events.rs
@@ -57,6 +57,24 @@ pub struct IncomingEvent {
     pub payload: Value,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoutingMetadata {
+    #[serde(default)]
+    pub tool: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub repo_name: Option<String>,
+    #[serde(default)]
+    pub repo_path: Option<String>,
+    #[serde(default)]
+    pub worktree_path: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct IncomingEventWire {
     #[serde(rename = "type", alias = "kind", alias = "event")]
@@ -610,6 +628,28 @@ impl IncomingEvent {
                 payload.insert("worktree_path".to_string(), json!(worktree_path));
             }
         }
+        self
+    }
+
+    pub fn with_routing_metadata(mut self, routing: &RoutingMetadata) -> Self {
+        let Some(payload) = self.payload.as_object_mut() else {
+            return self;
+        };
+
+        for (key, value) in [
+            ("tool", routing.tool.as_deref()),
+            ("project", routing.project.as_deref()),
+            ("repo_name", routing.repo_name.as_deref()),
+            ("repo_path", routing.repo_path.as_deref()),
+            ("worktree_path", routing.worktree_path.as_deref()),
+            ("session_id", routing.session_id.as_deref()),
+            ("branch", routing.branch.as_deref()),
+        ] {
+            if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+                payload.insert(key.to_string(), json!(value));
+            }
+        }
+
         self
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,6 +393,7 @@ fn format_tmux_list(registrations: &[crate::source::RegisteredTmuxSession]) -> S
 #[cfg(test)]
 mod tests {
     use super::format_tmux_list;
+    use crate::events::RoutingMetadata;
     use crate::source::tmux::{ParentProcessInfo, RegisteredTmuxSession, RegistrationSource};
 
     #[test]
@@ -401,6 +402,7 @@ mod tests {
             session: "issue-105".into(),
             channel: Some("alerts".into()),
             mention: Some("<@123>".into()),
+            routing: RoutingMetadata::default(),
             keywords: vec!["error".into(), "complete".into()],
             keyword_window_secs: 30,
             stale_minutes: 10,

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use crate::Result;
 use crate::config::{AppConfig, RouteRule, default_sink_name};
 use crate::dynamic_tokens;
-use crate::events::{IncomingEvent, MessageFormat};
+use crate::events::{IncomingEvent, MessageFormat, RoutingMetadata};
 #[cfg(test)]
 use crate::render::DefaultRenderer;
 use crate::render::Renderer;
@@ -185,11 +185,7 @@ impl Router {
 
     fn routes_for<'a>(&'a self, event: &IncomingEvent) -> Vec<&'a RouteRule> {
         let context = event.template_context();
-        self.config
-            .routes
-            .iter()
-            .filter(|route| route_matches(route, event.canonical_kind(), &context))
-            .collect()
+        matching_routes_for(&self.config.routes, event.canonical_kind(), &context)
     }
 
     fn target_for(
@@ -244,14 +240,24 @@ impl Router {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn resolve_tmux_session_channel(
     config: &AppConfig,
     session_name: &str,
 ) -> Option<String> {
-    let tmux_event =
-        IncomingEvent::tmux_keyword(session_name.to_string(), String::new(), String::new(), None);
-    let tmux_context = tmux_event.template_context();
-    let session_event = IncomingEvent {
+    resolve_tmux_session_channel_with_metadata(config, session_name, &RoutingMetadata::default())
+}
+
+pub(crate) fn resolve_tmux_session_channel_with_metadata(
+    config: &AppConfig,
+    session_name: &str,
+    routing: &RoutingMetadata,
+) -> Option<String> {
+    let tmux_context =
+        IncomingEvent::tmux_keyword(session_name.to_string(), String::new(), String::new(), None)
+            .with_routing_metadata(routing)
+            .template_context();
+    let session_context = IncomingEvent {
         kind: "session.started".to_string(),
         channel: None,
         mention: None,
@@ -262,17 +268,33 @@ pub(crate) fn resolve_tmux_session_channel(
             "session": session_name,
             "tool": "tmux",
         }),
-    };
-    let session_context = session_event.template_context();
+    }
+    .with_routing_metadata(routing)
+    .template_context();
+    let prefer_metadata = prefers_metadata_first_routing("tmux.keyword", &tmux_context)
+        || prefers_metadata_first_routing("session.started", &session_context);
+    let mut preferred = Vec::new();
+    let mut heuristic = Vec::new();
 
-    for route in &config.routes {
-        let matches_tmux = route_matches(route, tmux_event.canonical_kind(), &tmux_context);
-        let matches_session =
-            route_matches(route, session_event.canonical_kind(), &session_context);
-        if !(matches_tmux || matches_session) || route.effective_sink() != "discord" {
+    for route in config.routes.iter().filter(|route| {
+        route_matches(route, "tmux.keyword", &tmux_context)
+            || route_matches(route, "session.started", &session_context)
+    }) {
+        if prefer_metadata && route_uses_session_name_prefix_heuristics(route) {
+            heuristic.push(route);
+        } else {
+            preferred.push(route);
+        }
+    }
+
+    if !prefer_metadata {
+        preferred.extend(heuristic);
+    }
+
+    for route in preferred {
+        if route.effective_sink() != "discord" {
             continue;
         }
-
         if let Some(channel) = route_channel(route) {
             return Some(channel.to_string());
         }
@@ -316,6 +338,60 @@ fn route_matches(
                 .get(key)
                 .map(|actual| glob_match(expected, actual))
                 .unwrap_or(false)
+        })
+}
+
+fn matching_routes_for<'a>(
+    routes: &'a [RouteRule],
+    canonical_kind: &str,
+    context: &std::collections::BTreeMap<String, String>,
+) -> Vec<&'a RouteRule> {
+    let prefer_metadata = prefers_metadata_first_routing(canonical_kind, context);
+    let mut preferred = Vec::new();
+    let mut heuristic = Vec::new();
+
+    for route in routes
+        .iter()
+        .filter(|route| route_matches(route, canonical_kind, context))
+    {
+        if prefer_metadata && route_uses_session_name_prefix_heuristics(route) {
+            heuristic.push(route);
+        } else {
+            preferred.push(route);
+        }
+    }
+
+    if !prefer_metadata {
+        preferred.extend(heuristic);
+    }
+
+    preferred
+}
+
+fn prefers_metadata_first_routing(
+    canonical_kind: &str,
+    context: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    if !(canonical_kind.starts_with("session.") || canonical_kind.starts_with("tmux.")) {
+        return false;
+    }
+
+    [
+        "project",
+        "repo_name",
+        "repo_path",
+        "worktree_path",
+        "session_id",
+    ]
+    .into_iter()
+    .filter_map(|key| context.get(key))
+    .any(|value| !value.trim().is_empty())
+}
+
+fn route_uses_session_name_prefix_heuristics(route: &RouteRule) -> bool {
+    !route.filter.is_empty()
+        && route.filter.iter().all(|(key, expected)| {
+            matches!(key.as_str(), "session" | "session_name") && expected.contains('*')
         })
 }
 
@@ -371,7 +447,7 @@ pub(crate) fn glob_match(pattern: &str, value: &str) -> bool {
 mod tests {
     use super::*;
     use crate::config::{DefaultsConfig, RouteRule};
-    use crate::events::normalize_event;
+    use crate::events::{RoutingMetadata, normalize_event};
     use crate::render::DefaultRenderer;
     use crate::sink::{DiscordSink, SlackSink};
     use serde_json::json;
@@ -1280,6 +1356,106 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tmux_routes_prefer_repo_metadata_over_session_prefix_heuristics() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![
+                RouteRule {
+                    event: "tmux.*".into(),
+                    sink: "discord".into(),
+                    filter: [("session_name".to_string(), "clawhip-*".to_string())]
+                        .into_iter()
+                        .collect(),
+                    channel: Some("heuristic-route".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "tmux.*".into(),
+                    sink: "discord".into(),
+                    filter: [("repo_name".to_string(), "clawhip".to_string())]
+                        .into_iter()
+                        .collect(),
+                    channel: Some("metadata-route".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::tmux_keyword(
+            "clawhip-issue-152".into(),
+            "error".into(),
+            "boom".into(),
+            None,
+        )
+        .with_routing_metadata(&RoutingMetadata {
+            repo_name: Some("clawhip".into()),
+            project: Some("clawhip".into()),
+            worktree_path: Some("/repo/clawhip.worktrees/issue-152".into()),
+            ..RoutingMetadata::default()
+        });
+
+        let deliveries = router.resolve(&event).await.unwrap();
+        assert_eq!(
+            deliveries.first().map(|delivery| &delivery.target),
+            Some(&SinkTarget::DiscordChannel("metadata-route".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn session_routes_prefer_repo_metadata_over_session_prefix_heuristics() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![
+                RouteRule {
+                    event: "session.*".into(),
+                    sink: "discord".into(),
+                    filter: [("session_name".to_string(), "clawhip-*".to_string())]
+                        .into_iter()
+                        .collect(),
+                    channel: Some("heuristic-route".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "session.*".into(),
+                    sink: "discord".into(),
+                    filter: [("repo_name".to_string(), "clawhip".to_string())]
+                        .into_iter()
+                        .collect(),
+                    channel: Some("metadata-route".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = normalize_event(IncomingEvent {
+            kind: "session.started".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session_name": "clawhip-issue-152",
+                "repo_name": "clawhip",
+                "worktree_path": "/repo/clawhip.worktrees/issue-152",
+            }),
+        });
+
+        let deliveries = router.resolve(&event).await.unwrap();
+        assert_eq!(
+            deliveries.first().map(|delivery| &delivery.target),
+            Some(&SinkTarget::DiscordChannel("metadata-route".into()))
+        );
+    }
+
+    #[tokio::test]
     async fn webhook_route_is_used_as_delivery_target() {
         let config = AppConfig {
             defaults: DefaultsConfig {
@@ -1603,6 +1779,81 @@ mod tests {
         assert_eq!(
             resolve_tmux_session_channel(&config, "xeroclaw-42").as_deref(),
             Some("xeroclaw-dev")
+        );
+    }
+
+    #[test]
+    fn resolve_tmux_session_channel_with_metadata_prefers_repo_route_over_prefix_heuristic() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![
+                RouteRule {
+                    event: "tmux.*".into(),
+                    filter: BTreeMap::from([("session".into(), "clawhip-*".into())]),
+                    sink: "discord".into(),
+                    channel: Some("heuristic-route".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "tmux.*".into(),
+                    filter: BTreeMap::from([("repo_name".into(), "clawhip".into())]),
+                    sink: "discord".into(),
+                    channel: Some("metadata-route".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+
+        assert_eq!(
+            resolve_tmux_session_channel_with_metadata(
+                &config,
+                "clawhip-issue-152",
+                &RoutingMetadata {
+                    repo_name: Some("clawhip".into()),
+                    project: Some("clawhip".into()),
+                    worktree_path: Some("/repo/clawhip.worktrees/issue-152".into()),
+                    ..RoutingMetadata::default()
+                }
+            )
+            .as_deref(),
+            Some("metadata-route")
+        );
+    }
+
+    #[test]
+    fn resolve_tmux_session_channel_with_metadata_does_not_fallback_to_prefix_heuristics() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.*".into(),
+                filter: BTreeMap::from([("session".into(), "clawhip-*".into())]),
+                sink: "discord".into(),
+                channel: Some("heuristic-route".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        assert_eq!(
+            resolve_tmux_session_channel_with_metadata(
+                &config,
+                "clawhip-issue-152",
+                &RoutingMetadata {
+                    repo_name: Some("clawhip".into()),
+                    project: Some("clawhip".into()),
+                    worktree_path: Some("/repo/clawhip.worktrees/issue-152".into()),
+                    ..RoutingMetadata::default()
+                }
+            )
+            .as_deref(),
+            Some("default")
         );
     }
 

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -12,7 +12,7 @@ use tokio::time::sleep;
 use crate::Result;
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, TmuxSessionMonitor};
-use crate::events::{IncomingEvent, MessageFormat};
+use crate::events::{IncomingEvent, MessageFormat, RoutingMetadata};
 use crate::keyword_window::{PendingKeywordHits, collect_keyword_hits};
 use crate::router::glob_match;
 use crate::source::Source;
@@ -50,6 +50,8 @@ pub struct RegisteredTmuxSession {
     pub channel: Option<String>,
     pub mention: Option<String>,
     #[serde(default)]
+    pub routing: RoutingMetadata,
+    #[serde(default)]
     pub keywords: Vec<String>,
     #[serde(default = "default_keyword_window_secs")]
     pub keyword_window_secs: u64,
@@ -71,6 +73,7 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             session: value.session.clone(),
             channel: value.channel.clone(),
             mention: value.mention.clone(),
+            routing: RoutingMetadata::default(),
             keywords: value.keywords.clone(),
             keyword_window_secs: value.keyword_window_secs,
             stale_minutes: value.stale_minutes,
@@ -626,6 +629,7 @@ fn tmux_keyword_event(
     };
 
     event
+        .with_routing_metadata(&registration.routing)
         .with_mention(registration.mention.clone())
         .with_format(registration.format.clone())
 }
@@ -643,6 +647,7 @@ fn tmux_stale_event(
         last_line,
         registration.channel.clone(),
     )
+    .with_routing_metadata(&registration.routing)
     .with_mention(registration.mention.clone())
     .with_format(registration.format.clone())
 }
@@ -856,6 +861,7 @@ mod tests {
             session: "issue-24".into(),
             channel: Some("alerts".into()),
             mention: Some("<@123>".into()),
+            routing: RoutingMetadata::default(),
             keywords: keywords.into_iter().map(str::to_string).collect(),
             keyword_window_secs: 30,
             stale_minutes: 15,
@@ -901,6 +907,30 @@ PR created #7",
         assert_eq!(event.payload["keyword"], "error");
         assert_eq!(event.payload["line"], "boom");
         assert_eq!(event.payload["hit_count"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn tmux_keyword_event_carries_registered_routing_metadata() {
+        let mut registration = registration(vec!["error"]);
+        registration.routing = RoutingMetadata {
+            project: Some("clawhip".into()),
+            repo_name: Some("clawhip".into()),
+            worktree_path: Some("/repo/clawhip.worktrees/issue-152".into()),
+            ..RoutingMetadata::default()
+        };
+
+        let event = tmux_keyword_event(
+            &registration,
+            "clawhip-issue-152".into(),
+            vec![("error".into(), "boom".into())],
+        );
+
+        assert_eq!(event.payload["project"], "clawhip");
+        assert_eq!(event.payload["repo_name"], "clawhip");
+        assert_eq!(
+            event.payload["worktree_path"],
+            "/repo/clawhip.worktrees/issue-152"
+        );
     }
 
     #[test]
@@ -979,6 +1009,7 @@ PR created #7",
                     session: "issue-105".into(),
                     channel: Some("alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["error".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -995,6 +1026,7 @@ PR created #7",
                     session: "wrapper".into(),
                     channel: Some("alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["panic".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1014,6 +1046,7 @@ PR created #7",
                     session: "stale-config".into(),
                     channel: Some("alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["panic".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1034,6 +1067,7 @@ PR created #7",
                     session: "issue-105".into(),
                     channel: Some("alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["error".into(), "complete".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1081,6 +1115,7 @@ PR created #7",
         let registration = RegisteredTmuxSession {
             format: Some(MessageFormat::Compact),
             mention: None,
+            routing: RoutingMetadata::default(),
             ..registration(vec!["error", "complete"])
         };
         let start = Instant::now();
@@ -1128,6 +1163,7 @@ PR created #7",
         let registration = RegisteredTmuxSession {
             format: Some(MessageFormat::Compact),
             mention: None,
+            routing: RoutingMetadata::default(),
             ..registration(vec!["error", "complete"])
         };
         let start = Instant::now();
@@ -1161,6 +1197,7 @@ PR created #7",
         let registration = RegisteredTmuxSession {
             format: Some(MessageFormat::Compact),
             mention: None,
+            routing: RoutingMetadata::default(),
             ..registration(vec!["error"])
         };
         let start = Instant::now();
@@ -1224,6 +1261,7 @@ error: failed";
         let registration = RegisteredTmuxSession {
             format: Some(MessageFormat::Compact),
             mention: None,
+            routing: RoutingMetadata::default(),
             ..registration(vec!["error", "complete"])
         };
         let start = Instant::now();
@@ -1282,6 +1320,7 @@ error: failed";
         let registration = RegisteredTmuxSession {
             format: Some(MessageFormat::Compact),
             mention: None,
+            routing: RoutingMetadata::default(),
             ..registration(vec!["error"])
         };
         let start = Instant::now();
@@ -1338,6 +1377,7 @@ error: failed";
                 session: "rcc-*".into(),
                 channel: Some("alerts".into()),
                 mention: None,
+                routing: RoutingMetadata::default(),
                 keywords: vec!["panic".into()],
                 keyword_window_secs: 30,
                 stale_minutes: 10,
@@ -1367,6 +1407,7 @@ error: failed";
                     session: "rcc-*".into(),
                     channel: Some("rcc-alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["panic".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1380,6 +1421,7 @@ error: failed";
                     session: "omx-*".into(),
                     channel: Some("omx-alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["error".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1407,6 +1449,7 @@ error: failed";
                     session: "exact-session".into(),
                     channel: Some("alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["panic".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1420,6 +1463,7 @@ error: failed";
                     session: "rcc-*".into(),
                     channel: Some("alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["panic".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1446,6 +1490,7 @@ error: failed";
                     session: "*".into(),
                     channel: Some("default-alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["error".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1459,6 +1504,7 @@ error: failed";
                     session: "rcc-api".into(),
                     channel: Some("rcc-alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["panic".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1485,6 +1531,7 @@ error: failed";
                     session: "*".into(),
                     channel: Some("default-alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["error".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1498,6 +1545,7 @@ error: failed";
                     session: "rcc-*".into(),
                     channel: Some("rcc-alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["panic".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1529,6 +1577,7 @@ error: failed";
                     session: "*abc*".into(),
                     channel: Some("broad-alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["error".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,
@@ -1542,6 +1591,7 @@ error: failed";
                     session: "abc*".into(),
                     channel: Some("specific-alerts".into()),
                     mention: None,
+                    routing: RoutingMetadata::default(),
                     keywords: vec!["panic".into()],
                     keyword_window_secs: 30,
                     stale_minutes: 10,

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 use std::time::Duration;
 
 use tokio::process::Command;
@@ -8,7 +9,8 @@ use crate::Result;
 use crate::cli::{TmuxNewArgs, TmuxWatchArgs, TmuxWrapperFormat};
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
-use crate::router::resolve_tmux_session_channel;
+use crate::events::RoutingMetadata;
+use crate::router::resolve_tmux_session_channel_with_metadata;
 use crate::source::tmux::{
     ParentProcessInfo, RegisteredTmuxSession, RegistrationSource, content_hash,
     current_timestamp_rfc3339, monitor_registered_session, session_exists, tmux_bin,
@@ -42,6 +44,7 @@ struct TmuxMonitorArgs {
     session: String,
     channel: Option<String>,
     mention: Option<String>,
+    routing: RoutingMetadata,
     keywords: Vec<String>,
     keyword_window_secs: u64,
     stale_minutes: u64,
@@ -57,6 +60,7 @@ impl From<&TmuxNewArgs> for TmuxMonitorArgs {
             session: value.session.clone(),
             channel: value.channel.clone(),
             mention: value.mention.clone(),
+            routing: routing_metadata_for_cwd(value.cwd.as_deref()),
             keywords: value.keywords.clone(),
             keyword_window_secs: default_keyword_window_secs(),
             stale_minutes: value.stale_minutes,
@@ -72,7 +76,11 @@ impl TmuxMonitorArgs {
     fn from_new_args(value: &TmuxNewArgs, config: &AppConfig) -> Self {
         let mut monitor_args = Self::from(value);
         if monitor_args.channel.is_none() {
-            monitor_args.channel = resolve_tmux_session_channel(config, &value.session);
+            monitor_args.channel = resolve_tmux_session_channel_with_metadata(
+                config,
+                &value.session,
+                &monitor_args.routing,
+            );
         }
         monitor_args
     }
@@ -84,6 +92,7 @@ impl From<&TmuxWatchArgs> for TmuxMonitorArgs {
             session: value.session.clone(),
             channel: value.channel.clone(),
             mention: value.mention.clone(),
+            routing: routing_metadata_for_session(&value.session),
             keywords: value.keywords.clone(),
             keyword_window_secs: default_keyword_window_secs(),
             stale_minutes: value.stale_minutes,
@@ -101,6 +110,7 @@ impl From<TmuxMonitorArgs> for RegisteredTmuxSession {
             session: value.session,
             channel: value.channel,
             mention: value.mention,
+            routing: value.routing,
             keywords: value.keywords,
             keyword_window_secs: value.keyword_window_secs,
             stale_minutes: value.stale_minutes,
@@ -111,6 +121,80 @@ impl From<TmuxMonitorArgs> for RegisteredTmuxSession {
             active_wrapper_monitor: true,
         }
     }
+}
+
+fn routing_metadata_for_cwd(cwd: Option<&str>) -> RoutingMetadata {
+    let Some(cwd) = cwd.map(str::trim).filter(|cwd| !cwd.is_empty()) else {
+        return RoutingMetadata::default();
+    };
+    let workdir = Path::new(cwd);
+    let worktree_path = fs::canonicalize(workdir)
+        .unwrap_or_else(|_| workdir.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
+    let repo_path = git_output(workdir, &["rev-parse", "--show-toplevel"]);
+    let project = detect_project(workdir).or_else(|| {
+        repo_path
+            .as_deref()
+            .map(|path| dir_basename(Path::new(path)))
+    });
+    let branch = git_output(workdir, &["branch", "--show-current"]);
+
+    RoutingMetadata {
+        project: project.clone(),
+        repo_name: project,
+        repo_path,
+        worktree_path: Some(worktree_path),
+        branch,
+        ..RoutingMetadata::default()
+    }
+}
+
+fn routing_metadata_for_session(session: &str) -> RoutingMetadata {
+    let cwd = std::process::Command::new(tmux_bin())
+        .args([
+            "display-message",
+            "-p",
+            "-t",
+            session,
+            "#{pane_current_path}",
+        ])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    routing_metadata_for_cwd(cwd.as_deref())
+}
+
+fn detect_project(workdir: &Path) -> Option<String> {
+    let common_dir = git_output(
+        workdir,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?;
+
+    Path::new(&common_dir)
+        .parent()
+        .and_then(|path| path.file_name())
+        .map(|name| name.to_string_lossy().into_owned())
+}
+
+fn git_output(workdir: &Path, args: &[&str]) -> Option<String> {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(workdir)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn dir_basename(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".into())
 }
 
 async fn register_and_start_monitor(
@@ -368,6 +452,19 @@ mod tests {
     use super::*;
     use crate::config::{AppConfig, DefaultsConfig, RouteRule};
     use std::collections::BTreeMap;
+    use std::process::Command as StdCommand;
+    use tempfile::tempdir;
+
+    fn init_git_repo() -> tempfile::TempDir {
+        let dir = tempdir().expect("tempdir");
+        let status = StdCommand::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(dir.path())
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init should succeed");
+        dir
+    }
 
     #[test]
     fn build_command_to_send_preserves_shell_arguments_when_joining() {
@@ -485,6 +582,7 @@ mod tests {
             session: "issue-105".into(),
             channel: Some("alerts".into()),
             mention: None,
+            routing: RoutingMetadata::default(),
             keywords: vec!["error".into()],
             keyword_window_secs: 30,
             stale_minutes: 10,
@@ -512,6 +610,7 @@ mod tests {
             session: "issue-105".into(),
             channel: Some("alerts".into()),
             mention: Some("<@123>".into()),
+            routing: RoutingMetadata::default(),
             keywords: vec!["error".into(), "complete".into()],
             keyword_window_secs: 30,
             stale_minutes: 12,
@@ -577,6 +676,65 @@ mod tests {
         let monitor_args = TmuxMonitorArgs::from_new_args(&args, &config);
 
         assert_eq!(monitor_args.channel.as_deref(), Some("xeroclaw-dev"));
+    }
+
+    #[test]
+    fn new_args_auto_resolve_channel_prefers_repo_metadata_over_session_prefix_heuristics() {
+        let repo = init_git_repo();
+        let args = TmuxNewArgs {
+            session: "clawhip-issue-152".into(),
+            window_name: None,
+            cwd: Some(repo.path().to_string_lossy().into_owned()),
+            channel: None,
+            mention: None,
+            keywords: Vec::new(),
+            stale_minutes: 10,
+            format: None,
+            attach: false,
+            retry_enter: true,
+            retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
+            retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
+            shell: None,
+            command: vec!["codex".into()],
+        };
+        let repo_name = repo
+            .path()
+            .file_name()
+            .and_then(|value| value.to_str())
+            .expect("repo name")
+            .to_string();
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: crate::events::MessageFormat::Compact,
+            },
+            routes: vec![
+                RouteRule {
+                    event: "tmux.*".into(),
+                    filter: BTreeMap::from([("session".into(), "clawhip-*".into())]),
+                    sink: "discord".into(),
+                    channel: Some("heuristic-route".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "session.*".into(),
+                    filter: BTreeMap::from([("repo_name".into(), repo_name)]),
+                    sink: "discord".into(),
+                    channel: Some("metadata-route".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+
+        let monitor_args = TmuxMonitorArgs::from_new_args(&args, &config);
+
+        assert_eq!(monitor_args.channel.as_deref(), Some("metadata-route"));
+        assert_eq!(
+            monitor_args.routing.worktree_path.as_deref(),
+            Some(repo.path().to_string_lossy().as_ref())
+        );
+        assert!(monitor_args.routing.repo_name.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- prefer stable repo/project/worktree metadata over session-name prefix heuristics when resolving tmux/session routes
- thread routing metadata through tmux registrations and emitted tmux events so channel resolution uses authoritative metadata first
- add regression tests covering metadata-first routing and heuristic-only fallback behavior

## Verification
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings