### PR TITLE
feat: dashboard pinning with edit-in-place slots and session lifecycle

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,28 @@ pub struct ProvidersConfig {
     pub discord: DiscordConfig,
     #[serde(default)]
     pub slack: SlackConfig,
+    #[serde(default)]
+    pub gemini: GeminiConfig,
+    #[serde(default)]
+    pub openrouter: OpenRouterConfig,
+    #[serde(default)]
+    pub openai: OpenAiConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GeminiConfig {
+    pub api_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpenRouterConfig {
+    pub api_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpenAiConfig {
+    pub api_key: Option<String>,
+    pub base_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -287,6 +309,25 @@ pub struct TmuxSessionMonitor {
     pub channel: Option<String>,
     pub mention: Option<String>,
     pub format: Option<MessageFormat>,
+    // ── Optional tmux content transformation ──
+    #[serde(default)]
+    pub summarize: bool,
+    #[serde(default = "default_summarizer")]
+    pub summarizer: String,
+    #[serde(default)]
+    pub heartbeat_mins: u64,
+    /// Minimum number of new lines added before triggering summarization. 0 = no filter.
+    #[serde(default)]
+    pub min_new_lines: usize,
+    /// Minimum minutes between LLM summarization calls for this session. 0 = no throttle.
+    #[serde(default)]
+    pub summarize_interval_mins: u64,
+    /// Minutes between heartbeat events. 0 = disable. Overrides heartbeat_mins when set.
+    #[serde(default)]
+    pub heartbeat_interval: u64,
+    /// Minimum minutes between AI summary events. 0 = use summarize_interval_mins.
+    #[serde(default)]
+    pub summary_interval: u64,
 }
 
 impl Default for TmuxSessionMonitor {
@@ -299,6 +340,13 @@ impl Default for TmuxSessionMonitor {
             channel: None,
             mention: None,
             format: None,
+            summarize: false,
+            summarizer: default_summarizer(),
+            heartbeat_mins: 0,
+            min_new_lines: 0,
+            summarize_interval_mins: 0,
+            heartbeat_interval: 0,
+            summary_interval: 0,
         }
     }
 }
@@ -426,6 +474,10 @@ fn default_cron_timezone() -> String {
 }
 fn default_true() -> bool {
     true
+}
+
+fn default_summarizer() -> String {
+    "gemini:gemini-2.5-flash".to_string()
 }
 
 pub fn default_sink_name() -> String {
@@ -1082,6 +1134,7 @@ mod tests {
                     legacy_default_channel: None,
                 },
                 slack: SlackConfig::default(),
+                ..Default::default()
             },
             routes: vec![RouteRule {
                 event: "tmux.keyword".into(),
@@ -1319,6 +1372,7 @@ message = " ping "
                     legacy_default_channel: None,
                 },
                 slack: SlackConfig::default(),
+                ..Default::default()
             },
             cron: CronConfig {
                 poll_interval_secs: 30,

--- a/src/config.rs
+++ b/src/config.rs
@@ -328,6 +328,15 @@ pub struct TmuxSessionMonitor {
     /// Minimum minutes between AI summary events. 0 = use summarize_interval_mins.
     #[serde(default)]
     pub summary_interval: u64,
+    #[serde(default)]
+    pub detect_waiting: bool,
+    /// Cooldown minutes between waiting-for-input alerts. 0 = no cooldown.
+    #[serde(default)]
+    pub waiting_interval: u64,
+    /// Event kinds that trigger the @mention. Empty = mention applies to all events.
+    /// Valid values: "keyword", "waiting_for_input", "content_changed", "stale", "heartbeat".
+    #[serde(default)]
+    pub mention_on: Vec<String>,
 }
 
 impl Default for TmuxSessionMonitor {
@@ -347,6 +356,9 @@ impl Default for TmuxSessionMonitor {
             summarize_interval_mins: 0,
             heartbeat_interval: 0,
             summary_interval: 0,
+            detect_waiting: false,
+            waiting_interval: 0,
+            mention_on: Vec::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -337,6 +337,21 @@ pub struct TmuxSessionMonitor {
     /// Valid values: "keyword", "waiting_for_input", "content_changed", "stale", "heartbeat".
     #[serde(default)]
     pub mention_on: Vec<String>,
+    /// Pin and update the status/heartbeat dashboard message in-place.
+    /// Dashboard is implicit: enabled when any pin_* = true.
+    #[serde(default)]
+    pub pin_status: bool,
+    /// Pin and update the summary dashboard message in-place.
+    #[serde(default)]
+    pub pin_summary: bool,
+    /// Pin and update the alert dashboard message in-place.
+    #[serde(default)]
+    pub pin_alerts: bool,
+    #[serde(default)]
+    pub pin_activity: bool,
+    /// Pin keyword hits as a rolling log dashboard slot. Default false (backward compat).
+    #[serde(default)]
+    pub pin_keywords: bool,
 }
 
 impl Default for TmuxSessionMonitor {
@@ -359,6 +374,11 @@ impl Default for TmuxSessionMonitor {
             detect_waiting: false,
             waiting_interval: 0,
             mention_on: Vec::new(),
+            pin_status: true,
+            pin_summary: true,
+            pin_alerts: true,
+            pin_activity: true,
+            pin_keywords: false,
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -734,6 +734,7 @@ mod tests {
                     name: Some("codex".into()),
                 }),
                 active_wrapper_monitor: true,
+                ..Default::default()
             },
         );
         let state = AppState {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,10 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::Result;
@@ -14,6 +15,16 @@ use crate::core::dlq::{Dlq, DlqEntry};
 use crate::core::rate_limit::RateLimiter;
 use crate::sink::{SinkMessage, SinkTarget};
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct DashboardSlotIds {
+    pub status: Option<String>,
+    pub summary: Option<String>,
+    pub alert: Option<String>,
+    pub activity: Option<String>,
+    pub keywords: Option<String>,
+}
+
+const DASHBOARD_SEPARATOR: &str = "\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}\u{2501}";
 const MAX_ATTEMPTS: u32 = 3;
 const JITTER_MS: u64 = 50;
 const CIRCUIT_FAILURE_THRESHOLD: u32 = 3;
@@ -34,6 +45,20 @@ struct DiscordState {
     limiter: RateLimiter,
     circuits: HashMap<String, CircuitBreaker>,
     dlq: Dlq,
+    /// Tracks the last Discord message ID for edit-in-place event types.
+    /// Key: "{channel_id}:{edit_key}".
+    last_heartbeat_msg_ids: HashMap<String, String>,
+    /// Accumulated rendered content for append-only keyword messages.
+    /// Key: "{channel_id}:keywords:{session}".
+    accumulated_keyword_content: HashMap<String, String>,
+    /// Dashboard message IDs per "{channel}:{session}".
+    dashboard_ids: HashMap<String, DashboardSlotIds>,
+    /// Rolling activity log per "{channel}:{session}" -- last 5 events.
+    activity_log: HashMap<String, VecDeque<String>>,
+    /// Rolling keyword hit log per "{channel}:{session}".
+    keyword_log: HashMap<String, VecDeque<String>>,
+    /// Path to dashboard persistence file.
+    dashboard_path: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -69,6 +94,15 @@ impl DiscordClient {
             .unwrap_or_else(|_| "https://discord.com/api/v10".to_string());
         let webhook_client = reqwest::Client::new();
 
+        let dashboard_path = std::env::var("HOME")
+            .ok()
+            .map(|h| PathBuf::from(h).join(".clawhip").join("dashboard.json"));
+        let dashboard_ids: HashMap<String, DashboardSlotIds> = dashboard_path
+            .as_ref()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+
         Ok(Self {
             bot_client,
             webhook_client,
@@ -77,6 +111,12 @@ impl DiscordClient {
                 limiter: RateLimiter::new(RATE_LIMIT_CAPACITY, RATE_LIMIT_REFILL_PER_SEC),
                 circuits: HashMap::new(),
                 dlq: Dlq::default(),
+                last_heartbeat_msg_ids: HashMap::new(),
+                accumulated_keyword_content: HashMap::new(),
+                dashboard_ids,
+                activity_log: HashMap::new(),
+                keyword_log: HashMap::new(),
+                dashboard_path,
             })),
         })
     }
@@ -97,7 +137,120 @@ impl DiscordClient {
 
             let result = match target {
                 SinkTarget::DiscordChannel(channel_id) => {
-                    self.send_message(channel_id, &message.content).await
+                    let session = message.payload["session"].as_str().unwrap_or("unknown");
+                    let dashboard_slot = message.payload["dashboard_component"].as_str();
+
+                    if let Some(slot) = dashboard_slot {
+                        let ts = time::OffsetDateTime::now_utc()
+                            .format(&time::format_description::well_known::Rfc3339)
+                            .unwrap_or_default();
+                        let dashboard_content = if slot == "keywords" {
+                            let entry =
+                                format!("`{ts}` {}", truncate_keyword_entry(&message.content));
+                            let log_text = self.push_keyword_log(channel_id, session, &entry);
+                            format!(
+                                "\u{1f511} `{session}` \u{00b7} Keyword Hits\n{DASHBOARD_SEPARATOR}\n{log_text}"
+                            )
+                        } else if slot == "alert"
+                            && message.payload["resolved"].as_bool().unwrap_or(false)
+                        {
+                            format!("✅ `{session}` — Input received, continuing...")
+                        } else {
+                            render_dashboard_slot(
+                                slot,
+                                session,
+                                &message.event_kind,
+                                &message.content,
+                            )
+                        };
+
+                        let activity_entry = format!(
+                            "`{ts}` {} -- {}",
+                            message.event_kind,
+                            truncate_activity(&message.content)
+                        );
+                        let activity_text =
+                            self.push_activity(channel_id, session, &activity_entry);
+                        let activity_content = format!(
+                            "\u{1f4dc} `{session}` \u{00b7} Recent Activity\n{DASHBOARD_SEPARATOR}\n{activity_text}"
+                        );
+                        let should_pin_activity =
+                            message.payload["pin_activity"].as_bool().unwrap_or(true);
+                        let _ = self
+                            .update_dashboard_slot(
+                                channel_id,
+                                session,
+                                "activity",
+                                &activity_content,
+                                should_pin_activity,
+                            )
+                            .await;
+
+                        self.update_dashboard_slot(
+                            channel_id,
+                            session,
+                            slot,
+                            &dashboard_content,
+                            true,
+                        )
+                        .await
+                    } else {
+                        match message.event_kind.as_str() {
+                            "tmux.session_ended" => {
+                                self.clear_session_dashboard(channel_id, session).await;
+                                return Ok(());
+                            }
+                            "tmux.heartbeat" => {
+                                self.send_or_edit_keyed(
+                                    channel_id,
+                                    &format!("heartbeat:{session}"),
+                                    &message.content,
+                                )
+                                .await
+                            }
+                            "tmux.waiting_for_input" => {
+                                let content =
+                                    if message.payload["resolved"].as_bool().unwrap_or(false) {
+                                        format!("✅ `{session}` — Input received, continuing...")
+                                    } else {
+                                        message.content.clone()
+                                    };
+                                self.send_or_edit_keyed(
+                                    channel_id,
+                                    &format!("waiting:{session}"),
+                                    &content,
+                                )
+                                .await
+                            }
+                            "tmux.content_changed"
+                                if message.payload["content_mode"].as_str() == Some("raw") =>
+                            {
+                                self.send_or_edit_keyed(
+                                    channel_id,
+                                    &format!("raw:{session}"),
+                                    &message.content,
+                                )
+                                .await
+                            }
+                            "tmux.stale" => {
+                                self.send_or_edit_keyed(
+                                    channel_id,
+                                    &format!("stale:{session}"),
+                                    &message.content,
+                                )
+                                .await
+                            }
+                            "tmux.keyword" => {
+                                self.append_keyword_keyed(
+                                    channel_id,
+                                    &format!("keywords:{session}"),
+                                    &message.content,
+                                )
+                                .await
+                            }
+                            _ => self.send_message(channel_id, &message.content).await,
+                        }
+                    }
                 }
                 SinkTarget::DiscordWebhook(webhook_url) => {
                     self.send_webhook(webhook_url, &message.content).await
@@ -148,10 +301,158 @@ impl DiscordClient {
         })?;
 
         self.execute_request(
-            client.post(url).json(&json!({ "content": content })),
+            client
+                .post(url)
+                .json(&json!({ "content": truncate_discord(content) })),
             "Discord API request",
         )
         .await
+    }
+
+    /// Send a message and return the Discord message ID on success.
+    async fn send_message_returning_id(
+        &self,
+        channel_id: &str,
+        content: &str,
+    ) -> std::result::Result<Option<String>, DiscordSendError> {
+        let url = format!(
+            "{}/channels/{}/messages",
+            self.api_base.trim_end_matches('/'),
+            channel_id
+        );
+        let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
+            message: "missing Discord bot token for channel delivery".to_string(),
+            retry_after: None,
+        })?;
+        self.execute_request_returning_id(
+            client
+                .post(url)
+                .json(&json!({ "content": truncate_discord(content) })),
+            "Discord API request",
+        )
+        .await
+    }
+
+    /// Edit an existing Discord message.
+    async fn edit_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+        content: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let url = format!(
+            "{}/channels/{}/messages/{}",
+            self.api_base.trim_end_matches('/'),
+            channel_id,
+            message_id
+        );
+        let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
+            message: "missing Discord bot token for channel delivery".to_string(),
+            retry_after: None,
+        })?;
+        self.execute_request(
+            client
+                .patch(url)
+                .json(&json!({ "content": truncate_discord(content) })),
+            "Discord edit request",
+        )
+        .await
+    }
+
+    /// For edit-in-place event types (heartbeat, raw, waiting): edit the previous
+    /// message for this key if possible, otherwise post a new one and store the ID.
+    /// `edit_key` is a logical key like "heartbeat:session-name" or "content:session-name".
+    async fn send_or_edit_keyed(
+        &self,
+        channel_id: &str,
+        edit_key: &str,
+        content: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let key = format!("{channel_id}:{edit_key}");
+        let existing_id = {
+            let state = self.state.lock().expect("discord state lock");
+            state.last_heartbeat_msg_ids.get(&key).cloned()
+        };
+
+        if let Some(msg_id) = existing_id {
+            match self.edit_message(channel_id, &msg_id, content).await {
+                Ok(()) => return Ok(()),
+                Err(e) if e.message.contains("404") || e.message.contains("Unknown Message") => {
+                    // Message was deleted; fall through to create a new one
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let msg_id = self.send_message_returning_id(channel_id, content).await?;
+        if let Some(id) = msg_id {
+            let mut state = self.state.lock().expect("discord state lock");
+            state.last_heartbeat_msg_ids.insert(key, id);
+        }
+        Ok(())
+    }
+
+    /// Append new keyword hits to an existing message, or post a new one if none exists.
+    /// When appended content would exceed the Discord limit, starts a fresh message.
+    async fn append_keyword_keyed(
+        &self,
+        channel_id: &str,
+        edit_key: &str,
+        new_content: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let key = format!("{channel_id}:{edit_key}");
+        let (existing_id, accumulated) = {
+            let state = self.state.lock().expect("discord state lock");
+            let id = state.last_heartbeat_msg_ids.get(&key).cloned();
+            let acc = state
+                .accumulated_keyword_content
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            (id, acc)
+        };
+
+        let updated = if accumulated.is_empty() {
+            new_content.to_string()
+        } else {
+            format!("{accumulated}\n{new_content}")
+        };
+        // If appending would overflow, start a fresh message
+        let (content_to_send, is_continuation) = if updated.len() > 1990 {
+            (new_content.to_string(), false)
+        } else {
+            (updated, true)
+        };
+        let content_to_send = truncate_discord(&content_to_send).to_string();
+
+        if is_continuation && let Some(msg_id) = existing_id {
+            match self
+                .edit_message(channel_id, &msg_id, &content_to_send)
+                .await
+            {
+                Ok(()) => {
+                    let mut state = self.state.lock().expect("discord state lock");
+                    state
+                        .accumulated_keyword_content
+                        .insert(key, content_to_send);
+                    return Ok(());
+                }
+                Err(e) if e.message.contains("404") || e.message.contains("Unknown Message") => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        let msg_id = self
+            .send_message_returning_id(channel_id, &content_to_send)
+            .await?;
+        if let Some(id) = msg_id {
+            let mut state = self.state.lock().expect("discord state lock");
+            state.last_heartbeat_msg_ids.insert(key.clone(), id);
+            state
+                .accumulated_keyword_content
+                .insert(key, content_to_send);
+        }
+        Ok(())
     }
 
     async fn send_webhook(
@@ -162,10 +463,33 @@ impl DiscordClient {
         self.execute_request(
             self.webhook_client
                 .post(webhook_url_with_wait(webhook_url))
-                .json(&json!({ "content": content })),
+                .json(&json!({ "content": truncate_discord(content) })),
             "Discord webhook request",
         )
         .await
+    }
+
+    async fn execute_request_returning_id(
+        &self,
+        request: reqwest::RequestBuilder,
+        label: &str,
+    ) -> std::result::Result<Option<String>, DiscordSendError> {
+        let response = request.send().await.map_err(|error| DiscordSendError {
+            message: format!("{label} failed: {error}"),
+            retry_after: None,
+        })?;
+
+        if response.status().is_success() {
+            let body = response.json::<serde_json::Value>().await.ok();
+            return Ok(body.and_then(|v| v["id"].as_str().map(str::to_string)));
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Err(DiscordSendError {
+            message: format!("{label} failed with {status}: {body}"),
+            retry_after: parse_retry_after(status, &body),
+        })
     }
 
     async fn execute_request(
@@ -188,6 +512,187 @@ impl DiscordClient {
             message: format!("{label} failed with {status}: {body}"),
             retry_after: parse_retry_after(status, &body),
         })
+    }
+
+    /// Pin a message in a Discord channel.
+    async fn pin_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let url = format!(
+            "{}/channels/{}/pins/{}",
+            self.api_base.trim_end_matches('/'),
+            channel_id,
+            message_id
+        );
+        let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
+            message: "missing Discord bot token for pinning".to_string(),
+            retry_after: None,
+        })?;
+        self.execute_request(client.put(url).json(&json!({})), "Discord pin request")
+            .await
+    }
+
+    async fn unpin_message(
+        &self,
+        channel_id: &str,
+        message_id: &str,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let url = format!(
+            "{}/channels/{}/pins/{}",
+            self.api_base.trim_end_matches('/'),
+            channel_id,
+            message_id
+        );
+        let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
+            message: "missing Discord bot token for unpinning".to_string(),
+            retry_after: None,
+        })?;
+        self.execute_request(client.delete(url), "Discord unpin request")
+            .await
+    }
+
+    /// Unpin all dashboard messages for a session and clear its slot IDs.
+    async fn clear_session_dashboard(&self, channel_id: &str, session: &str) {
+        let slot_key = format!("{channel_id}:{session}");
+
+        // Collect message IDs while holding the lock, then release before async calls
+        let ids_to_unpin = {
+            let state = self.state.lock().expect("discord state lock");
+            let Some(ids) = state.dashboard_ids.get(&slot_key) else {
+                return;
+            };
+            [
+                ids.status.clone(),
+                ids.summary.clone(),
+                ids.alert.clone(),
+                ids.activity.clone(),
+                ids.keywords.clone(),
+            ]
+        };
+
+        for msg_id in ids_to_unpin.into_iter().flatten() {
+            let _ = self.unpin_message(channel_id, &msg_id).await;
+        }
+
+        // Clear the IDs and persist
+        {
+            let mut state = self.state.lock().expect("discord state lock");
+            state.dashboard_ids.remove(&slot_key);
+            // Also clear in-memory keyword and activity logs for this session
+            state
+                .keyword_log
+                .retain(|k, _| !k.starts_with(&format!("{channel_id}:{session}")));
+            state
+                .activity_log
+                .retain(|k, _| !k.starts_with(&format!("{channel_id}:{session}")));
+        }
+        self.persist_dashboard();
+    }
+
+    /// Persist dashboard message IDs to disk.
+    fn persist_dashboard(&self) {
+        let state = self.state.lock().expect("discord state lock");
+        let Some(ref path) = state.dashboard_path else {
+            return;
+        };
+        if let Ok(json) = serde_json::to_string_pretty(&state.dashboard_ids) {
+            let _ = std::fs::write(path, json);
+        }
+    }
+
+    /// Update (or create) a pinned dashboard slot message.
+    async fn update_dashboard_slot(
+        &self,
+        channel_id: &str,
+        session: &str,
+        slot: &str,
+        content: &str,
+        should_pin: bool,
+    ) -> std::result::Result<(), DiscordSendError> {
+        let slot_key = format!("{channel_id}:{session}");
+
+        let existing_id = {
+            let state = self.state.lock().expect("discord state lock");
+            state
+                .dashboard_ids
+                .get(&slot_key)
+                .and_then(|ids| match slot {
+                    "status" => ids.status.clone(),
+                    "summary" => ids.summary.clone(),
+                    "alert" => ids.alert.clone(),
+                    "activity" => ids.activity.clone(),
+                    "keywords" => ids.keywords.clone(),
+                    _ => None,
+                })
+        };
+
+        if let Some(msg_id) = existing_id {
+            match self.edit_message(channel_id, &msg_id, content).await {
+                Ok(()) => return Ok(()),
+                Err(e) if e.message.contains("404") || e.message.contains("Unknown Message") => {
+                    let mut state = self.state.lock().expect("discord state lock");
+                    if let Some(ids) = state.dashboard_ids.get_mut(&slot_key) {
+                        match slot {
+                            "status" => ids.status = None,
+                            "summary" => ids.summary = None,
+                            "alert" => ids.alert = None,
+                            "activity" => ids.activity = None,
+                            "keywords" => ids.keywords = None,
+                            _ => {}
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let new_id = self.send_message_returning_id(channel_id, content).await?;
+        if let Some(id) = new_id {
+            if should_pin {
+                let _ = self.pin_message(channel_id, &id).await;
+            }
+            {
+                let mut state = self.state.lock().expect("discord state lock");
+                let ids = state.dashboard_ids.entry(slot_key).or_default();
+                match slot {
+                    "status" => ids.status = Some(id),
+                    "summary" => ids.summary = Some(id),
+                    "alert" => ids.alert = Some(id),
+                    "activity" => ids.activity = Some(id),
+                    "keywords" => ids.keywords = Some(id),
+                    _ => {}
+                }
+            }
+            self.persist_dashboard();
+        }
+        Ok(())
+    }
+
+    /// Push an entry to the rolling activity log and return the combined log text.
+    fn push_activity(&self, channel_id: &str, session: &str, entry: &str) -> String {
+        let key = format!("{channel_id}:{session}");
+        let mut state = self.state.lock().expect("discord state lock");
+        let log = state.activity_log.entry(key).or_default();
+        if log.len() >= 5 {
+            log.pop_front();
+        }
+        log.push_back(entry.to_string());
+        log.iter().cloned().collect::<Vec<_>>().join("\n")
+    }
+
+    /// Push an entry to the rolling keyword log. Drops oldest entries when total chars exceed 1800.
+    fn push_keyword_log(&self, channel_id: &str, session: &str, entry: &str) -> String {
+        let key = format!("{channel_id}:{session}");
+        let mut state = self.state.lock().expect("discord state lock");
+        let log = state.keyword_log.entry(key).or_default();
+        log.push_back(entry.to_string());
+        // Drop oldest entries until total content fits within ~1800 chars
+        while log.iter().map(|e| e.len() + 1).sum::<usize>() > 1800 && log.len() > 1 {
+            log.pop_front();
+        }
+        log.iter().cloned().collect::<Vec<_>>().join("\n")
     }
 
     fn allow_request(&self, key: &str) -> bool {
@@ -293,6 +798,20 @@ fn jitter_for_attempt(attempt: u32) -> Duration {
     Duration::from_millis(JITTER_MS * u64::from(attempt))
 }
 
+/// Truncate content to Discord's 2000-char message limit, appending "…" if clipped.
+fn truncate_discord(content: &str) -> &str {
+    const LIMIT: usize = 1990;
+    if content.len() <= LIMIT {
+        return content;
+    }
+    // Walk back to a char boundary
+    let mut end = LIMIT;
+    while !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    &content[..end]
+}
+
 fn webhook_url_with_wait(webhook_url: &str) -> String {
     if webhook_url.contains("wait=") {
         webhook_url.to_string()
@@ -300,6 +819,74 @@ fn webhook_url_with_wait(webhook_url: &str) -> String {
         format!("{webhook_url}&wait=true")
     } else {
         format!("{webhook_url}?wait=true")
+    }
+}
+
+/// Render dashboard-formatted content for a given slot.
+fn render_dashboard_slot(slot: &str, session: &str, event_kind: &str, content: &str) -> String {
+    match slot {
+        "status" => {
+            let status_icon = if event_kind == "tmux.stale" {
+                "\u{23f1}\u{fe0f} Stale"
+            } else {
+                "\u{1f493} Active"
+            };
+            let body = truncate_dashboard(content, 1500);
+            format!(
+                "\u{1f4ca} `{session}` \u{00b7} Status\n{DASHBOARD_SEPARATOR}\n{status_icon}\n{body}"
+            )
+        }
+        "summary" => {
+            let body = truncate_dashboard(content, 1500);
+            format!("\u{1f4cb} `{session}` \u{00b7} Latest Output\n{DASHBOARD_SEPARATOR}\n{body}")
+        }
+        "alert" => {
+            let body = truncate_dashboard(content, 1500);
+            format!(
+                "\u{1f6a8} `{session}` \u{00b7} **WAITING FOR INPUT**\n{DASHBOARD_SEPARATOR}\n{body}"
+            )
+        }
+        _ => content.to_string(),
+    }
+}
+
+/// Truncate content for dashboard slots to stay within Discord limits.
+fn truncate_dashboard(content: &str, max_len: usize) -> String {
+    if content.len() <= max_len {
+        content.to_string()
+    } else {
+        let mut end = max_len;
+        while !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}\u{2026}", &content[..end])
+    }
+}
+
+/// Truncate a single activity log entry to keep the rolling log compact.
+/// Truncate for keywords rolling log entries — preserves all lines (for multi-hit aggregated
+/// events), capping total entry length to 300 chars.
+fn truncate_keyword_entry(content: &str) -> String {
+    if content.len() <= 300 {
+        return content.to_string();
+    }
+    let mut end = 300;
+    while !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\u{2026}", &content[..end])
+}
+
+fn truncate_activity(content: &str) -> String {
+    let first_line = content.lines().next().unwrap_or(content);
+    if first_line.len() > 120 {
+        let mut end = 120;
+        while !first_line.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}\u{2026}", &first_line[..end])
+    } else {
+        first_line.to_string()
     }
 }
 
@@ -417,5 +1004,34 @@ mod tests {
         assert_eq!(dlq.len(), 1);
         assert_eq!(dlq[0].payload["repo"], "clawhip");
         assert_eq!(dlq[0].retry_count, 3);
+    }
+
+    #[test]
+    fn push_keyword_log_accumulates_and_evicts_oldest() {
+        let config = Arc::new(AppConfig::default());
+        let client = DiscordClient::from_config(config).unwrap();
+
+        // Small entries accumulate
+        let r1 = client.push_keyword_log("ch1", "sess", "entry1");
+        assert_eq!(r1, "entry1");
+        let r2 = client.push_keyword_log("ch1", "sess", "entry2");
+        assert_eq!(r2, "entry1\nentry2");
+
+        // Large entry forces eviction of oldest
+        let big = "x".repeat(1000);
+        client.push_keyword_log("ch1", "sess", &big);
+        let r4 = client.push_keyword_log("ch1", "sess", &big);
+        // After adding two ~1000-char entries, total > 1800 so oldest should be evicted
+        assert!(
+            !r4.starts_with("entry1"),
+            "oldest entry should have been evicted"
+        );
+    }
+
+    #[test]
+    fn render_dashboard_slot_keywords_falls_through_to_content() {
+        // keywords slot content is built inline in send(), render_dashboard_slot is not used for it
+        let result = render_dashboard_slot("keywords", "test-session", "tmux.keyword", "some hits");
+        assert_eq!(result, "some hits");
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -673,6 +673,19 @@ impl IncomingEvent {
         }
     }
 
+    pub fn tmux_session_ended(session: String, channel: Option<String>) -> Self {
+        Self {
+            kind: "tmux.session_ended".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session": session,
+            }),
+        }
+    }
+
     pub fn with_mention(mut self, mention: Option<String>) -> Self {
         self.mention = mention;
         self

--- a/src/events.rs
+++ b/src/events.rs
@@ -605,6 +605,53 @@ impl IncomingEvent {
         }
     }
 
+    /// Tmux content changed — with AI-generated summary.
+    #[allow(clippy::too_many_arguments)]
+    pub fn tmux_content_changed_with_metadata(
+        session: String,
+        pane_name: String,
+        summary: String,
+        raw_truncated: String,
+        backend: String,
+        content_mode: String,
+        channel: Option<String>,
+    ) -> Self {
+        Self {
+            kind: "tmux.content_changed".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session": session,
+                "pane": pane_name,
+                "summary": summary,
+                "raw_truncated": raw_truncated,
+                "backend": backend,
+                "content_mode": content_mode,
+            }),
+        }
+    }
+
+    /// Heartbeat — no changes detected for a given interval.
+    pub fn tmux_heartbeat(
+        session: String,
+        minutes_since_change: u64,
+        channel: Option<String>,
+    ) -> Self {
+        Self {
+            kind: "tmux.heartbeat".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session": session,
+                "minutes_since_change": minutes_since_change,
+            }),
+        }
+    }
+
     pub fn with_mention(mut self, mention: Option<String>) -> Self {
         self.mention = mention;
         self

--- a/src/events.rs
+++ b/src/events.rs
@@ -652,6 +652,27 @@ impl IncomingEvent {
         }
     }
 
+    /// Session is waiting for user input.
+    pub fn tmux_waiting_for_input(
+        session: String,
+        pane_name: String,
+        prompt_snapshot: String,
+        channel: Option<String>,
+    ) -> Self {
+        Self {
+            kind: "tmux.waiting_for_input".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "session": session,
+                "pane": pane_name,
+                "prompt_snapshot": prompt_snapshot,
+            }),
+        }
+    }
+
     pub fn with_mention(mut self, mention: Option<String>) -> Self {
         self.mention = mention;
         self

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod router;
 mod sink;
 mod slack;
 mod source;
+mod summarize;
 mod tmux_wrapper;
 mod update;
 
@@ -399,6 +400,7 @@ mod tests {
                 name: Some("codex".into()),
             }),
             active_wrapper_monitor: true,
