### PR TITLE
release: refresh Cargo.lock for 0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clawhip"
-version = "0.5.5"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary
- The 0.6.4 version bump in `Cargo.toml` left `Cargo.lock` pinned at `clawhip 0.5.5`
- `cargo publish --dry-run --locked` in the Release workflow (run 24226287914) failed with *"cannot update the lock file … because --locked was passed"*
- Fix: `cargo update -p clawhip` to sync the lock entry to 0.6.4

## Test plan
- [x] `cargo publish --dry-run --locked --package clawhip` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)