### PR TITLE
feat: tmux snapshot summarization, dashboard pinning, and waiting-for-input detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # clawhip — AGENTS.md
 
-Daemon-first event gateway for Discord. Routes GitHub, tmux, and custom events to channels.
+Daemon-first event gateway for Discord and Slack. Routes GitHub, tmux, git, workspace, and cron events to channels. Supports LLM-powered tmux snapshot summarization and per-session dashboard pinning.
 
 ## Working agreements
 
@@ -9,6 +9,8 @@ Daemon-first event gateway for Discord. Routes GitHub, tmux, and custom events t
 - New routes/filters: add integration tests.
 - CLI subcommands: include `--help` descriptions for all flags.
 - Keep the daemon lightweight — no unnecessary allocations in the hot path.
+- Keyword dedup is within-window only; do not carry `seen` state across windows.
+- Dashboard slot edits go through `update_dashboard_slot`; do not post new messages for pinned slots.
 
 ## Review guidelines
 
@@ -18,6 +20,7 @@ Daemon-first event gateway for Discord. Routes GitHub, tmux, and custom events t
 - TOML config parsing: ensure new fields have sensible defaults (don't break existing configs).
 - Route matching: verify glob patterns are tested with edge cases.
 - tmux integration: confirm session monitoring handles missing/dead sessions gracefully.
+- Summarization: LLM calls must run as background tasks and never block the poll loop.
 - New dependencies must be justified — prefer std library where possible.
 - Daemon lifecycle: verify clean shutdown and signal handling.
 - Test coverage: flag new logic paths that lack corresponding tests.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,118 +1,159 @@
-# clawhip Architecture — v0.4.0
+# clawhip Architecture — v0.5.x
 
-clawhip v0.4.0 ships a daemon-first event pipeline for Discord delivery, plus the clone-local install/memory surfaces that wrap it. This document describes the architecture that is present on the `release/0.4.0` branch.
+clawhip is a daemon-first event pipeline for Discord and Slack delivery. This document reflects the architecture on the current development branch.
 
 ## Release themes
 
-- typed event model
-- multi-delivery router
-- extracted event sources
+- typed event model with normalized session contract
+- multi-delivery router (Discord bot, Discord webhook, Slack webhook)
+- extracted event sources (git, GitHub, tmux, workspace, cron)
 - renderer/sink separation
-- install lifecycle polish
-- filesystem memory scaffolds
+- tmux snapshot summarization with pluggable LLM backends
+- dashboard pinning: up to 5 per-session in-place Discord messages
+- waiting-for-input detection and resolved state machine
+- batch dispatch with per-stream windows
 
 ## High-level flow
 
 ```text
-[CLI / webhook / git / GitHub / tmux]
+[CLI / webhook / git / GitHub / tmux / workspace / cron]
               -> [sources]
               -> [mpsc queue]
-              -> [dispatcher]
-              -> [router -> renderer -> discord sink]
-              -> [Discord REST delivery]
+              -> [dispatcher + batcher]
+              -> [router -> renderer -> discord/slack sink]
+              -> [Discord REST / Slack webhook delivery]
 ```
 
 ## Core components
 
 ### Typed event model (`crate::event`)
 
-The daemon accepts legacy `IncomingEvent` payloads at ingress, normalizes them, and converts them into typed internal events through `crate::event::compat`. That gives v0.4.0 a typed event model without breaking the existing CLI and HTTP surfaces.
-
-Key event families shipped in v0.4.0:
+The daemon accepts legacy `IncomingEvent` payloads at ingress and normalizes them through `crate::event::compat` into typed internal events. The canonical event families are:
 
 - custom events
-- git commit and branch-change events
-- GitHub issue opened / commented / closed events
-- GitHub pull-request status change events
-- agent lifecycle events
-- tmux keyword and stale-session events
+- git: `git.commit`, `git.branch-changed`
+- github: `github.issue-opened`, `github.issue-commented`, `github.issue-closed`, `github.pr-status-changed`, `github.ci-started`, `github.ci-passed`, `github.ci-failed`, `github.ci-cancelled`
+- agent/session: `agent.*` (legacy) and `session.*` (native contract)
+- tmux: `tmux.keyword`, `tmux.stale`, `tmux.content_changed`, `tmux.heartbeat`, `tmux.waiting_for_input`, `tmux.session_ended`
+- workspace: `workspace.skill.activated`, `workspace.session.*`, `workspace.hud.*`
+- cron: `cron.job`
 
 ### Sources (`crate::source`)
 
-Event production is split into dedicated sources behind the `Source` trait:
+Each source implements the `Source` trait and feeds a shared Tokio `mpsc` queue:
 
-- `GitSource` polls configured repositories for commit and branch changes
-- `GitHubSource` polls configured repositories for issue and PR changes
-- `TmuxSource` monitors tmux sessions for keyword hits and stale panes
-
-All sources feed a shared Tokio `mpsc` queue. This replaces the earlier tighter coupling between monitors, routing, and transport.
+- `GitSource` — polls configured repos for commit and branch changes
+- `GitHubSource` — polls GitHub API for issue and PR state changes; also polls CI run status
+- `TmuxSource` — monitors tmux sessions per poll cycle; drives keyword detection, stale detection, heartbeat, summarization, and waiting-for-input state machine
+- `WorkspaceSource` — watches filesystem paths for file changes using a debounced poll loop; supports worktree discovery
+- `CronSource` — evaluates cron schedules on each tick and emits `cron.job` events for matching jobs
 
 ### Dispatcher (`crate::dispatch`)
 
-`Dispatcher` is the queue consumer. For each incoming event it:
+`Dispatcher` is the queue consumer. For each event it:
 
-1. resolves matching deliveries with the router
-2. renders content for each delivery
-3. hands the rendered message to the configured sink
-4. continues best-effort when one delivery fails
+1. classifies the event as routine, CI, or bypass
+2. buffers routine events in a per-delivery-signature batcher (default 5s window)
+3. buffers CI events in a separate CI batcher (default 30s window)
+4. bypass events (failures, alerts, stale) skip the batcher entirely
+5. resolves deliveries through the router, renders each one, and hands it to the sink
+6. continues best-effort when one delivery fails; failed deliveries land in the DLQ
 
-This is the central coordination point for the v0.4.0 pipeline.
+Batch windows are configurable via `[dispatch].routine_batch_window_secs` and `[dispatch].ci_batch_window_secs`. Setting routine window to `0` disables batching.
 
 ### Router (`crate::router`)
 
-The router now resolves **0..N deliveries per event**. In practice that means:
-
-- multiple route rules can match the same event
-- a match no longer stops at the first rule
-- each resolved delivery keeps the destination target, format, template, and mention context
-
-This is the main behavioral change behind the v0.4.0 multi-delivery architecture.
+Resolves **0..N deliveries per event**. Multiple route rules can match the same event; all matches are collected and delivered independently. Each resolved delivery carries its destination target, format, template, mention context, and dynamic-token opt-in flag.
 
 ### Renderer (`crate::render`)
 
-Rendering is now explicit. The default renderer is responsible for formatting supported event bodies into compact, alert, inline, or raw output before transport.
+Formats event bodies into `compact`, `alert`, `raw`, or custom template output. The renderer is sink-agnostic; the Discord and Slack sinks each receive the same rendered string.
 
-That keeps message formatting out of the transport layer and makes the dispatch pipeline easier to extend and test.
+### Sink (`crate::discord`, `crate::slack`)
 
-### Sink (`crate::sink`)
+Two sinks ship:
 
-Transport is represented by the `Sink` trait. The primary shipped sink in v0.4.0 is the Discord sink, which delivers either to a Discord channel or a Discord webhook target.
+- **Discord sink** — delivers to a bot-token channel or a Discord webhook; handles 429 rate limiting with retry-after backoff; exhausted retries go to the DLQ
+- **Slack sink** — delivers to a Slack incoming webhook URL
 
-The renderer/sink split is important even with a single shipped sink because it removes transport concerns from routing and event modeling.
+## Summarization (`crate::summarize`)
 
-## Configuration model
+Triggered by `TmuxSource` when pane content changes and `summarize = true` is set. Runs as a non-blocking background task so it never stalls the poll loop.
 
-The preferred Discord configuration surface in v0.4.0 is:
+Backends:
 
-```toml
-[providers.discord]
-token = "..."
-default_channel = "1234567890"
-```
+| Spec | Implementation |
+|---|---|
+| `raw` | Returns truncated pane content verbatim |
+| `gemini:<model>` | Shells out to the `gemini` CLI subprocess |
+| `openrouter:<model>` | HTTP POST to OpenRouter chat completions API |
+| `openai:<model>` / `openai-compatible:<model>` | HTTP POST to OpenAI-compatible chat completions API |
 
-Legacy `[discord]` configuration is still accepted and normalized on load for backward compatibility.
+The summarizer produces `tmux.content_changed` events with `content_mode: "raw"` (raw passthrough) or `"summary"` (LLM result). Raw mode edits a single living Discord message per session; summary mode posts a new message each time to build a historical record.
 
-Routes continue to use the familiar event/filter model, with a `sink` field that defaults to `"discord"`:
+## Dashboard pinning (`crate::discord`)
 
-```toml
-[[routes]]
-event = "github.*"
-filter = { repo = "clawhip" }
-sink = "discord"
-channel = "1480171113253175356"
-mention = "<@1465264645320474637>"
-format = "compact"
-```
+Each monitored tmux session maintains up to 5 pinned Discord messages, edited in-place rather than posting new messages. Slot names and their event sources:
+
+| Slot | Trigger | Default |
+|---|---|---|
+| `status` | `tmux.heartbeat` | pinned (on) |
+| `summary` | `tmux.content_changed` | pinned (on) |
+| `alert` | `tmux.waiting_for_input`, `tmux.waiting_resolved` | pinned (on) |
+| `activity` | all dashboard events (rolling log) | pinned (on) |
+| `keywords` | `tmux.keyword` (rolling log) | not pinned (off) |
+
+Message IDs are persisted to `~/.clawhip/dashboard.json`. On daemon restart, existing message IDs are reused so edits land on the same messages. When a session ends (`tmux.session_ended`), all pinned messages for that session are unpinned via the Discord API and the session entry is cleared from `dashboard.json`.
+
+When a slot message does not yet exist, a new message is posted and its ID is saved. Subsequent events for the same slot edit that message in-place (PATCH).
+
+## Waiting-for-input state machine (`crate::source::tmux`)
+
+`TmuxSource` tracks a per-pane `is_waiting: bool` flag. On each poll cycle, `is_waiting_for_input()` inspects the last 3 non-empty lines of pane content (filtered from `capture-pane -S -200` output, which pads with blank rows) and matches against a list of patterns covering interactive prompts, confirmation dialogs, credential prompts, and Claude Code tool-approval flows.
+
+State transitions:
+
+- `(false, Some(prompt))` → emit `tmux.waiting_for_input`, set `is_waiting = true`
+- `(true, None)` → emit `tmux.waiting_resolved`, set `is_waiting = false`
+- `(true, Some(_))` — still waiting, suppress duplicate events
+
+The 3-line window is intentional: after one user reply (output line + echoed command + new shell prompt = 3 non-empty lines), the original waiting prompt falls out of the window, triggering the resolved transition.
+
+`tmux.waiting_for_input` and `tmux.waiting_resolved` both carry `dashboard_component = "alert"` when `pin_alerts = true`, routing them to the alert dashboard slot. Resolved events render as `✅ \`session\` — Input received, continuing...`.
+
+## Keyword windowing (`crate::keyword_window`)
+
+`PendingKeywordHits` accumulates keyword hits within a time window. Deduplication is within-window only: the same `(keyword, line)` pair is reported at most once per window. After a window is flushed, the next window starts fresh — identical pairs can fire again in subsequent windows.
+
+When `keyword_window_secs` expires, hits are emitted as a single `tmux.keyword` event. The window is per-session and per-daemon-registration.
+
+## Configuration model (`crate::config`)
+
+Top-level sections:
+
+- `[providers.discord]` / legacy `[discord]` — Discord bot token and default channel
+- `[providers.gemini]`, `[providers.openrouter]`, `[providers.openai]` — LLM API keys
+- `[daemon]` — bind host, port, base URL
+- `[defaults]` — fallback channel and format
+- `[dispatch]` — batch window tuning
+- `[[routes]]` — event routing rules
+- `[monitors]` — global poll interval, GitHub token, source configs
+- `[[monitors.git.repos]]` — git repo monitors
+- `[[monitors.tmux.sessions]]` — tmux session monitors with full dashboard/summarization config
+- `[[monitors.workspace]]` — filesystem change monitors
+- `[cron]` + `[[cron.jobs]]` — scheduled message delivery
+
+See README for the complete field-level reference.
 
 ## Delivery semantics
 
-v0.4.0 currently uses these delivery rules:
-
 - per-source FIFO through the shared queue
-- best-effort multi-delivery; one failed delivery does not stop the others
-- no built-in retry queue
-- source-level tmux keyword windowing, with dispatch remaining stateless
+- routine events are batched per delivery signature; bypass events skip the batcher
+- best-effort multi-delivery; one failed delivery does not block others
+- 429 rate-limit responses are retried with retry-after backoff
+- exhausted retries go to an in-memory DLQ for observability
+- source-level tmux keyword windowing; dispatch is otherwise stateless
 
 ## Operational verification
 
-The release branch includes a live verification runbook in [`docs/live-verification.md`](docs/live-verification.md). It covers daemon status, custom events, git events, GitHub issue/PR flows, and tmux monitoring.
+See [`docs/live-verification.md`](docs/live-verification.md) for the full runbook.

--- a/README.md
+++ b/README.md
@@ -915,6 +915,274 @@ Required live sign-off presets:
 - tmux watch
 - install/update/uninstall
 
+## Complete config reference
+
+Config file: `~/.clawhip/config.toml` (override with `CLAWHIP_CONFIG=/path/to/config.toml`)
+
+### Top-level structure
+
+```toml
+[providers.discord]    # Discord bot token and default channel
+[providers.gemini]     # Gemini API key (alternative to env var)
+[providers.openrouter] # OpenRouter API key (alternative to env var)
+[providers.openai]     # OpenAI API key and base URL (alternative to env vars)
+[daemon]               # Bind host, port, base URL
+[defaults]             # Fallback channel and format
+[dispatch]             # Batch window tuning
+[[routes]]             # Event routing rules (one per [[routes]] block)
+[monitors]             # Poll interval, GitHub token, git/tmux/workspace sources
+[[monitors.git.repos]] # Git repo monitors (one per block)
+[[monitors.tmux.sessions]] # Tmux session monitors (one per block)
+[[monitors.workspace]] # Workspace file-change monitors (one per block)
+[cron]                 # Cron scheduler config
+[[cron.jobs]]          # Cron jobs (one per block)
+```
+
+### `[providers.discord]`
+
+```toml
+[providers.discord]
+token = "Bot-token-here"
+default_channel = "1480171113253175356"
+```
+
+Legacy `[discord]` is accepted and merged at load time. Conflicting values between `[discord]` and `[providers.discord]` are a load error.
+
+Token resolution order: config file → `DISCORD_TOKEN` → `CLAWHIP_DISCORD_BOT_TOKEN` → `DISCORD_BOT_TOKEN`.
+
+### `[providers.gemini]`, `[providers.openrouter]`, `[providers.openai]`
+
+Store API keys in config instead of (or in addition to) environment variables:
+
+```toml
+[providers.gemini]
+api_key = "AIza..."
+
+[providers.openrouter]
+api_key = "sk-or-..."
+
+[providers.openai]
+api_key = "sk-..."
+base_url = "https://api.x.ai/v1"  # optional; override for xAI, Ollama, etc.
+```
+
+Environment variable equivalents: `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`.
+
+### `[daemon]`
+
+```toml
+[daemon]
+bind_host = "0.0.0.0"        # default: 0.0.0.0
+port = 25294                  # default: 25294
+base_url = "http://127.0.0.1:25294"  # default: http://127.0.0.1:<port>
+```
+
+`base_url` is used by thin-client CLI commands to reach the daemon. Change it when running the daemon on a remote host or non-default port.
+
+### `[defaults]`
+
+```toml
+[defaults]
+channel = "1480171113253175356"  # fallback channel when no route matches
+format = "compact"               # fallback format: "compact" | "alert" | "raw" (default: compact)
+```
+
+### `[dispatch]`
+
+```toml
+[dispatch]
+routine_batch_window_secs = 5    # Discord routine burst batch window (default: 5; 0 = disable)
+ci_batch_window_secs = 30        # GitHub CI batch flush window (default: 30)
+```
+
+`routine_batch_window_secs`: groups routine deliveries (commits, keywords, agent events) into a single Discord message within the window. Set to `0` to disable batching entirely. Mentions are suppressed when 2+ items are batched together.
+
+`ci_batch_window_secs`: how long clawhip waits before flushing a GitHub CI job batch. Increase for workflows with jobs that run over several minutes.
+
+### `[[routes]]`
+
+```toml
+[[routes]]
+event = "tmux.*"               # required; glob matched against event kind
+filter = { session = "dev" }   # optional; payload key/value filters
+sink = "discord"               # "discord" (default) | "slack"
+channel = "1480171113253175356" # Discord channel ID (bot-token mode)
+webhook = "https://discord.com/api/webhooks/..."  # Discord webhook (no token needed)
+slack_webhook = "https://hooks.slack.com/services/..."  # Slack webhook
+mention = "<@1465264645320474637>"  # prepended to rendered message
+format = "compact"             # "compact" | "alert" | "raw"; overrides defaults.format
+template = "{{session}}: {{content}}"  # custom template string; overrides format
+allow_dynamic_tokens = false   # enable {sh:...}, {env:...}, {tmux_tail:...} expansion
+```
+
+Filter keys for session events: `tool`, `repo_name`, `session_name`, `issue_number`, `branch`.
+Filter keys for git/github events: `repo`, `repo_name`.
+
+Routes are evaluated in order; the first match wins. Events with no matching route fall back to `defaults.channel`.
+
+### `[monitors]`
+
+```toml
+[monitors]
+poll_interval_secs = 5           # global poll interval for all sources (default: 5)
+github_token = "ghp_..."         # GitHub API token for issue/PR polling
+github_api_base = "https://api.github.com"  # override for GitHub Enterprise
+```
+
+`github_token` is also read from the `GITHUB_TOKEN` environment variable.
+
+### `[[monitors.git.repos]]`
+
+```toml
+[[monitors.git.repos]]
+path = "/home/user/projects/myapp"  # required; local repo path
+name = "myapp"                      # optional; used in event payloads and route filters
+remote = "origin"                   # default: "origin"
+github_repo = "owner/myapp"        # optional; enables GitHub issue/PR polling
+emit_commits = true                 # emit git.commit on new commits (default: true)
+emit_branch_changes = true          # emit git.branch-changed on branch switches (default: true)
+emit_issue_opened = true            # emit github.issue-opened via polling (default: true)
+emit_pr_status = false              # emit github.pr-status-changed via polling (default: false)
+channel = "1480171113253175356"    # optional; override channel for this repo's events
+mention = "<@123>"                  # optional; mention for this repo's events
+format = "compact"                  # optional; format override
+```
+
+### `[[monitors.tmux.sessions]]`
+
+```toml
+[[monitors.tmux.sessions]]
+session = "my-session"             # required; tmux session name or glob (e.g. "rcc-*")
+channel = "1480171113253175356"    # required; Discord channel for this session's events
+mention = "<@123>"                 # optional; mention prepended to events
+format = "compact"                 # optional; "compact" | "alert" | "raw"
+
+# ── Keyword detection ─────────────────────────────────────────────────────────
+keywords = ["error", "fail", "complete"]  # keywords to watch for in pane output
+keyword_window_secs = 30          # dedup window: same (keyword, line) pair suppressed within window (default: 30)
+
+# ── Stale detection ───────────────────────────────────────────────────────────
+stale_minutes = 10                # minutes of inactivity before tmux.stale fires (default: 10; 0 = disable)
+stale_interval = 0                # alias for stale_minutes; overrides stale_minutes when set
+
+# ── Summarization ─────────────────────────────────────────────────────────────
+summarize = false                 # enable pane snapshot summarization (default: false)
+summarizer = "gemini:gemini-2.5-flash"  # backend (see table below)
+min_new_lines = 0                 # min net new lines required to trigger summarization (0 = no filter)
+summarize_interval_mins = 0       # min minutes between LLM calls (0 = no throttle)
+summary_interval = 0              # alias for summarize_interval_mins; overrides when set
+
+# ── Heartbeat ─────────────────────────────────────────────────────────────────
+heartbeat_mins = 0                # minutes of idle before tmux.heartbeat fires (0 = disable)
+heartbeat_interval = 0            # alias for heartbeat_mins; overrides when set
+
+# ── Input detection ───────────────────────────────────────────────────────────
+detect_waiting = false            # emit tmux.waiting_for_input when pane blocks on input (default: false)
+waiting_interval = 0              # cooldown minutes between waiting alerts (0 = no cooldown)
+
+# ── Mention filtering ─────────────────────────────────────────────────────────
+mention_on = []                   # restrict @mention to specific event kinds
+                                  # values: "keyword" | "waiting_for_input" | "content_changed"
+                                  #         | "stale" | "heartbeat"
+                                  # empty = mention applies to all events (default)
+
+# ── Dashboard pinning ─────────────────────────────────────────────────────────
+# Dashboard is a set of up to 5 pinned Discord messages edited in-place.
+# Enabled automatically when any pin_* = true.
+pin_status = true                 # pin status/heartbeat slot (default: true)
+pin_summary = true                # pin AI summary slot (default: true)
+pin_alerts = true                 # pin waiting-for-input alert slot (default: true)
+pin_activity = true               # pin rolling activity log slot (default: true)
+pin_keywords = false              # pin rolling keyword hits slot (default: false)
+activity_interval = 0             # cooldown minutes between activity log updates (0 = no cooldown)
+```
+
+#### Summarizer backends
+
+| Config value | Description | Requires |
+|---|---|---|
+| `raw` | Latest terminal output verbatim (no LLM) | nothing |
+| `gemini` / `gemini:<model>` | Gemini CLI subprocess | `gemini` CLI in PATH |
+| `openrouter:<model>` | OpenRouter API | `OPENROUTER_API_KEY` or `[providers.openrouter]` |
+| `openai:<model>` | OpenAI API | `OPENAI_API_KEY` or `[providers.openai]` |
+| `openai-compatible:<model>` | Any OpenAI-compatible endpoint | `OPENAI_API_KEY` + `OPENAI_BASE_URL` |
+
+Default models when no model suffix is given: Gemini → `gemini-2.5-flash`, OpenRouter → `openai/gpt-4o-mini`, OpenAI → `gpt-4o-mini`.
+
+#### Dashboard delivery behavior
+
+| Event | Discord behavior | Slot |
+|---|---|---|
+| `tmux.content_changed` (raw) | Edit in-place | summary |
+| `tmux.content_changed` (AI summary) | New message | — |
+| `tmux.heartbeat` | Edit in-place | status |
+| `tmux.waiting_for_input` | Edit in-place | alert |
+| `tmux.waiting_resolved` | Edit in-place (✅) | alert |
+| `tmux.keyword` (pin_keywords=true) | Edit in-place rolling log | keywords |
+| `tmux.keyword` (pin_keywords=false) | New message | — |
+| `tmux.stale` | New message | — |
+| `tmux.session_ended` | Unpin all slots, clear dashboard | — |
+
+Dashboard message IDs are persisted to `~/.clawhip/dashboard.json` so in-place edits survive daemon restarts.
+
+### `[[monitors.workspace]]`
+
+Watches filesystem paths for file changes and emits `workspace.*` events.
+
+```toml
+[[monitors.workspace]]
+path = "/home/user/projects/myapp"  # required; root path to watch
+watch_dirs = [".omc", ".claude"]    # subdirs to watch (default: [".omc", ".claude"])
+discover_worktrees = false           # auto-discover git worktrees under path (default: false)
+channel = "1480171113253175356"     # optional; channel override
+mention = "<@123>"                   # optional; mention override
+format = "compact"                   # optional; format override
+events = ["skill.activated"]         # optional; restrict to specific event kinds (empty = all)
+poll_interval_secs = 5               # optional; override global poll_interval_secs for this monitor
+debounce_ms = 500                    # deduplicate rapid file changes within this window (default: 500)
+```
+
+### `[[cron.jobs]]`
+
+Scheduled message delivery using cron expressions.
+
+```toml
+[cron]
+poll_interval_secs = 30  # how often clawhip checks the cron schedule (default: 30)
+
+[[cron.jobs]]
+id = "daily-standup"             # required; unique job identifier
+kind = "custom-message"          # required; currently only "custom-message" is supported
+schedule = "0 9 * * 1-5"         # required; cron expression (minute hour dom month dow)
+timezone = "UTC"                  # default: "UTC" (only UTC accepted; others rejected)
+enabled = true                   # default: true; set false to disable without removing
+message = "🌅 Morning standup reminder — check open PRs and blockers."
+channel = "1480171113253175356"  # optional; override defaults.channel for this job
+mention = "<@123>"               # optional; mention prepended to message
+format = "compact"               # optional; format override
+```
+
+Cron schedule syntax supports standard five-field expressions including lists (`1,3,5`), ranges (`1-5`), and steps (`*/15`).
+
+Job IDs must be unique within the config. Duplicate IDs are rejected at load time.
+
+### Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `CLAWHIP_CONFIG` | Override config file path |
+| `DISCORD_TOKEN` | Discord bot token (highest priority env source) |
+| `CLAWHIP_DISCORD_BOT_TOKEN` | Discord bot token (second priority) |
+| `DISCORD_BOT_TOKEN` | Discord bot token (third priority) |
+| `GITHUB_TOKEN` | GitHub API token for issue/PR polling |
+| `GEMINI_API_KEY` | Gemini API key for summarization |
+| `OPENROUTER_API_KEY` | OpenRouter API key for summarization |
+| `OPENAI_API_KEY` | OpenAI API key for summarization |
+| `OPENAI_BASE_URL` | OpenAI-compatible base URL (e.g. xAI, Ollama) |
+| `CLAWHIP_SKIP_STAR_PROMPT` | Set to `1` to skip post-install GitHub star prompt |
+
+Config file values take precedence over environment variables for API keys. Discord token resolution always prefers env vars over config.
+
 ## Minimal operational commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -631,6 +631,82 @@ Verification:
 - emit keyword in pane
 - confirm Discord message body and mention
 
+### 13. tmux snapshot summarization preset
+
+Input:
+- built-in config monitor with `summarize = true` on a `[[monitors.tmux.sessions]]` entry
+
+Behavior:
+- on pane content change, spawn a non-blocking background task (does NOT stall the poll loop)
+- call the configured summarizer backend
+- emit `tmux.content_changed` with `content_mode = "raw"` or `"summary"` depending on backend
+- `raw` mode: edits a single living Discord message per session with the latest terminal output
+- `summary` mode: posts a new Discord message per AI summary (historical record)
+- `tmux.heartbeat`: edits the same Discord message per session while session is idle
+- `tmux.waiting_for_input`: edits the same Discord message per session while waiting for user input
+
+Verification:
+- generate ≥ `min_new_lines` new lines in the monitored session
+- confirm `📋` (raw) or `🤖` (AI summary) message in target channel
+- confirm heartbeat `💓` message updates in-place after idle interval
+- confirm `⏳` waiting message updates in-place when session blocks on input
+
+#### Session config reference
+
+```toml
+[[monitors.tmux.sessions]]
+session = "my-session"
+channel = "YOUR_CHANNEL_ID"
+
+# ── Summarization ─────────────────────────────────────────────────────────────
+summarize = true                        # enable snapshot summarization
+summarizer = "gemini:gemini-2.5-flash"  # see backend options below
+summarize_interval_mins = 5             # min minutes between LLM calls (0 = no throttle)
+min_new_lines = 3                       # min net new lines before triggering (0 = no filter)
+
+# ── Input detection ───────────────────────────────────────────────────────────
+detect_waiting = true    # emit tmux.waiting_for_input when session blocks on input
+
+# ── Heartbeat ─────────────────────────────────────────────────────────────────
+heartbeat_mins = 5       # emit tmux.heartbeat after this many idle minutes (0 = disabled)
+
+# ── Keywords (real-time, always fires regardless of summarize settings) ────────
+keywords = ["error", "complete", "done", "fail"]
+keyword_window_secs = 30  # debounce window; deduplicates across flushes
+```
+
+#### Summarizer backends
+
+| Config value | Description | Requires |
+|---|---|---|
+| `raw` | Passes latest terminal output directly (no LLM) | nothing |
+| `gemini` / `gemini:<model>` | Gemini CLI subprocess | `gemini` CLI in PATH |
+| `openrouter:<model>` | OpenRouter API | `OPENROUTER_API_KEY` env var |
+| `openai:<model>` | OpenAI or any OpenAI-compatible endpoint | `OPENAI_API_KEY` env var |
+| `openai-compatible:<model>` | Same as `openai:` | `OPENAI_API_KEY` env var |
+
+For non-OpenRouter OpenAI-compatible endpoints (xAI Grok, Together AI, Ollama, etc.), set `OPENAI_BASE_URL` before starting the daemon:
+
+```bash
+export OPENAI_BASE_URL="https://api.x.ai/v1"
+export OPENAI_API_KEY="your-key"
+# config: summarizer = "openai:grok-3"
+```
+
+Default models when no model is specified: Gemini → `gemini-2.5-flash`, OpenRouter → `openai/gpt-4o-mini`, OpenAI → `gpt-4o-mini`.
+
+#### Discord delivery behavior
+
+| Event | Discord behavior | Key |
+|---|---|---|
+| `tmux.content_changed` (raw) | **Edit in-place** | one message per session |
+| `tmux.content_changed` (AI summary) | **New message** | historical record |
+| `tmux.heartbeat` | **Edit in-place** | one message per session |
+| `tmux.waiting_for_input` | **Edit in-place** | one message per session |
+| `tmux.keyword` | **New message** | real-time, deduped across windows |
+
+Keywords fire in real-time regardless of `summarize_interval_mins`. The same `(keyword, line)` pair is never repeated across consecutive keyword messages.
+
 ### 12. install lifecycle preset
 
 Input:
@@ -687,6 +763,9 @@ Verification:
 ### tmux family
 - `tmux.keyword`
 - `tmux.stale`
+- `tmux.content_changed` — pane content changed; carries `content_mode: "raw" | "summary"`
+- `tmux.heartbeat` — session idle for configured interval; **edits** the previous heartbeat message in-place
+- `tmux.waiting_for_input` — session is blocking on user input; **edits** previous waiting message in-place
 
 ## Route contract
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,28 @@ pub struct ProvidersConfig {
     pub discord: DiscordConfig,
     #[serde(default)]
     pub slack: SlackConfig,
+    #[serde(default)]
+    pub gemini: GeminiConfig,
+    #[serde(default)]
+    pub openrouter: OpenRouterConfig,
+    #[serde(default)]
+    pub openai: OpenAiConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GeminiConfig {
+    pub api_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpenRouterConfig {
+    pub api_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpenAiConfig {
+    pub api_key: Option<String>,
+    pub base_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -300,6 +322,41 @@ pub struct TmuxSessionMonitor {
     /// Minimum minutes between LLM summarization calls for this session. 0 = no throttle.
     #[serde(default)]
     pub summarize_interval_mins: u64,
+    /// Event kinds that trigger the @mention. Empty = mention applies to all events.
+    /// Valid values: "keyword", "waiting_for_input", "content_changed", "stale", "heartbeat".
+    #[serde(default)]
+    pub mention_on: Vec<String>,
+    /// Pin and update the status/heartbeat dashboard message in-place.
+    /// Dashboard is implicit: enabled when any pin_* = true.
+    #[serde(default = "default_true")]
+    pub pin_status: bool,
+    /// Pin and update the summary dashboard message in-place.
+    #[serde(default = "default_true")]
+    pub pin_summary: bool,
+    /// Pin and update the alert dashboard message in-place.
+    #[serde(default = "default_true")]
+    pub pin_alerts: bool,
+    /// Pin and update the rolling activity log message in-place.
+    #[serde(default = "default_true")]
+    pub pin_activity: bool,
+    /// Pin keyword hits as a rolling log dashboard slot. Default false (backward compat).
+    #[serde(default)]
+    pub pin_keywords: bool,
+    /// Minutes between heartbeat events. 0 = disable. Overrides heartbeat_mins when set.
+    #[serde(default)]
+    pub heartbeat_interval: u64,
+    /// Minutes before a session is considered stale. 0 = disable. Overrides stale_minutes when set.
+    #[serde(default)]
+    pub stale_interval: u64,
+    /// Minimum minutes between AI summary events. 0 = use summarize_interval_mins.
+    #[serde(default)]
+    pub summary_interval: u64,
+    /// Cooldown minutes between waiting-for-input alerts. 0 = no cooldown.
+    #[serde(default)]
+    pub waiting_interval: u64,
+    /// Cooldown minutes between activity log updates. 0 = no cooldown.
+    #[serde(default)]
+    pub activity_interval: u64,
 }
 
 impl Default for TmuxSessionMonitor {
@@ -318,6 +375,17 @@ impl Default for TmuxSessionMonitor {
             detect_waiting: false,
             min_new_lines: 0,
             summarize_interval_mins: 0,
+            mention_on: Vec::new(),
+            pin_status: true,
+            pin_summary: true,
+            pin_alerts: true,
+            pin_activity: true,
+            pin_keywords: false,
+            heartbeat_interval: 0,
+            stale_interval: 0,
+            summary_interval: 0,
+            waiting_interval: 0,
+            activity_interval: 0,
         }
     }
 }
@@ -455,7 +523,7 @@ pub fn default_sink_name() -> String {
     "discord".to_string()
 }
 
-const DISCORD_TOKEN_ENV_VARS: [&str; 2] = ["DISCORD_TOKEN", "CLAWHIP_DISCORD_BOT_TOKEN"];
+const DISCORD_TOKEN_ENV_VARS: [&str; 3] = ["DISCORD_TOKEN", "CLAWHIP_DISCORD_BOT_TOKEN", "DISCORD_BOT_TOKEN"];
 
 fn merge_legacy_discord_field(
     field: &str,
@@ -564,9 +632,41 @@ impl AppConfig {
     }
 
     pub fn effective_token(&self) -> Option<String> {
-        self.effective_token_with(|name| env::var(name).ok())
+        self.effective_token_with(|name| {
+            env::var(name).ok().or_else(|| load_clawhip_dot_env(name))
+        })
     }
 
+}
+
+/// Parse a single KEY=VALUE line from a .env file, stripping optional quotes.
+fn parse_dot_env_key(content: &str, key: &str) -> Option<String> {
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            if k.trim() == key {
+                let v = v.trim().trim_matches('"').trim_matches('\'');
+                if !v.is_empty() {
+                    return Some(v.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Load a key from ~/.clawhip/.env if the file exists.
+fn load_clawhip_dot_env(key: &str) -> Option<String> {
+    let home = env::var("HOME").ok()?;
+    let path = std::path::Path::new(&home).join(".clawhip").join(".env");
+    let content = fs::read_to_string(path).ok()?;
+    parse_dot_env_key(&content, key)
+}
+
+impl AppConfig {
     fn effective_token_with<F>(&self, get_env: F) -> Option<String>
     where
         F: FnMut(&str) -> Option<String>,
@@ -1017,6 +1117,55 @@ mod tests {
     }
 
     #[test]
+    fn parse_dot_env_key_basic() {
+        let content = "DISCORD_BOT_TOKEN=abc123\nOTHER=val\n";
+        assert_eq!(
+            parse_dot_env_key(content, "DISCORD_BOT_TOKEN").as_deref(),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn parse_dot_env_key_strips_quotes() {
+        assert_eq!(
+            parse_dot_env_key("K=\"quoted\"\n", "K").as_deref(),
+            Some("quoted")
+        );
+        assert_eq!(
+            parse_dot_env_key("K='single'\n", "K").as_deref(),
+            Some("single")
+        );
+    }
+
+    #[test]
+    fn parse_dot_env_key_ignores_comments_and_blanks() {
+        let content = "# comment\n\nDISCORD_BOT_TOKEN=tok\n";
+        assert_eq!(
+            parse_dot_env_key(content, "DISCORD_BOT_TOKEN").as_deref(),
+            Some("tok")
+        );
+    }
+
+    #[test]
+    fn parse_dot_env_key_missing_returns_none() {
+        assert_eq!(parse_dot_env_key("OTHER=val\n", "DISCORD_BOT_TOKEN"), None);
+    }
+
+    #[test]
+    fn effective_token_falls_back_to_dot_env_via_callback() {
+        // Simulate what effective_token does: env var missing, .env returns value
+        let config = AppConfig::default();
+        // We can't write to HOME in tests, but we can verify the env-callback path
+        // by passing a closure that simulates the .env file content.
+        let token = config.effective_token_with(|name| {
+            // Simulate: env var not set, but .env file contains the token
+            let dot_env = "DISCORD_BOT_TOKEN=dot-env-token\n";
+            parse_dot_env_key(dot_env, name)
+        });
+        assert_eq!(token.as_deref(), Some("dot-env-token"));
+    }
+
+    #[test]
     fn provider_discord_token_is_used_when_present() {
         let mut config = AppConfig::default();
         config.providers.discord.bot_token = Some("config-token".into());
@@ -1105,6 +1254,9 @@ mod tests {
                     legacy_default_channel: None,
                 },
                 slack: SlackConfig::default(),
+                gemini: GeminiConfig::default(),
+                openrouter: OpenRouterConfig::default(),
+                openai: OpenAiConfig::default(),
             },
             routes: vec![RouteRule {
                 event: "tmux.keyword".into(),
@@ -1342,6 +1494,9 @@ message = " ping "
                     legacy_default_channel: None,
                 },
                 slack: SlackConfig::default(),
+                gemini: GeminiConfig::default(),
+                openrouter: OpenRouterConfig::default(),
+                openai: OpenAiConfig::default(),
             },
             cron: CronConfig {
                 poll_interval_secs: 30,

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,6 +285,15 @@ pub struct TmuxSessionMonitor {
     pub channel: Option<String>,
     pub mention: Option<String>,
     pub format: Option<MessageFormat>,
+    // ── Optional tmux content transformation ──
+    #[serde(default)]
+    pub summarize: bool,
+    #[serde(default = "default_summarizer")]
+    pub summarizer: String,
+    #[serde(default)]
+    pub heartbeat_mins: u64,
+    #[serde(default)]
+    pub detect_waiting: bool,
 }
 
 impl Default for TmuxSessionMonitor {
@@ -297,6 +306,10 @@ impl Default for TmuxSessionMonitor {
             channel: None,
             mention: None,
             format: None,
+            summarize: false,
+            summarizer: default_summarizer(),
+            heartbeat_mins: 0,
+            detect_waiting: false,
         }
     }
 }
@@ -424,6 +437,10 @@ fn default_cron_timezone() -> String {
 }
 fn default_true() -> bool {
     true
+}
+
+fn default_summarizer() -> String {
+    "gemini:gemini-2.5-flash".to_string()
 }
 
 pub fn default_sink_name() -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,6 +294,12 @@ pub struct TmuxSessionMonitor {
     pub heartbeat_mins: u64,
     #[serde(default)]
     pub detect_waiting: bool,
+    /// Minimum number of new lines added before triggering summarization. 0 = no filter.
+    #[serde(default)]
+    pub min_new_lines: usize,
+    /// Minimum minutes between LLM summarization calls for this session. 0 = no throttle.
+    #[serde(default)]
+    pub summarize_interval_mins: u64,
 }
 
 impl Default for TmuxSessionMonitor {
@@ -310,6 +316,8 @@ impl Default for TmuxSessionMonitor {
             summarizer: default_summarizer(),
             heartbeat_mins: 0,
             detect_waiting: false,
+            min_new_lines: 0,
+            summarize_interval_mins: 0,
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -619,6 +619,7 @@ mod tests {
                     name: Some("codex".into()),
                 }),
                 active_wrapper_monitor: true,
+                ..Default::default()
             },
         );
         let state = AppState {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,10 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::Result;
@@ -14,6 +15,16 @@ use crate::core::dlq::{Dlq, DlqEntry};
 use crate::core::rate_limit::RateLimiter;
 use crate::sink::{SinkMessage, SinkTarget};
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct DashboardSlotIds {
+    pub status: Option<String>,
+    pub summary: Option<String>,
+    pub alert: Option<String>,
+    pub activity: Option<String>,
+    pub keywords: Option<String>,
+}
+
+const DASHBOARD_SEPARATOR: &str = "\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}";
 const MAX_ATTEMPTS: u32 = 3;
 const JITTER_MS: u64 = 50;
 const CIRCUIT_FAILURE_THRESHOLD: u32 = 3;
@@ -34,9 +45,20 @@ struct DiscordState {
     limiter: RateLimiter,
     circuits: HashMap<String, CircuitBreaker>,
     dlq: Dlq,
-    /// Tracks the last Discord message ID sent for each heartbeat session+channel.
-    /// Key: "{channel_id}:{session}". Used to edit instead of post new messages.
+    /// Tracks the last Discord message ID for edit-in-place event types.
+    /// Key: "{channel_id}:{edit_key}".
     last_heartbeat_msg_ids: HashMap<String, String>,
+    /// Accumulated rendered content for append-only keyword messages.
+    /// Key: "{channel_id}:keywords:{session}".
+    accumulated_keyword_content: HashMap<String, String>,
+    /// Dashboard message IDs per "{channel}:{session}".
+    dashboard_ids: HashMap<String, DashboardSlotIds>,
+    /// Rolling activity log per "{channel}:{session}" -- last 5 events.
+    activity_log: HashMap<String, VecDeque<String>>,
+    /// Rolling keyword hit log per "{channel}:{session}".
+    keyword_log: HashMap<String, VecDeque<String>>,
+    /// Path to dashboard persistence file.
+    dashboard_path: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -72,6 +94,15 @@ impl DiscordClient {
             .unwrap_or_else(|_| "https://discord.com/api/v10".to_string());
         let webhook_client = reqwest::Client::new();
 
+        let dashboard_path = std::env::var("HOME")
+            .ok()
+            .map(|h| PathBuf::from(h).join(".clawhip").join("dashboard.json"));
+        let dashboard_ids: HashMap<String, DashboardSlotIds> = dashboard_path
+            .as_ref()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+
         Ok(Self {
             bot_client,
             webhook_client,
@@ -81,6 +112,11 @@ impl DiscordClient {
                 circuits: HashMap::new(),
                 dlq: Dlq::default(),
                 last_heartbeat_msg_ids: HashMap::new(),
+                accumulated_keyword_content: HashMap::new(),
+                dashboard_ids,
+                activity_log: HashMap::new(),
+                keyword_log: HashMap::new(),
+                dashboard_path,
             })),
         })
     }
@@ -102,21 +138,97 @@ impl DiscordClient {
             let result = match target {
                 SinkTarget::DiscordChannel(channel_id) => {
                     let session = message.payload["session"].as_str().unwrap_or("unknown");
-                    let edit_key = match message.event_kind.as_str() {
-                        "tmux.heartbeat" => Some(format!("heartbeat:{session}")),
-                        "tmux.waiting_for_input" => Some(format!("waiting:{session}")),
-                        "tmux.content_changed"
-                            if message.payload["content_mode"].as_str() == Some("raw") =>
+                    let dashboard_slot = message.payload["dashboard_component"].as_str();
+
+                    if let Some(slot) = dashboard_slot {
+                        let ts = time::OffsetDateTime::now_utc()
+                            .format(&time::format_description::well_known::Rfc3339)
+                            .unwrap_or_default();
+                        let dashboard_content = if slot == "keywords" {
+                            let entry = format!("`{ts}` {}", truncate_keyword_entry(&message.content));
+                            let log_text = self.push_keyword_log(channel_id, session, &entry);
+                            format!("\u{1f511} `{session}` \u{00b7} Keyword Hits\n{DASHBOARD_SEPARATOR}\n{log_text}")
+                        } else if slot == "alert"
+                            && message.payload["resolved"].as_bool().unwrap_or(false)
                         {
-                            Some(format!("raw:{session}"))
-                        }
-                        _ => None,
-                    };
-                    if let Some(key) = edit_key {
-                        self.send_or_edit_keyed(channel_id, &key, &message.content)
+                            format!("✅ `{session}` — Input received, continuing...")
+                        } else {
+                            render_dashboard_slot(
+                                slot,
+                                session,
+                                &message.event_kind,
+                                &message.content,
+                            )
+                        };
+
+                        let activity_entry =
+                            format!("`{ts}` {} -- {}", message.event_kind, truncate_activity(&message.content));
+                        let activity_text = self.push_activity(channel_id, session, &activity_entry);
+                        let activity_content = format!(
+                            "\u{1f4dc} `{session}` \u{00b7} Recent Activity\n{DASHBOARD_SEPARATOR}\n{activity_text}"
+                        );
+                        let should_pin_activity = message.payload["pin_activity"].as_bool().unwrap_or(true);
+                        let _ = self
+                            .update_dashboard_slot(channel_id, session, "activity", &activity_content, should_pin_activity)
+                            .await;
+
+                        self.update_dashboard_slot(channel_id, session, slot, &dashboard_content, true)
                             .await
                     } else {
-                        self.send_message(channel_id, &message.content).await
+                        match message.event_kind.as_str() {
+                            "tmux.session_ended" => {
+                                self.clear_session_dashboard(channel_id, session).await;
+                                return Ok(());
+                            }
+                            "tmux.heartbeat" => {
+                                self.send_or_edit_keyed(
+                                    channel_id,
+                                    &format!("heartbeat:{session}"),
+                                    &message.content,
+                                )
+                                .await
+                            }
+                            "tmux.waiting_for_input" => {
+                                let content = if message.payload["resolved"].as_bool().unwrap_or(false) {
+                                    format!("✅ `{session}` — Input received, continuing...")
+                                } else {
+                                    message.content.clone()
+                                };
+                                self.send_or_edit_keyed(
+                                    channel_id,
+                                    &format!("waiting:{session}"),
+                                    &content,
+                                )
+                                .await
+                            }
+                            "tmux.content_changed"
+                                if message.payload["content_mode"].as_str() == Some("raw") =>
+                            {
+                                self.send_or_edit_keyed(
+                                    channel_id,
+                                    &format!("raw:{session}"),
+                                    &message.content,
+                                )
+                                .await
+                            }
+                            "tmux.stale" => {
+                                self.send_or_edit_keyed(
+                                    channel_id,
+                                    &format!("stale:{session}"),
+                                    &message.content,
+                                )
+                                .await
+                            }
+                            "tmux.keyword" => {
+                                self.append_keyword_keyed(
+                                    channel_id,
+                                    &format!("keywords:{session}"),
+                                    &message.content,
+                                )
+                                .await
+                            }
+                            _ => self.send_message(channel_id, &message.content).await,
+                        }
                     }
                 }
                 SinkTarget::DiscordWebhook(webhook_url) => {
@@ -222,7 +334,7 @@ impl DiscordClient {
 
     /// For edit-in-place event types (heartbeat, raw, waiting): edit the previous
     /// message for this key if possible, otherwise post a new one and store the ID.
-    /// `edit_key` is a logical key like "heartbeat:session-name" or "raw:session-name".
+    /// `edit_key` is a logical key like "heartbeat:session-name" or "content:session-name".
     async fn send_or_edit_keyed(
         &self,
         channel_id: &str,
@@ -249,6 +361,70 @@ impl DiscordClient {
         if let Some(id) = msg_id {
             let mut state = self.state.lock().expect("discord state lock");
             state.last_heartbeat_msg_ids.insert(key, id);
+        }
+        Ok(())
+    }
+
+    /// Append new keyword hits to an existing message, or post a new one if none exists.
+    /// When appended content would exceed the Discord limit, starts a fresh message.
+    async fn append_keyword_keyed(
+        &self,
+        channel_id: &str,
+        edit_key: &str,
+        new_content: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let key = format!("{channel_id}:{edit_key}");
+        let (existing_id, accumulated) = {
+            let state = self.state.lock().expect("discord state lock");
+            let id = state.last_heartbeat_msg_ids.get(&key).cloned();
+            let acc = state
+                .accumulated_keyword_content
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            (id, acc)
+        };
+
+        let updated = if accumulated.is_empty() {
+            new_content.to_string()
+        } else {
+            format!("{accumulated}\n{new_content}")
+        };
+        // If appending would overflow, start a fresh message
+        let (content_to_send, is_continuation) = if updated.len() > 1990 {
+            (new_content.to_string(), false)
+        } else {
+            (updated, true)
+        };
+        let content_to_send = truncate_discord(&content_to_send).to_string();
+
+        if is_continuation {
+            if let Some(msg_id) = existing_id {
+                match self.edit_message(channel_id, &msg_id, &content_to_send).await {
+                    Ok(()) => {
+                        let mut state = self.state.lock().expect("discord state lock");
+                        state
+                            .accumulated_keyword_content
+                            .insert(key, content_to_send);
+                        return Ok(());
+                    }
+                    Err(e)
+                        if e.message.contains("404")
+                            || e.message.contains("Unknown Message") => {}
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+
+        let msg_id = self
+            .send_message_returning_id(channel_id, &content_to_send)
+            .await?;
+        if let Some(id) = msg_id {
+            let mut state = self.state.lock().expect("discord state lock");
+            state.last_heartbeat_msg_ids.insert(key.clone(), id);
+            state
+                .accumulated_keyword_content
+                .insert(key, content_to_send);
         }
         Ok(())
     }
@@ -313,6 +489,183 @@ impl DiscordClient {
             message: format!("{label} failed with {status}: {body}"),
             retry_after: parse_retry_after(status, &body),
         })
+    }
+
+    /// Pin a message in a Discord channel.
+    async fn pin_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let url = format!(
+            "{}/channels/{}/pins/{}",
+            self.api_base.trim_end_matches('/'),
+            channel_id,
+            message_id
+        );
+        let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
+            message: "missing Discord bot token for pinning".to_string(),
+            retry_after: None,
+        })?;
+        self.execute_request(client.put(url).json(&json!({})), "Discord pin request")
+            .await
+    }
+
+    async fn unpin_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let url = format!(
+            "{}/channels/{}/pins/{}",
+            self.api_base.trim_end_matches('/'),
+            channel_id,
+            message_id
+        );
+        let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
+            message: "missing Discord bot token for unpinning".to_string(),
+            retry_after: None,
+        })?;
+        self.execute_request(client.delete(url), "Discord unpin request")
+            .await
+    }
+
+    /// Unpin all dashboard messages for a session and clear its slot IDs.
+    async fn clear_session_dashboard(&self, channel_id: &str, session: &str) {
+        let slot_key = format!("{channel_id}:{session}");
+
+        // Collect message IDs while holding the lock, then release before async calls
+        let ids_to_unpin = {
+            let state = self.state.lock().expect("discord state lock");
+            let Some(ids) = state.dashboard_ids.get(&slot_key) else {
+                return;
+            };
+            [
+                ids.status.clone(),
+                ids.summary.clone(),
+                ids.alert.clone(),
+                ids.activity.clone(),
+                ids.keywords.clone(),
+            ]
+        };
+
+        for msg_id in ids_to_unpin.into_iter().flatten() {
+            let _ = self.unpin_message(channel_id, &msg_id).await;
+        }
+
+        // Clear the IDs and persist
+        {
+            let mut state = self.state.lock().expect("discord state lock");
+            state.dashboard_ids.remove(&slot_key);
+            // Also clear in-memory keyword and activity logs for this session
+            state.keyword_log.retain(|k, _| !k.starts_with(&format!("{channel_id}:{session}")));
+            state.activity_log.retain(|k, _| !k.starts_with(&format!("{channel_id}:{session}")));
+        }
+        self.persist_dashboard();
+    }
+
+    /// Persist dashboard message IDs to disk.
+    fn persist_dashboard(&self) {
+        let state = self.state.lock().expect("discord state lock");
+        let Some(ref path) = state.dashboard_path else {
+            return;
+        };
+        if let Ok(json) = serde_json::to_string_pretty(&state.dashboard_ids) {
+            let _ = std::fs::write(path, json);
+        }
+    }
+
+    /// Update (or create) a pinned dashboard slot message.
+    async fn update_dashboard_slot(
+        &self,
+        channel_id: &str,
+        session: &str,
+        slot: &str,
+        content: &str,
+        should_pin: bool,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let slot_key = format!("{channel_id}:{session}");
+
+        let existing_id = {
+            let state = self.state.lock().expect("discord state lock");
+            state
+                .dashboard_ids
+                .get(&slot_key)
+                .and_then(|ids| match slot {
+                    "status" => ids.status.clone(),
+                    "summary" => ids.summary.clone(),
+                    "alert" => ids.alert.clone(),
+                    "activity" => ids.activity.clone(),
+                    "keywords" => ids.keywords.clone(),
+                    _ => None,
+                })
+        };
+
+        if let Some(msg_id) = existing_id {
+            match self.edit_message(channel_id, &msg_id, content).await {
+                Ok(()) => return Ok(()),
+                Err(e) if e.message.contains("404") || e.message.contains("Unknown Message") => {
+                    let mut state = self.state.lock().expect("discord state lock");
+                    if let Some(ids) = state.dashboard_ids.get_mut(&slot_key) {
+                        match slot {
+                            "status" => ids.status = None,
+                            "summary" => ids.summary = None,
+                            "alert" => ids.alert = None,
+                            "activity" => ids.activity = None,
+                            "keywords" => ids.keywords = None,
+                            _ => {}
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let new_id = self.send_message_returning_id(channel_id, content).await?;
+        if let Some(id) = new_id {
+            if should_pin {
+                let _ = self.pin_message(channel_id, &id).await;
+            }
+            {
+                let mut state = self.state.lock().expect("discord state lock");
+                let ids = state.dashboard_ids.entry(slot_key).or_default();
+                match slot {
+                    "status" => ids.status = Some(id),
+                    "summary" => ids.summary = Some(id),
+                    "alert" => ids.alert = Some(id),
+                    "activity" => ids.activity = Some(id),
+                    "keywords" => ids.keywords = Some(id),
+                    _ => {}
+                }
+            }
+            self.persist_dashboard();
+        }
+        Ok(())
+    }
+
+    /// Push an entry to the rolling activity log and return the combined log text.
+    fn push_activity(&self, channel_id: &str, session: &str, entry: &str) -> String {
+        let key = format!("{channel_id}:{session}");
+        let mut state = self.state.lock().expect("discord state lock");
+        let log = state.activity_log.entry(key).or_default();
+        if log.len() >= 5 {
+            log.pop_front();
+        }
+        log.push_back(entry.to_string());
+        log.iter().cloned().collect::<Vec<_>>().join("\n")
+    }
+
+    /// Push an entry to the rolling keyword log. Drops oldest entries when total chars exceed 1800.
+    fn push_keyword_log(&self, channel_id: &str, session: &str, entry: &str) -> String {
+        let key = format!("{channel_id}:{session}");
+        let mut state = self.state.lock().expect("discord state lock");
+        let log = state.keyword_log.entry(key).or_default();
+        log.push_back(entry.to_string());
+        // Drop oldest entries until total content fits within ~1800 chars
+        while log.iter().map(|e| e.len() + 1).sum::<usize>() > 1800 && log.len() > 1 {
+            log.pop_front();
+        }
+        log.iter().cloned().collect::<Vec<_>>().join("\n")
     }
 
     fn allow_request(&self, key: &str) -> bool {
@@ -442,6 +795,70 @@ fn webhook_url_with_wait(webhook_url: &str) -> String {
     }
 }
 
+/// Render dashboard-formatted content for a given slot.
+fn render_dashboard_slot(slot: &str, session: &str, event_kind: &str, content: &str) -> String {
+    match slot {
+        "status" => {
+            let status_icon = if event_kind == "tmux.stale" {
+                "\u{23f1}\u{fe0f} Stale"
+            } else {
+                "\u{1f493} Active"
+            };
+            let body = truncate_dashboard(content, 1500);
+            format!("\u{1f4ca} `{session}` \u{00b7} Status\n{DASHBOARD_SEPARATOR}\n{status_icon}\n{body}")
+        }
+        "summary" => {
+            let body = truncate_dashboard(content, 1500);
+            format!("\u{1f4cb} `{session}` \u{00b7} Latest Output\n{DASHBOARD_SEPARATOR}\n{body}")
+        }
+        "alert" => {
+            let body = truncate_dashboard(content, 1500);
+            format!("\u{1f6a8} `{session}` \u{00b7} **WAITING FOR INPUT**\n{DASHBOARD_SEPARATOR}\n{body}")
+        }
+        _ => content.to_string(),
+    }
+}
+
+/// Truncate content for dashboard slots to stay within Discord limits.
+fn truncate_dashboard(content: &str, max_len: usize) -> String {
+    if content.len() <= max_len {
+        content.to_string()
+    } else {
+        let mut end = max_len;
+        while !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}\u{2026}", &content[..end])
+    }
+}
+
+/// Truncate a single activity log entry to keep the rolling log compact.
+/// Truncate for keywords rolling log entries — preserves all lines (for multi-hit aggregated
+/// events), capping total entry length to 300 chars.
+fn truncate_keyword_entry(content: &str) -> String {
+    if content.len() <= 300 {
+        return content.to_string();
+    }
+    let mut end = 300;
+    while !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\u{2026}", &content[..end])
+}
+
+fn truncate_activity(content: &str) -> String {
+    let first_line = content.lines().next().unwrap_or(content);
+    if first_line.len() > 120 {
+        let mut end = 120;
+        while !first_line.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}\u{2026}", &first_line[..end])
+    } else {
+        first_line.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -556,5 +973,31 @@ mod tests {
         assert_eq!(dlq.len(), 1);
         assert_eq!(dlq[0].payload["repo"], "clawhip");
         assert_eq!(dlq[0].retry_count, 3);
+    }
+
+    #[test]
+    fn push_keyword_log_accumulates_and_evicts_oldest() {
+        let config = Arc::new(AppConfig::default());
+        let client = DiscordClient::from_config(config).unwrap();
+
+        // Small entries accumulate
+        let r1 = client.push_keyword_log("ch1", "sess", "entry1");
+        assert_eq!(r1, "entry1");
+        let r2 = client.push_keyword_log("ch1", "sess", "entry2");
+        assert_eq!(r2, "entry1\nentry2");
+
+        // Large entry forces eviction of oldest
+        let big = "x".repeat(1000);
+        client.push_keyword_log("ch1", "sess", &big);
+        let r4 = client.push_keyword_log("ch1", "sess", &big);
+        // After adding two ~1000-char entries, total > 1800 so oldest should be evicted
+        assert!(!r4.starts_with("entry1"), "oldest entry should have been evicted");
+    }
+
+    #[test]
+    fn render_dashboard_slot_keywords_falls_through_to_content() {
+        // keywords slot content is built inline in send(), render_dashboard_slot is not used for it
+        let result = render_dashboard_slot("keywords", "test-session", "tmux.keyword", "some hits");
+        assert_eq!(result, "some hits");
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -34,6 +34,9 @@ struct DiscordState {
     limiter: RateLimiter,
     circuits: HashMap<String, CircuitBreaker>,
     dlq: Dlq,
+    /// Tracks the last Discord message ID sent for each heartbeat session+channel.
+    /// Key: "{channel_id}:{session}". Used to edit instead of post new messages.
+    last_heartbeat_msg_ids: HashMap<String, String>,
 }
 
 #[derive(Debug)]
@@ -77,6 +80,7 @@ impl DiscordClient {
                 limiter: RateLimiter::new(RATE_LIMIT_CAPACITY, RATE_LIMIT_REFILL_PER_SEC),
                 circuits: HashMap::new(),
                 dlq: Dlq::default(),
+                last_heartbeat_msg_ids: HashMap::new(),
             })),
         })
     }
@@ -97,7 +101,23 @@ impl DiscordClient {
 
             let result = match target {
                 SinkTarget::DiscordChannel(channel_id) => {
-                    self.send_message(channel_id, &message.content).await
+                    let session = message.payload["session"].as_str().unwrap_or("unknown");
+                    let edit_key = match message.event_kind.as_str() {
+                        "tmux.heartbeat" => Some(format!("heartbeat:{session}")),
+                        "tmux.waiting_for_input" => Some(format!("waiting:{session}")),
+                        "tmux.content_changed"
+                            if message.payload["content_mode"].as_str() == Some("raw") =>
+                        {
+                            Some(format!("raw:{session}"))
+                        }
+                        _ => None,
+                    };
+                    if let Some(key) = edit_key {
+                        self.send_or_edit_keyed(channel_id, &key, &message.content)
+                            .await
+                    } else {
+                        self.send_message(channel_id, &message.content).await
+                    }
                 }
                 SinkTarget::DiscordWebhook(webhook_url) => {
                     self.send_webhook(webhook_url, &message.content).await
@@ -148,10 +168,89 @@ impl DiscordClient {
         })?;
 
         self.execute_request(
-            client.post(url).json(&json!({ "content": content })),
+            client.post(url).json(&json!({ "content": truncate_discord(content) })),
             "Discord API request",
         )
         .await
+    }
+
+    /// Send a message and return the Discord message ID on success.
+    async fn send_message_returning_id(
+        &self,
+        channel_id: &str,
+        content: &str,
+    ) -> std::result::Result<Option<String>, DiscordSendError> {
+        let url = format!(
+            "{}/channels/{}/messages",
+            self.api_base.trim_end_matches('/'),
+            channel_id
+        );
+        let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
+            message: "missing Discord bot token for channel delivery".to_string(),
+            retry_after: None,
+        })?;
+        self.execute_request_returning_id(
+            client.post(url).json(&json!({ "content": truncate_discord(content) })),
+            "Discord API request",
+        )
+        .await
+    }
+
+    /// Edit an existing Discord message.
+    async fn edit_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        content: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let url = format!(
+            "{}/channels/{}/messages/{}",
+            self.api_base.trim_end_matches('/'),
+            channel_id,
+            message_id
+        );
+        let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
+            message: "missing Discord bot token for channel delivery".to_string(),
+            retry_after: None,
+        })?;
+        self.execute_request(
+            client.patch(url).json(&json!({ "content": truncate_discord(content) })),
+            "Discord edit request",
+        )
+        .await
+    }
+
+    /// For edit-in-place event types (heartbeat, raw, waiting): edit the previous
+    /// message for this key if possible, otherwise post a new one and store the ID.
+    /// `edit_key` is a logical key like "heartbeat:session-name" or "raw:session-name".
+    async fn send_or_edit_keyed(
+        &self,
+        channel_id: &str,
+        edit_key: &str,
+        content: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let key = format!("{channel_id}:{edit_key}");
+        let existing_id = {
+            let state = self.state.lock().expect("discord state lock");
+            state.last_heartbeat_msg_ids.get(&key).cloned()
+        };
+
+        if let Some(msg_id) = existing_id {
+            match self.edit_message(channel_id, &msg_id, content).await {
+                Ok(()) => return Ok(()),
+                Err(e) if e.message.contains("404") || e.message.contains("Unknown Message") => {
+                    // Message was deleted; fall through to create a new one
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let msg_id = self.send_message_returning_id(channel_id, content).await?;
+        if let Some(id) = msg_id {
+            let mut state = self.state.lock().expect("discord state lock");
+            state.last_heartbeat_msg_ids.insert(key, id);
+        }
+        Ok(())
     }
 
     async fn send_webhook(
@@ -162,10 +261,36 @@ impl DiscordClient {
         self.execute_request(
             self.webhook_client
                 .post(webhook_url_with_wait(webhook_url))
-                .json(&json!({ "content": content })),
+                .json(&json!({ "content": truncate_discord(content) })),
             "Discord webhook request",
         )
         .await
+    }
+
+    async fn execute_request_returning_id(
+        &self,
+        request: reqwest::RequestBuilder,
+        label: &str,
+    ) -> std::result::Result<Option<String>, DiscordSendError> {
+        let response = request.send().await.map_err(|error| DiscordSendError {
+            message: format!("{label} failed: {error}"),
+            retry_after: None,
+        })?;
+
+        if response.status().is_success() {
+            let body = response
+                .json::<serde_json::Value>()
+                .await
+                .ok();
+            return Ok(body.and_then(|v| v["id"].as_str().map(str::to_string)));
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Err(DiscordSendError {
+            message: format!("{label} failed with {status}: {body}"),
+            retry_after: parse_retry_after(status, &body),
+        })
     }
 
     async fn execute_request(
@@ -291,6 +416,20 @@ fn target_rate_limit_key(target: &SinkTarget) -> String {
 
 fn jitter_for_attempt(attempt: u32) -> Duration {
     Duration::from_millis(JITTER_MS * u64::from(attempt))
+}
+
+/// Truncate content to Discord's 2000-char message limit, appending "…" if clipped.
+fn truncate_discord(content: &str) -> &str {
+    const LIMIT: usize = 1990;
+    if content.len() <= LIMIT {
+        return content;
+    }
+    // Walk back to a char boundary
+    let mut end = LIMIT;
+    while !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    &content[..end]
 }
 
 fn webhook_url_with_wait(webhook_url: &str) -> String {

--- a/src/events.rs
+++ b/src/events.rs
@@ -464,6 +464,19 @@ impl IncomingEvent {
         }
     }
 
+    pub fn tmux_session_ended(session: String, channel: Option<String>) -> Self {
+        Self {
+            kind: "tmux.session_ended".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session": session,
+            }),
+        }
+    }
+
     pub fn tmux_keyword(
         session: String,
         keyword: String,
@@ -1948,7 +1961,7 @@ mod tests {
         assert_eq!(event.payload["hits"].as_array().unwrap().len(), 2);
         assert_eq!(
             event.render_default(&MessageFormat::Compact).unwrap(),
-            "tmux:issue-24 matched 2 keyword hits:\n- 'error': build failed\n- 'complete': job complete"
+            "🔑 tmux:issue-24 matched 2 keyword hits:\n- 'error': build failed\n- 'complete': job complete"
         );
         assert_eq!(
             event.render_default(&MessageFormat::Alert).unwrap(),

--- a/src/events.rs
+++ b/src/events.rs
@@ -550,6 +550,74 @@ impl IncomingEvent {
         }
     }
 
+    /// Tmux content changed — with AI-generated summary.
+    #[allow(clippy::too_many_arguments)]
+    pub fn tmux_content_changed_with_metadata(
+        session: String,
+        pane_name: String,
+        summary: String,
+        raw_truncated: String,
+        backend: String,
+        content_mode: String,
+        channel: Option<String>,
+    ) -> Self {
+        Self {
+            kind: "tmux.content_changed".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session": session,
+                "pane": pane_name,
+                "summary": summary,
+                "raw_truncated": raw_truncated,
+                "backend": backend,
+                "content_mode": content_mode,
+            }),
+        }
+    }
+
+    /// Session is waiting for user input.
+    pub fn tmux_waiting_for_input(
+        session: String,
+        pane_name: String,
+        prompt_snapshot: String,
+        channel: Option<String>,
+    ) -> Self {
+        Self {
+            kind: "tmux.waiting_for_input".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session": session,
+                "pane": pane_name,
+                "prompt_snapshot": prompt_snapshot,
+            }),
+        }
+    }
+
+    /// Heartbeat — no changes detected for a given interval.
+    pub fn tmux_heartbeat(
+        session: String,
+        minutes_since_change: u64,
+        channel: Option<String>,
+    ) -> Self {
+        Self {
+            kind: "tmux.heartbeat".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session": session,
+                "minutes_since_change": minutes_since_change,
+            }),
+        }
+    }
+
     pub fn with_mention(mut self, mention: Option<String>) -> Self {
         self.mention = mention;
         self

--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -39,18 +39,6 @@ impl PendingKeywordHits {
     pub fn into_hits(self) -> Vec<KeywordHit> {
         self.hits
     }
-
-    /// Consume this window's hits and return a fresh window that carries the
-    /// `seen` set forward, so already-reported (keyword, line) pairs are
-    /// never repeated in future windows.
-    pub fn flush_and_reset(self, now: Instant) -> (Vec<KeywordHit>, Self) {
-        let next = Self {
-            started_at: now,
-            hits: Vec::new(),
-            seen: self.seen,
-        };
-        (self.hits, next)
-    }
 }
 
 pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) -> Vec<KeywordHit> {

--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -39,6 +39,18 @@ impl PendingKeywordHits {
     pub fn into_hits(self) -> Vec<KeywordHit> {
         self.hits
     }
+
+    /// Consume this window's hits and return a fresh window that carries the
+    /// `seen` set forward, so already-reported (keyword, line) pairs are
+    /// never repeated in future windows.
+    pub fn flush_and_reset(self, now: Instant) -> (Vec<KeywordHit>, Self) {
+        let next = Self {
+            started_at: now,
+            hits: Vec::new(),
+            seen: self.seen,
+        };
+        (self.hits, next)
+    }
 }
 
 pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) -> Vec<KeywordHit> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod router;
 mod sink;
 mod slack;
 mod source;
+mod summarize;
 mod tmux_wrapper;
 
 use std::sync::Arc;
@@ -350,6 +351,7 @@ mod tests {
                 name: Some("codex".into()),
             }),
             active_wrapper_monitor: true,
+            ..Default::default()
         }]);
 
         assert!(output.contains(

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -253,23 +253,20 @@ impl Renderer for DefaultRenderer {
             ("tmux.keyword", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
 
             ("tmux.stale", MessageFormat::Compact) => format!(
-                "tmux:{} pane {} stale for {}m (last: {})",
+                "💤 **{}**: no new output for {}m · {}",
                 string_field(payload, "session")?,
-                string_field(payload, "pane")?,
                 payload.field_u64("minutes")?,
                 string_field(payload, "last_line")?
             ),
             ("tmux.stale", MessageFormat::Alert) => format!(
-                "🚨 tmux session {} pane {} stale for {}m (last: {})",
+                "🚨 tmux:{} stale for {}m · {}",
                 string_field(payload, "session")?,
-                string_field(payload, "pane")?,
                 payload.field_u64("minutes")?,
                 string_field(payload, "last_line")?
             ),
             ("tmux.stale", MessageFormat::Inline) => format!(
-                "[tmux stale:{} {}] {}m",
+                "💤 [{}] {}m",
                 string_field(payload, "session")?,
-                string_field(payload, "pane")?,
                 payload.field_u64("minutes")?
             ),
             ("tmux.stale", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
@@ -777,7 +774,7 @@ fn render_aggregated_tmux_keyword(
                     format!("🚨 tmux session {session} hit {hit_count} keyword matches:")
                 }
                 MessageFormat::Compact => {
-                    format!("tmux:{session} matched {hit_count} keyword hits:")
+                    format!("🔑 tmux:{session} matched {hit_count} keyword hits:")
                 }
                 _ => unreachable!(),
             };

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -274,6 +274,73 @@ impl Renderer for DefaultRenderer {
             ),
             ("tmux.stale", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
 
+            ("tmux.content_changed", MessageFormat::Compact) => {
+                let session = string_field(payload, "session")?;
+                if content_mode(payload) == "raw" {
+                    let raw = string_field(payload, "raw_truncated")?;
+                    format!("📋 **{session}**: {raw}")
+                } else {
+                    let summary = string_field(payload, "summary")?;
+                    format!("🤖 **{session}**: {summary}")
+                }
+            }
+            ("tmux.content_changed", MessageFormat::Alert) => {
+                let session = string_field(payload, "session")?;
+                if content_mode(payload) == "raw" {
+                    let raw = string_field(payload, "raw_truncated")?;
+                    format!("📋 **{session}**\n```\n{raw}\n```")
+                } else {
+                    let summary = string_field(payload, "summary")?;
+                    format!("🤖 **{session}**\n{summary}")
+                }
+            }
+            ("tmux.content_changed", MessageFormat::Inline) => {
+                let session = string_field(payload, "session")?;
+                if content_mode(payload) == "raw" {
+                    format!("📋 [{session}]")
+                } else {
+                    let summary = string_field(payload, "summary")?;
+                    format!("🤖 [{session}] {summary}")
+                }
+            }
+            ("tmux.content_changed", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
+
+            ("tmux.waiting_for_input", MessageFormat::Compact) => {
+                let session = string_field(payload, "session")?;
+                let prompt = optional_string_field(payload, "prompt_snapshot")
+                    .unwrap_or_else(|| "no prompt".to_string());
+                format!("⏳ **{session}**:\n```\n{prompt}\n```")
+            }
+            ("tmux.waiting_for_input", MessageFormat::Alert) => {
+                let session = string_field(payload, "session")?;
+                let prompt = optional_string_field(payload, "prompt_snapshot")
+                    .unwrap_or_else(|| "no prompt".to_string());
+                format!("⏳ **{session}**:\n```\n{prompt}\n```")
+            }
+            ("tmux.waiting_for_input", MessageFormat::Inline) => {
+                let session = string_field(payload, "session")?;
+                format!("⏳ [{session}]")
+            }
+            ("tmux.waiting_for_input", MessageFormat::Raw) => {
+                serde_json::to_string_pretty(payload)?
+            }
+
+            ("tmux.heartbeat", MessageFormat::Compact) => {
+                let session = string_field(payload, "session")?;
+                let minutes = payload.field_u64("minutes_since_change")?;
+                format!("💓 **{session}**: idle for {minutes}m")
+            }
+            ("tmux.heartbeat", MessageFormat::Alert) => {
+                let session = string_field(payload, "session")?;
+                let minutes = payload.field_u64("minutes_since_change")?;
+                format!("💓 **{session}**: idle for {minutes}m")
+            }
+            ("tmux.heartbeat", MessageFormat::Inline) => {
+                let session = string_field(payload, "session")?;
+                format!("💓 [{session}]")
+            }
+            ("tmux.heartbeat", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
+
             (_, MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
             (_, _) => serde_json::to_string(payload)?,
         };
@@ -299,6 +366,10 @@ fn optional_string_field(payload: &Value, key: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
+}
+
+fn content_mode(payload: &Value) -> String {
+    optional_string_field(payload, "content_mode").unwrap_or_else(|| "summary".to_string())
 }
 
 fn optional_u64_field(payload: &Value, key: &str) -> Option<u64> {
@@ -817,5 +888,88 @@ mod tests {
             .render(&event, &MessageFormat::Compact)
             .unwrap();
         assert_eq!(rendered, "git:repo@main 1234567 ship it");
+    }
+
+    #[test]
+    fn renders_tmux_content_changed_formats() {
+        let renderer = DefaultRenderer;
+        let event = IncomingEvent::tmux_content_changed_with_metadata(
+            "issue-24".into(),
+            "0.1".into(),
+            "Agent fixed the failing test".into(),
+            "tail".into(),
+            "gemini-cli".into(),
+            "summary".into(),
+            None,
+        );
+
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Compact).unwrap(),
+            "🤖 **issue-24**: Agent fixed the failing test"
+        );
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Inline).unwrap(),
+            "🤖 [issue-24] Agent fixed the failing test"
+        );
+    }
+
+    #[test]
+    fn renders_tmux_content_changed_raw_formats() {
+        let renderer = DefaultRenderer;
+        let event = IncomingEvent::tmux_content_changed_with_metadata(
+            "issue-24".into(),
+            "0.1".into(),
+            "ignored".into(),
+            "cargo build\nerror: failed".into(),
+            "raw".into(),
+            "raw".into(),
+            None,
+        );
+
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Compact).unwrap(),
+            "📋 **issue-24**: cargo build\nerror: failed"
+        );
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Inline).unwrap(),
+            "📋 [issue-24]"
+        );
+    }
+
+    #[test]
+    fn renders_tmux_waiting_for_input_formats() {
+        let renderer = DefaultRenderer;
+        let event = IncomingEvent::tmux_waiting_for_input(
+            "issue-24".into(),
+            "0.1".into(),
+            "Press enter to continue".into(),
+            None,
+        );
+
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Inline).unwrap(),
+            "⏳ [issue-24]"
+        );
+        assert!(
+            renderer
+                .render(&event, &MessageFormat::Compact)
+                .unwrap()
+                .starts_with("⏳ **issue-24**")
+        );
+    }
+
+    #[test]
+    fn renders_tmux_heartbeat_formats() {
+        let renderer = DefaultRenderer;
+        let event = IncomingEvent::tmux_heartbeat("issue-24".into(), 42, None);
+
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Compact).unwrap(),
+            "💓 **issue-24**: idle for 42m"
+        );
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Inline).unwrap(),
+            "💓 [issue-24]"
+        );
     }
 }

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -751,7 +751,13 @@ fn render_aggregated_tmux_keyword(
     let hit_count = optional_u64_field(payload, "hit_count")
         .map(|count| count as usize)
         .unwrap_or(hits.len());
-    let summaries = hits
+    const MAX_HITS_SHOWN: usize = 10;
+    let visible_hits = if hits.len() > MAX_HITS_SHOWN {
+        &hits[hits.len() - MAX_HITS_SHOWN..]
+    } else {
+        hits.as_slice()
+    };
+    let summaries = visible_hits
         .iter()
         .filter_map(|hit| {
             let keyword = hit.get("keyword").and_then(Value::as_str)?.trim();

--- a/src/router.rs
+++ b/src/router.rs
@@ -299,6 +299,9 @@ fn route_candidates(kind: &str) -> Vec<&str> {
         | "session.handoff-needed" => {
             vec![kind, "session.*"]
         }
+        "tmux.content_changed" | "tmux.waiting_for_input" | "tmux.heartbeat" => {
+            vec![kind, "tmux.*"]
+        }
         other => vec![other],
     }
 }

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::process::Command;
 use tokio::sync::{RwLock, mpsc};
@@ -76,6 +77,33 @@ pub struct RegisteredTmuxSession {
     pub min_new_lines: usize,
     #[serde(default)]
     pub summarize_interval_mins: u64,
+    /// Event kinds for which the `mention` is prepended. Empty = mention applies to all events.
+    #[serde(default)]
+    pub mention_on: Vec<String>,
+    #[serde(default = "default_true")]
+    pub pin_status: bool,
+    #[serde(default = "default_true")]
+    pub pin_summary: bool,
+    #[serde(default = "default_true")]
+    pub pin_alerts: bool,
+    #[serde(default = "default_true")]
+    pub pin_activity: bool,
+    #[serde(default)]
+    pub pin_keywords: bool,
+    #[serde(default)]
+    pub heartbeat_interval: u64,
+    #[serde(default)]
+    pub stale_interval: u64,
+    #[serde(default)]
+    pub summary_interval: u64,
+    #[serde(default)]
+    pub waiting_interval: u64,
+    #[serde(default)]
+    pub activity_interval: u64,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
@@ -98,7 +126,54 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             detect_waiting: value.detect_waiting,
             min_new_lines: value.min_new_lines,
             summarize_interval_mins: value.summarize_interval_mins,
+            mention_on: value.mention_on.clone(),
+            pin_status: value.pin_status,
+            pin_summary: value.pin_summary,
+            pin_alerts: value.pin_alerts,
+            pin_activity: value.pin_activity,
+            pin_keywords: value.pin_keywords,
+            heartbeat_interval: value.heartbeat_interval,
+            stale_interval: value.stale_interval,
+            summary_interval: value.summary_interval,
+            waiting_interval: value.waiting_interval,
+            activity_interval: value.activity_interval,
         }
+    }
+}
+
+impl RegisteredTmuxSession {
+    /// Effective heartbeat interval: heartbeat_interval overrides heartbeat_mins when > 0.
+    pub fn effective_heartbeat_mins(&self) -> u64 {
+        if self.heartbeat_interval > 0 { self.heartbeat_interval } else { self.heartbeat_mins }
+    }
+
+    /// Effective stale threshold: stale_interval overrides stale_minutes when > 0.
+    pub fn effective_stale_minutes(&self) -> u64 {
+        if self.stale_interval > 0 { self.stale_interval } else { self.stale_minutes }
+    }
+
+    /// Effective summary throttle: summary_interval overrides summarize_interval_mins when > 0.
+    pub fn effective_summary_interval(&self) -> u64 {
+        if self.summary_interval > 0 { self.summary_interval } else { self.summarize_interval_mins }
+    }
+}
+
+/// Inject dashboard routing fields into an event payload.
+fn inject_dashboard_payload(event: &mut IncomingEvent, slot: &str, pin_activity: bool) {
+    event.payload["dashboard_component"] = json!(slot);
+    event.payload["pin_activity"] = json!(pin_activity);
+}
+
+/// Returns the mention string for an event kind, respecting `mention_on` filter.
+/// If `mention_on` is empty, the mention applies to all event kinds.
+fn effective_mention(registration: &RegisteredTmuxSession, event_kind: &str) -> Option<String> {
+    if registration.mention_on.is_empty() {
+        return registration.mention.clone();
+    }
+    if registration.mention_on.iter().any(|k| k == event_kind) {
+        registration.mention.clone()
+    } else {
+        None
     }
 }
 