+            ..Default::default()
         }]);
 
         assert!(output.contains(

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -303,6 +303,53 @@ impl Renderer for DefaultRenderer {
             ),
             ("tmux.stale", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
 
+            ("tmux.content_changed", MessageFormat::Compact) => {
+                let session = string_field(payload, "session")?;
+                if content_mode(payload) == "raw" {
+                    let raw = string_field(payload, "raw_truncated")?;
+                    format!("📋 **{session}**: {raw}")
+                } else {
+                    let summary = string_field(payload, "summary")?;
+                    format!("🤖 **{session}**: {summary}")
+                }
+            }
+            ("tmux.content_changed", MessageFormat::Alert) => {
+                let session = string_field(payload, "session")?;
+                if content_mode(payload) == "raw" {
+                    let raw = string_field(payload, "raw_truncated")?;
+                    format!("📋 **{session}**\n```\n{raw}\n```")
+                } else {
+                    let summary = string_field(payload, "summary")?;
+                    format!("🤖 **{session}**\n{summary}")
+                }
+            }
+            ("tmux.content_changed", MessageFormat::Inline) => {
+                let session = string_field(payload, "session")?;
+                if content_mode(payload) == "raw" {
+                    format!("📋 [{session}]")
+                } else {
+                    let summary = string_field(payload, "summary")?;
+                    format!("🤖 [{session}] {summary}")
+                }
+            }
+            ("tmux.content_changed", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
+
+            ("tmux.heartbeat", MessageFormat::Compact) => {
+                let session = string_field(payload, "session")?;
+                let minutes = payload.field_u64("minutes_since_change")?;
+                format!("💓 **{session}**: idle for {minutes}m")
+            }
+            ("tmux.heartbeat", MessageFormat::Alert) => {
+                let session = string_field(payload, "session")?;
+                let minutes = payload.field_u64("minutes_since_change")?;
+                format!("💓 **{session}**: idle for {minutes}m")
+            }
+            ("tmux.heartbeat", MessageFormat::Inline) => {
+                let session = string_field(payload, "session")?;
+                format!("💓 [{session}]")
+            }
+            ("tmux.heartbeat", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
+
             (_, MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
             (_, _) => serde_json::to_string(payload)?,
         };
@@ -328,6 +375,10 @@ fn optional_string_field(payload: &Value, key: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
+}
+
+fn content_mode(payload: &Value) -> String {
+    optional_string_field(payload, "content_mode").unwrap_or_else(|| "summary".to_string())
 }
 
 fn optional_u64_field(payload: &Value, key: &str) -> Option<u64> {
@@ -964,5 +1015,66 @@ mod tests {
             .unwrap();
         assert!(rendered.starts_with("🚨"));
         assert!(rendered.contains("release published"));
+    }
+
+    #[test]
+    fn renders_tmux_content_changed_formats() {
+        let renderer = DefaultRenderer;
+        let event = IncomingEvent::tmux_content_changed_with_metadata(
+            "issue-24".into(),
+            "0.1".into(),
+            "Agent fixed the failing test".into(),
+            "tail".into(),
+            "gemini-cli".into(),
+            "summary".into(),
+            None,
+        );
+
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Compact).unwrap(),
+            "🤖 **issue-24**: Agent fixed the failing test"
+        );
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Inline).unwrap(),
+            "🤖 [issue-24] Agent fixed the failing test"
+        );
+    }
+
+    #[test]
+    fn renders_tmux_content_changed_raw_formats() {
+        let renderer = DefaultRenderer;
+        let event = IncomingEvent::tmux_content_changed_with_metadata(
+            "issue-24".into(),
+            "0.1".into(),
+            "ignored".into(),
+            "cargo build\nerror: failed".into(),
+            "raw".into(),
+            "raw".into(),
+            None,
+        );
+
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Compact).unwrap(),
+            "📋 **issue-24**: cargo build\nerror: failed"
+        );
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Inline).unwrap(),
+            "📋 [issue-24]"
+        );
+    }
+
+    #[test]
+    fn renders_tmux_heartbeat_formats() {
+        let renderer = DefaultRenderer;
+        let event = IncomingEvent::tmux_heartbeat("issue-24".into(), 42, None);
+
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Compact).unwrap(),
+            "💓 **issue-24**: idle for 42m"
+        );
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Inline).unwrap(),
+            "💓 [issue-24]"
+        );
     }
 }

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -350,6 +350,26 @@ impl Renderer for DefaultRenderer {
             }
             ("tmux.heartbeat", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
 
+            ("tmux.waiting_for_input", MessageFormat::Compact) => {
+                let session = string_field(payload, "session")?;
+                let prompt = optional_string_field(payload, "prompt_snapshot")
+                    .unwrap_or_else(|| "no prompt".to_string());
+                format!("⏳ **{session}**:\n```\n{prompt}\n```")
+            }
+            ("tmux.waiting_for_input", MessageFormat::Alert) => {
+                let session = string_field(payload, "session")?;
+                let prompt = optional_string_field(payload, "prompt_snapshot")
+                    .unwrap_or_else(|| "no prompt".to_string());
+                format!("⏳ **{session}**:\n```\n{prompt}\n```")
+            }
+            ("tmux.waiting_for_input", MessageFormat::Inline) => {
+                let session = string_field(payload, "session")?;
+                format!("⏳ [{session}]")
+            }
+            ("tmux.waiting_for_input", MessageFormat::Raw) => {
+                serde_json::to_string_pretty(payload)?
+            }
+
             (_, MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
             (_, _) => serde_json::to_string(payload)?,
         };
@@ -1075,6 +1095,28 @@ mod tests {
         assert_eq!(
             renderer.render(&event, &MessageFormat::Inline).unwrap(),
             "💓 [issue-24]"
+        );
+    }
+
+    #[test]
+    fn renders_tmux_waiting_for_input_formats() {
+        let renderer = DefaultRenderer;
+        let event = IncomingEvent::tmux_waiting_for_input(
+            "issue-24".into(),
+            "0.1".into(),
+            "Press enter to continue".into(),
+            None,
+        );
+
+        assert_eq!(
+            renderer.render(&event, &MessageFormat::Inline).unwrap(),
+            "⏳ [issue-24]"
+        );
+        assert!(
+            renderer
+                .render(&event, &MessageFormat::Compact)
+                .unwrap()
+                .starts_with("⏳ **issue-24**")
         );
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -321,6 +321,9 @@ fn route_candidates(kind: &str) -> Vec<&str> {
         | "session.handoff-needed" => {
             vec![kind, "session.*"]
         }
+        "tmux.content_changed" | "tmux.heartbeat" => {
+            vec![kind, "tmux.*"]
+        }
         other => vec![other],
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -321,7 +321,10 @@ fn route_candidates(kind: &str) -> Vec<&str> {
         | "session.handoff-needed" => {
             vec![kind, "session.*"]
         }
-        "tmux.content_changed" | "tmux.heartbeat" | "tmux.waiting_for_input" => {
+        "tmux.content_changed"
+        | "tmux.heartbeat"
+        | "tmux.waiting_for_input"
+        | "tmux.session_ended" => {
             vec![kind, "tmux.*"]
         }
         other => vec![other],

--- a/src/router.rs
+++ b/src/router.rs
@@ -321,7 +321,7 @@ fn route_candidates(kind: &str) -> Vec<&str> {
         | "session.handoff-needed" => {
             vec![kind, "session.*"]
         }
-        "tmux.content_changed" | "tmux.heartbeat" => {
+        "tmux.content_changed" | "tmux.heartbeat" | "tmux.waiting_for_input" => {
             vec![kind, "tmux.*"]
         }
         other => vec![other],

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -16,6 +16,7 @@ use crate::events::{IncomingEvent, MessageFormat, RoutingMetadata};
 use crate::keyword_window::{PendingKeywordHits, collect_keyword_hits};
 use crate::router::glob_match;
 use crate::source::Source;
+use crate::summarize::{SummarizedContent, build_summarizer};
 
 pub type SharedTmuxRegistry = Arc<RwLock<HashMap<String, RegisteredTmuxSession>>>;
 
@@ -44,7 +45,7 @@ pub struct ParentProcessInfo {
     pub name: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RegisteredTmuxSession {
     pub session: String,
     pub channel: Option<String>,
@@ -65,6 +66,32 @@ pub struct RegisteredTmuxSession {
     pub parent_process: Option<ParentProcessInfo>,
     #[serde(default)]
     pub active_wrapper_monitor: bool,
+    #[serde(default)]
+    pub summarize: bool,
+    #[serde(default)]
+    pub summarizer: String,
+    #[serde(default)]
+    pub heartbeat_mins: u64,
+    #[serde(default)]
+    pub min_new_lines: usize,
+    #[serde(default)]
+    pub summarize_interval_mins: u64,
+    #[serde(default)]
+    pub heartbeat_interval: u64,
+    #[serde(default)]
+    pub summary_interval: u64,
+}
+
+impl RegisteredTmuxSession {
+    /// Effective heartbeat interval: heartbeat_interval overrides heartbeat_mins when > 0.
+    pub fn effective_heartbeat_mins(&self) -> u64 {
+        if self.heartbeat_interval > 0 { self.heartbeat_interval } else { self.heartbeat_mins }
+    }
+
+    /// Effective summary throttle: summary_interval overrides summarize_interval_mins when > 0.
+    pub fn effective_summary_interval(&self) -> u64 {
+        if self.summary_interval > 0 { self.summary_interval } else { self.summarize_interval_mins }
+    }
 }
 
 impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
@@ -82,6 +109,13 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             registration_source: RegistrationSource::ConfigMonitor,
             parent_process: None,
             active_wrapper_monitor: false,
+            summarize: value.summarize,
+            summarizer: value.summarizer.clone(),
+            heartbeat_mins: value.heartbeat_mins,
+            min_new_lines: value.min_new_lines,
+            summarize_interval_mins: value.summarize_interval_mins,
+            heartbeat_interval: value.heartbeat_interval,
+            summary_interval: value.summary_interval,
         }
     }
 }
@@ -151,6 +185,8 @@ struct TmuxPaneState {
 struct TmuxMonitorState {
     panes: HashMap<String, TmuxPaneState>,
     pending_keyword_hits: HashMap<String, PendingKeywordHits>,
+    session_last_heartbeat: HashMap<String, Instant>,
+    session_last_summarized: HashMap<String, Instant>,
 }
 
 struct TmuxPaneSnapshot {
@@ -164,9 +200,12 @@ struct TmuxPaneSnapshot {
 pub async fn monitor_registered_session(
     registration: RegisteredTmuxSession,
     client: DaemonClient,
+    providers: crate::config::ProvidersConfig,
 ) -> Result<()> {
     let mut panes = HashMap::new();
     let mut pending_keyword_hits = None;
+    let mut last_heartbeat = None;
+    let mut last_summarized: Option<Instant> = None;
     let poll_interval = Duration::from_secs(1);
 
     loop {
@@ -230,12 +269,34 @@ pub async fn monitor_registered_session(
                         );
                         push_pending_keyword_hits(&mut pending_keyword_hits, now, hits);
 
+                        if registration.summarize
+                            && should_summarize_now(
+                                last_summarized,
+                                registration.effective_summary_interval(),
+                                registration.min_new_lines,
+                                &existing.snapshot,
+                                &pane.content,
+                                now,
+                            )
+                        {
+                            spawn_content_changed_task(
+                                client.clone(),
+                                registration.clone(),
+                                pane.session.clone(),
+                                pane.pane_name.clone(),
+                                pane.content.clone(),
+                                providers.clone(),
+                            );
+                            last_summarized = Some(now);
+                        }
+
                         existing.session = pane.session;
                         existing.pane_name = pane.pane_name;
                         existing.content_hash = hash;
                         existing.snapshot = pane.content;
                         existing.last_change = now;
                         existing.last_stale_notification = None;
+                        last_heartbeat = Some(now);
                     } else if should_emit_stale(existing, now, registration.stale_minutes) {
                         client
                             .emit(tmux_stale_event(
@@ -252,6 +313,14 @@ pub async fn monitor_registered_session(
         }
 
         panes.retain(|pane_id, _| active_panes.contains(pane_id));
+        maybe_emit_registered_session_heartbeat(
+            &registration,
+            &client,
+            &panes,
+            &mut last_heartbeat,
+            Instant::now(),
+        )
+        .await?;
         sleep(poll_interval).await;
     }
 
@@ -311,6 +380,7 @@ async fn poll_tmux(
     for (session_name, registration) in &sessions {
         if registration.active_wrapper_monitor {
             state.pending_keyword_hits.remove(session_name);
+            state.session_last_heartbeat.remove(session_name);
             continue;
         }
 
@@ -338,6 +408,7 @@ async fn poll_tmux(
                 )
                 .await?;
                 state.panes.retain(|_, pane| pane.session != *session_name);
+                state.session_last_heartbeat.remove(session_name);
                 continue;
             }
             Err(error) => {
@@ -352,6 +423,7 @@ async fn poll_tmux(
 
         match snapshot_tmux_session(session_name).await {
             Ok(panes) => {
+                let mut session_changed = false;
                 for pane in panes {
                     let pane_key = format!("{}::{}", pane.session, pane.pane_id);
                     active_panes.insert(pane_key.clone());
@@ -373,6 +445,10 @@ async fn poll_tmux(
                                     pane_dead: pane.pane_dead,
                                 },
                             );
+                            state
+                                .session_last_heartbeat
+                                .insert(session_name.clone(), now);
+                            session_changed = true;
                             None
                         }
                         Some(existing) => {
@@ -383,11 +459,37 @@ async fn poll_tmux(
                                     &pane.content,
                                     &registration.keywords,
                                 );
+                                if registration.summarize
+                                    && should_summarize_now(
+                                        state.session_last_summarized.get(session_name).copied(),
+                                        registration.effective_summary_interval(),
+                                        registration.min_new_lines,
+                                        &existing.snapshot,
+                                        &pane.content,
+                                        now,
+                                    )
+                                {
+                                    spawn_content_changed_task(
+                                        tx.clone(),
+                                        registration.clone(),
+                                        session_name.clone(),
+                                        pane.pane_name.clone(),
+                                        pane.content.clone(),
+                                        config.providers.clone(),
+                                    );
+                                    state
+                                        .session_last_summarized
+                                        .insert(session_name.to_string(), now);
+                                }
                                 existing.pane_name = pane.pane_name;
                                 existing.snapshot = pane.content;
                                 existing.content_hash = hash;
                                 existing.last_change = now;
                                 existing.last_stale_notification = None;
+                                state
+                                    .session_last_heartbeat
+                                    .insert(session_name.clone(), now);
+                                session_changed = true;
                                 Some(hits)
                             } else {
                                 if should_emit_stale(existing, now, registration.stale_minutes) {
@@ -414,6 +516,15 @@ async fn poll_tmux(
                         );
                     }
                 }
+                maybe_emit_session_heartbeat(
+                    session_name,
+                    registration,
+                    tx,
+                    state,
+                    Instant::now(),
+                    session_changed,
+                )
+                .await?;
             }
             Err(error) => eprintln!(
                 "clawhip source tmux snapshot failed for {}: {error}",
@@ -433,6 +544,12 @@ async fn poll_tmux(
 
     state
         .pending_keyword_hits
+        .retain(|session, _| sessions.contains_key(session));
+    state
+        .session_last_heartbeat
+        .retain(|session, _| sessions.contains_key(session));
+    state
+        .session_last_summarized
         .retain(|session, _| sessions.contains_key(session));
 
     Ok(())
@@ -650,6 +767,184 @@ fn tmux_stale_event(
     .with_routing_metadata(&registration.routing)
     .with_mention(registration.mention.clone())
     .with_format(registration.format.clone())
+}
+
+fn tmux_content_changed_event(
+    registration: &RegisteredTmuxSession,
+    session: String,
+    pane: String,
+    content: SummarizedContent,
+) -> IncomingEvent {
+    IncomingEvent::tmux_content_changed_with_metadata(
+        session,
+        pane,
+        content.summary,
+        content.raw_truncated,
+        content.backend,
+        content.content_mode.as_str().to_string(),
+        registration.channel.clone(),
+    )
+    .with_mention(registration.mention.clone())
+    .with_format(registration.format.clone())
+}
+
+fn spawn_content_changed_task<E>(
+    emitter: E,
+    registration: RegisteredTmuxSession,
+    session_name: String,
+    pane_name: String,
+    content: String,
+    providers: crate::config::ProvidersConfig,
+) where
+    E: EventEmitter + Clone + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        match build_summarizer(&registration.summarizer, &providers) {
+            Ok(summarizer) => match summarizer.summarize(&content, &session_name).await {
+                Ok(transformed) => {
+                    let event = tmux_content_changed_event(
+                        &registration,
+                        session_name,
+                        pane_name,
+                        transformed,
+                    );
+                    let _ = emitter.emit(event).await;
+                }
+                Err(error) => {
+                    eprintln!("clawhip: summarize failed for {session_name}: {error}");
+                }
+            },
+            Err(error) => {
+                eprintln!(
+                    "clawhip: could not initialize summarizer '{}' for {session_name}: {error}",
+                    registration.summarizer
+                );
+            }
+        }
+    });
+}
+
+fn tmux_heartbeat_event(
+    registration: &RegisteredTmuxSession,
+    session: String,
+    minutes_since_change: u64,
+) -> IncomingEvent {
+    IncomingEvent::tmux_heartbeat(session, minutes_since_change, registration.channel.clone())
+        .with_mention(registration.mention.clone())
+        .with_format(registration.format.clone())
+}
+
+fn count_new_lines(old: &str, new: &str) -> usize {
+    new.lines().count().saturating_sub(old.lines().count())
+}
+
+fn should_summarize_now(
+    last_summarized: Option<Instant>,
+    interval_mins: u64,
+    min_new_lines: usize,
+    old_content: &str,
+    new_content: &str,
+    now: Instant,
+) -> bool {
+    if min_new_lines > 0 && count_new_lines(old_content, new_content) < min_new_lines {
+        return false;
+    }
+    if interval_mins == 0 {
+        return true;
+    }
+    last_summarized
+        .map(|t| now.duration_since(t) >= Duration::from_secs(interval_mins * 60))
+        .unwrap_or(true)
+}
+
+async fn maybe_emit_session_heartbeat<E: EventEmitter>(
+    session_name: &str,
+    registration: &RegisteredTmuxSession,
+    emitter: &E,
+    state: &mut TmuxMonitorState,
+    now: Instant,
+    session_changed: bool,
+) -> Result<()> {
+    if registration.effective_heartbeat_mins() == 0 {
+        state.session_last_heartbeat.remove(session_name);
+        return Ok(());
+    }
+
+    if session_changed {
+        state
+            .session_last_heartbeat
+            .insert(session_name.to_string(), now);
+    }
+
+    let interval = Duration::from_secs(registration.effective_heartbeat_mins() * 60);
+    let Some(last_change) = state
+        .panes
+        .values()
+        .filter(|pane| pane.session == session_name)
+        .map(|pane| pane.last_change)
+        .max()
+    else {
+        state
+            .session_last_heartbeat
+            .entry(session_name.to_string())
+            .or_insert(now);
+        return Ok(());
+    };
+
+    let last_heartbeat = state
+        .session_last_heartbeat
+        .entry(session_name.to_string())
+        .or_insert(now);
+    if now.duration_since(last_change) < interval || now.duration_since(*last_heartbeat) < interval
+    {
+        return Ok(());
+    }
+
+    emitter
+        .emit(tmux_heartbeat_event(
+            registration,
+            session_name.to_string(),
+            now.duration_since(last_change).as_secs() / 60,
+        ))
+        .await?;
+    *last_heartbeat = now;
+    Ok(())
+}
+
+async fn maybe_emit_registered_session_heartbeat<E: EventEmitter>(
+    registration: &RegisteredTmuxSession,
+    emitter: &E,
+    panes: &HashMap<String, TmuxPaneState>,
+    last_heartbeat: &mut Option<Instant>,
+    now: Instant,
+) -> Result<()> {
+    if registration.effective_heartbeat_mins() == 0 {
+        *last_heartbeat = None;
+        return Ok(());
+    }
+
+    let interval = Duration::from_secs(registration.effective_heartbeat_mins() * 60);
+    let Some(last_change) = panes.values().map(|pane| pane.last_change).max() else {
+        last_heartbeat.get_or_insert(now);
+        return Ok(());
+    };
+
+    let last_heartbeat_at = last_heartbeat.get_or_insert(now);
+    if now.duration_since(last_change) < interval
+        || now.duration_since(*last_heartbeat_at) < interval
+    {
+        return Ok(());
+    }
+
+    emitter
+        .emit(tmux_heartbeat_event(
+            registration,
+            registration.session.clone(),
+            now.duration_since(last_change).as_secs() / 60,
+        ))
+        .await?;
+    *last_heartbeat_at = now;
+    Ok(())
 }
 
 async fn flush_pending_keyword_hits<E: EventEmitter>(
@@ -870,6 +1165,7 @@ mod tests {
             registration_source: RegistrationSource::ConfigMonitor,
             parent_process: None,
             active_wrapper_monitor: false,
+            ..Default::default()
         }
     }
 
@@ -988,6 +1284,7 @@ PR created #7",
             keyword_window_secs: 30,
             stale_minutes: 10,
             format: None,
+            ..Default::default()
         };
 
         let registration = RegisteredTmuxSession::from(&monitor);
@@ -1018,6 +1315,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ),
             (
@@ -1038,6 +1336,7 @@ PR created #7",
                         name: Some("codex".into()),
                     }),
                     active_wrapper_monitor: true,
+                    ..Default::default()
                 },
             ),
             (
@@ -1055,6 +1354,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ),
         ]);
@@ -1076,6 +1376,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             )]),
         );
@@ -1386,6 +1687,7 @@ error: failed";
                 registration_source: RegistrationSource::ConfigMonitor,
                 parent_process: None,
                 active_wrapper_monitor: false,
+                ..Default::default()
             }],
             Some(&available_sessions),
         );
