### PR TITLE
feat(provenance): add explain CLI and stop-event context enrichment (closes #188)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,6 +137,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: HooksCommands,
     },
+    /// Explain how an event would be routed without actually dispatching it.
+    ///
+    /// Shows which routes match, which filters pass/fail, and where the
+    /// event would be delivered — useful for debugging config.
+    Explain(ExplainArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -157,6 +162,32 @@ pub struct EmitArgs {
     pub event_type: String,
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub fields: Vec<String>,
+}
+
+/// Arguments for `clawhip explain`.
+///
+/// Mirrors `EmitArgs` so operators can explain the exact same event shape
+/// they would normally emit — with `--channel`, `--format`, `--payload` JSON,
+/// and ad-hoc `--key value` fields.
+#[derive(Debug, Clone, Args)]
+pub struct ExplainArgs {
+    /// Event type (canonical or alias, same as `clawhip emit`).
+    pub event_type: String,
+    /// Emit output as JSON instead of the human-readable text report.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub fields: Vec<String>,
+}
+
+impl ExplainArgs {
+    pub fn into_event(self) -> crate::Result<crate::events::IncomingEvent> {
+        EmitArgs {
+            event_type: self.event_type,
+            fields: self.fields,
+        }
+        .into_event()
+    }
 }
 
 #[derive(Debug, Clone, Default, Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod lifecycle;
 mod memory;
 mod native_hooks;
 mod plugins;
+mod provenance;
 mod render;
 mod router;
 mod sink;
@@ -28,8 +29,9 @@ use std::sync::Arc;
 use clap::Parser;
 
 use crate::cli::{
-    AgentCommands, Cli, Commands, ConfigCommand, CronCommands, GitCommands, GithubCommands,
-    HooksCommands, MemoryCommands, NativeCommands, PluginCommands, TmuxCommands, UpdateCommands,
+    AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs, GitCommands,
+    GithubCommands, HooksCommands, MemoryCommands, NativeCommands, PluginCommands, TmuxCommands,
+    UpdateCommands,
 };
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, SetupEdits};
@@ -74,6 +76,7 @@ async fn real_main() -> Result<()> {
             let client = DaemonClient::from_config(config.as_ref());
             send_incoming_event(&client, args.into_event()?).await
         }