@@ -160,6 +235,7 @@ struct TmuxPaneState {
     content_hash: u64,
     last_change: Instant,
     last_stale_notification: Option<Instant>,
+    is_waiting: bool,
 }
 
 #[derive(Default)]
@@ -180,6 +256,7 @@ struct TmuxPaneSnapshot {
 pub async fn monitor_registered_session(
     registration: RegisteredTmuxSession,
     client: DaemonClient,
+    providers: crate::config::ProvidersConfig,
 ) -> Result<()> {
     let mut panes = HashMap::new();
     let mut pending_keyword_hits = None;
@@ -234,6 +311,7 @@ pub async fn monitor_registered_session(
                             snapshot: pane.content,
                             last_change: now,
                             last_stale_notification: None,
+                            is_waiting: false,
                         },
                     );
                     last_heartbeat = Some(now);
@@ -250,7 +328,7 @@ pub async fn monitor_registered_session(
                         if registration.summarize
                             && should_summarize_now(
                                 last_summarized,
-                                registration.summarize_interval_mins,
+                                registration.effective_summary_interval(),
                                 registration.min_new_lines,
                                 &existing.snapshot,
                                 &pane.content,
@@ -263,21 +341,36 @@ pub async fn monitor_registered_session(
                                 pane.session.clone(),
                                 pane.pane_name.clone(),
                                 pane.content.clone(),
+                                providers.clone(),
                             );
                             last_summarized = Some(now);
                         }
 
-                        if registration.detect_waiting
-                            && let Some(prompt) = is_waiting_for_input(&pane.content)
-                        {
-                            client
-                                .emit(tmux_waiting_for_input_event(
-                                    &registration,
-                                    pane.session.clone(),
-                                    pane.pane_name.clone(),
-                                    prompt,
-                                ))
-                                .await?;
+                        if registration.detect_waiting {
+                            let waiting_prompt = is_waiting_for_input(&pane.content);
+                            match (existing.is_waiting, &waiting_prompt) {
+                                (false, Some(prompt)) => {
+                                    client
+                                        .emit(tmux_waiting_for_input_event(
+                                            &registration,
+                                            pane.session.clone(),
+                                            pane.pane_name.clone(),
+                                            prompt.clone(),
+                                        ))
+                                        .await?;
+                                }
+                                (true, None) => {
+                                    client
+                                        .emit(tmux_waiting_resolved_event(
+                                            &registration,
+                                            pane.session.clone(),
+                                            pane.pane_name.clone(),
+                                        ))
+                                        .await?;
+                                }
+                                _ => {}
+                            }
+                            existing.is_waiting = waiting_prompt.is_some();
                         }
 
                         existing.session = pane.session;
@@ -287,7 +380,7 @@ pub async fn monitor_registered_session(
                         existing.last_change = now;
                         existing.last_stale_notification = None;
                         last_heartbeat = Some(now);
-                    } else if should_emit_stale(existing, now, registration.stale_minutes) {
+                    } else if should_emit_stale(existing, now, registration.effective_stale_minutes()) {
                         client
                             .emit(tmux_stale_event(
                                 &registration,
@@ -388,6 +481,10 @@ async fn poll_tmux(
         match session_exists(session_name).await {
             Ok(false) => {
                 sessions_to_unregister.push(session_name.clone());
+                let _ = tx.emit(IncomingEvent::tmux_session_ended(
+                    session_name.clone(),
+                    registration.channel.clone(),
+                )).await;
                 flush_session_pending_keyword_hits(
                     &mut state.pending_keyword_hits,
                     session_name,
@@ -432,6 +529,7 @@ async fn poll_tmux(
                                     content_hash: hash,
                                     last_change: now,
                                     last_stale_notification: None,
+                                    is_waiting: false,
                                 },
                             );
                             state
@@ -450,7 +548,7 @@ async fn poll_tmux(
                                 if registration.summarize
                                     && should_summarize_now(
                                         state.session_last_summarized.get(session_name).copied(),
-                                        registration.summarize_interval_mins,
+                                        registration.effective_summary_interval(),
                                         registration.min_new_lines,
                                         &existing.snapshot,
                                         &pane.content,
@@ -463,21 +561,35 @@ async fn poll_tmux(
                                         session_name.clone(),
                                         pane.pane_name.clone(),
                                         pane.content.clone(),
+                                        config.providers.clone(),
                                     );
                                     state
                                         .session_last_summarized
                                         .insert(session_name.to_string(), now);
                                 }
-                                if registration.detect_waiting
-                                    && let Some(prompt) = is_waiting_for_input(&pane.content)
-                                {
-                                    tx.emit(tmux_waiting_for_input_event(
-                                        registration,
-                                        session_name.clone(),
-                                        pane.pane_name.clone(),
-                                        prompt,
-                                    ))
-                                    .await?;
+                                if registration.detect_waiting {
+                                    let waiting_prompt = is_waiting_for_input(&pane.content);
+                                    match (existing.is_waiting, &waiting_prompt) {
+                                        (false, Some(prompt)) => {
+                                            tx.emit(tmux_waiting_for_input_event(
+                                                registration,
+                                                session_name.clone(),
+                                                pane.pane_name.clone(),
+                                                prompt.clone(),
+                                            ))
+                                            .await?;
+                                        }
+                                        (true, None) => {
+                                            tx.emit(tmux_waiting_resolved_event(
+                                                registration,
+                                                session_name.clone(),
+                                                pane.pane_name.clone(),
+                                            ))
+                                            .await?;
+                                        }
+                                        _ => {}
+                                    }
+                                    existing.is_waiting = waiting_prompt.is_some();
                                 }
                                 existing.pane_name = pane.pane_name;
                                 existing.snapshot = pane.content;
@@ -743,9 +855,13 @@ fn tmux_keyword_event(
         IncomingEvent::tmux_keywords(session, hits, registration.channel.clone())
     };
 
+    let mut event = event
+        .with_mention(effective_mention(registration, "keyword"))
+        .with_format(registration.format.clone());
+    if registration.pin_keywords {
+        inject_dashboard_payload(&mut event, "keywords", registration.pin_activity);
+    }
     event
-        .with_mention(registration.mention.clone())
-        .with_format(registration.format.clone())
 }
 
 fn tmux_stale_event(
@@ -754,15 +870,19 @@ fn tmux_stale_event(
     pane: String,
     last_line: String,
 ) -> IncomingEvent {
-    IncomingEvent::tmux_stale(
+    let mut event = IncomingEvent::tmux_stale(
         session,
         pane,
-        registration.stale_minutes,
+        registration.effective_stale_minutes(),
         last_line,
         registration.channel.clone(),
     )
-    .with_mention(registration.mention.clone())
-    .with_format(registration.format.clone())
+    .with_mention(effective_mention(registration, "stale"))
+    .with_format(registration.format.clone());
+    if registration.pin_status {
+        inject_dashboard_payload(&mut event, "status", registration.pin_activity);
+    }
+    event
 }
 
 fn tmux_content_changed_event(
@@ -771,7 +891,7 @@ fn tmux_content_changed_event(
     pane: String,
     content: SummarizedContent,
 ) -> IncomingEvent {
-    IncomingEvent::tmux_content_changed_with_metadata(
+    let mut event = IncomingEvent::tmux_content_changed_with_metadata(
         session,
         pane,
         content.summary,
@@ -780,8 +900,12 @@ fn tmux_content_changed_event(
         content.content_mode.as_str().to_string(),
         registration.channel.clone(),
     )
-    .with_mention(registration.mention.clone())
-    .with_format(registration.format.clone())
+    .with_mention(effective_mention(registration, "content_changed"))
+    .with_format(registration.format.clone());
+    if registration.pin_summary {
+        inject_dashboard_payload(&mut event, "summary", registration.pin_activity);
+    }
+    event
 }
 
 fn spawn_content_changed_task<E>(
@@ -790,11 +914,12 @@ fn spawn_content_changed_task<E>(
     session_name: String,
     pane_name: String,
     content: String,
+    providers: crate::config::ProvidersConfig,
 ) where
     E: EventEmitter + Clone + Send + Sync + 'static,
 {
     tokio::spawn(async move {
-        match build_summarizer(&registration.summarizer) {
+        match build_summarizer(&registration.summarizer, &providers) {
             Ok(summarizer) => match summarizer.summarize(&content, &session_name).await {
                 Ok(transformed) => {
                     let event = tmux_content_changed_event(
@@ -825,14 +950,34 @@ fn tmux_waiting_for_input_event(
     pane: String,
     prompt_snapshot: String,
 ) -> IncomingEvent {
-    IncomingEvent::tmux_waiting_for_input(
+    let mut event = IncomingEvent::tmux_waiting_for_input(
         session,
         pane,
         prompt_snapshot,
         registration.channel.clone(),
     )
-    .with_mention(registration.mention.clone())
-    .with_format(registration.format.clone())
+    .with_mention(effective_mention(registration, "waiting_for_input"))
+    .with_format(registration.format.clone());
+    if registration.pin_alerts {
+        inject_dashboard_payload(&mut event, "alert", registration.pin_activity);
+    }
+    event
+}
+
+fn tmux_waiting_resolved_event(
+    registration: &RegisteredTmuxSession,
+    session: String,
+    pane_name: String,
+) -> IncomingEvent {
+    let mut event =
+        IncomingEvent::tmux_waiting_for_input(session, pane_name, String::new(), registration.channel.clone());
+    event.payload["resolved"] = json!(true);
+    // Mirror the same dashboard routing as the waiting event so the resolved
+    // message updates the pinned alert slot (not a separate keyed message).
+    if registration.pin_alerts {
+        inject_dashboard_payload(&mut event, "alert", registration.pin_activity);
+    }
+    event.with_format(registration.format.clone())
 }
 
 fn tmux_heartbeat_event(
@@ -840,9 +985,14 @@ fn tmux_heartbeat_event(
     session: String,
     minutes_since_change: u64,
 ) -> IncomingEvent {
-    IncomingEvent::tmux_heartbeat(session, minutes_since_change, registration.channel.clone())
-        .with_mention(registration.mention.clone())
-        .with_format(registration.format.clone())
+    let mut event =
+        IncomingEvent::tmux_heartbeat(session, minutes_since_change, registration.channel.clone())
+            .with_mention(effective_mention(registration, "heartbeat"))
+            .with_format(registration.format.clone());
+    if registration.pin_status {
+        inject_dashboard_payload(&mut event, "status", registration.pin_activity);
+    }
+    event
 }
 
 fn count_new_lines(old: &str, new: &str) -> usize {
@@ -869,25 +1019,102 @@ fn should_summarize_now(
 }
 
 fn is_waiting_for_input(content: &str) -> Option<String> {
-    let patterns = [
+    // Patterns checked against the last 3 non-empty lines (case-insensitive).
+    // Covers common interactive prompts and OMC/OMX agent harness approval flows.
+    let multiline_patterns: &[&str] = &[
+        // Generic waiting phrases
         "waiting for input",
         "awaiting user input",
         "press enter",
         "hit enter",
+        "press any key",
+        // Confirmation prompts
+        "[y/n]",
+        "(y/n)",
+        "[yes/no]",
+        "(yes/no)",
+        // Common action confirmations
+        "proceed?",
+        "continue?",
+        "overwrite?",
+        "replace?",
+        "do you want to",
+        // Menu / choice prompts
+        "enter your choice",
+        "select an option",
+        // Claude Code / OMC tool approval patterns
+        "allow, deny",
+        "allow this action",
+        "always allow",
+        "approve or deny",
+        "run this tool",
+        // Generic approval keyword at line start
+        "approve:",
+        // Credential prompts (password entry blocks terminal)
+        "password:",
+        "passphrase:",
+        "enter password",
+        // Common agent/tool confirmation phrases
+        "want me to",
+        "shall i",
+        "should i proceed",
+        "should i continue",
+        // Interactive setup confirmations
+        "is this ok?",
+        "(ctrl+c to abort)",
+        // CC permission mode picker indicator
+        "bypassPermissions",
     ];
-    let last_10 = content.lines().rev().take(10).collect::<Vec<_>>();
-    let last_10_combined = last_10
-        .iter()
+
+    // Take the last 3 non-empty lines, skipping blank padding rows.
+    // capture-pane pads the visible area with blank rows; a window of 3 non-empty
+    // lines covers real interactive prompts (which always appear as one of the last
+    // 3 non-empty lines) while being small enough that a single reply line (output
+    // + new prompt = 3 lines: output, command, new-prompt) pushes the waiting
+    // prompt out of the window, triggering the resolved transition.
+    let recent: Vec<&str> = content
+        .lines()
         .rev()
-        .copied()
-        .collect::<Vec<_>>()
-        .join("\n")
-        .to_lowercase();
-    for pattern in &patterns {
-        if last_10_combined.contains(pattern) {
-            return Some(last_10.iter().rev().copied().collect::<Vec<_>>().join("\n"));
+        .filter(|l| !l.trim().is_empty())
+        .take(3)
+        .collect();
+    if recent.is_empty() {
+        return None;
+    }
+
+    let snapshot: String = recent.iter().rev().copied().collect::<Vec<_>>().join("\n");
+    let snapshot_lower = snapshot.to_lowercase();
+
+    for pattern in multiline_patterns {
+        if snapshot_lower.contains(pattern) {
+            return Some(snapshot.clone());
         }
     }
+
+    // Check the last non-empty line for short interactive-prompt endings.
+    let last_nonempty = recent.first().copied().unwrap_or("");
+    let trimmed = last_nonempty.trim_end();
+    if trimmed.len() <= 40 {
+        let prompt_suffixes: &[&str] = &[
+            "❯",
+            "$ ",
+            "% ",
+            "... ",
+            "? ",
+        ];
+        for suffix in prompt_suffixes {
+            if trimmed.ends_with(suffix) || trimmed == suffix.trim() {
+                return Some(snapshot);
+            }
+        }
+    }
+
+    // ❯ at the start of a short line indicates an interactive menu selector
+    // (e.g., Claude Code permission mode picker)
+    if trimmed.starts_with('❯') && trimmed.len() <= 80 {
+        return Some(snapshot);
+    }
+
     None
 }
 
@@ -899,7 +1126,7 @@ async fn maybe_emit_session_heartbeat<E: EventEmitter>(
     now: Instant,
     session_changed: bool,
 ) -> Result<()> {
-    if registration.heartbeat_mins == 0 {
+    if registration.effective_heartbeat_mins() == 0 {
         state.session_last_heartbeat.remove(session_name);
         return Ok(());
     }
@@ -910,7 +1137,7 @@ async fn maybe_emit_session_heartbeat<E: EventEmitter>(
             .insert(session_name.to_string(), now);
     }
 
-    let interval = Duration::from_secs(registration.heartbeat_mins * 60);
+    let interval = Duration::from_secs(registration.effective_heartbeat_mins() * 60);
     let Some(last_change) = state
         .panes
         .values()
@@ -952,12 +1179,12 @@ async fn maybe_emit_registered_session_heartbeat<E: EventEmitter>(
     last_heartbeat: &mut Option<Instant>,
     now: Instant,
 ) -> Result<()> {
-    if registration.heartbeat_mins == 0 {
+    if registration.effective_heartbeat_mins() == 0 {
         *last_heartbeat = None;
         return Ok(());
     }
 
-    let interval = Duration::from_secs(registration.heartbeat_mins * 60);
+    let interval = Duration::from_secs(registration.effective_heartbeat_mins() * 60);
     let Some(last_change) = panes.values().map(|pane| pane.last_change).max() else {
         last_heartbeat.get_or_insert(now);
         return Ok(());
@@ -1001,21 +1228,11 @@ async fn flush_pending_keyword_hits<E: EventEmitter>(
     let Some(pending) = pending_keyword_hits.take() else {
         return Ok(());
     };
-    let (raw_hits, next_window) = if force {
-        (pending.into_hits(), None)
-    } else {
-        let (hits, reset) = pending.flush_and_reset(now);
-        (hits, Some(reset))
-    };
-    let hits = raw_hits
+    let hits = pending
+        .into_hits()
         .into_iter()
         .map(|hit| (hit.keyword, hit.line))
         .collect::<Vec<_>>();
-    // Restore the reset window (with seen carried forward) before emitting so
-    // new hits arriving during the await are not lost.
-    if let Some(w) = next_window {
-        *pending_keyword_hits = Some(w);
-    }
     if hits.is_empty() {
         return Ok(());
     }
@@ -1320,6 +1537,35 @@ PR created #7",
             }
             other => panic!("expected aggregated tmux keyword body, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn tmux_keyword_event_with_pin_keywords_sets_dashboard_payload() {
+        let mut registration = registration(vec!["error"]);
+        registration.pin_keywords = true;
+
+        let event = tmux_keyword_event(
+            &registration,
+            "issue-24".into(),
+            vec![("error".into(), "boom".into())],
+        );
+
+        assert_eq!(event.payload["dashboard_component"], "keywords");
+        assert_eq!(event.payload["pin_activity"], false);
+    }
+
+    #[test]
+    fn tmux_keyword_event_without_pin_keywords_no_dashboard_payload() {
+        let registration = registration(vec!["error"]);
+        // pin_keywords defaults to false
+
+        let event = tmux_keyword_event(
+            &registration,
+            "issue-24".into(),
+            vec![("error".into(), "boom".into())],
+        );
+
+        assert!(event.payload["dashboard_component"].is_null());
     }
 
     #[test]
@@ -1982,6 +2228,7 @@ error: failed";
             content_hash: 0,
             last_change: Instant::now() - Duration::from_secs(3600),
             last_stale_notification: None,
+            is_waiting: false,
         };
         // stale_minutes=0 should never emit, even after 1 hour idle
         assert!(!should_emit_stale(&pane, Instant::now(), 0));
@@ -1996,8 +2243,112 @@ error: failed";
             content_hash: 0,
             last_change: Instant::now() - Duration::from_secs(3600),
             last_stale_notification: None,
+            is_waiting: false,
         };
         // stale_minutes=1 should emit after 1 hour idle
         assert!(should_emit_stale(&pane, Instant::now(), 1));
+    }
+
+    // ── is_waiting_for_input tests ──────────────────────────────────────────
+
+    #[test]
+    fn waiting_detects_press_enter() {
+        assert!(is_waiting_for_input("some output\nPress enter to continue:").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_yn_bracket() {
+        assert!(is_waiting_for_input("Overwrite file? [Y/n]").is_some());
+        assert!(is_waiting_for_input("Continue? [y/N]").is_some());
+        assert!(is_waiting_for_input("Proceed? (y/n)").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_proceed_continue_overwrite() {
+        assert!(is_waiting_for_input("Do you want to proceed?").is_some());
+        assert!(is_waiting_for_input("continue?").is_some());
+        assert!(is_waiting_for_input("overwrite?").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_omc_tool_approval() {
+        // Claude Code tool approval format
+        assert!(is_waiting_for_input("Allow, Deny, Always allow (A/d/!)?").is_some());
+        assert!(is_waiting_for_input("always allow").is_some());
+        assert!(is_waiting_for_input("run this tool").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_menu_prompts() {
+        assert!(is_waiting_for_input("Enter your choice:").is_some());
+        assert!(is_waiting_for_input("Select an option").is_some());
+        assert!(is_waiting_for_input("Press any key to continue").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_do_you_want_to() {
+        assert!(is_waiting_for_input("Do you want to install these packages?").is_some());
+    }
+
+    #[test]
+    fn waiting_ignores_normal_output() {
+        assert!(is_waiting_for_input("cargo build --release\nCompiling clawhip v0.5.4\nFinished dev profile").is_none());
+        assert!(is_waiting_for_input("").is_none());
+    }
+
+    #[test]
+    fn waiting_only_checks_last_3_lines() {
+        // Trigger phrase buried beyond the 3-line window should NOT match.
+        // 4 non-empty filler lines push "press enter" out of the window.
+        let buried = "press enter\n".to_string() + &"line\n".repeat(4);
+        assert!(is_waiting_for_input(&buried).is_none());
+        // Trailing blank lines are ignored, so this still doesn't match
+        let buried_with_blanks = "press enter\n".to_string() + &"line\n".repeat(4) + &"\n".repeat(20);
+        assert!(is_waiting_for_input(&buried_with_blanks).is_none());
+        // Pattern at exactly position 3 (last of window) still matches
+        let at_edge = "line\n".repeat(2) + "press enter\n";
+        assert!(is_waiting_for_input(&at_edge).is_some());
+    }
+
+    #[test]
+    fn waiting_detects_omc_cursor_prompt() {
+        // Short last line ending with ❯ (OMC tool approval cursor)
+        assert!(is_waiting_for_input("Allow, Deny, Always allow\n❯").is_some());
+    }
+
+    // ── mention_on tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn effective_mention_empty_mention_on_applies_to_all() {
+        let reg = RegisteredTmuxSession {
+            mention: Some("<@123>".into()),
+            mention_on: vec![],
+            ..registration(vec![])
+        };
+        assert_eq!(effective_mention(&reg, "keyword").as_deref(), Some("<@123>"));
+        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), Some("<@123>"));
+        assert_eq!(effective_mention(&reg, "heartbeat").as_deref(), Some("<@123>"));
+    }
+
+    #[test]
+    fn effective_mention_filters_by_event_kind() {
+        let reg = RegisteredTmuxSession {
+            mention: Some("<@123>".into()),
+            mention_on: vec!["waiting_for_input".into()],
+            ..registration(vec![])
+        };
+        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), Some("<@123>"));
+        assert_eq!(effective_mention(&reg, "keyword").as_deref(), None);
+        assert_eq!(effective_mention(&reg, "heartbeat").as_deref(), None);
+    }
+
+    #[test]
+    fn effective_mention_no_mention_returns_none() {
+        let reg = RegisteredTmuxSession {
+            mention: None,
+            mention_on: vec!["waiting_for_input".into()],
+            ..registration(vec![])
+        };
+        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), None);
     }
 }

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -16,6 +16,7 @@ use crate::events::{IncomingEvent, MessageFormat};
 use crate::keyword_window::{PendingKeywordHits, collect_keyword_hits};
 use crate::router::glob_match;
 use crate::source::Source;
+use crate::summarize::{SummarizedContent, build_summarizer};
 
 pub type SharedTmuxRegistry = Arc<RwLock<HashMap<String, RegisteredTmuxSession>>>;
 
@@ -44,7 +45,7 @@ pub struct ParentProcessInfo {
     pub name: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RegisteredTmuxSession {
     pub session: String,
     pub channel: Option<String>,
@@ -63,6 +64,14 @@ pub struct RegisteredTmuxSession {
     pub parent_process: Option<ParentProcessInfo>,
     #[serde(default)]
     pub active_wrapper_monitor: bool,
+    #[serde(default)]
+    pub summarize: bool,
+    #[serde(default)]
+    pub summarizer: String,
+    #[serde(default)]
+    pub heartbeat_mins: u64,
+    #[serde(default)]
+    pub detect_waiting: bool,
 }
 
 impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
@@ -79,6 +88,10 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             registration_source: RegistrationSource::ConfigMonitor,
             parent_process: None,
             active_wrapper_monitor: false,
+            summarize: value.summarize,
+            summarizer: value.summarizer.clone(),
+            heartbeat_mins: value.heartbeat_mins,
+            detect_waiting: value.detect_waiting,
         }
     }
 }
@@ -147,6 +160,7 @@ struct TmuxPaneState {
 struct TmuxMonitorState {
     panes: HashMap<String, TmuxPaneState>,
     pending_keyword_hits: HashMap<String, PendingKeywordHits>,
+    session_last_heartbeat: HashMap<String, Instant>,
 }
 
 struct TmuxPaneSnapshot {
@@ -162,6 +176,7 @@ pub async fn monitor_registered_session(
 ) -> Result<()> {
     let mut panes = HashMap::new();
     let mut pending_keyword_hits = None;
+    let mut last_heartbeat = None;
     let poll_interval = Duration::from_secs(1);
 
     loop {
@@ -213,6 +228,7 @@ pub async fn monitor_registered_session(
                             last_stale_notification: None,
                         },
                     );
+                    last_heartbeat = Some(now);
                 }
                 Some(existing) => {
                     if existing.content_hash != hash {
@@ -223,12 +239,36 @@ pub async fn monitor_registered_session(
                         );
                         push_pending_keyword_hits(&mut pending_keyword_hits, now, hits);
 
+                        if registration.summarize {
+                            spawn_content_changed_task(
+                                client.clone(),
+                                registration.clone(),
+                                pane.session.clone(),
+                                pane.pane_name.clone(),
+                                pane.content.clone(),
+                            );
+                        }
+
+                        if registration.detect_waiting
+                            && let Some(prompt) = is_waiting_for_input(&pane.content)
+                        {
+                            client
+                                .emit(tmux_waiting_for_input_event(
+                                    &registration,
+                                    pane.session.clone(),
+                                    pane.pane_name.clone(),
+                                    prompt,
+                                ))
+                                .await?;
+                        }
+
                         existing.session = pane.session;
                         existing.pane_name = pane.pane_name;
                         existing.content_hash = hash;
                         existing.snapshot = pane.content;
                         existing.last_change = now;
                         existing.last_stale_notification = None;
+                        last_heartbeat = Some(now);
                     } else if should_emit_stale(existing, now, registration.stale_minutes) {
                         client
                             .emit(tmux_stale_event(
@@ -245,6 +285,14 @@ pub async fn monitor_registered_session(
         }
 
         panes.retain(|pane_id, _| active_panes.contains(pane_id));
+        maybe_emit_registered_session_heartbeat(
+            &registration,
+            &client,
+            &panes,
+            &mut last_heartbeat,
+            Instant::now(),
+        )
+        .await?;
         sleep(poll_interval).await;
     }
 
@@ -304,6 +352,7 @@ async fn poll_tmux(
     for (session_name, registration) in &sessions {
         if registration.active_wrapper_monitor {
             state.pending_keyword_hits.remove(session_name);
+            state.session_last_heartbeat.remove(session_name);
             continue;
         }
 
@@ -331,6 +380,7 @@ async fn poll_tmux(
                 )
                 .await?;
                 state.panes.retain(|_, pane| pane.session != *session_name);
+                state.session_last_heartbeat.remove(session_name);
                 continue;
             }
             Err(error) => {
@@ -345,6 +395,7 @@ async fn poll_tmux(
 
         match snapshot_tmux_session(session_name).await {
             Ok(panes) => {
+                let mut session_changed = false;
                 for pane in panes {
                     let pane_key = format!("{}::{}", pane.session, pane.pane_id);
                     active_panes.insert(pane_key.clone());
@@ -365,6 +416,10 @@ async fn poll_tmux(
                                     last_stale_notification: None,
                                 },
                             );
+                            state
+                                .session_last_heartbeat
+                                .insert(session_name.clone(), now);
+                            session_changed = true;
                             None
                         }
                         Some(existing) => {
@@ -374,11 +429,35 @@ async fn poll_tmux(
                                     &pane.content,
                                     &registration.keywords,
                                 );
+                                if registration.summarize {
+                                    spawn_content_changed_task(
+                                        tx.clone(),
+                                        registration.clone(),
+                                        session_name.clone(),
+                                        pane.pane_name.clone(),
+                                        pane.content.clone(),
+                                    );
+                                }
+                                if registration.detect_waiting
+                                    && let Some(prompt) = is_waiting_for_input(&pane.content)
+                                {
+                                    tx.emit(tmux_waiting_for_input_event(
+                                        registration,
+                                        session_name.clone(),
+                                        pane.pane_name.clone(),
+                                        prompt,
+                                    ))
+                                    .await?;
+                                }
                                 existing.pane_name = pane.pane_name;
                                 existing.snapshot = pane.content;
                                 existing.content_hash = hash;
                                 existing.last_change = now;
                                 existing.last_stale_notification = None;
+                                state
+                                    .session_last_heartbeat
+                                    .insert(session_name.clone(), now);
+                                session_changed = true;
                                 Some(hits)
                             } else {
                                 if should_emit_stale(existing, now, registration.stale_minutes) {
@@ -405,6 +484,15 @@ async fn poll_tmux(
                         );
                     }
                 }
+                maybe_emit_session_heartbeat(
+                    session_name,
+                    registration,
+                    tx,
+                    state,
+                    Instant::now(),
+                    session_changed,
+                )
+                .await?;
             }
             Err(error) => eprintln!(
                 "clawhip source tmux snapshot failed for {}: {error}",
@@ -424,6 +512,9 @@ async fn poll_tmux(
 
     state
         .pending_keyword_hits
+        .retain(|session, _| sessions.contains_key(session));
+    state
+        .session_last_heartbeat
         .retain(|session, _| sessions.contains_key(session));
 
     Ok(())
@@ -641,6 +732,199 @@ fn tmux_stale_event(
     .with_format(registration.format.clone())
 }
 
+fn tmux_content_changed_event(
+    registration: &RegisteredTmuxSession,
+    session: String,
+    pane: String,
+    content: SummarizedContent,
+) -> IncomingEvent {
+    IncomingEvent::tmux_content_changed_with_metadata(
+        session,
+        pane,
+        content.summary,
+        content.raw_truncated,
+        content.backend,
+        content.content_mode.as_str().to_string(),
+        registration.channel.clone(),
+    )
+    .with_mention(registration.mention.clone())
+    .with_format(registration.format.clone())
+}
+
+fn spawn_content_changed_task<E>(
+    emitter: E,
+    registration: RegisteredTmuxSession,
+    session_name: String,
+    pane_name: String,
+    content: String,
+) where
+    E: EventEmitter + Clone + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        match build_summarizer(&registration.summarizer) {
+            Ok(summarizer) => match summarizer.summarize(&content, &session_name).await {
+                Ok(transformed) => {
+                    let event = tmux_content_changed_event(
+                        &registration,
+                        session_name,
+                        pane_name,
+                        transformed,
+                    );
+                    let _ = emitter.emit(event).await;
+                }
+                Err(error) => {
+                    eprintln!("clawhip: summarize failed for {session_name}: {error}");
+                }
+            },
+            Err(error) => {
+                eprintln!(
+                    "clawhip: could not initialize summarizer '{}' for {session_name}: {error}",
+                    registration.summarizer
+                );
+            }
+        }
+    });
+}
+
+fn tmux_waiting_for_input_event(
+    registration: &RegisteredTmuxSession,
+    session: String,
+    pane: String,
+    prompt_snapshot: String,
+) -> IncomingEvent {
+    IncomingEvent::tmux_waiting_for_input(
+        session,
+        pane,
+        prompt_snapshot,
+        registration.channel.clone(),
+    )
+    .with_mention(registration.mention.clone())
+    .with_format(registration.format.clone())
+}
+
+fn tmux_heartbeat_event(
+    registration: &RegisteredTmuxSession,
+    session: String,
+    minutes_since_change: u64,
+) -> IncomingEvent {
+    IncomingEvent::tmux_heartbeat(session, minutes_since_change, registration.channel.clone())
+        .with_mention(registration.mention.clone())
+        .with_format(registration.format.clone())
+}
+
+fn is_waiting_for_input(content: &str) -> Option<String> {
+    let patterns = [
+        "waiting for input",
+        "awaiting user input",
+        "press enter",
+        "hit enter",
+    ];
+    let last_10 = content.lines().rev().take(10).collect::<Vec<_>>();
+    let last_10_combined = last_10
+        .iter()
+        .rev()
+        .copied()
+        .collect::<Vec<_>>()
+        .join("\n")
+        .to_lowercase();
+    for pattern in &patterns {
+        if last_10_combined.contains(pattern) {
+            return Some(last_10.iter().rev().copied().collect::<Vec<_>>().join("\n"));
+        }
+    }
+    None
+}
+
+async fn maybe_emit_session_heartbeat<E: EventEmitter>(
+    session_name: &str,
+    registration: &RegisteredTmuxSession,
+    emitter: &E,
+    state: &mut TmuxMonitorState,
+    now: Instant,
+    session_changed: bool,
+) -> Result<()> {
+    if registration.heartbeat_mins == 0 {
+        state.session_last_heartbeat.remove(session_name);
+        return Ok(());
+    }
+
+    if session_changed {
+        state
+            .session_last_heartbeat
+            .insert(session_name.to_string(), now);
+    }
+
+    let interval = Duration::from_secs(registration.heartbeat_mins * 60);
+    let Some(last_change) = state
+        .panes
+        .values()
+        .filter(|pane| pane.session == session_name)
+        .map(|pane| pane.last_change)
+        .max()
+    else {
+        state
+            .session_last_heartbeat
+            .entry(session_name.to_string())
+            .or_insert(now);
+        return Ok(());
+    };
+
+    let last_heartbeat = state
+        .session_last_heartbeat
+        .entry(session_name.to_string())
+        .or_insert(now);
+    if now.duration_since(last_change) < interval || now.duration_since(*last_heartbeat) < interval
+    {
+        return Ok(());
+    }
+
+    emitter
+        .emit(tmux_heartbeat_event(
+            registration,
+            session_name.to_string(),
+            now.duration_since(last_change).as_secs() / 60,
+        ))
+        .await?;
+    *last_heartbeat = now;
+    Ok(())
+}
+
+async fn maybe_emit_registered_session_heartbeat<E: EventEmitter>(
+    registration: &RegisteredTmuxSession,
+    emitter: &E,
+    panes: &HashMap<String, TmuxPaneState>,
+    last_heartbeat: &mut Option<Instant>,
+    now: Instant,
+) -> Result<()> {
+    if registration.heartbeat_mins == 0 {
+        *last_heartbeat = None;
+        return Ok(());
+    }
+
+    let interval = Duration::from_secs(registration.heartbeat_mins * 60);
+    let Some(last_change) = panes.values().map(|pane| pane.last_change).max() else {
+        last_heartbeat.get_or_insert(now);
+        return Ok(());
+    };
+
+    let last_heartbeat_at = last_heartbeat.get_or_insert(now);
+    if now.duration_since(last_change) < interval
+        || now.duration_since(*last_heartbeat_at) < interval
+    {
+        return Ok(());
+    }
+
+    emitter
+        .emit(tmux_heartbeat_event(
+            registration,
+            registration.session.clone(),
+            now.duration_since(last_change).as_secs() / 60,
+        ))
+        .await?;
+    *last_heartbeat_at = now;
+    Ok(())
+}
+
 async fn flush_pending_keyword_hits<E: EventEmitter>(
     pending_keyword_hits: &mut Option<PendingKeywordHits>,
     registration: &RegisteredTmuxSession,
@@ -856,6 +1140,7 @@ mod tests {
             registration_source: RegistrationSource::ConfigMonitor,
             parent_process: None,
             active_wrapper_monitor: false,
+            ..Default::default()
         }
     }
 
@@ -950,6 +1235,7 @@ PR created #7",
             keyword_window_secs: 30,
             stale_minutes: 10,
             format: None,
+            ..Default::default()
         };
 
         let registration = RegisteredTmuxSession::from(&monitor);
@@ -979,6 +1265,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ),
             (
@@ -998,6 +1285,7 @@ PR created #7",
                         name: Some("codex".into()),
                     }),
                     active_wrapper_monitor: true,
+                    ..Default::default()
                 },
             ),
             (
@@ -1014,6 +1302,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ),
         ]);
@@ -1034,6 +1323,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             )]),
         );
@@ -1338,6 +1628,7 @@ error: failed";
                 registration_source: RegistrationSource::ConfigMonitor,
                 parent_process: None,
                 active_wrapper_monitor: false,
+                ..Default::default()
             }],
             Some(&available_sessions),
         );
@@ -1367,6 +1658,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "omx-*".into(),
@@ -1380,6 +1672,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             Some(&available_sessions),
@@ -1407,6 +1700,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "rcc-*".into(),
@@ -1420,6 +1714,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             None,
@@ -1446,6 +1741,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "rcc-api".into(),
@@ -1459,6 +1755,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             Some(&available_sessions),
@@ -1485,6 +1782,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "rcc-*".into(),
@@ -1498,6 +1796,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             Some(&available_sessions),
@@ -1529,6 +1828,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "abc*".into(),
@@ -1542,6 +1842,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             Some(&available_sessions),

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -72,6 +72,10 @@ pub struct RegisteredTmuxSession {
     pub heartbeat_mins: u64,
     #[serde(default)]
     pub detect_waiting: bool,
+    #[serde(default)]
+    pub min_new_lines: usize,
+    #[serde(default)]
+    pub summarize_interval_mins: u64,
 }
 
 impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
@@ -92,6 +96,8 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             summarizer: value.summarizer.clone(),
             heartbeat_mins: value.heartbeat_mins,
             detect_waiting: value.detect_waiting,
+            min_new_lines: value.min_new_lines,
+            summarize_interval_mins: value.summarize_interval_mins,
         }
     }
 }
@@ -161,6 +167,7 @@ struct TmuxMonitorState {
     panes: HashMap<String, TmuxPaneState>,
     pending_keyword_hits: HashMap<String, PendingKeywordHits>,
     session_last_heartbeat: HashMap<String, Instant>,
+    session_last_summarized: HashMap<String, Instant>,
 }
 
 struct TmuxPaneSnapshot {
@@ -177,6 +184,7 @@ pub async fn monitor_registered_session(
     let mut panes = HashMap::new();
     let mut pending_keyword_hits = None;
     let mut last_heartbeat = None;
+    let mut last_summarized: Option<Instant> = None;
     let poll_interval = Duration::from_secs(1);
 
     loop {
@@ -239,7 +247,16 @@ pub async fn monitor_registered_session(
                         );
                         push_pending_keyword_hits(&mut pending_keyword_hits, now, hits);
 
-                        if registration.summarize {
+                        if registration.summarize
+                            && should_summarize_now(
+                                last_summarized,
+                                registration.summarize_interval_mins,
+                                registration.min_new_lines,
+                                &existing.snapshot,
+                                &pane.content,
+                                now,
+                            )
+                        {
                             spawn_content_changed_task(
                                 client.clone(),
                                 registration.clone(),
@@ -247,6 +264,7 @@ pub async fn monitor_registered_session(
                                 pane.pane_name.clone(),
                                 pane.content.clone(),
                             );
+                            last_summarized = Some(now);
                         }
 
                         if registration.detect_waiting
@@ -429,7 +447,16 @@ async fn poll_tmux(
                                     &pane.content,
                                     &registration.keywords,
                                 );
-                                if registration.summarize {
+                                if registration.summarize
+                                    && should_summarize_now(
+                                        state.session_last_summarized.get(session_name).copied(),
+                                        registration.summarize_interval_mins,
+                                        registration.min_new_lines,
+                                        &existing.snapshot,
+                                        &pane.content,
+                                        now,
+                                    )
+                                {
                                     spawn_content_changed_task(
                                         tx.clone(),
                                         registration.clone(),
@@ -437,6 +464,9 @@ async fn poll_tmux(
                                         pane.pane_name.clone(),
                                         pane.content.clone(),
                                     );
+                                    state
+                                        .session_last_summarized
+                                        .insert(session_name.to_string(), now);
                                 }
                                 if registration.detect_waiting
                                     && let Some(prompt) = is_waiting_for_input(&pane.content)
@@ -515,6 +545,9 @@ async fn poll_tmux(
         .retain(|session, _| sessions.contains_key(session));
     state
         .session_last_heartbeat
+        .retain(|session, _| sessions.contains_key(session));
+    state
+        .session_last_summarized
         .retain(|session, _| sessions.contains_key(session));
 
     Ok(())
@@ -812,6 +845,29 @@ fn tmux_heartbeat_event(
         .with_format(registration.format.clone())
 }
 
+fn count_new_lines(old: &str, new: &str) -> usize {
+    new.lines().count().saturating_sub(old.lines().count())
+}
+
+fn should_summarize_now(
+    last_summarized: Option<Instant>,
+    interval_mins: u64,
+    min_new_lines: usize,
+    old_content: &str,
+    new_content: &str,
+    now: Instant,
+) -> bool {
+    if min_new_lines > 0 && count_new_lines(old_content, new_content) < min_new_lines {
+        return false;
+    }
+    if interval_mins == 0 {
+        return true;
+    }
+    last_summarized
+        .map(|t| now.duration_since(t) >= Duration::from_secs(interval_mins * 60))
+        .unwrap_or(true)
+}
+
 fn is_waiting_for_input(content: &str) -> Option<String> {
     let patterns = [
         "waiting for input",
@@ -945,11 +1001,21 @@ async fn flush_pending_keyword_hits<E: EventEmitter>(
     let Some(pending) = pending_keyword_hits.take() else {
         return Ok(());
     };
-    let hits = pending
-        .into_hits()
+    let (raw_hits, next_window) = if force {
+        (pending.into_hits(), None)
+    } else {
+        let (hits, reset) = pending.flush_and_reset(now);
+        (hits, Some(reset))
+    };
+    let hits = raw_hits
         .into_iter()
         .map(|hit| (hit.keyword, hit.line))
         .collect::<Vec<_>>();
+    // Restore the reset window (with seen carried forward) before emitting so
+    // new hits arriving during the await are not lost.
+    if let Some(w) = next_window {
+        *pending_keyword_hits = Some(w);
+    }
     if hits.is_empty() {
         return Ok(());
     }
@@ -1126,6 +1192,58 @@ mod tests {
     use super::*;
     use crate::event::{EventBody, compat::from_incoming_event};
     use crate::keyword_window::KeywordHit;
+
+    #[test]
+    fn count_new_lines_returns_net_addition() {
+        assert_eq!(count_new_lines("a\nb\n", "a\nb\nc\nd\n"), 2);
+    }
+
+    #[test]
+    fn count_new_lines_no_change_returns_zero() {
+        assert_eq!(count_new_lines("a\nb\n", "a\nb\n"), 0);
+    }
+
+    #[test]
+    fn count_new_lines_fewer_lines_returns_zero() {
+        assert_eq!(count_new_lines("a\nb\nc\n", "a\n"), 0);
+    }
+
+    #[test]
+    fn should_summarize_now_no_filter_no_throttle() {
+        assert!(should_summarize_now(None, 0, 0, "old", "new", Instant::now()));
+    }
+
+    #[test]
+    fn should_summarize_now_min_new_lines_blocks_when_insufficient() {
+        assert!(!should_summarize_now(None, 0, 5, "a\nb\n", "a\nb\nc\n", Instant::now()));
+    }
+
+    #[test]
+    fn should_summarize_now_min_new_lines_allows_when_met() {
+        let old = "a\n".repeat(10);
+        let new = format!("{}{}", old, "b\n".repeat(5));
+        assert!(should_summarize_now(None, 0, 5, &old, &new, Instant::now()));
+    }
+
+    #[test]
+    fn should_summarize_now_interval_blocks_when_too_soon() {
+        let now = Instant::now();
+        let recent = now - Duration::from_secs(30);
+        // interval_mins=5 but only 30 seconds elapsed
+        assert!(!should_summarize_now(Some(recent), 5, 0, "old", "new", now));
+    }
+
+    #[test]
+    fn should_summarize_now_interval_allows_when_expired() {
+        let now = Instant::now();
+        let old_enough = now - Duration::from_secs(6 * 60);
+        assert!(should_summarize_now(Some(old_enough), 5, 0, "old", "new", now));
+    }
+
+    #[test]
+    fn should_summarize_now_no_prior_summarize_always_allowed_with_throttle() {
+        assert!(should_summarize_now(None, 5, 0, "old", "new", Instant::now()));
+    }
 
     fn registration(keywords: Vec<&str>) -> RegisteredTmuxSession {
         RegisteredTmuxSession {

--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -6,6 +6,8 @@ use reqwest::Client;
 use serde_json::{Value, json};
 use tokio::process::Command;
 
+use crate::config::ProvidersConfig;
+
 const MAX_INPUT_CHARS: usize = 4000;
 const DEFAULT_GEMINI_MODEL: &str = "gemini-2.5-flash";
 const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-4o-mini";
@@ -103,14 +105,19 @@ pub fn parse_summarizer_spec(
 
 pub fn build_summarizer(
     summarizer: &str,
+    providers: &ProvidersConfig,
 ) -> Result<Box<dyn Summarizer>, Box<dyn Error + Send + Sync>> {
     match parse_summarizer_spec(summarizer)? {
         SummarizerSpec::Gemini { model } => Ok(Box::new(GeminiCli { model })),
-        SummarizerSpec::OpenRouter { model } => {
-            Ok(Box::new(OpenAiCompatibleSummarizer::new_openrouter(model)?))
-        }
+        SummarizerSpec::OpenRouter { model } => Ok(Box::new(
+            OpenAiCompatibleSummarizer::new_openrouter(model, providers.openrouter.api_key.as_deref())?,
+        )),
         SummarizerSpec::OpenAiCompatible { model } => Ok(Box::new(
-            OpenAiCompatibleSummarizer::new_openai_compatible(model)?,
+            OpenAiCompatibleSummarizer::new_openai_compatible(
+                model,
+                providers.openai.api_key.as_deref(),
+                providers.openai.base_url.as_deref(),
+            )?,
         )),
         SummarizerSpec::Raw => Ok(Box::new(RawPassthroughSummarizer)),
     }
@@ -130,6 +137,22 @@ pub fn truncate_for_summarizer(content: &str) -> &str {
     &content[start..]
 }
 
+fn resolve_key(
+    config_key: Option<&str>,
+    env_var: &str,
+    backend: &str,
+) -> Result<String, Box<dyn Error + Send + Sync>> {
+    if let Some(key) = config_key.filter(|k| !k.trim().is_empty()) {
+        return Ok(key.to_string());
+    }
+    std::env::var(env_var).map_err(|_| {
+        format!(
+            "{env_var} is required for {backend} summarizer; set it via [providers.{backend}].api_key in config.toml or as an environment variable"
+        )
+        .into()
+    })
+}
+
 fn default_if_empty(value: &str, default: &str) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -140,7 +163,15 @@ fn default_if_empty(value: &str, default: &str) -> String {
 }
 
 fn summarize_system_prompt() -> &'static str {
-    "You summarize tmux session output for developer monitoring. Focus on what the agent is doing, any errors encountered, and current status. Keep it concise (2-5 sentences). If the output shows the agent is waiting for input, say so explicitly. Respond in plain text."
+    "You summarize tmux session output for developer monitoring. \
+     Focus on what the agent is doing, any errors encountered, and current status. \
+     Keep it concise (2-5 sentences).\n\n\
+     IMPORTANT: If the terminal output indicates the session is waiting for user input — for example: \
+     a [Y/n] confirmation prompt, 'Press enter to continue', 'Allow, Deny, Always allow' tool approval \
+     (Claude Code style), 'continue?', 'proceed?', 'overwrite?', an interactive menu asking for a choice, \
+     or a shell/REPL prompt awaiting a command — begin your response with exactly this line:\n\
+     STATUS: WAITING_FOR_INPUT\n\n\
+     Otherwise do not include a STATUS line. Respond in plain text."
 }
 
 fn summarize_user_prompt(session: &str, content: &str) -> String {
@@ -285,28 +316,26 @@ struct OpenAiCompatibleSummarizer {
 }
 
 impl OpenAiCompatibleSummarizer {
-    fn new_openrouter(model: String) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        Self::new(
-            "openrouter",
-            OPENROUTER_BASE_URL.to_string(),
-            std::env::var("OPENROUTER_API_KEY")
-                .map_err(|_| "OPENROUTER_API_KEY is required for openrouter summarizer")?,
-            model,
-        )
+    fn new_openrouter(
+        model: String,
+        config_key: Option<&str>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let api_key = resolve_key(config_key, "OPENROUTER_API_KEY", "openrouter")?;
+        Self::new("openrouter", OPENROUTER_BASE_URL.to_string(), api_key, model)
     }
 
-    fn new_openai_compatible(model: String) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        let base_url = std::env::var("OPENAI_BASE_URL")
-            .ok()
-            .filter(|value| !value.trim().is_empty())
+    fn new_openai_compatible(
+        model: String,
+        config_key: Option<&str>,
+        config_base_url: Option<&str>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let base_url = config_base_url
+            .filter(|v| !v.trim().is_empty())
+            .map(str::to_string)
+            .or_else(|| std::env::var("OPENAI_BASE_URL").ok().filter(|v| !v.trim().is_empty()))
             .unwrap_or_else(|| DEFAULT_OPENAI_BASE_URL.to_string());
-        Self::new(
-            "openai-compatible",
-            base_url,
-            std::env::var("OPENAI_API_KEY")
-                .map_err(|_| "OPENAI_API_KEY is required for openai summarizer")?,
-            model,
-        )
+        let api_key = resolve_key(config_key, "OPENAI_API_KEY", "openai")?;
+        Self::new("openai-compatible", base_url, api_key, model)
     }
 
     fn new(
@@ -522,6 +551,18 @@ mod tests {
 
     #[test]
     fn build_summarizer_supports_raw() {
-        assert!(build_summarizer("raw").is_ok());
+        assert!(build_summarizer("raw", &ProvidersConfig::default()).is_ok());
+    }
+
+    #[test]
+    fn system_prompt_includes_waiting_for_input_status_marker() {
+        let prompt = summarize_system_prompt();
+        assert!(
+            prompt.contains("STATUS: WAITING_FOR_INPUT"),
+            "system prompt must instruct the LLM to emit STATUS: WAITING_FOR_INPUT"
+        );
+        // Confirm it covers the key OMC/OMX trigger patterns
+        assert!(prompt.contains("[Y/n]") || prompt.contains("Allow, Deny"));
+        assert!(prompt.contains("continue?") || prompt.contains("proceed?"));
     }
 }

--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -1,0 +1,527 @@
+use std::error::Error;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::{Value, json};
+use tokio::process::Command;
+
+const MAX_INPUT_CHARS: usize = 4000;
+const DEFAULT_GEMINI_MODEL: &str = "gemini-2.5-flash";
+const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-4o-mini";
+const DEFAULT_OPENAI_MODEL: &str = "gpt-4o-mini";
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+const HTTP_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentMode {
+    Summary,
+    Raw,
+}
+
+impl ContentMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Summary => "summary",
+            Self::Raw => "raw",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SummarizedContent {
+    pub summary: String,
+    pub raw_truncated: String,
+    pub backend: String,
+    pub content_mode: ContentMode,
+}
+
+/// Trait for tmux content summarizers/transformers.
+#[async_trait]
+pub trait Summarizer: Send + Sync {
+    fn name(&self) -> &str;
+
+    async fn summarize(
+        &self,
+        content: &str,
+        session: &str,
+    ) -> Result<SummarizedContent, Box<dyn Error + Send + Sync>>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SummarizerSpec {
+    Gemini { model: String },
+    OpenRouter { model: String },
+    OpenAiCompatible { model: String },
+    Raw,
+}
+
+pub fn parse_summarizer_spec(
+    summarizer: &str,
+) -> Result<SummarizerSpec, Box<dyn Error + Send + Sync>> {
+    let trimmed = summarizer.trim();
+    let gemini_default = || SummarizerSpec::Gemini {
+        model: DEFAULT_GEMINI_MODEL.to_string(),
+    };
+    if trimmed.eq_ignore_ascii_case("raw") {
+        return Ok(SummarizerSpec::Raw);
+    }
+    if trimmed.eq_ignore_ascii_case("openrouter") {
+        return Ok(SummarizerSpec::OpenRouter {
+            model: DEFAULT_OPENROUTER_MODEL.to_string(),
+        });
+    }
+    if let Some(model) = trimmed.strip_prefix("openrouter:") {
+        return Ok(SummarizerSpec::OpenRouter {
+            model: default_if_empty(model, DEFAULT_OPENROUTER_MODEL),
+        });
+    }
+    if trimmed.eq_ignore_ascii_case("openai") || trimmed.eq_ignore_ascii_case("openai-compatible") {
+        return Ok(SummarizerSpec::OpenAiCompatible {
+            model: DEFAULT_OPENAI_MODEL.to_string(),
+        });
+    }
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("gemini") {
+        return Ok(gemini_default());
+    }
+    if let Some(model) = trimmed
+        .strip_prefix("openai:")
+        .or_else(|| trimmed.strip_prefix("openai-compatible:"))
+    {
+        return Ok(SummarizerSpec::OpenAiCompatible {
+            model: default_if_empty(model, DEFAULT_OPENAI_MODEL),
+        });
+    }
+    if let Some(model) = trimmed.strip_prefix("gemini:") {
+        return Ok(SummarizerSpec::Gemini {
+            model: default_if_empty(model, DEFAULT_GEMINI_MODEL),
+        });
+    }
+    Err(format!("unsupported summarizer backend '{trimmed}'").into())
+}
+
+pub fn build_summarizer(
+    summarizer: &str,
+) -> Result<Box<dyn Summarizer>, Box<dyn Error + Send + Sync>> {
+    match parse_summarizer_spec(summarizer)? {
+        SummarizerSpec::Gemini { model } => Ok(Box::new(GeminiCli { model })),
+        SummarizerSpec::OpenRouter { model } => {
+            Ok(Box::new(OpenAiCompatibleSummarizer::new_openrouter(model)?))
+        }
+        SummarizerSpec::OpenAiCompatible { model } => Ok(Box::new(
+            OpenAiCompatibleSummarizer::new_openai_compatible(model)?,
+        )),
+        SummarizerSpec::Raw => Ok(Box::new(RawPassthroughSummarizer)),
+    }
+}
+
+/// Truncate content to the last `MAX_INPUT_CHARS` characters.
+pub fn truncate_for_summarizer(content: &str) -> &str {
+    if content.len() <= MAX_INPUT_CHARS {
+        return content;
+    }
+    let start = content.len() - MAX_INPUT_CHARS;
+    let start = content[start..]
+        .char_indices()
+        .next()
+        .map(|(i, _)| start + i)
+        .unwrap_or(start);
+    &content[start..]
+}
+
+fn default_if_empty(value: &str, default: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn summarize_system_prompt() -> &'static str {
+    "You summarize tmux session output for developer monitoring. Focus on what the agent is doing, any errors encountered, and current status. Keep it concise (2-5 sentences). If the output shows the agent is waiting for input, say so explicitly. Respond in plain text."
+}
+
+fn summarize_user_prompt(session: &str, content: &str) -> String {
+    format!("Session: {session}\n\n{}", truncate_for_summarizer(content))
+}
+
+fn summarize_result(summary: String, raw_truncated: String, backend: &str) -> SummarizedContent {
+    SummarizedContent {
+        summary,
+        raw_truncated,
+        backend: backend.to_string(),
+        content_mode: ContentMode::Summary,
+    }
+}
+
+fn raw_result(raw_truncated: String, backend: &str) -> SummarizedContent {
+    SummarizedContent {
+        summary: raw_truncated.clone(),
+        raw_truncated,
+        backend: backend.to_string(),
+        content_mode: ContentMode::Raw,
+    }
+}
+
+fn openai_chat_request(model: &str, session: &str, content: &str) -> Value {
+    json!({
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": summarize_system_prompt(),
+            },
+            {
+                "role": "user",
+                "content": summarize_user_prompt(session, content),
+            }
+        ],
+        "temperature": 0.2
+    })
+}
+
+fn extract_openai_response_text(value: &Value) -> Option<String> {
+    let content = value.pointer("/choices/0/message/content")?;
+    match content {
+        Value::String(text) => Some(text.trim().to_string()).filter(|text| !text.is_empty()),
+        Value::Array(parts) => {
+            let joined = parts
+                .iter()
+                .filter_map(|part| {
+                    part.get("text")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|text| !text.is_empty())
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            if joined.trim().is_empty() {
+                None
+            } else {
+                Some(joined)
+            }
+        }
+        _ => None,
+    }
+}
+
+pub struct GeminiCli {
+    model: String,
+}
+
+#[async_trait]
+impl Summarizer for GeminiCli {
+    fn name(&self) -> &str {
+        "gemini-cli"
+    }
+
+    async fn summarize(
+        &self,
+        content: &str,
+        session: &str,
+    ) -> Result<SummarizedContent, Box<dyn Error + Send + Sync>> {
+        let raw_truncated = truncate_for_summarizer(content).to_string();
+        let prompt = format!(
+            "{}\n\n{}",
+            summarize_system_prompt(),
+            summarize_user_prompt(session, content)
+        );
+        let output = Command::new("gemini")
+            .arg("-m")
+            .arg(&self.model)
+            .arg("-p")
+            .arg(&prompt)
+            .output()
+            .await
+            .map_err(|e| format!("failed to spawn gemini CLI: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "gemini CLI exited with status {}: {}",
+                output.status,
+                stderr.trim()
+            )
+            .into());
+        }
+
+        let summary = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if summary.is_empty() {
+            return Err("gemini returned an empty summary".into());
+        }
+
+        Ok(summarize_result(summary, raw_truncated, self.name()))
+    }
+}
+
+pub struct RawPassthroughSummarizer;
+
+#[async_trait]
+impl Summarizer for RawPassthroughSummarizer {
+    fn name(&self) -> &str {
+        "raw"
+    }
+
+    async fn summarize(
+        &self,
+        content: &str,
+        _session: &str,
+    ) -> Result<SummarizedContent, Box<dyn Error + Send + Sync>> {
+        Ok(raw_result(
+            truncate_for_summarizer(content).to_string(),
+            self.name(),
+        ))
+    }
+}
+
+struct OpenAiCompatibleSummarizer {
+    client: Client,
+    backend_name: &'static str,
+    base_url: String,
+    api_key: String,
+    model: String,
+}
+
+impl OpenAiCompatibleSummarizer {
+    fn new_openrouter(model: String) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        Self::new(
+            "openrouter",
+            OPENROUTER_BASE_URL.to_string(),
+            std::env::var("OPENROUTER_API_KEY")
+                .map_err(|_| "OPENROUTER_API_KEY is required for openrouter summarizer")?,
+            model,
+        )
+    }
+
+    fn new_openai_compatible(model: String) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let base_url = std::env::var("OPENAI_BASE_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_OPENAI_BASE_URL.to_string());
+        Self::new(
+            "openai-compatible",
+            base_url,
+            std::env::var("OPENAI_API_KEY")
+                .map_err(|_| "OPENAI_API_KEY is required for openai summarizer")?,
+            model,
+        )
+    }
+
+    fn new(
+        backend_name: &'static str,
+        base_url: String,
+        api_key: String,
+        model: String,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
+            .build()?;
+        Ok(Self {
+            client,
+            backend_name,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key,
+            model,
+        })
+    }
+
+    fn chat_completions_url(&self) -> String {
+        format!("{}/chat/completions", self.base_url)
+    }
+}
+
+#[async_trait]
+impl Summarizer for OpenAiCompatibleSummarizer {
+    fn name(&self) -> &str {
+        self.backend_name
+    }
+
+    async fn summarize(
+        &self,
+        content: &str,
+        session: &str,
+    ) -> Result<SummarizedContent, Box<dyn Error + Send + Sync>> {
+        let raw_truncated = truncate_for_summarizer(content).to_string();
+        let response = self
+            .client
+            .post(self.chat_completions_url())
+            .bearer_auth(&self.api_key)
+            .json(&openai_chat_request(&self.model, session, content))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "{} API request failed with {}: {}",
+                self.backend_name, status, body
+            )
+            .into());
+        }
+
+        let payload = response.json::<Value>().await?;
+        let Some(summary) = extract_openai_response_text(&payload) else {
+            return Err(format!("{} API returned no summary text", self.backend_name).into());
+        };
+
+        Ok(summarize_result(summary, raw_truncated, self.name()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_content_unchanged() {
+        let content = "hello world";
+        assert_eq!(truncate_for_summarizer(content), "hello world");
+    }
+
+    #[test]
+    fn truncate_long_content() {
+        let content = "A".repeat(5000);
+        let truncated = truncate_for_summarizer(&content);
+        assert_eq!(truncated.len(), 4000);
+        assert_eq!(truncated, "A".repeat(4000));
+    }
+
+    #[test]
+    fn truncate_at_char_boundary() {
+        let prefix = "A".repeat(3998);
+        let content = format!("{}€{}", prefix, "Z");
+        let truncated = truncate_for_summarizer(&content);
+        assert!(truncated.len() <= 4000);
+    }
+
+    #[test]
+    fn parse_summarizer_spec_supports_raw() {
+        assert_eq!(parse_summarizer_spec("raw").unwrap(), SummarizerSpec::Raw);
+    }
+
+    #[test]
+    fn parse_summarizer_spec_supports_openrouter() {
+        assert_eq!(
+            parse_summarizer_spec("openrouter:google/gemini-2.5-flash").unwrap(),
+            SummarizerSpec::OpenRouter {
+                model: "google/gemini-2.5-flash".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_supports_openai() {
+        assert_eq!(
+            parse_summarizer_spec("openai:gpt-4.1-mini").unwrap(),
+            SummarizerSpec::OpenAiCompatible {
+                model: "gpt-4.1-mini".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_defaults_gemini() {
+        assert_eq!(
+            parse_summarizer_spec("gemini").unwrap(),
+            SummarizerSpec::Gemini {
+                model: DEFAULT_GEMINI_MODEL.into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_with_gemini_model() {
+        assert_eq!(
+            parse_summarizer_spec("gemini:gemini-2.5-pro").unwrap(),
+            SummarizerSpec::Gemini {
+                model: "gemini-2.5-pro".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_empty_gemini_model_uses_default() {
+        assert_eq!(
+            parse_summarizer_spec("gemini:").unwrap(),
+            SummarizerSpec::Gemini {
+                model: DEFAULT_GEMINI_MODEL.into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_rejects_unknown_prefix() {
+        assert!(parse_summarizer_spec("custom:something").is_err());
+    }
+
+    #[tokio::test]
+    async fn raw_passthrough_returns_truncated_content() {
+        let output = RawPassthroughSummarizer
+            .summarize("hello world", "issue-24")
+            .await
+            .unwrap();
+        assert_eq!(output.summary, "hello world");
+        assert_eq!(output.raw_truncated, "hello world");
+        assert_eq!(output.backend, "raw");
+        assert_eq!(output.content_mode, ContentMode::Raw);
+    }
+
+    #[test]
+    fn openai_chat_request_contains_model_and_messages() {
+        let payload = openai_chat_request("gpt-4o-mini", "issue-24", "build failed");
+        assert_eq!(payload["model"], "gpt-4o-mini");
+        assert_eq!(payload["messages"][0]["role"], "system");
+        assert_eq!(payload["messages"][1]["role"], "user");
+        assert!(
+            payload["messages"][1]["content"]
+                .as_str()
+                .unwrap()
+                .contains("issue-24")
+        );
+    }
+
+    #[test]
+    fn extract_openai_response_text_supports_string_content() {
+        let payload = json!({
+            "choices": [
+                {
+                    "message": {
+                        "content": "agent fixed the test"
+                    }
+                }
+            ]
+        });
+        assert_eq!(
+            extract_openai_response_text(&payload).as_deref(),
+            Some("agent fixed the test")
+        );
+    }
+
+    #[test]
+    fn extract_openai_response_text_supports_content_parts() {
+        let payload = json!({
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "agent is compiling"},
+                            {"type": "text", "text": "waiting on cargo"}
+                        ]
+                    }
+                }
+            ]
+        });
+        assert_eq!(
+            extract_openai_response_text(&payload).as_deref(),
+            Some("agent is compiling\nwaiting on cargo")
+        );
+    }
+
+    #[test]
+    fn build_summarizer_supports_raw() {
+        assert!(build_summarizer("raw").is_ok());
+    }
+}

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -115,6 +115,17 @@ impl From<TmuxMonitorArgs> for RegisteredTmuxSession {
             detect_waiting: false,
             min_new_lines: 0,
             summarize_interval_mins: 0,
+            mention_on: Vec::new(),
+            pin_status: true,
+            pin_summary: true,
+            pin_alerts: true,
+            pin_activity: true,
+            pin_keywords: true,
+            heartbeat_interval: 0,
+            stale_interval: 0,
+            summary_interval: 0,
+            waiting_interval: 0,
+            activity_interval: 0,
         }
     }
 }
@@ -129,8 +140,9 @@ async fn register_and_start_monitor(
     client.register_tmux(&registration).await?;
 
     let monitor_client = client.clone();
+    let providers = config.providers.clone();
     Ok(tokio::spawn(async move {
-        monitor_registered_session(registration, monitor_client).await
+        monitor_registered_session(registration, monitor_client, providers).await
     }))
 }
 
@@ -535,6 +547,17 @@ mod tests {
             detect_waiting: false,
             min_new_lines: 0,
             summarize_interval_mins: 0,
+            mention_on: Vec::new(),
+            pin_status: true,
+            pin_summary: true,
+            pin_alerts: true,
+            pin_activity: true,
+            pin_keywords: false,
+            heartbeat_interval: 0,
+            stale_interval: 0,
+            summary_interval: 0,
+            waiting_interval: 0,
+            activity_interval: 0,
         });
 
         assert!(log.contains("session=issue-105"));

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -113,6 +113,8 @@ impl From<TmuxMonitorArgs> for RegisteredTmuxSession {
             summarizer: String::new(),
             heartbeat_mins: 0,
             detect_waiting: false,
+            min_new_lines: 0,
+            summarize_interval_mins: 0,
         }
     }
 }
@@ -531,6 +533,8 @@ mod tests {
             summarizer: String::new(),
             heartbeat_mins: 0,
             detect_waiting: false,
+            min_new_lines: 0,
+            summarize_interval_mins: 0,
         });
 
         assert!(log.contains("session=issue-105"));

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -109,6 +109,10 @@ impl From<TmuxMonitorArgs> for RegisteredTmuxSession {
             registration_source: value.registration_source,
             parent_process: value.parent_process,
             active_wrapper_monitor: true,
+            summarize: false,
+            summarizer: String::new(),
+            heartbeat_mins: 0,
+            detect_waiting: false,
         }
     }
 }
@@ -523,6 +527,10 @@ mod tests {
                 name: Some("codex".into()),
             }),
             active_wrapper_monitor: true,
+            summarize: false,
+            summarizer: String::new(),
+            heartbeat_mins: 0,
+            detect_waiting: false,
         });
 
         assert!(log.contains("session=issue-105"));


### PR DESCRIPTION
## Summary

This PR adds three major features to the tmux monitoring pipeline: LLM-powered snapshot summarization with multiple backends, a per-session dashboard pinning system that maintains up to 5 in-place Discord messages, and a waiting-for-input state machine that detects when a pane is blocking on user input and clears the alert automatically when the user responds.

---

## Snapshot summarization

A new `summarize` option on `[[monitors.tmux.sessions]]` enables pane content snapshots to be processed by a pluggable summarizer and delivered to Discord on content change.

```toml
[[monitors.tmux.sessions]]
session = "my-session"
channel = "YOUR_CHANNEL_ID"
summarize = true
summarizer = "gemini:gemini-2.5-flash"
summarize_interval_mins = 5
min_new_lines = 3
```

**Backends:**

| Config value | Description | Requires |
|---|---|---|
| `raw` | Latest terminal output verbatim, no LLM | nothing |
| `gemini` / `gemini:<model>` | Gemini CLI subprocess | `gemini` CLI in PATH |
| `openrouter:<model>` | OpenRouter chat completions API | `OPENROUTER_API_KEY` |
| `openai:<model>` | OpenAI chat completions API | `OPENAI_API_KEY` |
| `openai-compatible:<model>` | Any OpenAI-compatible endpoint | `OPENAI_API_KEY` + `OPENAI_BASE_URL` |

Default models when no suffix is given: Gemini → `gemini-2.5-flash`, OpenRouter → `openai/gpt-4o-mini`, OpenAI → `gpt-4o-mini`.

API keys can be set via environment variables (`GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`) or in config under `[providers.gemini]`, `[providers.openrouter]`, and `[providers.openai]`.

Summarization runs as a non-blocking background task and never stalls the poll loop. `summarize_interval_mins` throttles LLM calls; `min_new_lines` requires a minimum of net new lines before triggering.

**Discord delivery:**
- `raw` mode: edits a single living Discord message per session with the latest terminal output (`📋`)
- AI summary mode: posts a new message per summary for a historical record (`🤖`)

---

## Dashboard pinning

Each monitored tmux session maintains up to 5 pinned Discord messages, edited in-place rather than posting new messages. This keeps the channel clean and makes session state immediately visible at a glance.

**Slots:**

| Slot | Trigger | Default |
|---|---|---|
| `status` | `tmux.heartbeat` | enabled |
| `summary` | `tmux.content_changed` | enabled |
| `alert` | `tmux.waiting_for_input` / resolved | enabled |
| `activity` | rolling log of all events | enabled |
| `keywords` | rolling keyword hit log | disabled |

```toml
[[monitors.tmux.sessions]]
session = "my-session"
channel = "YOUR_CHANNEL_ID"
pin_status = true      # heartbeat slot (default: true)
pin_summary = true     # content/summary slot (default: true)
pin_alerts = true      # waiting-for-input alert slot (default: true)
pin_activity = true    # rolling activity log (default: true)
pin_keywords = false   # rolling keyword log (default: false)
```

Message IDs are persisted to `~/.clawhip/dashboard.json` and survive daemon restarts. When a tmux session ends (`tmux.session_ended`), all pinned messages are unpinned via the Discord API and the session entry is cleared from `dashboard.json`.

---

## Waiting-for-input detection

When `detect_waiting = true`, the tmux monitor inspects the last 3 non-empty lines of each pane's content on every poll cycle and emits events when it detects an interactive prompt.

```toml
[[monitors.tmux.sessions]]
session = "my-session"
channel = "YOUR_CHANNEL_ID"
detect_waiting = true
waiting_interval = 0   # cooldown minutes between alerts (0 = no cooldown)
```

Detected patterns include: `[y/n]`, `(yes/no)`, `proceed?`, `continue?`, `overwrite?`, `password:`, `press enter`, `do you want to`, menu selectors, and Claude Code tool-approval flows (`allow, deny`, `always allow`, etc.).

**State machine:**
- Pane transitions from idle → blocking: emits `tmux.waiting_for_input`, pins an `⏳` alert message
- Pane transitions from blocking → active (prompt disappears after reply): emits `tmux.waiting_resolved`, updates the same alert slot to `✅ \`session\` — Input received, continuing...`

The 3 non-empty line window is intentional: after one user reply (output + echoed command + new shell prompt = 3 non-empty lines), the original waiting prompt leaves the window, triggering the resolved transition. This correctly handles `capture-pane -S -200` output which pads the visible area with blank rows.

---

## Keyword windowing fix

The keyword dedup `seen` set is now scoped to a single window only. Previously the set was carried forward into the next window via `flush_and_reset`, permanently suppressing repeated `(keyword, line)` pairs across windows. Now each window starts fresh — the same keyword hit can fire again in a later window if the line reappears.

---

## New config fields (all optional, backward-compatible)

```toml
[[monitors.tmux.sessions]]
# Summarization
summarize = false
summarizer = "gemini:gemini-2.5-flash"
min_new_lines = 0
summarize_interval_mins = 0
summary_interval = 0          # alias for summarize_interval_mins

# Heartbeat
heartbeat_mins = 0
heartbeat_interval = 0        # alias for heartbeat_mins

# Waiting detection
detect_waiting = false
waiting_interval = 0

# Mention filtering
mention_on = []               # e.g. ["keyword", "waiting_for_input"]

# Dashboard pinning
pin_status = true
pin_summary = true
pin_alerts = true
pin_activity = true
pin_keywords = false
activity_interval = 0

# Interval overrides
stale_interval = 0            # alias for stale_minutes
```

New provider config:
```toml
[providers.gemini]
api_key = "..."

[providers.openrouter]
api_key = "..."

[providers.openai]
api_key = "..."
base_url = "..."              # optional; for xAI, Ollama, etc.
```

---

## Test coverage

- `waiting_detects_*` — pattern detection for all prompt families
- `waiting_only_checks_last_3_lines` — blank-row padding and window boundary
- `session_keyword_hits_aggregate_across_panes_and_dedup_within_window`
- `session_keyword_hits_flush_when_window_expires`
- `flush_pending_keyword_hits_aggregates_unique_hits`
- `flush_pending_keyword_hits_clears_window_after_send_attempt`
- `identical_keyword_lines_can_emit_again_after_window_flush`
- Summarizer backend unit tests (raw passthrough, OpenAI request shape, response parsing, truncation, system prompt)

All 322 unit tests pass.