@@ -1416,6 +1718,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "omx-*".into(),
@@ -1430,6 +1733,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             Some(&available_sessions),
@@ -1458,6 +1762,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "rcc-*".into(),
@@ -1472,6 +1777,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             None,
@@ -1499,6 +1805,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "rcc-api".into(),
@@ -1513,6 +1820,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             Some(&available_sessions),
@@ -1540,6 +1848,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "rcc-*".into(),
@@ -1554,6 +1863,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             Some(&available_sessions),
@@ -1586,6 +1896,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
                 RegisteredTmuxSession {
                     session: "abc*".into(),
@@ -1600,6 +1911,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    ..Default::default()
                 },
             ],
             Some(&available_sessions),
@@ -1655,5 +1967,57 @@ error: failed";
         };
         // Dead pane should never emit stale, even after 1 hour idle
         assert!(!should_emit_stale(&pane, Instant::now(), 1));
+    }
+
+    #[test]
+    fn count_new_lines_no_change_returns_zero() {
+        assert_eq!(count_new_lines("a\nb\n", "a\nb\n"), 0);
+    }
+
+    #[test]
+    fn count_new_lines_fewer_lines_returns_zero() {
+        assert_eq!(count_new_lines("a\nb\nc\n", "a\n"), 0);
+    }
+
+    #[test]
+    fn count_new_lines_returns_net_addition() {
+        assert_eq!(count_new_lines("a\nb\n", "a\nb\nc\nd\n"), 2);
+    }
+
+    #[test]
+    fn should_summarize_now_no_filter_no_throttle() {
+        assert!(should_summarize_now(None, 0, 0, "old", "new", Instant::now()));
+    }
+
+    #[test]
+    fn should_summarize_now_no_prior_summarize_always_allowed_with_throttle() {
+        assert!(should_summarize_now(None, 5, 0, "old", "new", Instant::now()));
+    }
+
+    #[test]
+    fn should_summarize_now_interval_allows_when_expired() {
+        let now = Instant::now();
+        let old_enough = now - Duration::from_secs(6 * 60);
+        assert!(should_summarize_now(Some(old_enough), 5, 0, "old", "new", now));
+    }
+
+    #[test]
+    fn should_summarize_now_interval_blocks_when_too_soon() {
+        let now = Instant::now();
+        let recent = now - Duration::from_secs(30);
+        // interval_mins=5 but only 30 seconds elapsed
+        assert!(!should_summarize_now(Some(recent), 5, 0, "old", "new", now));
+    }
+
+    #[test]
+    fn should_summarize_now_min_new_lines_allows_when_met() {
+        let old = "a\n".repeat(10);
+        let new = format!("{}{}", old, "b\n".repeat(5));
+        assert!(should_summarize_now(None, 0, 5, &old, &new, Instant::now()));
+    }
+
+    #[test]
+    fn should_summarize_now_min_new_lines_blocks_when_insufficient() {
+        assert!(!should_summarize_now(None, 0, 5, "a\nb\n", "a\nb\nc\n", Instant::now()));
     }
 }

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::process::Command;
 use tokio::sync::{RwLock, mpsc};