+        Commands::Explain(args) => run_explain(config.as_ref(), args),
         Commands::Setup(args) => {
             let mut editable = AppConfig::load_or_default(&config_path)?;
             editable.apply_setup_edits(SetupEdits {
@@ -337,6 +340,24 @@ async fn real_main() -> Result<()> {
 async fn send_incoming_event(client: &DaemonClient, event: IncomingEvent) -> Result<()> {
     let event = prepare_event(event)?;
     client.send_event(&event).await
+}
+
+fn run_explain(config: &AppConfig, args: ExplainArgs) -> Result<()> {
+    let json_output = args.json;
+    // Only normalize the event (for canonical_kind / template_context), skip
+    // the strict typed-envelope validation that prepare_event does — explain
+    // must work even with partial payloads an operator types by hand.
+    let event = crate::events::normalize_event(args.into_event()?);
+    let router = router::Router::new(Arc::new(config.clone()));
+    let provenance = router.explain(&event);
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&provenance)?);
+    } else {
+        print!("{provenance}");
+    }
+
+    Ok(())
 }
 
 fn render_tmux_list(registrations: &[crate::source::RegisteredTmuxSession]) {

--- a/src/native_hooks.rs
+++ b/src/native_hooks.rs
@@ -304,6 +304,13 @@ pub fn incoming_event_from_native_hook_json(
             .or_else(|| payload.pointer("/event_payload/augmentation")),
     );
 
+    apply_stop_context(
+        &mut normalized,
+        payload
+            .get("stop_context")
+            .or_else(|| payload.pointer("/event_payload/stop_context")),
+    );
+
     Ok(crate::events::IncomingEvent {
         kind: canonical_kind.to_string(),
         channel: None,
@@ -518,6 +525,12 @@ function collectTmuxMetadata(input, cwd) {
   return Object.keys(direct).length > 0 ? direct : null;
 }
 
+function truncate(text, maxLen = 200) {
+  if (!text || typeof text !== 'string') return '';
+  const trimmed = text.trim();
+  return trimmed.length <= maxLen ? trimmed : trimmed.slice(0, maxLen) + '…';
+}
+
 function maybeWritePromptSubmitState(repoRoot, provider, eventName, input) {
   const normalizedEvent = String(eventName || '').trim().toLowerCase();
   if (
@@ -530,6 +543,7 @@ function maybeWritePromptSubmitState(repoRoot, provider, eventName, input) {
   }
 
   try {
+    const promptText = input.prompt || input.user_prompt || input.message || '';
     const path = join(repoRoot, '.clawhip', 'state', 'prompt-submit.json');
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, JSON.stringify({
@@ -538,7 +552,27 @@ function maybeWritePromptSubmitState(repoRoot, provider, eventName, input) {
       event_name: eventName,
       session_id: input.session_id || input.sessionId || null,
       turn_id: input.turn_id || input.turnId || null,
+      prompt_summary: truncate(promptText),
     }, null, 2) + '\n');
+  } catch {}
+}
+
+function maybeEnrichStopEvent(repoRoot, payload, eventName) {
+  const normalizedEvent = String(eventName || '').trim().toLowerCase();
+  if (normalizedEvent !== 'stop' && normalizedEvent !== 'sessionstop' && normalizedEvent !== 'session-stopped') {
+    return;
+  }
+  try {
+    const path = join(repoRoot, '.clawhip', 'state', 'prompt-submit.json');
+    if (!existsSync(path)) return;
+    const raw = readFileSync(path, 'utf8');
+    const state = parseJson(raw, null);
+    if (!state) return;
+    payload.stop_context = {
+      last_prompt_at: state.observed_at || null,
+      last_prompt_summary: state.prompt_summary || null,
+      last_turn_id: state.turn_id || null,
+    };
   } catch {}
 }
 
@@ -595,6 +629,7 @@ async function main() {
   }
 
   maybeWritePromptSubmitState(repoRoot, provider, eventName, input);
+  maybeEnrichStopEvent(repoRoot, payload, eventName);
 
   spawnSync('clawhip', ['native', 'hook', '--provider', provider], {
     input: JSON.stringify(payload),
@@ -751,6 +786,47 @@ fn apply_augmentation(payload: &mut Map<String, Value>, augmentation: Option<&Va
     }
 
     payload.insert("augmentation".into(), Value::Object(augmentation.clone()));
+}
+
+/// For stop events, propagate the last-prompt context into top-level fields
+/// so templates and renderers can reference them without digging into nested
+/// objects.
+fn apply_stop_context(payload: &mut Map<String, Value>, stop_context: Option<&Value>) {
+    let Some(stop_context) = stop_context.and_then(Value::as_object) else {
+        return;
+    };
+
+    if let Some(summary) = stop_context
+        .get("last_prompt_summary")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        if !payload.contains_key("summary") {
+            payload.insert("summary".into(), json!(summary));
+        }
+        payload.insert("last_prompt_summary".into(), json!(summary));
+    }
+
+    if let Some(at) = stop_context
+        .get("last_prompt_at")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        payload.insert("last_prompt_at".into(), json!(at));
+    }
+
+    if let Some(turn_id) = stop_context
+        .get("last_turn_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        payload.insert("last_turn_id".into(), json!(turn_id));
+    }
+
+    payload.insert("stop_context".into(), Value::Object(stop_context.clone()));
 }
 
 fn merge_object_like(payload: &mut Map<String, Value>, key: &str, incoming: Value) {
@@ -1048,5 +1124,86 @@ mod tests {
             Some(expected),
             "infer_repo_root should return the main repo, not the worktree"
         );
+    }
+
+    #[test]
+    fn stop_event_payload_surfaces_stop_context_summary() {
+        let event = incoming_event_from_native_hook_json(&json!({
+            "provider": "claude-code",
+            "directory": "/repo/clawhip",
+            "event_name": "Stop",
+            "stop_context": {
+                "last_prompt_at": "2026-04-10T12:34:56Z",
+                "last_prompt_summary": "wire up event provenance for issue 188",
+                "last_turn_id": "turn-99"
+            }
+        }))
+        .expect("event");
+
+        assert_eq!(event.kind, "session.stopped");
+        assert_eq!(
+            event.payload["last_prompt_summary"],
+            json!("wire up event provenance for issue 188")
+        );
+        assert_eq!(
+            event.payload["last_prompt_at"],
+            json!("2026-04-10T12:34:56Z")
+        );
+        assert_eq!(event.payload["last_turn_id"], json!("turn-99"));
+        // summary is backfilled from last_prompt_summary when absent, so the
+        // default renderer's inline/compact mode has something meaningful to show.
+        assert_eq!(
+            event.payload["summary"],
+            json!("wire up event provenance for issue 188")
+        );
+        // The original nested stop_context is retained for callers that want it.
+        assert!(event.payload["stop_context"].is_object());
+    }
+
+    #[test]
+    fn stop_event_without_stop_context_does_not_invent_summary() {
+        let event = incoming_event_from_native_hook_json(&json!({
+            "provider": "claude-code",
+            "directory": "/repo/clawhip",
+            "event_name": "Stop"
+        }))
+        .expect("event");
+
+        assert_eq!(event.kind, "session.stopped");
+        assert!(event.payload.get("stop_context").is_none());
+        assert!(event.payload.get("last_prompt_summary").is_none());
+        assert!(event.payload.get("summary").is_none());
+    }
+
+    #[test]
+    fn stop_event_respects_preexisting_summary_over_stop_context() {
+        let event = incoming_event_from_native_hook_json(&json!({
+            "provider": "claude-code",
+            "directory": "/repo/clawhip",
+            "event_name": "Stop",
+            "stop_context": {
+                "last_prompt_summary": "older prompt"
+            },
+            "augmentation": {
+                "summary": "explicit override"
+            }
+        }))
+        .expect("event");
+
+        // augmentation ran first and set summary; stop_context must not clobber it
+        assert_eq!(event.payload["summary"], json!("explicit override"));
+        // but the raw prompt context is still exposed for renderers that want it
+        assert_eq!(event.payload["last_prompt_summary"], json!("older prompt"));
+    }
+
+    #[test]
+    fn hook_script_saves_prompt_summary_and_enriches_stop_events() {
+        // Sanity-check the embedded JS hook script text so refactors of the
+        // string constant don't silently drop the stop-context plumbing.
+        let script = super::generated_hook_script();
+        assert!(script.contains("maybeEnrichStopEvent"));
+        assert!(script.contains("prompt_summary"));
+        assert!(script.contains("stop_context"));
+        assert!(script.contains("last_prompt_summary"));
     }
 }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -1,0 +1,260 @@
+//! Structured provenance for event routing decisions.
+//!
+//! A [`Provenance`] record explains *why* an event was (or was not) delivered
+//! to a given sink. Operators can ask for provenance via `clawhip explain` to
+//! answer questions like "what emitted this message?" and "why did this route
+//! fire?" without having to read the config by hand.
+
+use std::fmt;
+
+use serde::Serialize;
+
+/// Complete provenance trace for a routing decision on a single event.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Provenance {
+    /// Original event kind as submitted by the caller.
+    pub event_kind: String,
+    /// Canonical kind after normalization (what the router actually matches on).
+    pub canonical_kind: String,
+    /// Candidate route keys tried in order.
+    pub route_candidates: Vec<String>,
+    /// One entry per configured route describing why it matched or not.
+    pub routes: Vec<RouteExplanation>,
+    /// The concrete deliveries this event would produce, in dispatch order.
+    pub deliveries: Vec<DeliveryExplanation>,
+}
+
+/// Outcome of evaluating a single [`RouteRule`](crate::config::RouteRule) against an event.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RouteExplanation {
+    /// Zero-based index in `config.routes`.
+    pub route_index: usize,
+    /// The event pattern from the route rule (as written in config).
+    pub event_pattern: String,
+    /// Whether every condition (pattern + all filters) passed.
+    pub matched: bool,
+    /// Whether the event pattern alone matched the canonical kind.
+    pub pattern_matched: bool,
+    /// Per-filter match details. Empty when the route has no filters.
+    pub filter_results: Vec<FilterResult>,
+}
+
+/// Per-filter match detail.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FilterResult {
+    /// Filter key (e.g. `repo_name`, `branch`).
+    pub key: String,
+    /// Expected glob pattern from the route config.
+    pub pattern: String,
+    /// Actual value observed on the event, if any.
+    pub actual: Option<String>,
+    /// Whether the actual value matched the pattern.
+    pub matched: bool,
+}
+
+/// A delivery that would be produced by the dispatcher.
+///
+/// `matched_route_index == None` means the delivery came from the default
+/// fallback (no configured route matched the event).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DeliveryExplanation {
+    pub sink: String,
+    pub target: String,
+    pub channel: Option<String>,
+    pub format: String,
+    pub mention: Option<String>,
+    pub template: Option<String>,
+    pub matched_route_index: Option<usize>,
+}
+
+impl fmt::Display for Provenance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "event: {}", self.event_kind)?;
+        if self.canonical_kind != self.event_kind {
+            writeln!(f, "canonical: {}", self.canonical_kind)?;
+        }
+        writeln!(f, "route candidates: {}", self.route_candidates.join(", "))?;
+
+        if self.routes.is_empty() {
+            writeln!(f, "routes: (none configured)")?;
+        } else {
+            writeln!(f, "routes:")?;
+            for route in &self.routes {
+                writeln!(f, "  {}", route)?;
+            }
+        }
+
+        if self.deliveries.is_empty() {
+            writeln!(f, "deliveries: (none - event would be dropped)")?;
+        } else {
+            writeln!(f, "deliveries:")?;
+            for delivery in &self.deliveries {
+                writeln!(f, "  {}", delivery)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for RouteExplanation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let status = if self.matched { "MATCH" } else { "skip " };
+        write!(
+            f,
+            "[{status}] #{idx} event={pattern:?}",
+            idx = self.route_index,
+            pattern = self.event_pattern,
+        )?;
+        if !self.pattern_matched {
+            write!(f, " (pattern mismatch)")?;
+        }
+        for filter in &self.filter_results {
+            write!(f, " {filter}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for FilterResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let marker = if self.matched { "✓" } else { "✗" };
+        let actual = self
+            .actual
+            .as_deref()
+            .map(|v| format!("{v:?}"))
+            .unwrap_or_else(|| "<missing>".to_string());
+        write!(
+            f,
+            "{marker}{key}:{pattern:?}→{actual}",
+            key = self.key,
+            pattern = self.pattern,
+        )
+    }
+}
+
+impl fmt::Display for DeliveryExplanation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let route_tag = match self.matched_route_index {
+            Some(idx) => format!("route #{idx}"),
+            None => "default".to_string(),
+        };
+        write!(
+            f,
+            "[{route_tag}] {sink} → {target} (format={format}",
+            sink = self.sink,
+            target = self.target,
+            format = self.format,
+        )?;
+        if let Some(mention) = self.mention.as_deref() {
+            write!(f, ", mention={mention:?}")?;
+        }
+        if self.template.is_some() {
+            write!(f, ", template=custom")?;
+        }
+        write!(f, ")")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_provenance_renders_matched_and_skipped_routes() {
+        let provenance = Provenance {
+            event_kind: "git.commit".into(),
+            canonical_kind: "git.commit".into(),
+            route_candidates: vec!["git.commit".into(), "github.commit".into()],
+            routes: vec![
+                RouteExplanation {
+                    route_index: 0,
+                    event_pattern: "git.commit".into(),
+                    matched: true,
+                    pattern_matched: true,
+                    filter_results: vec![FilterResult {
+                        key: "repo_name".into(),
+                        pattern: "clawhip".into(),
+                        actual: Some("clawhip".into()),
+                        matched: true,
+                    }],
+                },
+                RouteExplanation {
+                    route_index: 1,
+                    event_pattern: "git.commit".into(),
+                    matched: false,
+                    pattern_matched: true,
+                    filter_results: vec![FilterResult {
+                        key: "branch".into(),
+                        pattern: "main".into(),
+                        actual: Some("feature".into()),
+                        matched: false,
+                    }],
+                },
+            ],
+            deliveries: vec![DeliveryExplanation {
+                sink: "discord".into(),
+                target: "DiscordChannel(\"commits\")".into(),
+                channel: Some("commits".into()),
+                format: "compact".into(),
+                mention: Some("@devs".into()),
+                template: None,
+                matched_route_index: Some(0),
+            }],
+        };
+
+        let output = provenance.to_string();
+        assert!(output.contains("event: git.commit"));
+        assert!(output.contains("route candidates: git.commit, github.commit"));
+        assert!(output.contains("[MATCH] #0"));
+        assert!(output.contains("[skip ] #1"));
+        assert!(output.contains("✓repo_name"));
+        assert!(output.contains("✗branch"));
+        assert!(output.contains("[route #0] discord"));
+        assert!(output.contains("@devs"));
+    }
+
+    #[test]
+    fn display_notes_when_no_deliveries_would_fire() {
+        let provenance = Provenance {
+            event_kind: "custom".into(),
+            canonical_kind: "custom".into(),
+            route_candidates: vec!["custom".into()],
+            routes: vec![],
+            deliveries: vec![],
+        };
+
+        let output = provenance.to_string();
+        assert!(output.contains("routes: (none configured)"));
+        assert!(output.contains("deliveries: (none - event would be dropped)"));
+    }
+
+    #[test]
+    fn display_marks_default_fallback_delivery() {
+        let provenance = Provenance {
+            event_kind: "custom".into(),
+            canonical_kind: "custom".into(),
+            route_candidates: vec!["custom".into()],
+            routes: vec![RouteExplanation {
+                route_index: 0,
+                event_pattern: "github.*".into(),
+                matched: false,
+                pattern_matched: false,
+                filter_results: vec![],
+            }],
+            deliveries: vec![DeliveryExplanation {
+                sink: "discord".into(),
+                target: "DiscordChannel(\"fallback\")".into(),
+                channel: Some("fallback".into()),
+                format: "alert".into(),
+                mention: None,
+                template: None,
+                matched_route_index: None,
+            }],
+        };
+
+        let output = provenance.to_string();
+        assert!(output.contains("(pattern mismatch)"));
+        assert!(output.contains("[default] discord"));
+    }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -6,6 +6,9 @@ use crate::Result;
 use crate::config::{AppConfig, RouteRule, default_sink_name};
 use crate::dynamic_tokens;
 use crate::events::{IncomingEvent, MessageFormat, RoutingMetadata};
+use crate::provenance::{
+    DeliveryExplanation, FilterResult, Provenance, RouteExplanation,
+};
 #[cfg(test)]
 use crate::render::DefaultRenderer;
 use crate::render::Renderer;
@@ -188,6 +191,88 @@ impl Router {
         matching_routes_for(&self.config.routes, event.canonical_kind(), &context)
     }
 
+    /// Produce a full provenance trace explaining how an event would be routed.
+    ///
+    /// Unlike [`resolve`](Self::resolve) this evaluates *every* configured route
+    /// and returns detailed match/mismatch reasons, so operators can answer
+    /// "what emitted this message and why".
+    pub fn explain(&self, event: &IncomingEvent) -> Provenance {
+        let canonical_kind = event.canonical_kind().to_string();
+        let context = event.template_context();
+        let candidates: Vec<String> = route_candidates(&canonical_kind)
+            .into_iter()
+            .map(String::from)
+            .collect();
+
+        let mut route_explanations = Vec::with_capacity(self.config.routes.len());
+        let mut matched_indices = Vec::new();
+
+        for (index, route) in self.config.routes.iter().enumerate() {
+            let pattern_matched = candidates
+                .iter()
+                .any(|candidate| glob_match(&route.event, candidate));
+
+            let filter_results: Vec<FilterResult> = route
+                .filter
+                .iter()
+                .map(|(key, expected)| {
+                    let actual = context.get(key).cloned();
+                    let matched = actual
+                        .as_ref()
+                        .map(|a| glob_match(expected, a))
+                        .unwrap_or(false);
+                    FilterResult {
+                        key: key.clone(),
+                        pattern: expected.clone(),
+                        actual,
+                        matched,
+                    }
+                })
+                .collect();
+
+            let all_filters_match =
+                filter_results.is_empty() || filter_results.iter().all(|f| f.matched);
+            let matched = pattern_matched && all_filters_match;
+
+            if matched {
+                matched_indices.push(index);
+            }
+
+            route_explanations.push(RouteExplanation {
+                route_index: index,
+                event_pattern: route.event.clone(),
+                matched,
+                pattern_matched,
+                filter_results,
+            });
+        }
+
+        let deliveries = if matched_indices.is_empty() {
+            match self.resolve_delivery(event, None) {
+                Ok(d) => vec![delivery_explanation(&d, None)],
+                Err(_) => vec![],
+            }
+        } else {
+            matched_indices
+                .iter()
+                .filter_map(|&idx| {
+                    let route = &self.config.routes[idx];
+                    self.resolve_delivery(event, Some(route))
+                        .ok()
+                        .map(|d| delivery_explanation(&d, Some(idx)))
+                })
+                .collect()
+        };
+
+        Provenance {
+            event_kind: event.kind.clone(),
+            canonical_kind,
+            route_candidates: candidates,
+            routes: route_explanations,
+            deliveries,
+        }
+    }
+
     fn target_for(
         &self,
         event: &IncomingEvent,
@@ -301,6 +386,30 @@ pub(crate) fn resolve_tmux_session_channel_with_metadata(
     }
 
     config.defaults.channel.clone()
+}
+
+fn delivery_explanation(
+    delivery: &ResolvedDelivery,
+    matched_route_index: Option<usize>,
+) -> DeliveryExplanation {
+    let (target_label, channel) = match &delivery.target {
+        SinkTarget::DiscordChannel(name) => (
+            format!("DiscordChannel({name:?})"),
+            Some(name.clone()),
+        ),
+        SinkTarget::DiscordWebhook(url) => (format!("DiscordWebhook({url})"), None),
+        SinkTarget::SlackWebhook(url) => (format!("SlackWebhook({url})"), None),
+    };
+
+    DeliveryExplanation {
+        sink: delivery.sink.clone(),
+        target: target_label,
+        channel,
+        format: delivery.format.as_str().to_string(),
+        mention: delivery.mention.clone(),
+        template: delivery.template.clone(),
+        matched_route_index,
+    }
 }
 
 fn route_candidates(kind: &str) -> Vec<&str> {
@@ -1927,5 +2036,214 @@ mod tests {
             .unwrap();
         assert!(request.contains("\"text\":\"hello from clawhip\""));
         assert!(request.contains("\"blocks\""));
+    }
+
+    // ── explain / provenance ─────────────────────────────────────
+
+    #[test]
+    fn explain_shows_matched_route_with_filter_details() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "git.commit".into(),
+                sink: "discord".into(),
+                filter: BTreeMap::from([("repo_name".into(), "clawhip".into())]),
+                channel: Some("commits".into()),
+                mention: Some("@devs".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event =
+            IncomingEvent::git_commit("clawhip".into(), "main".into(), "abc123".into(), "ship it".into(), None);
+
+        let provenance = router.explain(&event);
+
+        assert_eq!(provenance.canonical_kind, "git.commit");
+        assert!(provenance.route_candidates.contains(&"git.commit".to_string()));
+        assert_eq!(provenance.routes.len(), 1);
+        assert!(provenance.routes[0].matched);
+        assert!(provenance.routes[0].pattern_matched);
+        assert_eq!(provenance.routes[0].filter_results.len(), 1);
+        assert!(provenance.routes[0].filter_results[0].matched);
+        assert_eq!(provenance.routes[0].filter_results[0].key, "repo_name");
+        assert_eq!(
+            provenance.routes[0].filter_results[0].actual.as_deref(),
+            Some("clawhip")
+        );
+        assert_eq!(provenance.deliveries.len(), 1);
+        assert_eq!(provenance.deliveries[0].matched_route_index, Some(0));
+        assert_eq!(provenance.deliveries[0].sink, "discord");
+        assert_eq!(provenance.deliveries[0].channel.as_deref(), Some("commits"));
+    }
+
+    #[test]
+    fn explain_reports_filter_mismatch() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "git.commit".into(),
+                sink: "discord".into(),
+                filter: BTreeMap::from([("branch".into(), "main".into())]),
+                channel: Some("commits".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::git_commit(
+            "clawhip".into(),
+            "feature".into(),
+            "abc123".into(),
+            "wip".into(),
+            None,
+        );
+
+        let provenance = router.explain(&event);
+
+        assert_eq!(provenance.routes.len(), 1);
+        assert!(!provenance.routes[0].matched);
+        assert!(provenance.routes[0].pattern_matched);
+        assert!(!provenance.routes[0].filter_results[0].matched);
+        assert_eq!(
+            provenance.routes[0].filter_results[0].actual.as_deref(),
+            Some("feature")
+        );
+        // Falls through to default
+        assert_eq!(provenance.deliveries.len(), 1);
+        assert_eq!(provenance.deliveries[0].matched_route_index, None);
+        assert_eq!(provenance.deliveries[0].channel.as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn explain_pattern_mismatch_skips_route() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("fallback".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "github.*".into(),
+                sink: "discord".into(),
+                channel: Some("github".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::tmux_keyword(
+            "dev".into(),
+            "error".into(),
+            "segfault".into(),
+            None,
+        );
+
+        let provenance = router.explain(&event);
+
+        assert_eq!(provenance.routes.len(), 1);
+        assert!(!provenance.routes[0].matched);
+        assert!(!provenance.routes[0].pattern_matched);
+        assert_eq!(provenance.deliveries[0].matched_route_index, None);
+    }
+
+    #[test]
+    fn explain_multi_route_match_produces_multiple_deliveries() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![
+                RouteRule {
+                    event: "tmux.keyword".into(),
+                    sink: "discord".into(),
+                    channel: Some("ops".into()),
+                    mention: Some("@ops".into()),
+                    format: Some(MessageFormat::Alert),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "tmux.*".into(),
+                    sink: "discord".into(),
+                    channel: Some("eng".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event =
+            IncomingEvent::tmux_keyword("issue-42".into(), "error".into(), "boom".into(), None);
+
+        let provenance = router.explain(&event);
+
+        assert_eq!(provenance.routes.len(), 2);
+        assert!(provenance.routes[0].matched);
+        assert!(provenance.routes[1].matched);
+        assert_eq!(provenance.deliveries.len(), 2);
+        assert_eq!(provenance.deliveries[0].matched_route_index, Some(0));
+        assert_eq!(provenance.deliveries[0].channel.as_deref(), Some("ops"));
+        assert_eq!(provenance.deliveries[1].matched_route_index, Some(1));
+        assert_eq!(provenance.deliveries[1].channel.as_deref(), Some("eng"));
+    }
+
+    #[test]
+    fn explain_no_routes_and_no_default_produces_empty_deliveries() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: None,
+                format: MessageFormat::Compact,
+            },
+            routes: vec![],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::custom(None, "orphan".into());
+
+        let provenance = router.explain(&event);
+
+        assert!(provenance.routes.is_empty());
+        assert!(provenance.deliveries.is_empty());
+    }
+
+    #[test]
+    fn explain_json_serialization_roundtrips() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("general".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "git.commit".into(),
+                sink: "discord".into(),
+                channel: Some("commits".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::git_commit(
+            "repo".into(),
+            "main".into(),
+            "abc".into(),
+            "msg".into(),
+            None,
+        );
+
+        let provenance = router.explain(&event);
+        let json = serde_json::to_string(&provenance).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["canonical_kind"], "git.commit");
+        assert!(parsed["routes"].is_array());
+        assert!(parsed["deliveries"].is_array());
+        assert_eq!(parsed["deliveries"][0]["sink"], "discord");
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -6,9 +6,7 @@ use crate::Result;
 use crate::config::{AppConfig, RouteRule, default_sink_name};
 use crate::dynamic_tokens;
 use crate::events::{IncomingEvent, MessageFormat, RoutingMetadata};
-use crate::provenance::{
-    DeliveryExplanation, FilterResult, Provenance, RouteExplanation,
-};
+use crate::provenance::{DeliveryExplanation, FilterResult, Provenance, RouteExplanation};
 #[cfg(test)]
 use crate::render::DefaultRenderer;
 use crate::render::Renderer;
@@ -393,10 +391,9 @@ fn delivery_explanation(
     matched_route_index: Option<usize>,
 ) -> DeliveryExplanation {
     let (target_label, channel) = match &delivery.target {
-        SinkTarget::DiscordChannel(name) => (
-            format!("DiscordChannel({name:?})"),
-            Some(name.clone()),
-        ),
+        SinkTarget::DiscordChannel(name) => {
+            (format!("DiscordChannel({name:?})"), Some(name.clone()))
+        }
         SinkTarget::DiscordWebhook(url) => (format!("DiscordWebhook({url})"), None),
         SinkTarget::SlackWebhook(url) => (format!("SlackWebhook({url})"), None),
     };
@@ -2058,13 +2055,22 @@ mod tests {
             ..AppConfig::default()
         };
         let router = Router::new(Arc::new(config));
-        let event =
-            IncomingEvent::git_commit("clawhip".into(), "main".into(), "abc123".into(), "ship it".into(), None);
+        let event = IncomingEvent::git_commit(
+            "clawhip".into(),
+            "main".into(),
+            "abc123".into(),
+            "ship it".into(),
+            None,
+        );
 
         let provenance = router.explain(&event);
 
         assert_eq!(provenance.canonical_kind, "git.commit");
-        assert!(provenance.route_candidates.contains(&"git.commit".to_string()));
+        assert!(
+            provenance
+                .route_candidates
+                .contains(&"git.commit".to_string())
+        );
         assert_eq!(provenance.routes.len(), 1);
         assert!(provenance.routes[0].matched);
         assert!(provenance.routes[0].pattern_matched);
@@ -2138,12 +2144,8 @@ mod tests {
             ..AppConfig::default()
         };
         let router = Router::new(Arc::new(config));
-        let event = IncomingEvent::tmux_keyword(
-            "dev".into(),
-            "error".into(),
-            "segfault".into(),
-            None,
-        );
+        let event =
+            IncomingEvent::tmux_keyword("dev".into(), "error".into(), "segfault".into(), None);
 
         let provenance = router.explain(&event);
 


### PR DESCRIPTION
## Summary

Delivers the first concrete event provenance surface for clawhip so operators can answer "what emitted this message and why" without reading config by hand, plus the owner add-on: carry recent prompt context into native Claude/Codex `Stop` hook events.

Closes #188.

## What's in the slice

### Explain surface

- **New `src/provenance.rs` module** — `Provenance`, `RouteExplanation`, `FilterResult`, `DeliveryExplanation`, all serde-serializable, plus a human-readable `Display` impl (`MATCH` / `skip` markers, per-filter `✓`/`✗` annotations, default-fallback labeling).
- **`Router::explain(&event)`** — evaluates *every* configured route (not just the first match), records why each matched or didn't, then produces the exact deliveries the dispatcher would emit (including the default fallback when nothing matches). Pure read-only — no actual dispatch happens.
- **`clawhip explain <event-type> [--json] [--key value ...]`** — reuses the `emit` field parser so operators describe the same event shape they'd normally send. `--json` emits the structured record; otherwise a compact text report. Deliberately skips strict typed-envelope validation so partial, hand-typed payloads still produce a trace.

Example output on a config with a filtered `git.commit` route:

```
$ clawhip explain git.commit -- --repo clawhip --branch main --commit abc --summary "ship it"
event: git.commit
route candidates: git.commit, github.commit
routes:
  [MATCH] #0 event="git.commit" ✓repo_name:"clawhip"→"clawhip"
  [skip ] #1 event="tmux.*" (pattern mismatch)
deliveries:
  [route #0] discord → DiscordChannel("commits") (format=compact, mention="@devs")
```

And with a wrong repo, the filter failure and default fallback are both visible:

```
routes:
  [skip ] #0 event="git.commit" ✗repo_name:"clawhip"→"other"
  [skip ] #1 event="tmux.*" (pattern mismatch)
deliveries:
  [default] discord → DiscordChannel("fallback") (format=compact)
```

### Stop-event context add-on (from the owner follow-up)

- **Hook script** now persists `prompt_summary` (truncated) in `.clawhip/state/prompt-submit.json` on every `UserPromptSubmit`, and a new `maybeEnrichStopEvent` helper reads that state back on `Stop` events and attaches it as `stop_context` on the forwarded payload.
- **Rust `apply_stop_context`** promotes `last_prompt_at`, `last_prompt_summary`, `last_turn_id` to top-level payload fields on `session.stopped` events, backfilling `summary` only when not already set by augmentation — so renderers and templates can show what the session was working on without reopening the pane.

Net effect: a Discord stop notification for a Claude Code session carries the last prompt summary as `summary`, which the existing default renderer already surfaces. No route or config changes needed on the operator side.

## Test plan

All new logic is covered by unit tests in the three touched modules. The full `cargo test` suite has two pre-existing timing/network-flaky tests (`dispatcher_sends_bypass_events_immediately_while_routine_delivery_waits`, `direct_workflow_runs_skip_run_ids_already_seen_from_pr_checks`) that both pass in isolation and are unrelated to this change.

- [x] `cargo check` — clean
- [x] `cargo test router::tests::explain` — 6/6 pass
- [x] `cargo test provenance` — 3/3 pass
- [x] `cargo test native_hooks` — 12/12 pass (4 new)
- [x] Smoke-tested `clawhip explain` CLI end-to-end against a config with matched + mismatched routes and `--json` output
- [ ] Follow-up on CI: fix the two flaky dispatcher/github tests (separate concern — not touched by this PR)

## Follow-ups intentionally out of scope

- **Daemon-side persisted provenance**: the dispatcher currently logs errors but doesn't persist per-delivery provenance records. A natural next slice is to emit `Provenance` into a small in-memory ring buffer and expose it via `/debug/provenance` on the HTTP server so live deliveries can be inspected, not just dry-runs.
- **Richer stop context**: we only carry `last_prompt_summary` right now. A later slice could also plumb through tool-use counts, elapsed time, and the most recent tool error if present — the `stop_context` object is the right place for all of that.
- **Explain from live events**: `clawhip explain` currently takes ad-hoc args; a `--from-stdin` mode that accepts a JSON event blob would let operators pipe a failing event from logs straight into `explain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)