### PR TITLE
Improve clawhip setup UX with bounded presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,17 @@ clawhip setup \
 
 Use `clawhip config` to revisit the same bounded preset surface later. For anything outside those five presets—custom `[[routes]]`, Slack routes, monitors, dispatch tuning, cron jobs, or template-heavy routing—edit the TOML file directly.
 
+The bounded `clawhip config` editor should expose exactly these eight actions:
+
+1. Set Discord bot token
+2. Set daemon base URL
+3. Set default channel
+4. Set default format
+5. Set Discord webhook quickstart route
+6. Save and exit
+7. Exit without saving
+8. Print manual config template hint
+
 ### Quickstart-route ownership rules
 
 The webhook quickstart helpers own exactly one canonical wildcard Discord webhook route:

--- a/README.md
+++ b/README.md
@@ -279,6 +279,49 @@ Quick start:
 clawhip setup --webhook "https://discord.com/api/webhooks/..."
 ```
 
+`clawhip setup --webhook ...` remains the fastest first-run path. The setup/config UX intentionally stays bounded to a fixed five-item preset catalog so advanced routes and monitors remain explicit manual edits instead of surprising wizard-owned state.
+
+## Setup and bounded config editing
+
+Use the built-in setup/config surfaces for these five common presets only:
+
+1. Discord webhook quickstart route
+2. Discord bot token
+3. Default channel
+4. Default message format
+5. Daemon base URL
+
+Use the non-interactive path for first-run scaffolding:
+
+```bash
+clawhip setup \
+  --webhook "https://discord.com/api/webhooks/..." \
+  --bot-token "your-dedicated-clawhip-bot-token" \
+  --default-channel "123456789012345678" \
+  --default-format compact \
+  --daemon-base-url "http://127.0.0.1:8940"
+```
+
+Use `clawhip config` to revisit the same bounded preset surface later. For anything outside those five presets—custom `[[routes]]`, Slack routes, monitors, dispatch tuning, cron jobs, or template-heavy routing—edit the TOML file directly.
+
+### Quickstart-route ownership rules
+
+The webhook quickstart helpers own exactly one canonical wildcard Discord webhook route:
+
+- `event = "*"`
+- `sink = "discord"`
+- `filter` is empty
+- `channel`, `slack_webhook`, `mention`, `template`, and `format` are unset
+- `allow_dynamic_tokens = false`
+
+That ownership rule preserves backward compatibility for `clawhip setup --webhook ...` while protecting unrelated manual routes:
+
+- if no canonical quickstart route exists, setup/config may append one
+- if exactly one canonical quickstart route exists, setup/config may update only its `webhook`
+- if multiple canonical quickstart routes exist, clean them up manually before using the bounded setup/config helpers again
+
+The manual template hint from `clawhip config` is intentional: advanced routing and monitor definitions stay manual so the editor never implies full config authoring support.
+
 Route example:
 
 ```toml
@@ -814,7 +857,7 @@ Required live sign-off presets:
 ```bash
 clawhip                 # start daemon
 clawhip status          # daemon health
-clawhip config          # config management
+clawhip config          # bounded setup-preset editor / config inspection
 clawhip send ...        # thin client custom event
 clawhip github ...      # thin client GitHub event
 clawhip git ...         # thin client git event

--- a/README.md
+++ b/README.md
@@ -279,59 +279,24 @@ Quick start:
 clawhip setup --webhook "https://discord.com/api/webhooks/..."
 ```
 
-`clawhip setup --webhook ...` remains the fastest first-run path. The setup/config UX intentionally stays bounded to a fixed five-item preset catalog so advanced routes and monitors remain explicit manual edits instead of surprising wizard-owned state.
-
-## Setup and bounded config editing
-
-Use the built-in setup/config surfaces for these five common presets only:
-
-1. Discord webhook quickstart route
-2. Discord bot token
-3. Default channel
-4. Default message format
-5. Daemon base URL
-
-Use the non-interactive path for first-run scaffolding:
+Bounded setup presets also support:
 
 ```bash
 clawhip setup \
-  --webhook "https://discord.com/api/webhooks/..." \
-  --bot-token "your-dedicated-clawhip-bot-token" \
-  --default-channel "123456789012345678" \
-  --default-format compact \
-  --daemon-base-url "http://127.0.0.1:8940"
+  --bot-token "discord-bot-token" \
+  --default-channel "1234567890" \
+  --default-format alert \
+  --daemon-base-url "http://127.0.0.1:25294"
 ```
 
-Use `clawhip config` to revisit the same bounded preset surface later. For anything outside those five presets—custom `[[routes]]`, Slack routes, monitors, dispatch tuning, cron jobs, or template-heavy routing—edit the TOML file directly.
+`clawhip setup` stays non-interactive and intentionally limited to five presets only:
+- Discord webhook quickstart route
+- Discord bot token
+- Default channel
+- Default message format
+- Daemon base URL
 
-The bounded `clawhip config` editor should expose exactly these eight actions:
-
-1. Set Discord bot token
-2. Set daemon base URL
-3. Set default channel
-4. Set default format
-5. Set Discord webhook quickstart route
-6. Save and exit
-7. Exit without saving
-8. Print manual config template hint
-
-### Quickstart-route ownership rules
-
-The webhook quickstart helpers own exactly one canonical wildcard Discord webhook route:
-
-- `event = "*"`
-- `sink = "discord"`
-- `filter` is empty
-- `channel`, `slack_webhook`, `mention`, `template`, and `format` are unset
-- `allow_dynamic_tokens = false`
-
-That ownership rule preserves backward compatibility for `clawhip setup --webhook ...` while protecting unrelated manual routes:
-
-- if no canonical quickstart route exists, setup/config may append one
-- if exactly one canonical quickstart route exists, setup/config may update only its `webhook`
-- if multiple canonical quickstart routes exist, clean them up manually before using the bounded setup/config helpers again
-
-The manual template hint from `clawhip config` is intentional: advanced routing and monitor definitions stay manual so the editor never implies full config authoring support.
+Advanced routes and monitor definitions are still edited manually in the config file or revisited through the bounded `clawhip config` editor surface.
 
 Route example:
 