@@ -80,6 +81,13 @@ pub struct RegisteredTmuxSession {
     pub heartbeat_interval: u64,
     #[serde(default)]
     pub summary_interval: u64,
+    #[serde(default)]
+    pub detect_waiting: bool,
+    #[serde(default)]
+    pub waiting_interval: u64,
+    /// Event kinds for which the `mention` is prepended. Empty = mention applies to all events.
+    #[serde(default)]
+    pub mention_on: Vec<String>,
 }
 
 impl RegisteredTmuxSession {
@@ -116,7 +124,23 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             summarize_interval_mins: value.summarize_interval_mins,
             heartbeat_interval: value.heartbeat_interval,
             summary_interval: value.summary_interval,
+            detect_waiting: value.detect_waiting,
+            waiting_interval: value.waiting_interval,
+            mention_on: value.mention_on.clone(),
         }
+    }
+}
+
+/// Returns the mention string for an event kind, respecting `mention_on` filter.
+/// If `mention_on` is empty, the mention applies to all event kinds.
+fn effective_mention(registration: &RegisteredTmuxSession, event_kind: &str) -> Option<String> {
+    if registration.mention_on.is_empty() {
+        return registration.mention.clone();
+    }
+    if registration.mention_on.iter().any(|k| k == event_kind) {
+        registration.mention.clone()
+    } else {
+        None
     }
 }
 
