### PR TITLE
Fix OMC/OMX launch worktree semantics

### DIFF
--- a/src/native_hooks.rs
+++ b/src/native_hooks.rs
@@ -644,6 +644,33 @@ fn project_metadata_string(project_metadata: &Option<Value>, keys: &[&str]) -> O
 }
 
 fn infer_repo_root(directory: &str) -> Option<PathBuf> {
+    // Use --git-common-dir to derive the main repo root even when inside a
+    // worktree.  --show-toplevel returns the worktree root which is wrong for
+    // the repo_path field (issue #182).
+    if let Some(common_dir) = Command::new("git")
+        .args([
+            "-C",
+            directory,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        ])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        && let Some(repo_root) = Path::new(&common_dir).parent()
+    {
+        return Some(
+            repo_root
+                .canonicalize()
+                .unwrap_or_else(|_| repo_root.to_path_buf()),
+        );
+    }
+
+    // Fallback: --show-toplevel (correct for non-worktree checkouts).
     let output = Command::new("git")
         .args(["-C", directory, "rev-parse", "--show-toplevel"])
         .output()
@@ -936,5 +963,57 @@ mod tests {
         assert!(script.contains("tmux_session"));
         assert!(script.contains("tmux_client_count"));
         assert!(script.contains("tmux_attached"));
+    }
+
+    #[test]
+    fn infer_repo_root_returns_main_repo_for_worktree() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+
+        fn git(dir: &std::path::Path, args: &[&str]) {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("git");
+            assert!(
+                out.status.success(),
+                "git {:?}: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+
+        git(&repo, &["init"]);
+        std::fs::write(repo.join("README.md"), "init\n").expect("write");
+        git(&repo, &["add", "README.md"]);
+        git(
+            &repo,
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "-m",
+                "init",
+            ],
+        );
+        git(&repo, &["branch", "issue-182"]);
+
+        let wt = temp.path().join("wt-issue-182");
+        git(
+            &repo,
+            &["worktree", "add", &wt.to_string_lossy(), "issue-182"],
+        );
+
+        let result = super::infer_repo_root(&wt.to_string_lossy());
+        let expected = repo.canonicalize().expect("canonical");
+        assert_eq!(
+            result,
+            Some(expected),
+            "infer_repo_root should return the main repo, not the worktree"
+        );
     }
 }

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -132,7 +132,22 @@ fn routing_metadata_for_cwd(cwd: Option<&str>) -> RoutingMetadata {
         .unwrap_or_else(|_| workdir.to_path_buf())
         .to_string_lossy()
         .into_owned();
-    let repo_path = git_output(workdir, &["rev-parse", "--show-toplevel"]);
+    // Use --git-common-dir to derive the main repo root even when CWD is a
+    // worktree.  --show-toplevel would return the worktree root, making
+    // repo_path identical to worktree_path (issue #182).
+    let repo_path = git_output(
+        workdir,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )
+    .as_deref()
+    .and_then(|common_dir| Path::new(common_dir).parent())
+    .and_then(|root| {
+        root.canonicalize()
+            .unwrap_or_else(|_| root.to_path_buf())
+            .to_str()
+            .map(ToString::to_string)
+    })
+    .or_else(|| git_output(workdir, &["rev-parse", "--show-toplevel"]));
     let project = detect_project(workdir).or_else(|| {
         repo_path
             .as_deref()
@@ -812,6 +827,68 @@ mod tests {
                 Duration::from_millis(2),
                 Duration::from_millis(4)
             ]
+        );
+    }
+
+    #[test]
+    fn routing_metadata_repo_path_returns_main_repo_for_worktree() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+
+        let git = |dir: &std::path::Path, args: &[&str]| {
+            let out = StdCommand::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("git");
+            assert!(
+                out.status.success(),
+                "git {:?}: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+
+        git(&repo, &["init"]);
+        std::fs::write(repo.join("README.md"), "init\n").expect("write");
+        git(&repo, &["add", "README.md"]);
+        git(
+            &repo,
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "-m",
+                "init",
+            ],
+        );
+        git(&repo, &["branch", "issue-182"]);
+
+        let wt = temp.path().join("wt-issue-182");
+        git(
+            &repo,
+            &["worktree", "add", &wt.to_string_lossy(), "issue-182"],
+        );
+
+        let metadata = routing_metadata_for_cwd(Some(&wt.to_string_lossy()));
+        let expected_repo = repo
+            .canonicalize()
+            .expect("canonical")
+            .to_string_lossy()
+            .to_string();
+
+        assert_eq!(
+            metadata.repo_path.as_deref(),
+            Some(expected_repo.as_str()),
+            "repo_path should be main repo root, not worktree"
+        );
+        assert_eq!(metadata.branch.as_deref(), Some("issue-182"));
+        assert!(
+            metadata.worktree_path.as_deref() != metadata.repo_path.as_deref(),
+            "worktree_path and repo_path must differ for a worktree checkout"
         );
     }
 }


### PR DESCRIPTION
## Summary
- launch native `clawhip omc` / `clawhip omx launch` sessions from the main repo root while deriving `--worktree <branch>` from the selected worktree path
- pass the initial task prompt inline to OMC/OMX instead of delaying prompt injection with tmux `send-keys`
- align helper scripts, CLI help text, and README/SKILL/CHANGELOG docs with the new launch contract

## Testing
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test repo_root_with_worktree_branch`
- `cargo test resolve_launch_target_uses_repo_root_and_worktree_branch`
- `bash -n skills/omc/create.sh skills/omx/create.sh`

## Notes
- native launcher surface stays on `--workdir <worktree-path>`; clawhip now uses that path only to derive the repo root and target branch internally
- end-to-end live tmux launch against installed `omc`/`omx` binaries was not run in this branch