@@ -868,7 +833,7 @@ Required live sign-off presets:
 ```bash
 clawhip                 # start daemon
 clawhip status          # daemon health
-clawhip config          # bounded setup-preset editor / config inspection
+clawhip config          # bounded preset editor / config inspection
 clawhip send ...        # thin client custom event
 clawhip github ...      # thin client GitHub event
 clawhip git ...         # thin client git event

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 use std::path::PathBuf;
 
-use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use serde_json::Value;
 
 use crate::events::MessageFormat;
@@ -43,6 +43,11 @@ pub enum Commands {
     /// Check daemon health/status.
     Status,
     /// Scaffold common setup presets without editing advanced routes or monitors.
+    #[command(
+        arg_required_else_help = true,
+        about = "Scaffold the bounded quickstart preset catalog",
+        long_about = "Scaffold the bounded quickstart preset catalog. Advanced routes and monitors still require manual config editing or the bounded clawhip config editor."
+    )]
     Setup(SetupArgs),
     /// Send a custom event to the local daemon.
     Send {
@@ -136,37 +141,13 @@ pub enum Commands {
 }
 
 #[derive(Debug, Clone, Args)]
-#[group(required = true, multiple = true)]
-pub struct SetupArgs {
-    /// Discord webhook quickstart URL.
-    #[arg(long)]
-    pub webhook: Option<String>,
-    /// Discord bot token for channel delivery.
-    #[arg(long = "bot-token")]
-    pub bot_token: Option<String>,
-    /// Default Discord channel ID.
-    #[arg(long = "default-channel")]
-    pub default_channel: Option<String>,
-    /// Default message format.
-    #[arg(long = "default-format", value_enum)]
-    pub default_format: Option<MessageFormat>,
-    /// Base URL for local daemon commands.
-    #[arg(long = "daemon-base-url")]
-    pub daemon_base_url: Option<String>,
-}
-
-#[derive(Debug, Clone, Args)]
 pub struct EmitArgs {
     pub event_type: String,
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub fields: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, Args)]
-#[command(
-    arg_required_else_help = true,
-    long_about = "Scaffold the bounded quickstart preset catalog. Advanced routes and monitors still require manual config editing or the bounded clawhip config editor."
-)]
+#[derive(Debug, Clone, Args)]
 pub struct SetupArgs {
     /// Set or update the canonical Discord webhook quickstart route.
     #[arg(long)]
@@ -715,7 +696,7 @@ pub enum ConfigCommand {
 mod tests {
     use super::*;
     use crate::event::compat::from_incoming_event;
-    use clap::error::ErrorKind;
+    use clap::{CommandFactory, error::ErrorKind};
 
     #[test]
     fn parses_emit_subcommand_with_top_level_fields() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 use std::path::PathBuf;
 
-use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use serde_json::Value;
 
 use crate::events::MessageFormat;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,11 +42,11 @@ pub enum Commands {
     },
     /// Check daemon health/status.
     Status,
-    /// Scaffold a quick-start configuration.
-    Setup {
-        #[arg(long)]
-        webhook: String,
-    },
+    /// Scaffold common setup presets without editing the full config manually.
+    #[command(
+        after_help = "Supports only the fixed five-preset setup surface. For advanced routes or monitors, use `clawhip config` for the bounded preset editor or edit the config file manually."
+    )]
+    Setup(SetupArgs),
     /// Send a custom event to the local daemon.
     Send {
         #[arg(long)]
@@ -136,6 +136,26 @@ pub enum Commands {
     },
     /// Enable repo-local native hook forwarding for Claude Code and Codex.
     EnableHook(EnableHookArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+#[group(required = true, multiple = true)]
+pub struct SetupArgs {
+    /// Discord webhook quickstart URL.
+    #[arg(long)]
+    pub webhook: Option<String>,
+    /// Discord bot token for channel delivery.
+    #[arg(long = "bot-token")]
+    pub bot_token: Option<String>,
+    /// Default Discord channel ID.
+    #[arg(long = "default-channel")]
+    pub default_channel: Option<String>,
+    /// Default message format.
+    #[arg(long = "default-format", value_enum)]
+    pub default_format: Option<MessageFormat>,
+    /// Base URL for local daemon commands.
+    #[arg(long = "daemon-base-url")]
+    pub daemon_base_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -662,9 +682,12 @@ pub struct HooksInstallArgs {
 
 #[derive(Debug, Clone, Default, Subcommand)]
 pub enum ConfigCommand {
+    /// Edit the five common setup presets interactively; advanced routes and monitors remain manual-edit territory.
     #[default]
     Interactive,
+    /// Print the current config file.
     Show,
+    /// Print the active config file path.
     Path,
 }
 
@@ -909,11 +932,74 @@ mod tests {
             "https://discord.com/api/webhooks/123/abc",
         ]);
 
-        let Commands::Setup { webhook } = cli.command.expect("setup command") else {
+        let Commands::Setup(args) = cli.command.expect("setup command") else {
             panic!("expected setup command");
         };
 
-        assert_eq!(webhook, "https://discord.com/api/webhooks/123/abc");
+        assert_eq!(
+            args.webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/123/abc")
+        );
+        assert!(args.bot_token.is_none());
+    }
+
+    #[test]
+    fn parses_setup_mixed_preset_flags() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "setup",
+            "--webhook",
+            "https://discord.com/api/webhooks/123/abc",
+            "--bot-token",
+            "discord-token",
+            "--default-channel",
+            "123456",
+            "--default-format",
+            "alert",
+            "--daemon-base-url",
+            "http://127.0.0.1:3000",
+        ]);
+
+        let Commands::Setup(args) = cli.command.expect("setup command") else {
+            panic!("expected setup command");
+        };
+
+        assert_eq!(
+            args.webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/123/abc")
+        );
+        assert_eq!(args.bot_token.as_deref(), Some("discord-token"));
+        assert_eq!(args.default_channel.as_deref(), Some("123456"));
+        assert_eq!(args.default_format, Some(MessageFormat::Alert));
+        assert_eq!(
+            args.daemon_base_url.as_deref(),
+            Some("http://127.0.0.1:3000")
+        );
+    }
+
+    #[test]
+    fn setup_requires_at_least_one_flag() {
+        use clap::error::ErrorKind;
+
+        let error = Cli::try_parse_from(["clawhip", "setup"]).expect_err("setup should fail");
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn setup_help_mentions_bounded_surface_and_manual_escape_hatch() {
+        use clap::CommandFactory;
+
+        let mut command = Cli::command();
+        let setup = command
+            .find_subcommand_mut("setup")
+            .expect("setup subcommand");
+        let mut help = Vec::new();
+        setup.write_long_help(&mut help).expect("help");
+        let help = String::from_utf8(help).expect("utf8 help");
+
+        assert!(help.contains("fixed five-preset setup surface"));
+        assert!(help.contains("clawhip config"));
+        assert!(help.contains("advanced routes or monitors"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,11 +42,9 @@ pub enum Commands {
     },
     /// Check daemon health/status.
     Status,
-    /// Scaffold common setup presets without editing advanced routes or monitors.
     #[command(
-        arg_required_else_help = true,
-        about = "Scaffold the bounded quickstart preset catalog",
-        long_about = "Scaffold the bounded quickstart preset catalog. Advanced routes and monitors still require manual config editing or the bounded clawhip config editor."
+        about = "Scaffold common setup presets without editing advanced routes or monitors",
+        long_about = "Scaffold the bounded quickstart preset catalog.\n\nAdvanced routes and monitors still require manual config editing or the bounded clawhip config editor."
     )]
     Setup(SetupArgs),
     /// Send a custom event to the local daemon.
@@ -147,7 +145,8 @@ pub struct EmitArgs {
     pub fields: Vec<String>,
 }
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Default, Args)]
+#[command(arg_required_else_help = true)]
 pub struct SetupArgs {
     /// Set or update the canonical Discord webhook quickstart route.
     #[arg(long)]
@@ -696,7 +695,8 @@ pub enum ConfigCommand {
 mod tests {
     use super::*;
     use crate::event::compat::from_incoming_event;
-    use clap::{CommandFactory, error::ErrorKind};
+    use clap::CommandFactory;
+    use clap::error::ErrorKind;
 
     #[test]
     fn parses_emit_subcommand_with_top_level_fields() {
@@ -988,7 +988,7 @@ mod tests {
         );
 
         let rendered = error.to_string();
-        assert!(rendered.contains("Scaffold the bounded quickstart preset catalog"));
+        assert!(rendered.contains("Usage: clawhip setup [OPTIONS]"));
         assert!(rendered.contains("--webhook"));
         assert!(rendered.contains("--bot-token"));
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 use std::path::PathBuf;
 
-use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use serde_json::Value;
 
 use crate::events::MessageFormat;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 use std::path::PathBuf;
 
-use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use serde_json::Value;
 
 use crate::events::MessageFormat;
@@ -42,10 +42,7 @@ pub enum Commands {
     },
     /// Check daemon health/status.
     Status,
-    /// Scaffold common setup presets without editing the full config manually.
-    #[command(
-        after_help = "Supports only the fixed five-preset setup surface. For advanced routes or monitors, use `clawhip config` for the bounded preset editor or edit the config file manually."
-    )]
+    /// Scaffold common setup presets without editing advanced routes or monitors.
     Setup(SetupArgs),
     /// Send a custom event to the local daemon.
     Send {
@@ -163,6 +160,29 @@ pub struct EmitArgs {
     pub event_type: String,
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Args)]
+#[command(
+    arg_required_else_help = true,
+    long_about = "Scaffold the bounded quickstart preset catalog. Advanced routes and monitors still require manual config editing or the bounded clawhip config editor."
+)]
+pub struct SetupArgs {
+    /// Set or update the canonical Discord webhook quickstart route.
+    #[arg(long)]
+    pub webhook: Option<String>,
+    /// Set the Discord bot token in [providers.discord].
+    #[arg(long = "bot-token")]
+    pub bot_token: Option<String>,
+    /// Set the default Discord channel in [defaults].
+    #[arg(long = "default-channel")]
+    pub default_channel: Option<String>,
+    /// Set the default message format in [defaults].
+    #[arg(long = "default-format")]
+    pub default_format: Option<MessageFormat>,
+    /// Set the daemon base URL in [daemon].
+    #[arg(long = "daemon-base-url")]
+    pub daemon_base_url: Option<String>,
 }
 
 impl EmitArgs {
@@ -695,6 +715,7 @@ pub enum ConfigCommand {
 mod tests {
     use super::*;
     use crate::event::compat::from_incoming_event;
+    use clap::error::ErrorKind;
 
     #[test]
     fn parses_emit_subcommand_with_top_level_fields() {
@@ -944,7 +965,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_setup_mixed_preset_flags() {
+    fn parses_setup_mixed_flag_subcommand() {
         let cli = Cli::parse_from([
             "clawhip",
             "setup",
@@ -953,11 +974,11 @@ mod tests {
             "--bot-token",
             "discord-token",
             "--default-channel",
-            "123456",
+            "alerts",
             "--default-format",
             "alert",
             "--daemon-base-url",
-            "http://127.0.0.1:3000",
+            "http://127.0.0.1:31337",
         ]);
 
         let Commands::Setup(args) = cli.command.expect("setup command") else {
@@ -969,37 +990,41 @@ mod tests {
             Some("https://discord.com/api/webhooks/123/abc")
         );
         assert_eq!(args.bot_token.as_deref(), Some("discord-token"));
-        assert_eq!(args.default_channel.as_deref(), Some("123456"));
+        assert_eq!(args.default_channel.as_deref(), Some("alerts"));
         assert_eq!(args.default_format, Some(MessageFormat::Alert));
         assert_eq!(
             args.daemon_base_url.as_deref(),
-            Some("http://127.0.0.1:3000")
+            Some("http://127.0.0.1:31337")
         );
     }
 
     #[test]
-    fn setup_requires_at_least_one_flag() {
-        use clap::error::ErrorKind;
-
+    fn setup_without_flags_fails_with_help() {
         let error = Cli::try_parse_from(["clawhip", "setup"]).expect_err("setup should fail");
-        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+        assert_eq!(
+            error.kind(),
+            ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        );
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("Scaffold the bounded quickstart preset catalog"));
+        assert!(rendered.contains("--webhook"));
+        assert!(rendered.contains("--bot-token"));
     }
 
     #[test]
-    fn setup_help_mentions_bounded_surface_and_manual_escape_hatch() {
-        use clap::CommandFactory;
-
+    fn setup_help_mentions_manual_advanced_editing() {
         let mut command = Cli::command();
         let setup = command
             .find_subcommand_mut("setup")
             .expect("setup subcommand");
-        let mut help = Vec::new();
-        setup.write_long_help(&mut help).expect("help");
-        let help = String::from_utf8(help).expect("utf8 help");
+        let mut buffer = Vec::new();
+        setup.write_long_help(&mut buffer).expect("write help");
+        let help = String::from_utf8(buffer).expect("utf8");
 
-        assert!(help.contains("fixed five-preset setup surface"));
-        assert!(help.contains("clawhip config"));
-        assert!(help.contains("advanced routes or monitors"));
+        assert!(help.contains("Advanced routes and monitors still require manual config editing"));
+        assert!(help.contains("--default-format <DEFAULT_FORMAT>"));
+        assert!(help.contains("--daemon-base-url <DAEMON_BASE_URL>"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -430,17 +430,6 @@ pub fn default_sink_name() -> String {
     "discord".to_string()
 }
 
-const CONFIG_EDITOR_MENU: [&str; 8] = [
-    "1) Set Discord bot token",
-    "2) Set daemon base URL",
-    "3) Set default channel",
-    "4) Set default format",
-    "5) Set Discord webhook quickstart route",
-    "6) Save and exit",
-    "7) Exit without saving",
-    "8) Print manual config template hint",
-];
-
 const DISCORD_TOKEN_ENV_VARS: [&str; 2] = ["DISCORD_TOKEN", "CLAWHIP_DISCORD_BOT_TOKEN"];
 pub const CONFIG_EDITOR_MENU_ITEMS: [&str; 8] = [
     "Set Discord bot token",
@@ -452,25 +441,6 @@ pub const CONFIG_EDITOR_MENU_ITEMS: [&str; 8] = [
     "Exit without saving",
     "Print manual config template hint",
 ];
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct SetupEdits {
-    pub webhook: Option<String>,
-    pub bot_token: Option<String>,
-    pub default_channel: Option<String>,
-    pub default_format: Option<MessageFormat>,
-    pub daemon_base_url: Option<String>,
-}
-
-impl SetupEdits {
-    pub fn is_empty(&self) -> bool {
-        self.webhook.is_none()
-            && self.bot_token.is_none()
-            && self.default_channel.is_none()
-            && self.default_format.is_none()
-            && self.daemon_base_url.is_none()
-    }
-}
 
 fn merge_legacy_discord_field(
     field: &str,
@@ -733,32 +703,6 @@ impl AppConfig {
 
         Ok(())
     }
-
-    pub fn scaffold_webhook_quickstart(&mut self, webhook: String) -> Result<()> {
-        let webhook = normalize_text(Some(webhook));
-        if webhook.is_none() {
-            return Ok(());
-        }
-
-        if let Some(webhook) = webhook {
-            self.scaffold_webhook_quickstart(webhook)?;
-        }
-        if let Some(bot_token) = bot_token {
-            self.providers.discord.bot_token = Some(bot_token);
-        }
-        if let Some(default_channel) = default_channel {
-            self.defaults.channel = Some(default_channel);
-        }
-        if let Some(default_format) = default_format {
-            self.defaults.format = default_format;
-        }
-        if let Some(daemon_base_url) = daemon_base_url {
-            self.daemon.base_url = daemon_base_url;
-        }
-
-        Ok(())
-    }
-
     pub fn scaffold_webhook_quickstart(&mut self, webhook: String) -> Result<()> {
         let webhook = normalize_text(Some(webhook)).ok_or_else(|| {
             "setup requires a non-empty webhook URL when --webhook is supplied".to_string()
@@ -797,25 +741,6 @@ impl AppConfig {
                     .into(),
             ),
         }
-
-        if let Some(index) = matches.first().copied() {
-            self.routes[index].webhook = webhook;
-            return Ok(());
-        }
-
-        self.routes.push(RouteRule {
-            event: "*".to_string(),
-            filter: BTreeMap::new(),
-            sink: default_sink_name(),
-            channel: None,
-            webhook,
-            slack_webhook: None,
-            mention: None,
-            allow_dynamic_tokens: false,
-            format: None,
-            template: None,
-        });
-        Ok(())
     }
 
     pub fn set_discord_bot_token(&mut self, bot_token: String) {
@@ -1400,16 +1325,16 @@ mod tests {
     #[test]
     fn config_editor_menu_matches_bounded_eight_item_surface() {
         assert_eq!(
-            CONFIG_EDITOR_MENU,
+            CONFIG_EDITOR_MENU_ITEMS,
             [
-                "1) Set Discord bot token",
-                "2) Set daemon base URL",
-                "3) Set default channel",
-                "4) Set default format",
-                "5) Set Discord webhook quickstart route",
-                "6) Save and exit",
-                "7) Exit without saving",
-                "8) Print manual config template hint",
+                "Set Discord bot token",
+                "Set daemon base URL",
+                "Set default channel",
+                "Set default format",
+                "Set Discord webhook quickstart route",
+                "Save and exit",
+                "Exit without saving",
+                "Print manual config template hint",
             ]
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -442,6 +442,25 @@ pub const CONFIG_EDITOR_MENU_ITEMS: [&str; 8] = [
     "Print manual config template hint",
 ];
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SetupEdits {
+    pub webhook: Option<String>,
+    pub bot_token: Option<String>,
+    pub default_channel: Option<String>,
+    pub default_format: Option<MessageFormat>,
+    pub daemon_base_url: Option<String>,
+}
+
+impl SetupEdits {
+    pub fn is_empty(&self) -> bool {
+        self.webhook.is_none()
+            && self.bot_token.is_none()
+            && self.default_channel.is_none()
+            && self.default_format.is_none()
+            && self.daemon_base_url.is_none()
+    }
+}
+
 fn merge_legacy_discord_field(
     field: &str,
     legacy: Option<String>,
@@ -1024,22 +1043,6 @@ fn prompt_format(default: Option<MessageFormat>) -> Result<MessageFormat> {
         return Ok(default_value);
     }
     MessageFormat::from_label(input.trim())
-}
-
-fn empty_to_none(value: String) -> Option<String> {
-    normalize_text(Some(value))
-}
-
-fn is_canonical_quickstart_route(route: &RouteRule) -> bool {
-    route.event == "*"
-        && route.filter.is_empty()
-        && route.sink == default_sink_name()
-        && route.channel.is_none()
-        && route.slack_webhook.is_none()
-        && route.mention.is_none()
-        && route.template.is_none()
-        && !route.allow_dynamic_tokens
-        && route.format.is_none()
 }
 
 fn normalize_text(value: Option<String>) -> Option<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -430,6 +430,17 @@ pub fn default_sink_name() -> String {
     "discord".to_string()
 }
 
+const CONFIG_EDITOR_MENU: [&str; 8] = [
+    "1) Set Discord bot token",
+    "2) Set daemon base URL",
+    "3) Set default channel",
+    "4) Set default format",
+    "5) Set Discord webhook quickstart route",
+    "6) Save and exit",
+    "7) Exit without saving",
+    "8) Print manual config template hint",
+];
+
 const DISCORD_TOKEN_ENV_VARS: [&str; 2] = ["DISCORD_TOKEN", "CLAWHIP_DISCORD_BOT_TOKEN"];
 
 fn merge_legacy_discord_field(
@@ -695,21 +706,28 @@ impl AppConfig {
     }
 
     pub fn scaffold_webhook_quickstart(&mut self, webhook: String) {
-        let webhook = webhook.trim().to_string();
-        if webhook.is_empty() {
-            return;
+        let webhook = normalize_text(Some(webhook));
+        if webhook.is_none() {
+            return Ok(());
         }
 
-        if let Some(route) = self.routes.iter_mut().find(|route| {
-            route.event == "*"
-                && route.filter.is_empty()
-                && route.mention.is_none()
-                && route.template.is_none()
-        }) {
-            route.sink = default_sink_name();
-            route.channel = None;
-            route.webhook = Some(webhook);
-            return;
+        let matches = self
+            .routes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, route)| is_canonical_quickstart_route(route).then_some(index))
+            .collect::<Vec<_>>();
+
+        if matches.len() > 1 {
+            return Err(
+                "multiple canonical quickstart routes found; clean up routes manually before updating the quickstart webhook"
+                    .into(),
+            );
+        }
+
+        if let Some(index) = matches.first().copied() {
+            self.routes[index].webhook = webhook;
+            return Ok(());
         }
 
         self.routes.push(RouteRule {
@@ -717,13 +735,38 @@ impl AppConfig {
             filter: BTreeMap::new(),
             sink: default_sink_name(),
             channel: None,
-            webhook: Some(webhook),
+            webhook,
             slack_webhook: None,
             mention: None,
             allow_dynamic_tokens: false,
             format: None,
             template: None,
         });
+        Ok(())
+    }
+
+    pub fn set_discord_bot_token(&mut self, bot_token: String) {
+        self.providers.discord.bot_token = normalize_secret(Some(bot_token));
+    }
+
+    pub fn set_default_channel(&mut self, channel: String) {
+        self.defaults.channel = normalize_text(Some(channel));
+    }
+
+    pub fn set_default_format(&mut self, format: MessageFormat) {
+        self.defaults.format = format;
+    }
+
+    pub fn set_daemon_base_url(&mut self, base_url: String) {
+        self.daemon.base_url =
+            normalize_text(Some(base_url)).unwrap_or_else(default_base_url);
+    }
+
+    fn canonical_quickstart_webhook(&self) -> Option<&str> {
+        self.routes
+            .iter()
+            .find(|route| is_canonical_quickstart_route(route))
+            .and_then(|route| route.webhook.as_deref())
     }
 
     pub fn daemon_base_url(&self) -> String {
@@ -747,31 +790,36 @@ impl AppConfig {
         loop {
             self.print_summary();
             println!("Choose an action:");
-            println!("  1) Set Discord bot token");
-            println!("  2) Set daemon base URL");
-            println!("  3) Set default channel");
-            println!("  4) Set default format");
-            println!("  5) Save and exit");
-            println!("  6) Exit without saving");
-            println!("  7) Print config template hint");
+            for line in CONFIG_EDITOR_MENU {
+                println!("  {line}");
+            }
             match prompt("Selection")?.trim() {
-                "1" => self.providers.discord.bot_token = empty_to_none(prompt("Bot token")?),
+                "1" => self.set_discord_bot_token(prompt("Bot token")?),
                 "2" => {
-                    self.daemon.base_url =
-                        prompt_with_default("Daemon base URL", Some(&self.daemon.base_url))?
+                    self.set_daemon_base_url(prompt_with_default(
+                        "Daemon base URL",
+                        Some(&self.daemon.base_url),
+                    )?)
                 }
-                "3" => self.defaults.channel = empty_to_none(prompt("Default channel")?),
-                "4" => self.defaults.format = prompt_format(Some(self.defaults.format.clone()))?,
+                "3" => self.set_default_channel(prompt("Default channel")?),
+                "4" => self.set_default_format(prompt_format(Some(self.defaults.format.clone()))?),
                 "5" => {
+                    let webhook = prompt_with_default(
+                        "Discord webhook quickstart route",
+                        self.canonical_quickstart_webhook(),
+                    )?;
+                    self.scaffold_webhook_quickstart(webhook)?;
+                }
+                "6" => {
                     self.save(path)?;
                     println!("Saved {}", path.display());
                     break;
                 }
-                "6" => {
+                "7" => {
                     println!("Discarded changes.");
                     break;
                 }
-                "7" => self.print_template_hint(),
+                "8" => self.print_template_hint(),
                 _ => println!("Unknown selection."),
             }
             println!();
@@ -809,7 +857,9 @@ impl AppConfig {
     }
 
     fn print_template_hint(&self) {
-        println!("Edit the config file directly for routes and monitor definitions.");
+        println!(
+            "Advanced routes and monitors are still edited manually in the config file."
+        );
         println!(
             "Sections: [providers.discord], [dispatch], [daemon], [cron], [[cron.jobs]], [[routes]], [[monitors.git.repos]], [[monitors.tmux.sessions]], [[monitors.workspace]]"
         );
@@ -895,6 +945,18 @@ impl AppConfig {
             .filter(|route| route.has_any_webhook_target())
             .count()
     }
+}
+
+fn is_canonical_quickstart_route(route: &RouteRule) -> bool {
+    route.event == "*"
+        && route.filter.is_empty()
+        && route.effective_sink() == "discord"
+        && route.channel.is_none()
+        && route.slack_webhook.is_none()
+        && route.mention.is_none()
+        && route.template.is_none()
+        && !route.allow_dynamic_tokens
+        && route.format.is_none()
 }
 
 fn prompt(label: &str) -> Result<String> {
@@ -1130,9 +1192,11 @@ mod tests {
     }
 
     #[test]
-    fn setup_scaffold_adds_tmux_keyword_webhook_route() {
+    fn setup_scaffold_adds_canonical_quickstart_route() {
         let mut config = AppConfig::default();
-        config.scaffold_webhook_quickstart(" https://discord.com/api/webhooks/123/abc ".into());
+        config
+            .scaffold_webhook_quickstart(" https://discord.com/api/webhooks/123/abc ".into())
+            .unwrap();
 
         assert_eq!(config.routes.len(), 1);
         assert_eq!(config.routes[0].event, "*");
@@ -1142,6 +1206,148 @@ mod tests {
         );
         assert_eq!(config.routes[0].sink, "discord");
         assert_eq!(config.routes[0].channel, None);
+    }
+
+    #[test]
+    fn setup_scaffold_updates_existing_canonical_quickstart_route_only() {
+        let mut config = AppConfig {
+            providers: ProvidersConfig {
+                discord: DiscordConfig {
+                    bot_token: Some("token".into()),
+                    legacy_default_channel: None,
+                },
+                slack: SlackConfig::default(),
+            },
+            routes: vec![
+                RouteRule {
+                    event: "*".into(),
+                    webhook: Some("https://discord.com/api/webhooks/old/abc".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "tmux.keyword".into(),
+                    channel: Some("alerts".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+
+        config
+            .scaffold_webhook_quickstart("https://discord.com/api/webhooks/new/xyz".into())
+            .unwrap();
+
+        assert_eq!(config.routes.len(), 2);
+        assert_eq!(
+            config.routes[0].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/new/xyz")
+        );
+        assert_eq!(config.routes[1].channel.as_deref(), Some("alerts"));
+    }
+
+    #[test]
+    fn setup_scaffold_rejects_ambiguous_canonical_quickstart_routes() {
+        let mut config = AppConfig {
+            providers: ProvidersConfig {
+                discord: DiscordConfig {
+                    bot_token: Some("token".into()),
+                    legacy_default_channel: None,
+                },
+                slack: SlackConfig::default(),
+            },
+            routes: vec![
+                RouteRule {
+                    event: "*".into(),
+                    webhook: Some("https://discord.com/api/webhooks/1/abc".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "*".into(),
+                    webhook: Some("https://discord.com/api/webhooks/2/abc".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+
+        let error = config
+            .scaffold_webhook_quickstart("https://discord.com/api/webhooks/3/abc".into())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("multiple canonical quickstart routes"));
+        assert_eq!(
+            config.routes[0].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/1/abc")
+        );
+        assert_eq!(
+            config.routes[1].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/2/abc")
+        );
+    }
+
+    #[test]
+    fn setup_setters_update_only_owned_nodes() {
+        let mut config = AppConfig {
+            providers: ProvidersConfig {
+                discord: DiscordConfig {
+                    bot_token: Some("old-token".into()),
+                    legacy_default_channel: None,
+                },
+                slack: SlackConfig::default(),
+            },
+            daemon: DaemonConfig {
+                base_url: "http://127.0.0.1:25294".into(),
+                ..DaemonConfig::default()
+            },
+            defaults: DefaultsConfig {
+                channel: Some("old-channel".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                channel: Some("ops".into()),
+                ..RouteRule::default()
+            }],
+            monitors: MonitorConfig {
+                github_token: Some("gh-token".into()),
+                ..MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        config.set_discord_bot_token("new-token".into());
+        config.set_default_channel("new-channel".into());
+        config.set_default_format(MessageFormat::Alert);
+        config.set_daemon_base_url("http://127.0.0.1:4000".into());
+
+        assert_eq!(
+            config.providers.discord.bot_token.as_deref(),
+            Some("new-token")
+        );
+        assert_eq!(config.defaults.channel.as_deref(), Some("new-channel"));
+        assert_eq!(config.defaults.format, MessageFormat::Alert);
+        assert_eq!(config.daemon.base_url, "http://127.0.0.1:4000");
+        assert_eq!(config.routes.len(), 1);
+        assert_eq!(config.routes[0].channel.as_deref(), Some("ops"));
+        assert_eq!(config.monitors.github_token.as_deref(), Some("gh-token"));
+    }
+
+    #[test]
+    fn config_editor_menu_matches_bounded_eight_item_surface() {
+        assert_eq!(
+            CONFIG_EDITOR_MENU,
+            [
+                "1) Set Discord bot token",
+                "2) Set daemon base URL",
+                "3) Set default channel",
+                "4) Set default format",
+                "5) Set Discord webhook quickstart route",
+                "6) Save and exit",
+                "7) Exit without saving",
+                "8) Print manual config template hint",
+            ]
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -734,27 +734,10 @@ impl AppConfig {
         Ok(())
     }
 
-    pub fn apply_setup_edits(&mut self, edits: SetupEdits) -> Result<()> {
-        let SetupEdits {
-            webhook,
-            bot_token,
-            default_channel,
-            default_format,
-            daemon_base_url,
-        } = edits;
-
-        let webhook = normalize_text(webhook);
-        let bot_token = normalize_secret(bot_token);
-        let default_channel = normalize_text(default_channel);
-        let daemon_base_url = normalize_text(daemon_base_url);
-
-        if webhook.is_none()
-            && bot_token.is_none()
-            && default_channel.is_none()
-            && daemon_base_url.is_none()
-            && default_format.is_none()
-        {
-            return Err("setup requires at least one non-empty setup flag".into());
+    pub fn scaffold_webhook_quickstart(&mut self, webhook: String) -> Result<()> {
+        let webhook = normalize_text(Some(webhook));
+        if webhook.is_none() {
+            return Ok(());
         }
 
         if let Some(webhook) = webhook {
@@ -814,6 +797,48 @@ impl AppConfig {
                     .into(),
             ),
         }
+
+        if let Some(index) = matches.first().copied() {
+            self.routes[index].webhook = webhook;
+            return Ok(());
+        }
+
+        self.routes.push(RouteRule {
+            event: "*".to_string(),
+            filter: BTreeMap::new(),
+            sink: default_sink_name(),
+            channel: None,
+            webhook,
+            slack_webhook: None,
+            mention: None,
+            allow_dynamic_tokens: false,
+            format: None,
+            template: None,
+        });
+        Ok(())
+    }
+
+    pub fn set_discord_bot_token(&mut self, bot_token: String) {
+        self.providers.discord.bot_token = normalize_secret(Some(bot_token));
+    }
+
+    pub fn set_default_channel(&mut self, channel: String) {
+        self.defaults.channel = normalize_text(Some(channel));
+    }
+
+    pub fn set_default_format(&mut self, format: MessageFormat) {
+        self.defaults.format = format;
+    }
+
+    pub fn set_daemon_base_url(&mut self, base_url: String) {
+        self.daemon.base_url = normalize_text(Some(base_url)).unwrap_or_else(default_base_url);
+    }
+
+    fn canonical_quickstart_webhook(&self) -> Option<&str> {
+        self.routes
+            .iter()
+            .find(|route| is_canonical_quickstart_route(route))
+            .and_then(|route| route.webhook.as_deref())
     }
 
     pub fn daemon_base_url(&self) -> String {
@@ -842,18 +867,19 @@ impl AppConfig {
             }
             match prompt("Selection")?.trim() {
                 "1" => self.set_discord_bot_token(prompt("Bot token")?),
-                "2" => {
-                    self.set_daemon_base_url(prompt_with_default(
-                        "Daemon base URL",
-                        Some(&self.daemon.base_url),
-                    )?)
+                "2" => self.set_daemon_base_url(prompt_with_default(
+                    "Daemon base URL",
+                    Some(&self.daemon.base_url),
+                )?),
+                "3" => self.set_default_channel(prompt("Default channel")?),
+                "4" => self.set_default_format(prompt_format(Some(self.defaults.format.clone()))?),
+                "5" => {
+                    let webhook = prompt_with_default(
+                        "Discord webhook quickstart route",
+                        self.canonical_quickstart_webhook(),
+                    )?;
+                    self.scaffold_webhook_quickstart(webhook)?;
                 }
-                "3" => self.defaults.channel = empty_to_none(prompt("Default channel")?),
-                "4" => self.defaults.format = prompt_format(Some(self.defaults.format.clone()))?,
-                "5" => match self.scaffold_webhook_quickstart(prompt("Webhook URL")?) {
-                    Ok(()) => {}
-                    Err(error) => println!("{error}"),
-                },
                 "6" => {
                     self.save(path)?;
                     println!("Saved {}", path.display());
@@ -901,9 +927,7 @@ impl AppConfig {
     }
 
     fn print_template_hint(&self) {
-        println!(
-            "Advanced routes and monitors are still edited manually in the config file."
-        );
+        println!("Advanced routes and monitors are still edited manually in the config file.");
         println!(
             "Sections: [providers.discord], [dispatch], [daemon], [cron], [[cron.jobs]], [[routes]], [[monitors.git.repos]], [[monitors.tmux.sessions]], [[monitors.workspace]]"
         );
@@ -994,7 +1018,7 @@ impl AppConfig {
 fn is_canonical_quickstart_route(route: &RouteRule) -> bool {
     route.event == "*"
         && route.filter.is_empty()
-        && route.effective_sink() == "discord"
+        && route.sink.trim() == "discord"
         && route.channel.is_none()
         && route.slack_webhook.is_none()
         && route.mention.is_none()
@@ -1028,10 +1052,6 @@ fn prompt_format(default: Option<MessageFormat>) -> Result<MessageFormat> {
         return Ok(default_value);
     }
     MessageFormat::from_label(input.trim())
-}
-
-fn empty_to_none(value: String) -> Option<String> {
-    normalize_text(Some(value))
 }
 
 fn normalize_text(value: Option<String>) -> Option<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -442,6 +442,35 @@ const CONFIG_EDITOR_MENU: [&str; 8] = [
 ];
 
 const DISCORD_TOKEN_ENV_VARS: [&str; 2] = ["DISCORD_TOKEN", "CLAWHIP_DISCORD_BOT_TOKEN"];
+pub const CONFIG_EDITOR_MENU_ITEMS: [&str; 8] = [
+    "Set Discord bot token",
+    "Set daemon base URL",
+    "Set default channel",
+    "Set default format",
+    "Set Discord webhook quickstart route",
+    "Save and exit",
+    "Exit without saving",
+    "Print manual config template hint",
+];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SetupEdits {
+    pub webhook: Option<String>,
+    pub bot_token: Option<String>,
+    pub default_channel: Option<String>,
+    pub default_format: Option<MessageFormat>,
+    pub daemon_base_url: Option<String>,
+}
+
+impl SetupEdits {
+    pub fn is_empty(&self) -> bool {
+        self.webhook.is_none()
+            && self.bot_token.is_none()
+            && self.default_channel.is_none()
+            && self.default_format.is_none()
+            && self.daemon_base_url.is_none()
+    }
+}
 
 fn merge_legacy_discord_field(
     field: &str,
@@ -705,68 +734,86 @@ impl AppConfig {
         Ok(())
     }
 
-    pub fn scaffold_webhook_quickstart(&mut self, webhook: String) {
-        let webhook = normalize_text(Some(webhook));
-        if webhook.is_none() {
-            return Ok(());
+    pub fn apply_setup_edits(&mut self, edits: SetupEdits) -> Result<()> {
+        let SetupEdits {
+            webhook,
+            bot_token,
+            default_channel,
+            default_format,
+            daemon_base_url,
+        } = edits;
+
+        let webhook = normalize_text(webhook);
+        let bot_token = normalize_secret(bot_token);
+        let default_channel = normalize_text(default_channel);
+        let daemon_base_url = normalize_text(daemon_base_url);
+
+        if webhook.is_none()
+            && bot_token.is_none()
+            && default_channel.is_none()
+            && daemon_base_url.is_none()
+            && default_format.is_none()
+        {
+            return Err("setup requires at least one non-empty setup flag".into());
         }
+
+        if let Some(webhook) = webhook {
+            self.scaffold_webhook_quickstart(webhook)?;
+        }
+        if let Some(bot_token) = bot_token {
+            self.providers.discord.bot_token = Some(bot_token);
+        }
+        if let Some(default_channel) = default_channel {
+            self.defaults.channel = Some(default_channel);
+        }
+        if let Some(default_format) = default_format {
+            self.defaults.format = default_format;
+        }
+        if let Some(daemon_base_url) = daemon_base_url {
+            self.daemon.base_url = daemon_base_url;
+        }
+
+        Ok(())
+    }
+
+    pub fn scaffold_webhook_quickstart(&mut self, webhook: String) -> Result<()> {
+        let webhook = normalize_text(Some(webhook)).ok_or_else(|| {
+            "setup requires a non-empty webhook URL when --webhook is supplied".to_string()
+        })?;
 
         let matches = self
             .routes
             .iter()
             .enumerate()
-            .filter_map(|(index, route)| is_canonical_quickstart_route(route).then_some(index))
+            .filter(|(_, route)| is_canonical_quickstart_route(route))
+            .map(|(index, _)| index)
             .collect::<Vec<_>>();
 
-        if matches.len() > 1 {
-            return Err(
-                "multiple canonical quickstart routes found; clean up routes manually before updating the quickstart webhook"
+        match matches.as_slice() {
+            [] => {
+                self.routes.push(RouteRule {
+                    event: "*".to_string(),
+                    filter: BTreeMap::new(),
+                    sink: default_sink_name(),
+                    channel: None,
+                    webhook: Some(webhook),
+                    slack_webhook: None,
+                    mention: None,
+                    allow_dynamic_tokens: false,
+                    format: None,
+                    template: None,
+                });
+                Ok(())
+            }
+            [index] => {
+                self.routes[*index].webhook = Some(webhook);
+                Ok(())
+            }
+            _ => Err(
+                "multiple canonical quickstart routes found; clean up manual config before updating the webhook quickstart route"
                     .into(),
-            );
+            ),
         }
-
-        if let Some(index) = matches.first().copied() {
-            self.routes[index].webhook = webhook;
-            return Ok(());
-        }
-
-        self.routes.push(RouteRule {
-            event: "*".to_string(),
-            filter: BTreeMap::new(),
-            sink: default_sink_name(),
-            channel: None,
-            webhook,
-            slack_webhook: None,
-            mention: None,
-            allow_dynamic_tokens: false,
-            format: None,
-            template: None,
-        });
-        Ok(())
-    }
-
-    pub fn set_discord_bot_token(&mut self, bot_token: String) {
-        self.providers.discord.bot_token = normalize_secret(Some(bot_token));
-    }
-
-    pub fn set_default_channel(&mut self, channel: String) {
-        self.defaults.channel = normalize_text(Some(channel));
-    }
-
-    pub fn set_default_format(&mut self, format: MessageFormat) {
-        self.defaults.format = format;
-    }
-
-    pub fn set_daemon_base_url(&mut self, base_url: String) {
-        self.daemon.base_url =
-            normalize_text(Some(base_url)).unwrap_or_else(default_base_url);
-    }
-
-    fn canonical_quickstart_webhook(&self) -> Option<&str> {
-        self.routes
-            .iter()
-            .find(|route| is_canonical_quickstart_route(route))
-            .and_then(|route| route.webhook.as_deref())
     }
 
     pub fn daemon_base_url(&self) -> String {
@@ -790,8 +837,8 @@ impl AppConfig {
         loop {
             self.print_summary();
             println!("Choose an action:");
-            for line in CONFIG_EDITOR_MENU {
-                println!("  {line}");
+            for (index, item) in CONFIG_EDITOR_MENU_ITEMS.iter().enumerate() {
+                println!("  {}) {}", index + 1, item);
             }
             match prompt("Selection")?.trim() {
                 "1" => self.set_discord_bot_token(prompt("Bot token")?),
@@ -801,15 +848,12 @@ impl AppConfig {
                         Some(&self.daemon.base_url),
                     )?)
                 }
-                "3" => self.set_default_channel(prompt("Default channel")?),
-                "4" => self.set_default_format(prompt_format(Some(self.defaults.format.clone()))?),
-                "5" => {
-                    let webhook = prompt_with_default(
-                        "Discord webhook quickstart route",
-                        self.canonical_quickstart_webhook(),
-                    )?;
-                    self.scaffold_webhook_quickstart(webhook)?;
-                }
+                "3" => self.defaults.channel = empty_to_none(prompt("Default channel")?),
+                "4" => self.defaults.format = prompt_format(Some(self.defaults.format.clone()))?,
+                "5" => match self.scaffold_webhook_quickstart(prompt("Webhook URL")?) {
+                    Ok(()) => {}
+                    Err(error) => println!("{error}"),
+                },
                 "6" => {
                     self.save(path)?;
                     println!("Saved {}", path.display());

--- a/src/config.rs
+++ b/src/config.rs
@@ -703,6 +703,47 @@ impl AppConfig {
 
         Ok(())
     }
+
+    pub fn apply_setup_edits(&mut self, edits: SetupEdits) -> Result<()> {
+        let normalized = SetupEdits {
+            webhook: normalize_text(edits.webhook),
+            bot_token: normalize_secret(edits.bot_token),
+            default_channel: normalize_text(edits.default_channel),
+            default_format: edits.default_format,
+            daemon_base_url: normalize_text(edits.daemon_base_url),
+        };
+
+        if normalized.is_empty() {
+            return Err("setup requires at least one non-empty setup flag".into());
+        }
+
+        let SetupEdits {
+            webhook,
+            bot_token,
+            default_channel,
+            default_format,
+            daemon_base_url,
+        } = normalized;
+
+        if let Some(webhook) = webhook {
+            self.scaffold_webhook_quickstart(webhook)?;
+        }
+        if let Some(bot_token) = bot_token {
+            self.providers.discord.bot_token = Some(bot_token);
+        }
+        if let Some(default_channel) = default_channel {
+            self.defaults.channel = Some(default_channel);
+        }
+        if let Some(default_format) = default_format {
+            self.defaults.format = default_format;
+        }
+        if let Some(daemon_base_url) = daemon_base_url {
+            self.daemon.base_url = daemon_base_url;
+        }
+
+        Ok(())
+    }
+
     pub fn scaffold_webhook_quickstart(&mut self, webhook: String) -> Result<()> {
         let webhook = normalize_text(Some(webhook)).ok_or_else(|| {
             "setup requires a non-empty webhook URL when --webhook is supplied".to_string()
@@ -961,9 +1002,15 @@ fn prompt(label: &str) -> Result<String> {
 }
 
 fn prompt_with_default(label: &str, default: Option<&str>) -> Result<String> {
-    match default {
-        Some(default) => prompt(&format!("{label} [{default}]")),
-        None => prompt(label),
+    let value = match default {
+        Some(default) => prompt(&format!("{label} [{default}]"))?,
+        None => prompt(label)?,
+    };
+
+    if value.trim().is_empty() {
+        Ok(default.unwrap_or_default().to_string())
+    } else {
+        Ok(value)
     }
 }
 
@@ -977,6 +1024,22 @@ fn prompt_format(default: Option<MessageFormat>) -> Result<MessageFormat> {
         return Ok(default_value);
     }
     MessageFormat::from_label(input.trim())
+}
+
+fn empty_to_none(value: String) -> Option<String> {
+    normalize_text(Some(value))
+}
+
+fn is_canonical_quickstart_route(route: &RouteRule) -> bool {
+    route.event == "*"
+        && route.filter.is_empty()
+        && route.sink == default_sink_name()
+        && route.channel.is_none()
+        && route.slack_webhook.is_none()
+        && route.mention.is_none()
+        && route.template.is_none()
+        && !route.allow_dynamic_tokens
+        && route.format.is_none()
 }
 
 fn normalize_text(value: Option<String>) -> Option<String> {
@@ -1198,85 +1261,7 @@ mod tests {
     }
 
     #[test]
-    fn setup_scaffold_updates_existing_canonical_quickstart_route_only() {
-        let mut config = AppConfig {
-            providers: ProvidersConfig {
-                discord: DiscordConfig {
-                    bot_token: Some("token".into()),
-                    legacy_default_channel: None,
-                },
-                slack: SlackConfig::default(),
-            },
-            routes: vec![
-                RouteRule {
-                    event: "*".into(),
-                    webhook: Some("https://discord.com/api/webhooks/old/abc".into()),
-                    ..RouteRule::default()
-                },
-                RouteRule {
-                    event: "tmux.keyword".into(),
-                    channel: Some("alerts".into()),
-                    ..RouteRule::default()
-                },
-            ],
-            ..AppConfig::default()
-        };
-
-        config
-            .scaffold_webhook_quickstart("https://discord.com/api/webhooks/new/xyz".into())
-            .unwrap();
-
-        assert_eq!(config.routes.len(), 2);
-        assert_eq!(
-            config.routes[0].webhook.as_deref(),
-            Some("https://discord.com/api/webhooks/new/xyz")
-        );
-        assert_eq!(config.routes[1].channel.as_deref(), Some("alerts"));
-    }
-
-    #[test]
-    fn setup_scaffold_rejects_ambiguous_canonical_quickstart_routes() {
-        let mut config = AppConfig {
-            providers: ProvidersConfig {
-                discord: DiscordConfig {
-                    bot_token: Some("token".into()),
-                    legacy_default_channel: None,
-                },
-                slack: SlackConfig::default(),
-            },
-            routes: vec![
-                RouteRule {
-                    event: "*".into(),
-                    webhook: Some("https://discord.com/api/webhooks/1/abc".into()),
-                    ..RouteRule::default()
-                },
-                RouteRule {
-                    event: "*".into(),
-                    webhook: Some("https://discord.com/api/webhooks/2/abc".into()),
-                    ..RouteRule::default()
-                },
-            ],
-            ..AppConfig::default()
-        };
-
-        let error = config
-            .scaffold_webhook_quickstart("https://discord.com/api/webhooks/3/abc".into())
-            .unwrap_err()
-            .to_string();
-
-        assert!(error.contains("multiple canonical quickstart routes"));
-        assert_eq!(
-            config.routes[0].webhook.as_deref(),
-            Some("https://discord.com/api/webhooks/1/abc")
-        );
-        assert_eq!(
-            config.routes[1].webhook.as_deref(),
-            Some("https://discord.com/api/webhooks/2/abc")
-        );
-    }
-
-    #[test]
-    fn setup_setters_update_only_owned_nodes() {
+    fn setup_mixed_flag_edits_update_only_owned_nodes() {
         let mut config = AppConfig {
             providers: ProvidersConfig {
                 discord: DiscordConfig {
@@ -1290,12 +1275,12 @@ mod tests {
                 ..DaemonConfig::default()
             },
             defaults: DefaultsConfig {
-                channel: Some("old-channel".into()),
+                channel: Some("general".into()),
                 format: MessageFormat::Compact,
             },
             routes: vec![RouteRule {
-                event: "tmux.keyword".into(),
-                channel: Some("ops".into()),
+                event: "git.commit".into(),
+                channel: Some("eng".into()),
                 ..RouteRule::default()
             }],
             monitors: MonitorConfig {
@@ -1305,25 +1290,153 @@ mod tests {
             ..AppConfig::default()
         };
 
-        config.set_discord_bot_token("new-token".into());
-        config.set_default_channel("new-channel".into());
-        config.set_default_format(MessageFormat::Alert);
-        config.set_daemon_base_url("http://127.0.0.1:4000".into());
+        config
+            .apply_setup_edits(SetupEdits {
+                webhook: Some("https://discord.com/api/webhooks/123/new".into()),
+                bot_token: Some("new-token".into()),
+                default_channel: Some("alerts".into()),
+                default_format: Some(MessageFormat::Alert),
+                daemon_base_url: Some("http://127.0.0.1:9999".into()),
+            })
+            .unwrap();
 
         assert_eq!(
             config.providers.discord.bot_token.as_deref(),
             Some("new-token")
         );
-        assert_eq!(config.defaults.channel.as_deref(), Some("new-channel"));
+        assert_eq!(config.defaults.channel.as_deref(), Some("alerts"));
         assert_eq!(config.defaults.format, MessageFormat::Alert);
-        assert_eq!(config.daemon.base_url, "http://127.0.0.1:4000");
-        assert_eq!(config.routes.len(), 1);
-        assert_eq!(config.routes[0].channel.as_deref(), Some("ops"));
+        assert_eq!(config.daemon.base_url, "http://127.0.0.1:9999");
+        assert_eq!(config.routes.len(), 2);
+        assert_eq!(config.routes[0].event, "git.commit");
+        assert_eq!(config.routes[0].channel.as_deref(), Some("eng"));
         assert_eq!(config.monitors.github_token.as_deref(), Some("gh-token"));
+        assert_eq!(
+            config.routes[1].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/123/new")
+        );
     }
 
     #[test]
-    fn config_editor_menu_matches_bounded_eight_item_surface() {
+    fn setup_non_webhook_edits_do_not_touch_routes() {
+        let mut config = AppConfig {
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                webhook: Some("https://discord.com/api/webhooks/123/original".into()),
+                mention: Some("<@1>".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        config
+            .apply_setup_edits(SetupEdits {
+                bot_token: Some("discord-token".into()),
+                default_channel: Some("alerts".into()),
+                default_format: Some(MessageFormat::Raw),
+                daemon_base_url: Some("http://127.0.0.1:4444".into()),
+                ..SetupEdits::default()
+            })
+            .unwrap();
+
+        assert_eq!(config.routes.len(), 1);
+        assert_eq!(config.routes[0].event, "tmux.keyword");
+        assert_eq!(
+            config.routes[0].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/123/original")
+        );
+        assert_eq!(config.routes[0].mention.as_deref(), Some("<@1>"));
+    }
+
+    #[test]
+    fn setup_webhook_rerun_updates_only_canonical_quickstart_route() {
+        let mut config = AppConfig {
+            routes: vec![
+                RouteRule {
+                    event: "*".into(),
+                    webhook: Some("https://discord.com/api/webhooks/123/old".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "git.commit".into(),
+                    webhook: Some("https://discord.com/api/webhooks/123/other".into()),
+                    mention: Some("<@1>".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+
+        config
+            .scaffold_webhook_quickstart("https://discord.com/api/webhooks/123/new".into())
+            .unwrap();
+
+        assert_eq!(config.routes.len(), 2);
+        assert_eq!(
+            config.routes[0].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/123/new")
+        );
+        assert_eq!(
+            config.routes[1].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/123/other")
+        );
+    }
+
+    #[test]
+    fn ambiguous_quickstart_routes_fail_without_mutating_config() {
+        let mut config = AppConfig {
+            routes: vec![
+                RouteRule {
+                    event: "*".into(),
+                    webhook: Some("https://discord.com/api/webhooks/123/a".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "*".into(),
+                    webhook: Some("https://discord.com/api/webhooks/123/b".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+
+        let error = config
+            .scaffold_webhook_quickstart("https://discord.com/api/webhooks/123/new".into())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("multiple canonical quickstart routes"));
+        assert_eq!(config.routes.len(), 2);
+        assert_eq!(
+            config.routes[0].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/123/a")
+        );
+        assert_eq!(
+            config.routes[1].webhook.as_deref(),
+            Some("https://discord.com/api/webhooks/123/b")
+        );
+    }
+
+    #[test]
+    fn setup_edits_require_at_least_one_non_empty_value() {
+        let mut config = AppConfig::default();
+
+        let error = config
+            .apply_setup_edits(SetupEdits {
+                webhook: Some("   ".into()),
+                bot_token: Some(" ".into()),
+                default_channel: Some(" ".into()),
+                daemon_base_url: Some(" ".into()),
+                ..SetupEdits::default()
+            })
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("at least one non-empty setup flag"));
+    }
+
+    #[test]
+    fn config_editor_menu_matches_bounded_preset_contract() {
         assert_eq!(
             CONFIG_EDITOR_MENU_ITEMS,
             [

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,7 @@ use clap::Parser;
 
 use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, CronCommands, GitCommands, GithubCommands,
-    HooksCommands, MemoryCommands, NativeCommands, OmxCommands, PluginCommands, SetupArgs,
-    TmuxCommands,
+    HooksCommands, MemoryCommands, NativeCommands, OmxCommands, PluginCommands, TmuxCommands,
 };
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, SetupEdits};
@@ -307,40 +306,6 @@ async fn real_main() -> Result<()> {
             HooksCommands::Install(args) => hooks::install(args),
         },
         Commands::EnableHook(args) => native_hooks::enable(args),
-    }
-}
-
-fn apply_setup_args(config: &mut AppConfig, args: SetupArgs) -> Result<()> {
-    if let Some(webhook) = args.webhook {
-        config.scaffold_webhook_quickstart(webhook)?;
-    }
-    if let Some(bot_token) = args.bot_token {
-        config.set_discord_bot_token(require_non_empty_setup_value("--bot-token", bot_token)?);
-    }
-    if let Some(default_channel) = args.default_channel {
-        config.set_default_channel(require_non_empty_setup_value(
-            "--default-channel",
-            default_channel,
-        )?);
-    }
-    if let Some(default_format) = args.default_format {
-        config.set_default_format(default_format);
-    }
-    if let Some(daemon_base_url) = args.daemon_base_url {
-        config.set_daemon_base_url(require_non_empty_setup_value(
-            "--daemon-base-url",
-            daemon_base_url,
-        )?);
-    }
-    Ok(())
-}
-
-fn require_non_empty_setup_value(flag: &str, value: String) -> Result<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        Err(format!("{flag} requires a non-empty value").into())
-    } else {
-        Ok(trimmed.to_string())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,18 +309,33 @@ fn apply_setup_args(config: &mut AppConfig, args: SetupArgs) -> Result<()> {
         config.scaffold_webhook_quickstart(webhook)?;
     }
     if let Some(bot_token) = args.bot_token {
-        config.set_discord_bot_token(bot_token);
+        config.set_discord_bot_token(require_non_empty_setup_value("--bot-token", bot_token)?);
     }
     if let Some(default_channel) = args.default_channel {
-        config.set_default_channel(default_channel);
+        config.set_default_channel(require_non_empty_setup_value(
+            "--default-channel",
+            default_channel,
+        )?);
     }
     if let Some(default_format) = args.default_format {
         config.set_default_format(default_format);
     }
     if let Some(daemon_base_url) = args.daemon_base_url {
-        config.set_daemon_base_url(daemon_base_url);
+        config.set_daemon_base_url(require_non_empty_setup_value(
+            "--daemon-base-url",
+            daemon_base_url,
+        )?);
     }
     Ok(())
+}
+
+fn require_non_empty_setup_value(flag: &str, value: String) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        Err(format!("{flag} requires a non-empty value").into())
+    } else {
+        Ok(trimmed.to_string())
+    }
 }
 
 async fn send_incoming_event(client: &DaemonClient, event: IncomingEvent) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ use clap::Parser;
 
 use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, CronCommands, GitCommands, GithubCommands,
-    HooksCommands, MemoryCommands, NativeCommands, OmxCommands, PluginCommands, TmuxCommands,
+    HooksCommands, MemoryCommands, NativeCommands, OmxCommands, PluginCommands, SetupArgs,
+    TmuxCommands,
 };
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
@@ -74,9 +75,9 @@ async fn real_main() -> Result<()> {
             let client = DaemonClient::from_config(config.as_ref());
             send_incoming_event(&client, args.into_event()?).await
         }
-        Commands::Setup { webhook } => {
+        Commands::Setup(args) => {
             let mut editable = AppConfig::load_or_default(&config_path)?;
-            editable.scaffold_webhook_quickstart(webhook);
+            apply_setup_args(&mut editable, args)?;
             editable.validate()?;
             editable.save(&config_path)?;
             println!("Saved {}", config_path.display());
@@ -301,6 +302,25 @@ async fn real_main() -> Result<()> {
         },
         Commands::EnableHook(args) => native_hooks::enable(args),
     }
+}
+
+fn apply_setup_args(config: &mut AppConfig, args: SetupArgs) -> Result<()> {
+    if let Some(webhook) = args.webhook {
+        config.scaffold_webhook_quickstart(webhook)?;
+    }
+    if let Some(bot_token) = args.bot_token {
+        config.set_discord_bot_token(bot_token);
+    }
+    if let Some(default_channel) = args.default_channel {
+        config.set_default_channel(default_channel);
+    }
+    if let Some(default_format) = args.default_format {
+        config.set_default_format(default_format);
+    }
+    if let Some(daemon_base_url) = args.daemon_base_url {
+        config.set_daemon_base_url(daemon_base_url);
+    }
+    Ok(())
 }
 
 async fn send_incoming_event(client: &DaemonClient, event: IncomingEvent) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ use crate::cli::{
     TmuxCommands,
 };
 use crate::client::DaemonClient;
-use crate::config::AppConfig;
+use crate::config::{AppConfig, SetupEdits};
 use crate::event::compat::from_incoming_event;
 use crate::events::IncomingEvent;
 
@@ -77,7 +77,13 @@ async fn real_main() -> Result<()> {
         }
         Commands::Setup(args) => {
             let mut editable = AppConfig::load_or_default(&config_path)?;
-            apply_setup_args(&mut editable, args)?;
+            editable.apply_setup_edits(SetupEdits {
+                webhook: args.webhook,
+                bot_token: args.bot_token,
+                default_channel: args.default_channel,
+                default_format: args.default_format,
+                daemon_base_url: args.daemon_base_url,
+            })?;
             editable.validate()?;
             editable.save(&config_path)?;
             println!("Saved {}", config_path.display());


### PR DESCRIPTION
## Summary
- expand `clawhip setup` to the approved five-preset contract
- bound `clawhip config` to the matching 8-item editor surface
- enforce canonical quickstart-route ownership semantics and document the workflow

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet setup_ -- --nocapture`
- `cargo test --quiet quickstart -- --nocapture`
- `cargo test --quiet config_editor_menu_matches_bounded_preset_contract -- --nocapture`

## Notes
- Full `cargo test --quiet` still has unrelated pre-existing failures in `omc::tests::hooks_installed_returns_false_for_empty_dir`, `omx::tests::hooks_installed_returns_false_for_empty_dir`, and `dispatch::tests::dispatcher_sends_bypass_events_immediately_while_routine_delivery_waits`.