@@ -179,6 +203,7 @@ struct TmuxPaneState {
     last_change: Instant,
     last_stale_notification: Option<Instant>,
     pane_dead: bool,
+    is_waiting: bool,
 }
 
 #[derive(Default)]
@@ -256,6 +281,7 @@ pub async fn monitor_registered_session(
                             last_change: now,
                             last_stale_notification: None,
                             pane_dead: pane.pane_dead,
+                            is_waiting: false,
                         },
                     );
                 }
@@ -288,6 +314,33 @@ pub async fn monitor_registered_session(
                                 providers.clone(),
                             );
                             last_summarized = Some(now);
+                        }
+
+                        if registration.detect_waiting {
+                            let waiting_prompt = is_waiting_for_input(&pane.content);
+                            match (existing.is_waiting, &waiting_prompt) {
+                                (false, Some(prompt)) => {
+                                    client
+                                        .emit(tmux_waiting_for_input_event(
+                                            &registration,
+                                            pane.session.clone(),
+                                            pane.pane_name.clone(),
+                                            prompt.clone(),
+                                        ))
+                                        .await?;
+                                }
+                                (true, None) => {
+                                    client
+                                        .emit(tmux_waiting_resolved_event(
+                                            &registration,
+                                            pane.session.clone(),
+                                            pane.pane_name.clone(),
+                                        ))
+                                        .await?;
+                                }
+                                _ => {}
+                            }
+                            existing.is_waiting = waiting_prompt.is_some();
                         }
 
                         existing.session = pane.session;
@@ -443,6 +496,7 @@ async fn poll_tmux(
                                     last_change: now,
                                     last_stale_notification: None,
                                     pane_dead: pane.pane_dead,
+                                    is_waiting: false,
                                 },
                             );
                             state
@@ -480,6 +534,31 @@ async fn poll_tmux(
                                     state
                                         .session_last_summarized
                                         .insert(session_name.to_string(), now);
+                                }
+
+                                if registration.detect_waiting {
+                                    let waiting_prompt = is_waiting_for_input(&pane.content);
+                                    match (existing.is_waiting, &waiting_prompt) {
+                                        (false, Some(prompt)) => {
+                                            tx.emit(tmux_waiting_for_input_event(
+                                                registration,
+                                                session_name.clone(),
+                                                pane.pane_name.clone(),
+                                                prompt.clone(),
+                                            ))
+                                            .await?;
+                                        }
+                                        (true, None) => {
+                                            tx.emit(tmux_waiting_resolved_event(
+                                                registration,
+                                                session_name.clone(),
+                                                pane.pane_name.clone(),
+                                            ))
+                                            .await?;
+                                        }
+                                        _ => {}
+                                    }
+                                    existing.is_waiting = waiting_prompt.is_some();
                                 }
                                 existing.pane_name = pane.pane_name;
                                 existing.snapshot = pane.content;
@@ -747,7 +826,7 @@ fn tmux_keyword_event(
 
     event
         .with_routing_metadata(&registration.routing)
-        .with_mention(registration.mention.clone())
+        .with_mention(effective_mention(registration, "keyword"))
         .with_format(registration.format.clone())
 }
 
@@ -765,7 +844,7 @@ fn tmux_stale_event(
         registration.channel.clone(),
     )
     .with_routing_metadata(&registration.routing)
-    .with_mention(registration.mention.clone())
+    .with_mention(effective_mention(registration, "stale"))
     .with_format(registration.format.clone())
 }
 
@@ -945,6 +1024,127 @@ async fn maybe_emit_registered_session_heartbeat<E: EventEmitter>(
         .await?;
     *last_heartbeat_at = now;
     Ok(())
+}
+
+fn tmux_waiting_for_input_event(
+    registration: &RegisteredTmuxSession,
+    session: String,
+    pane: String,
+    prompt_snapshot: String,
+) -> IncomingEvent {
+    IncomingEvent::tmux_waiting_for_input(
+        session,
+        pane,
+        prompt_snapshot,
+        registration.channel.clone(),
+    )
+    .with_mention(effective_mention(registration, "waiting_for_input"))
+    .with_format(registration.format.clone())
+}
+
+fn tmux_waiting_resolved_event(
+    registration: &RegisteredTmuxSession,
+    session: String,
+    pane_name: String,
+) -> IncomingEvent {
+    let mut event =
+        IncomingEvent::tmux_waiting_for_input(session, pane_name, String::new(), registration.channel.clone());
+    event.payload["resolved"] = json!(true);
+    event.with_format(registration.format.clone())
+}
+
+fn is_waiting_for_input(content: &str) -> Option<String> {
+    // Patterns checked against the last 3 non-empty lines (case-insensitive).
+    // Covers common interactive prompts and OMC/OMX agent harness approval flows.
+    let multiline_patterns: &[&str] = &[
+        // Generic waiting phrases
+        "waiting for input",
+        "awaiting user input",
+        "press enter",
+        "hit enter",
+        "press any key",
+        // Confirmation prompts
+        "[y/n]",
+        "(y/n)",
+        "[yes/no]",
+        "(yes/no)",
+        // Common action confirmations
+        "proceed?",
+        "continue?",
+        "overwrite?",
+        "replace?",
+        "do you want to",
+        // Menu / choice prompts
+        "enter your choice",
+        "select an option",
+        // Claude Code / OMC tool approval patterns
+        "allow, deny",
+        "allow this action",
+        "always allow",
+        "approve or deny",
+        "run this tool",
+        // Generic approval keyword at line start
+        "approve:",
+        // Credential prompts (password entry blocks terminal)
+        "password:",
+        "passphrase:",
+        "enter password",
+        // Common agent/tool confirmation phrases
+        "want me to",
+        "shall i",
+        "should i proceed",
+        "should i continue",
+        // Interactive setup confirmations
+        "is this ok?",
+        "(ctrl+c to abort)",
+        // CC permission mode picker indicator
+        "bypassPermissions",
+    ];
+
+    // Take the last 3 non-empty lines, skipping blank padding rows.
+    let recent: Vec<&str> = content
+        .lines()
+        .rev()
+        .filter(|l| !l.trim().is_empty())
+        .take(3)
+        .collect();
+    if recent.is_empty() {
+        return None;
+    }
+
+    let snapshot: String = recent.iter().rev().copied().collect::<Vec<_>>().join("\n");
+    let snapshot_lower = snapshot.to_lowercase();
+
+    for pattern in multiline_patterns {
+        if snapshot_lower.contains(pattern) {
+            return Some(snapshot.clone());
+        }
+    }
+
+    // Check the last non-empty line for short interactive-prompt endings.
+    let last_nonempty = recent.first().copied().unwrap_or("");
+    let trimmed = last_nonempty.trim_end();
+    if trimmed.len() <= 40 {
+        let prompt_suffixes: &[&str] = &[
+            "❯",
+            "$ ",
+            "% ",
+            "... ",
+            "? ",
+        ];
+        for suffix in prompt_suffixes {
+            if trimmed.ends_with(suffix) || trimmed == suffix.trim() {
+                return Some(snapshot);
+            }
+        }
+    }
+
+    // ❯ at the start of a short line indicates an interactive menu selector
+    if trimmed.starts_with('❯') && trimmed.len() <= 80 {
+        return Some(snapshot);
+    }
+
+    None
 }
 
 async fn flush_pending_keyword_hits<E: EventEmitter>(
@@ -1934,6 +2134,7 @@ error: failed";
             last_change: Instant::now() - Duration::from_secs(3600),
             last_stale_notification: None,
             pane_dead: false,
+            is_waiting: false,
         };
         // stale_minutes=0 should never emit, even after 1 hour idle
         assert!(!should_emit_stale(&pane, Instant::now(), 0));
@@ -1949,6 +2150,7 @@ error: failed";
             last_change: Instant::now() - Duration::from_secs(3600),
             last_stale_notification: None,
             pane_dead: false,
+            is_waiting: false,
         };
         // stale_minutes=1 should emit after 1 hour idle
         assert!(should_emit_stale(&pane, Instant::now(), 1));
@@ -1964,6 +2166,7 @@ error: failed";
             last_change: Instant::now() - Duration::from_secs(3600),
             last_stale_notification: None,
             pane_dead: true,
+            is_waiting: false,
         };
         // Dead pane should never emit stale, even after 1 hour idle
         assert!(!should_emit_stale(&pane, Instant::now(), 1));
@@ -2019,5 +2222,108 @@ error: failed";
     #[test]
     fn should_summarize_now_min_new_lines_blocks_when_insufficient() {
         assert!(!should_summarize_now(None, 0, 5, "a\nb\n", "a\nb\nc\n", Instant::now()));
+    }
+
+    // ── is_waiting_for_input tests ──────────────────────────────────────────
+
+    #[test]
+    fn waiting_detects_press_enter() {
+        assert!(is_waiting_for_input("some output\nPress enter to continue:").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_yn_bracket() {
+        assert!(is_waiting_for_input("Overwrite file? [Y/n]").is_some());
+        assert!(is_waiting_for_input("Continue? [y/N]").is_some());
+        assert!(is_waiting_for_input("Proceed? (y/n)").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_proceed_continue_overwrite() {
+        assert!(is_waiting_for_input("Do you want to proceed?").is_some());
+        assert!(is_waiting_for_input("continue?").is_some());
+        assert!(is_waiting_for_input("overwrite?").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_omc_tool_approval() {
+        // Claude Code tool approval format
+        assert!(is_waiting_for_input("Allow, Deny, Always allow (A/d/!)?").is_some());
+        assert!(is_waiting_for_input("always allow").is_some());
+        assert!(is_waiting_for_input("run this tool").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_menu_prompts() {
+        assert!(is_waiting_for_input("Enter your choice:").is_some());
+        assert!(is_waiting_for_input("Select an option").is_some());
+        assert!(is_waiting_for_input("Press any key to continue").is_some());
+    }
+
+    #[test]
+    fn waiting_detects_do_you_want_to() {
+        assert!(is_waiting_for_input("Do you want to install these packages?").is_some());
+    }
+
+    #[test]
+    fn waiting_ignores_normal_output() {
+        assert!(is_waiting_for_input("cargo build --release\nCompiling clawhip v0.5.4\nFinished dev profile").is_none());
+        assert!(is_waiting_for_input("").is_none());
+    }
+
+    #[test]
+    fn waiting_only_checks_last_3_lines() {
+        // Trigger phrase buried beyond the 3-line window should NOT match.
+        // 4 non-empty filler lines push "press enter" out of the window.
+        let buried = "press enter\n".to_string() + &"line\n".repeat(4);
+        assert!(is_waiting_for_input(&buried).is_none());
+        // Trailing blank lines are ignored, so this still doesn't match
+        let buried_with_blanks = "press enter\n".to_string() + &"line\n".repeat(4) + &"\n".repeat(20);
+        assert!(is_waiting_for_input(&buried_with_blanks).is_none());
+        // Pattern at exactly position 3 (last of window) still matches
+        let at_edge = "line\n".repeat(2) + "press enter\n";
+        assert!(is_waiting_for_input(&at_edge).is_some());
+    }
+
+    #[test]
+    fn waiting_detects_omc_cursor_prompt() {
+        // Short last line ending with ❯ (OMC tool approval cursor)
+        assert!(is_waiting_for_input("Allow, Deny, Always allow\n❯").is_some());
+    }
+
+    // ── mention_on tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn effective_mention_empty_mention_on_applies_to_all() {
+        let reg = RegisteredTmuxSession {
+            mention: Some("<@123>".into()),
+            mention_on: vec![],
+            ..registration(vec![])
+        };
+        assert_eq!(effective_mention(&reg, "keyword").as_deref(), Some("<@123>"));
+        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), Some("<@123>"));
+        assert_eq!(effective_mention(&reg, "heartbeat").as_deref(), Some("<@123>"));
+    }
+
+    #[test]
+    fn effective_mention_filters_by_event_kind() {
+        let reg = RegisteredTmuxSession {
+            mention: Some("<@123>".into()),
+            mention_on: vec!["waiting_for_input".into()],
+            ..registration(vec![])
+        };
+        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), Some("<@123>"));
+        assert_eq!(effective_mention(&reg, "keyword").as_deref(), None);
+        assert_eq!(effective_mention(&reg, "heartbeat").as_deref(), None);
+    }
+
+    #[test]
+    fn effective_mention_no_mention_returns_none() {
+        let reg = RegisteredTmuxSession {
+            mention: None,
+            mention_on: vec!["waiting_for_input".into()],
+            ..registration(vec![])
+        };
+        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), None);
     }
 }

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -88,17 +88,35 @@ pub struct RegisteredTmuxSession {
     /// Event kinds for which the `mention` is prepended. Empty = mention applies to all events.
     #[serde(default)]
     pub mention_on: Vec<String>,
+    #[serde(default)]
+    pub pin_status: bool,
+    #[serde(default)]
+    pub pin_summary: bool,
+    #[serde(default)]
+    pub pin_alerts: bool,
+    #[serde(default)]
+    pub pin_activity: bool,
+    #[serde(default)]
+    pub pin_keywords: bool,
 }
 
 impl RegisteredTmuxSession {
     /// Effective heartbeat interval: heartbeat_interval overrides heartbeat_mins when > 0.
     pub fn effective_heartbeat_mins(&self) -> u64 {
-        if self.heartbeat_interval > 0 { self.heartbeat_interval } else { self.heartbeat_mins }
+        if self.heartbeat_interval > 0 {
+            self.heartbeat_interval
+        } else {
+            self.heartbeat_mins
+        }
     }
 
     /// Effective summary throttle: summary_interval overrides summarize_interval_mins when > 0.
     pub fn effective_summary_interval(&self) -> u64 {
-        if self.summary_interval > 0 { self.summary_interval } else { self.summarize_interval_mins }
+        if self.summary_interval > 0 {
+            self.summary_interval
+        } else {
+            self.summarize_interval_mins
+        }
     }
 }
 
@@ -127,6 +145,11 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             detect_waiting: value.detect_waiting,
             waiting_interval: value.waiting_interval,
             mention_on: value.mention_on.clone(),
+            pin_status: value.pin_status,
+            pin_summary: value.pin_summary,
+            pin_alerts: value.pin_alerts,
+            pin_activity: value.pin_activity,
+            pin_keywords: value.pin_keywords,
         }
     }
 }
@@ -451,6 +474,12 @@ async fn poll_tmux(
         match session_exists(session_name).await {
             Ok(false) => {
                 sessions_to_unregister.push(session_name.clone());
+                let _ = tx
+                    .emit(IncomingEvent::tmux_session_ended(
+                        session_name.clone(),
+                        registration.channel.clone(),
+                    ))
+                    .await;
                 flush_session_pending_keyword_hits(
                     &mut state.pending_keyword_hits,
                     session_name,
@@ -803,6 +832,12 @@ fn should_emit_stale(pane: &TmuxPaneState, now: Instant, stale_minutes: u64) -> 
             .unwrap_or(true)
 }
 
+/// Inject dashboard routing fields into an event payload.
+fn inject_dashboard_payload(event: &mut IncomingEvent, slot: &str, pin_activity: bool) {
+    event.payload["dashboard_component"] = json!(slot);
+    event.payload["pin_activity"] = json!(pin_activity);
+}
+
 fn tmux_keyword_event(
     registration: &RegisteredTmuxSession,
     session: String,
@@ -824,10 +859,14 @@ fn tmux_keyword_event(
         IncomingEvent::tmux_keywords(session, hits, registration.channel.clone())
     };
 
-    event
+    let mut event = event
         .with_routing_metadata(&registration.routing)
         .with_mention(effective_mention(registration, "keyword"))
-        .with_format(registration.format.clone())
+        .with_format(registration.format.clone());
+    if registration.pin_keywords {
+        inject_dashboard_payload(&mut event, "keywords", registration.pin_activity);
+    }
+    event
 }
 
 fn tmux_stale_event(
@@ -836,7 +875,7 @@ fn tmux_stale_event(
     pane: String,
     last_line: String,
 ) -> IncomingEvent {
-    IncomingEvent::tmux_stale(
+    let mut event = IncomingEvent::tmux_stale(
         session,
         pane,
         registration.stale_minutes,
@@ -845,7 +884,11 @@ fn tmux_stale_event(
     )
     .with_routing_metadata(&registration.routing)
     .with_mention(effective_mention(registration, "stale"))
-    .with_format(registration.format.clone())
+    .with_format(registration.format.clone());
+    if registration.pin_status {
+        inject_dashboard_payload(&mut event, "status", registration.pin_activity);
+    }
+    event
 }
 
 fn tmux_content_changed_event(
@@ -854,7 +897,7 @@ fn tmux_content_changed_event(
     pane: String,
     content: SummarizedContent,
 ) -> IncomingEvent {
-    IncomingEvent::tmux_content_changed_with_metadata(
+    let mut event = IncomingEvent::tmux_content_changed_with_metadata(
         session,
         pane,
         content.summary,
@@ -863,8 +906,12 @@ fn tmux_content_changed_event(
         content.content_mode.as_str().to_string(),
         registration.channel.clone(),
     )
-    .with_mention(registration.mention.clone())
-    .with_format(registration.format.clone())
+    .with_mention(effective_mention(registration, "content_changed"))
+    .with_format(registration.format.clone());
+    if registration.pin_summary {
+        inject_dashboard_payload(&mut event, "summary", registration.pin_activity);
+    }
+    event
 }
 
 fn spawn_content_changed_task<E>(
@@ -908,9 +955,14 @@ fn tmux_heartbeat_event(
     session: String,
     minutes_since_change: u64,
 ) -> IncomingEvent {
-    IncomingEvent::tmux_heartbeat(session, minutes_since_change, registration.channel.clone())
-        .with_mention(registration.mention.clone())
-        .with_format(registration.format.clone())
+    let mut event =
+        IncomingEvent::tmux_heartbeat(session, minutes_since_change, registration.channel.clone())
+            .with_mention(effective_mention(registration, "heartbeat"))
+            .with_format(registration.format.clone());
+    if registration.pin_status {
+        inject_dashboard_payload(&mut event, "status", registration.pin_activity);
+    }
+    event
 }
 
 fn count_new_lines(old: &str, new: &str) -> usize {
@@ -1032,14 +1084,18 @@ fn tmux_waiting_for_input_event(
     pane: String,
     prompt_snapshot: String,
 ) -> IncomingEvent {
-    IncomingEvent::tmux_waiting_for_input(
+    let mut event = IncomingEvent::tmux_waiting_for_input(
         session,
         pane,
         prompt_snapshot,
         registration.channel.clone(),
     )
     .with_mention(effective_mention(registration, "waiting_for_input"))
-    .with_format(registration.format.clone())
+    .with_format(registration.format.clone());
+    if registration.pin_alerts {
+        inject_dashboard_payload(&mut event, "alert", registration.pin_activity);
+    }
+    event
 }
 
 fn tmux_waiting_resolved_event(
@@ -1047,9 +1103,18 @@ fn tmux_waiting_resolved_event(
     session: String,
     pane_name: String,
 ) -> IncomingEvent {
-    let mut event =
-        IncomingEvent::tmux_waiting_for_input(session, pane_name, String::new(), registration.channel.clone());
+    let mut event = IncomingEvent::tmux_waiting_for_input(
+        session,
+        pane_name,
+        String::new(),
+        registration.channel.clone(),
+    );
     event.payload["resolved"] = json!(true);
+    // Mirror the same dashboard routing as the waiting event so the resolved
+    // message updates the pinned alert slot (not a separate keyed message).
+    if registration.pin_alerts {
+        inject_dashboard_payload(&mut event, "alert", registration.pin_activity);
+    }
     event.with_format(registration.format.clone())
 }
 
@@ -1125,13 +1190,7 @@ fn is_waiting_for_input(content: &str) -> Option<String> {
     let last_nonempty = recent.first().copied().unwrap_or("");
     let trimmed = last_nonempty.trim_end();
     if trimmed.len() <= 40 {
-        let prompt_suffixes: &[&str] = &[
-            "❯",
-            "$ ",
-            "% ",
-            "... ",
-            "? ",
-        ];
+        let prompt_suffixes: &[&str] = &["❯", "$ ", "% ", "... ", "? "];
         for suffix in prompt_suffixes {
             if trimmed.ends_with(suffix) || trimmed == suffix.trim() {
                 return Some(snapshot);
@@ -2189,19 +2248,40 @@ error: failed";
 
     #[test]
     fn should_summarize_now_no_filter_no_throttle() {
-        assert!(should_summarize_now(None, 0, 0, "old", "new", Instant::now()));
+        assert!(should_summarize_now(
+            None,
+            0,
+            0,
+            "old",
+            "new",
+            Instant::now()
+        ));
     }
 
     #[test]
     fn should_summarize_now_no_prior_summarize_always_allowed_with_throttle() {
-        assert!(should_summarize_now(None, 5, 0, "old", "new", Instant::now()));
+        assert!(should_summarize_now(
+            None,
+            5,
+            0,
+            "old",
+            "new",
+            Instant::now()
+        ));
     }
 
     #[test]
     fn should_summarize_now_interval_allows_when_expired() {
         let now = Instant::now();
         let old_enough = now - Duration::from_secs(6 * 60);
-        assert!(should_summarize_now(Some(old_enough), 5, 0, "old", "new", now));
+        assert!(should_summarize_now(
+            Some(old_enough),
+            5,
+            0,
+            "old",
+            "new",
+            now
+        ));
     }
 
     #[test]
@@ -2221,7 +2301,14 @@ error: failed";
 
     #[test]
     fn should_summarize_now_min_new_lines_blocks_when_insufficient() {
-        assert!(!should_summarize_now(None, 0, 5, "a\nb\n", "a\nb\nc\n", Instant::now()));
+        assert!(!should_summarize_now(
+            None,
+            0,
+            5,
+            "a\nb\n",
+            "a\nb\nc\n",
+            Instant::now()
+        ));
     }
 
     // ── is_waiting_for_input tests ──────────────────────────────────────────
@@ -2267,7 +2354,12 @@ error: failed";
 
     #[test]
     fn waiting_ignores_normal_output() {
-        assert!(is_waiting_for_input("cargo build --release\nCompiling clawhip v0.5.4\nFinished dev profile").is_none());
+        assert!(
+            is_waiting_for_input(
+                "cargo build --release\nCompiling clawhip v0.5.4\nFinished dev profile"
+            )
+            .is_none()
+        );
         assert!(is_waiting_for_input("").is_none());
     }
 
@@ -2278,7 +2370,8 @@ error: failed";
         let buried = "press enter\n".to_string() + &"line\n".repeat(4);
         assert!(is_waiting_for_input(&buried).is_none());
         // Trailing blank lines are ignored, so this still doesn't match
-        let buried_with_blanks = "press enter\n".to_string() + &"line\n".repeat(4) + &"\n".repeat(20);
+        let buried_with_blanks =
+            "press enter\n".to_string() + &"line\n".repeat(4) + &"\n".repeat(20);
         assert!(is_waiting_for_input(&buried_with_blanks).is_none());
         // Pattern at exactly position 3 (last of window) still matches
         let at_edge = "line\n".repeat(2) + "press enter\n";
@@ -2300,9 +2393,18 @@ error: failed";
             mention_on: vec![],
             ..registration(vec![])
         };
-        assert_eq!(effective_mention(&reg, "keyword").as_deref(), Some("<@123>"));
-        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), Some("<@123>"));
-        assert_eq!(effective_mention(&reg, "heartbeat").as_deref(), Some("<@123>"));
+        assert_eq!(
+            effective_mention(&reg, "keyword").as_deref(),
+            Some("<@123>")
+        );
+        assert_eq!(
+            effective_mention(&reg, "waiting_for_input").as_deref(),
+            Some("<@123>")
+        );
+        assert_eq!(
+            effective_mention(&reg, "heartbeat").as_deref(),
+            Some("<@123>")
+        );
     }
 
     #[test]
@@ -2312,7 +2414,10 @@ error: failed";
             mention_on: vec!["waiting_for_input".into()],
             ..registration(vec![])
         };
-        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), Some("<@123>"));
+        assert_eq!(
+            effective_mention(&reg, "waiting_for_input").as_deref(),
+            Some("<@123>")
+        );
         assert_eq!(effective_mention(&reg, "keyword").as_deref(), None);
         assert_eq!(effective_mention(&reg, "heartbeat").as_deref(), None);
     }
@@ -2324,6 +2429,24 @@ error: failed";
             mention_on: vec!["waiting_for_input".into()],
             ..registration(vec![])
         };
-        assert_eq!(effective_mention(&reg, "waiting_for_input").as_deref(), None);
+        assert_eq!(
+            effective_mention(&reg, "waiting_for_input").as_deref(),
+            None
+        );
+    }
+
+    #[test]
+    fn tmux_keyword_event_with_pin_keywords_sets_dashboard_payload() {
+        let mut registration = registration(vec!["error"]);
+        registration.pin_keywords = true;
+
+        let event = tmux_keyword_event(
+            &registration,
+            "issue-24".into(),
+            vec![("error".into(), "boom".into())],
+        );
+
+        assert_eq!(event.payload["dashboard_component"], "keywords");
+        assert_eq!(event.payload["pin_activity"], false);
     }
 }

--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -109,16 +109,19 @@ pub fn build_summarizer(
 ) -> Result<Box<dyn Summarizer>, Box<dyn Error + Send + Sync>> {
     match parse_summarizer_spec(summarizer)? {
         SummarizerSpec::Gemini { model } => Ok(Box::new(GeminiCli { model })),
-        SummarizerSpec::OpenRouter { model } => Ok(Box::new(
-            OpenAiCompatibleSummarizer::new_openrouter(model, providers.openrouter.api_key.as_deref())?,
-        )),
-        SummarizerSpec::OpenAiCompatible { model } => Ok(Box::new(
-            OpenAiCompatibleSummarizer::new_openai_compatible(
+        SummarizerSpec::OpenRouter { model } => {
+            Ok(Box::new(OpenAiCompatibleSummarizer::new_openrouter(
+                model,
+                providers.openrouter.api_key.as_deref(),
+            )?))
+        }
+        SummarizerSpec::OpenAiCompatible { model } => {
+            Ok(Box::new(OpenAiCompatibleSummarizer::new_openai_compatible(
                 model,
                 providers.openai.api_key.as_deref(),
                 providers.openai.base_url.as_deref(),
-            )?,
-        )),
+            )?))
+        }
         SummarizerSpec::Raw => Ok(Box::new(RawPassthroughSummarizer)),
     }
 }
@@ -321,7 +324,12 @@ impl OpenAiCompatibleSummarizer {
         config_key: Option<&str>,
     ) -> Result<Self, Box<dyn Error + Send + Sync>> {
         let api_key = resolve_key(config_key, "OPENROUTER_API_KEY", "openrouter")?;
-        Self::new("openrouter", OPENROUTER_BASE_URL.to_string(), api_key, model)
+        Self::new(
+            "openrouter",
+            OPENROUTER_BASE_URL.to_string(),
+            api_key,
+            model,
+        )
     }
 
     fn new_openai_compatible(
@@ -332,7 +340,11 @@ impl OpenAiCompatibleSummarizer {
         let base_url = config_base_url
             .filter(|v| !v.trim().is_empty())
             .map(str::to_string)
-            .or_else(|| std::env::var("OPENAI_BASE_URL").ok().filter(|v| !v.trim().is_empty()))
+            .or_else(|| {
+                std::env::var("OPENAI_BASE_URL")
+                    .ok()
+                    .filter(|v| !v.trim().is_empty())
+            })
             .unwrap_or_else(|| DEFAULT_OPENAI_BASE_URL.to_string());
         let api_key = resolve_key(config_key, "OPENAI_API_KEY", "openai")?;
         Self::new("openai-compatible", base_url, api_key, model)

--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -1,0 +1,568 @@
+use std::error::Error;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::{Value, json};
+use tokio::process::Command;
+
+use crate::config::ProvidersConfig;
+
+const MAX_INPUT_CHARS: usize = 4000;
+const DEFAULT_GEMINI_MODEL: &str = "gemini-2.5-flash";
+const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-4o-mini";
+const DEFAULT_OPENAI_MODEL: &str = "gpt-4o-mini";
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+const HTTP_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentMode {
+    Summary,
+    Raw,
+}
+
+impl ContentMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Summary => "summary",
+            Self::Raw => "raw",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SummarizedContent {
+    pub summary: String,
+    pub raw_truncated: String,
+    pub backend: String,
+    pub content_mode: ContentMode,
+}
+
+/// Trait for tmux content summarizers/transformers.
+#[async_trait]
+pub trait Summarizer: Send + Sync {
+    fn name(&self) -> &str;
+
+    async fn summarize(
+        &self,
+        content: &str,
+        session: &str,
+    ) -> Result<SummarizedContent, Box<dyn Error + Send + Sync>>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SummarizerSpec {
+    Gemini { model: String },
+    OpenRouter { model: String },
+    OpenAiCompatible { model: String },
+    Raw,
+}
+
+pub fn parse_summarizer_spec(
+    summarizer: &str,
+) -> Result<SummarizerSpec, Box<dyn Error + Send + Sync>> {
+    let trimmed = summarizer.trim();
+    let gemini_default = || SummarizerSpec::Gemini {
+        model: DEFAULT_GEMINI_MODEL.to_string(),
+    };
+    if trimmed.eq_ignore_ascii_case("raw") {
+        return Ok(SummarizerSpec::Raw);
+    }
+    if trimmed.eq_ignore_ascii_case("openrouter") {
+        return Ok(SummarizerSpec::OpenRouter {
+            model: DEFAULT_OPENROUTER_MODEL.to_string(),
+        });
+    }
+    if let Some(model) = trimmed.strip_prefix("openrouter:") {
+        return Ok(SummarizerSpec::OpenRouter {
+            model: default_if_empty(model, DEFAULT_OPENROUTER_MODEL),
+        });
+    }
+    if trimmed.eq_ignore_ascii_case("openai") || trimmed.eq_ignore_ascii_case("openai-compatible") {
+        return Ok(SummarizerSpec::OpenAiCompatible {
+            model: DEFAULT_OPENAI_MODEL.to_string(),
+        });
+    }
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("gemini") {
+        return Ok(gemini_default());
+    }
+    if let Some(model) = trimmed
+        .strip_prefix("openai:")
+        .or_else(|| trimmed.strip_prefix("openai-compatible:"))
+    {
+        return Ok(SummarizerSpec::OpenAiCompatible {
+            model: default_if_empty(model, DEFAULT_OPENAI_MODEL),
+        });
+    }
+    if let Some(model) = trimmed.strip_prefix("gemini:") {
+        return Ok(SummarizerSpec::Gemini {
+            model: default_if_empty(model, DEFAULT_GEMINI_MODEL),
+        });
+    }
+    Err(format!("unsupported summarizer backend '{trimmed}'").into())
+}
+
+pub fn build_summarizer(
+    summarizer: &str,
+    providers: &ProvidersConfig,
+) -> Result<Box<dyn Summarizer>, Box<dyn Error + Send + Sync>> {
+    match parse_summarizer_spec(summarizer)? {
+        SummarizerSpec::Gemini { model } => Ok(Box::new(GeminiCli { model })),
+        SummarizerSpec::OpenRouter { model } => Ok(Box::new(
+            OpenAiCompatibleSummarizer::new_openrouter(model, providers.openrouter.api_key.as_deref())?,
+        )),
+        SummarizerSpec::OpenAiCompatible { model } => Ok(Box::new(
+            OpenAiCompatibleSummarizer::new_openai_compatible(
+                model,
+                providers.openai.api_key.as_deref(),
+                providers.openai.base_url.as_deref(),
+            )?,
+        )),
+        SummarizerSpec::Raw => Ok(Box::new(RawPassthroughSummarizer)),
+    }
+}
+
+/// Truncate content to the last `MAX_INPUT_CHARS` characters.
+pub fn truncate_for_summarizer(content: &str) -> &str {
+    if content.len() <= MAX_INPUT_CHARS {
+        return content;
+    }
+    let start = content.len() - MAX_INPUT_CHARS;
+    let start = content[start..]
+        .char_indices()
+        .next()
+        .map(|(i, _)| start + i)
+        .unwrap_or(start);
+    &content[start..]
+}
+
+fn resolve_key(
+    config_key: Option<&str>,
+    env_var: &str,
+    backend: &str,
+) -> Result<String, Box<dyn Error + Send + Sync>> {
+    if let Some(key) = config_key.filter(|k| !k.trim().is_empty()) {
+        return Ok(key.to_string());
+    }
+    std::env::var(env_var).map_err(|_| {
+        format!(
+            "{env_var} is required for {backend} summarizer; set it via [providers.{backend}].api_key in config.toml or as an environment variable"
+        )
+        .into()
+    })
+}
+
+fn default_if_empty(value: &str, default: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn summarize_system_prompt() -> &'static str {
+    "You summarize tmux session output for developer monitoring. \
+     Focus on what the agent is doing, any errors encountered, and current status. \
+     Keep it concise (2-5 sentences).\n\n\
+     IMPORTANT: If the terminal output indicates the session is waiting for user input — for example: \
+     a [Y/n] confirmation prompt, 'Press enter to continue', 'Allow, Deny, Always allow' tool approval \
+     (Claude Code style), 'continue?', 'proceed?', 'overwrite?', an interactive menu asking for a choice, \
+     or a shell/REPL prompt awaiting a command — begin your response with exactly this line:\n\
+     STATUS: WAITING_FOR_INPUT\n\n\
+     Otherwise do not include a STATUS line. Respond in plain text."
+}
+
+fn summarize_user_prompt(session: &str, content: &str) -> String {
+    format!("Session: {session}\n\n{}", truncate_for_summarizer(content))
+}
+
+fn summarize_result(summary: String, raw_truncated: String, backend: &str) -> SummarizedContent {
+    SummarizedContent {
+        summary,
+        raw_truncated,
+        backend: backend.to_string(),
+        content_mode: ContentMode::Summary,
+    }
+}
+
+fn raw_result(raw_truncated: String, backend: &str) -> SummarizedContent {
+    SummarizedContent {
+        summary: raw_truncated.clone(),
+        raw_truncated,
+        backend: backend.to_string(),
+        content_mode: ContentMode::Raw,
+    }
+}
+
+fn openai_chat_request(model: &str, session: &str, content: &str) -> Value {
+    json!({
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": summarize_system_prompt(),
+            },
+            {
+                "role": "user",
+                "content": summarize_user_prompt(session, content),
+            }
+        ],
+        "temperature": 0.2
+    })
+}
+
+fn extract_openai_response_text(value: &Value) -> Option<String> {
+    let content = value.pointer("/choices/0/message/content")?;
+    match content {
+        Value::String(text) => Some(text.trim().to_string()).filter(|text| !text.is_empty()),
+        Value::Array(parts) => {
+            let joined = parts
+                .iter()
+                .filter_map(|part| {
+                    part.get("text")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|text| !text.is_empty())
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            if joined.trim().is_empty() {
+                None
+            } else {
+                Some(joined)
+            }
+        }
+        _ => None,
+    }
+}
+
+pub struct GeminiCli {
+    model: String,
+}
+
+#[async_trait]
+impl Summarizer for GeminiCli {
+    fn name(&self) -> &str {
+        "gemini-cli"
+    }
+
+    async fn summarize(
+        &self,
+        content: &str,
+        session: &str,
+    ) -> Result<SummarizedContent, Box<dyn Error + Send + Sync>> {
+        let raw_truncated = truncate_for_summarizer(content).to_string();
+        let prompt = format!(
+            "{}\n\n{}",
+            summarize_system_prompt(),
+            summarize_user_prompt(session, content)
+        );
+        let output = Command::new("gemini")
+            .arg("-m")
+            .arg(&self.model)
+            .arg("-p")
+            .arg(&prompt)
+            .output()
+            .await
+            .map_err(|e| format!("failed to spawn gemini CLI: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "gemini CLI exited with status {}: {}",
+                output.status,
+                stderr.trim()
+            )
+            .into());
+        }
+
+        let summary = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if summary.is_empty() {
+            return Err("gemini returned an empty summary".into());
+        }
+
+        Ok(summarize_result(summary, raw_truncated, self.name()))
+    }
+}
+
+pub struct RawPassthroughSummarizer;
+
+#[async_trait]
+impl Summarizer for RawPassthroughSummarizer {
+    fn name(&self) -> &str {
+        "raw"
+    }
+
+    async fn summarize(
+        &self,
+        content: &str,
+        _session: &str,
+    ) -> Result<SummarizedContent, Box<dyn Error + Send + Sync>> {
+        Ok(raw_result(
+            truncate_for_summarizer(content).to_string(),
+            self.name(),
+        ))
+    }
+}
+
+struct OpenAiCompatibleSummarizer {
+    client: Client,
+    backend_name: &'static str,
+    base_url: String,
+    api_key: String,
+    model: String,
+}
+
+impl OpenAiCompatibleSummarizer {
+    fn new_openrouter(
+        model: String,
+        config_key: Option<&str>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let api_key = resolve_key(config_key, "OPENROUTER_API_KEY", "openrouter")?;
+        Self::new("openrouter", OPENROUTER_BASE_URL.to_string(), api_key, model)
+    }
+
+    fn new_openai_compatible(
+        model: String,
+        config_key: Option<&str>,
+        config_base_url: Option<&str>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let base_url = config_base_url
+            .filter(|v| !v.trim().is_empty())
+            .map(str::to_string)
+            .or_else(|| std::env::var("OPENAI_BASE_URL").ok().filter(|v| !v.trim().is_empty()))
+            .unwrap_or_else(|| DEFAULT_OPENAI_BASE_URL.to_string());
+        let api_key = resolve_key(config_key, "OPENAI_API_KEY", "openai")?;
+        Self::new("openai-compatible", base_url, api_key, model)
+    }
+
+    fn new(
+        backend_name: &'static str,
+        base_url: String,
+        api_key: String,
+        model: String,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
+            .build()?;
+        Ok(Self {
+            client,
+            backend_name,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key,
+            model,
+        })
+    }
+
+    fn chat_completions_url(&self) -> String {
+        format!("{}/chat/completions", self.base_url)
+    }
+}
+
+#[async_trait]
+impl Summarizer for OpenAiCompatibleSummarizer {
+    fn name(&self) -> &str {
+        self.backend_name
+    }
+
+    async fn summarize(
+        &self,
+        content: &str,
+        session: &str,
+    ) -> Result<SummarizedContent, Box<dyn Error + Send + Sync>> {
+        let raw_truncated = truncate_for_summarizer(content).to_string();
+        let response = self
+            .client
+            .post(self.chat_completions_url())
+            .bearer_auth(&self.api_key)
+            .json(&openai_chat_request(&self.model, session, content))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "{} API request failed with {}: {}",
+                self.backend_name, status, body
+            )
+            .into());
+        }
+
+        let payload = response.json::<Value>().await?;
+        let Some(summary) = extract_openai_response_text(&payload) else {
+            return Err(format!("{} API returned no summary text", self.backend_name).into());
+        };
+
+        Ok(summarize_result(summary, raw_truncated, self.name()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_content_unchanged() {
+        let content = "hello world";
+        assert_eq!(truncate_for_summarizer(content), "hello world");
+    }
+
+    #[test]
+    fn truncate_long_content() {
+        let content = "A".repeat(5000);
+        let truncated = truncate_for_summarizer(&content);
+        assert_eq!(truncated.len(), 4000);
+        assert_eq!(truncated, "A".repeat(4000));
+    }
+
+    #[test]
+    fn truncate_at_char_boundary() {
+        let prefix = "A".repeat(3998);
+        let content = format!("{}€{}", prefix, "Z");
+        let truncated = truncate_for_summarizer(&content);
+        assert!(truncated.len() <= 4000);
+    }
+
+    #[test]
+    fn parse_summarizer_spec_supports_raw() {
+        assert_eq!(parse_summarizer_spec("raw").unwrap(), SummarizerSpec::Raw);
+    }
+
+    #[test]
+    fn parse_summarizer_spec_supports_openrouter() {
+        assert_eq!(
+            parse_summarizer_spec("openrouter:google/gemini-2.5-flash").unwrap(),
+            SummarizerSpec::OpenRouter {
+                model: "google/gemini-2.5-flash".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_supports_openai() {
+        assert_eq!(
+            parse_summarizer_spec("openai:gpt-4.1-mini").unwrap(),
+            SummarizerSpec::OpenAiCompatible {
+                model: "gpt-4.1-mini".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_defaults_gemini() {
+        assert_eq!(
+            parse_summarizer_spec("gemini").unwrap(),
+            SummarizerSpec::Gemini {
+                model: DEFAULT_GEMINI_MODEL.into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_with_gemini_model() {
+        assert_eq!(
+            parse_summarizer_spec("gemini:gemini-2.5-pro").unwrap(),
+            SummarizerSpec::Gemini {
+                model: "gemini-2.5-pro".into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_empty_gemini_model_uses_default() {
+        assert_eq!(
+            parse_summarizer_spec("gemini:").unwrap(),
+            SummarizerSpec::Gemini {
+                model: DEFAULT_GEMINI_MODEL.into()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_summarizer_spec_rejects_unknown_prefix() {
+        assert!(parse_summarizer_spec("custom:something").is_err());
+    }
+
+    #[tokio::test]
+    async fn raw_passthrough_returns_truncated_content() {
+        let output = RawPassthroughSummarizer
+            .summarize("hello world", "issue-24")
+            .await
+            .unwrap();
+        assert_eq!(output.summary, "hello world");
+        assert_eq!(output.raw_truncated, "hello world");
+        assert_eq!(output.backend, "raw");
+        assert_eq!(output.content_mode, ContentMode::Raw);
+    }
+
+    #[test]
+    fn openai_chat_request_contains_model_and_messages() {
+        let payload = openai_chat_request("gpt-4o-mini", "issue-24", "build failed");
+        assert_eq!(payload["model"], "gpt-4o-mini");
+        assert_eq!(payload["messages"][0]["role"], "system");
+        assert_eq!(payload["messages"][1]["role"], "user");
+        assert!(
+            payload["messages"][1]["content"]
+                .as_str()
+                .unwrap()
+                .contains("issue-24")
+        );
+    }
+
+    #[test]
+    fn extract_openai_response_text_supports_string_content() {
+        let payload = json!({
+            "choices": [
+                {
+                    "message": {
+                        "content": "agent fixed the test"
+                    }
+                }
+            ]
+        });
+        assert_eq!(
+            extract_openai_response_text(&payload).as_deref(),
+            Some("agent fixed the test")
+        );
+    }
+
+    #[test]
+    fn extract_openai_response_text_supports_content_parts() {
+        let payload = json!({
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "agent is compiling"},
+                            {"type": "text", "text": "waiting on cargo"}
+                        ]
+                    }
+                }
+            ]
+        });
+        assert_eq!(
+            extract_openai_response_text(&payload).as_deref(),
+            Some("agent is compiling\nwaiting on cargo")
+        );
+    }
+
+    #[test]
+    fn build_summarizer_supports_raw() {
+        assert!(build_summarizer("raw", &ProvidersConfig::default()).is_ok());
+    }
+
+    #[test]
+    fn system_prompt_includes_waiting_for_input_status_marker() {
+        let prompt = summarize_system_prompt();
+        assert!(
+            prompt.contains("STATUS: WAITING_FOR_INPUT"),
+            "system prompt must instruct the LLM to emit STATUS: WAITING_FOR_INPUT"
+        );
+        // Confirm it covers the key OMC/OMX trigger patterns
+        assert!(prompt.contains("[Y/n]") || prompt.contains("Allow, Deny"));
+        assert!(prompt.contains("continue?") || prompt.contains("proceed?"));
+    }
+}

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -119,6 +119,7 @@ impl From<TmuxMonitorArgs> for RegisteredTmuxSession {
             registration_source: value.registration_source,
             parent_process: value.parent_process,
             active_wrapper_monitor: true,
+            ..Default::default()
         }
     }
 }
@@ -207,8 +208,9 @@ async fn register_and_start_monitor(
     client.register_tmux(&registration).await?;
 
     let monitor_client = client.clone();
+    let providers = config.providers.clone();
     Ok(tokio::spawn(async move {
-        monitor_registered_session(registration, monitor_client).await
+        monitor_registered_session(registration, monitor_client, providers).await
     }))
 }
 
@@ -622,6 +624,7 @@ mod tests {
                 name: Some("codex".into()),
             }),
             active_wrapper_monitor: true,
+            ..Default::default()
         });
 
         assert!(log.contains("session=issue-105"));


### PR DESCRIPTION
## Summary

Adds a persistent "dashboard" for each monitored tmux session: a small set of Discord messages that are edited in-place rather than posting new messages on every event. This eliminates channel noise while keeping a live status view per session.

**Depends on**: #174 (summarization), #175 (waiting-for-input) — this branch includes those commits and adds dashboard pinning on top.

### Five slot types

| Slot | Config field | Content |
|------|-------------|---------|
| \`status\` | \`pin_status = true\` | Heartbeat / idle status, edited every \`heartbeat_interval\` mins |
| \`summary\` | \`pin_summary = true\` | LLM or raw snapshot summary, edited every \`summary_interval\` mins |
| \`alert\` | \`pin_alerts = true\` | Waiting-for-input alert; resolves to \`✅\` on input |
| \`activity\` | \`pin_activity = true\` | Rolling 5-entry activity log across all event types |
| \`keywords\` | \`pin_keywords = true\` | Last keyword hits, deduplicated within each window |

### Session lifecycle

- On first event: slot message created and pinned via Discord API
- On subsequent events: message edited in-place (PATCH)
- On session termination (\`tmux.session_ended\`): all slot messages unpinned, IDs cleared from \`dashboard.json\`
- Slot IDs persisted to \`~/.clawhip/dashboard.json\` — survives daemon restart

### Config example

```toml
[[monitors.tmux.sessions]]
session = "my-agent"
channel = "1234567890"
pin_status = true
pin_summary = false
pin_activity = true
pin_alerts = true
pin_keywords = true
heartbeat_interval = 1
summary_interval = 2
```

### Notes

- All \`pin_*\` fields default to \`false\` — opt-in per session
- Requires bot \`MANAGE_MESSAGES\` permission to pin/unpin
- If a pinned message is deleted externally, the daemon recreates it on the next event (404 handling)

## Test plan

- [x] \`cargo test\` — 368 tests passing (branch total)
- [x] Live integration tested end-to-end:
  - All 5 slot types created and confirmed \`pinned: true\` via Discord API
  - In-place edits confirmed (\`[edited]\` timestamp advances, message ID unchanged)
  - Session kill confirmed: \`dashboard.json\` cleared to \`{}\`, slots confirmed \`pinned: false\` via API
  - Daemon restart confirmed: slot IDs reloaded from \`dashboard.json\`, edits continue on existing messages