### PR TITLE
fix(tmux): stop false-negative SIGKILL after successful session launch (closes #194)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -530,6 +530,11 @@ pub struct TmuxNewArgs {
     pub format: Option<TmuxWrapperFormat>,
     #[arg(long, default_value_t = false)]
     pub attach: bool,
+    /// Keep the wrapper process alive to monitor the session in-process
+    /// (tighter 1 s polling). Without this flag the wrapper exits after
+    /// successful launch and the daemon takes over monitoring.
+    #[arg(long, default_value_t = false)]
+    pub follow: bool,
     #[arg(long, default_value_t = true, action = ArgAction::Set)]
     pub retry_enter: bool,
     #[arg(long, default_value_t = DEFAULT_RETRY_ENTER_COUNT)]
@@ -1063,6 +1068,55 @@ mod tests {
         assert_eq!(args.retry_enter_count, 6);
         assert_eq!(args.retry_enter_delay_ms, 400);
         assert_eq!(args.command, vec!["codex"]);
+    }
+
+    #[test]
+    fn tmux_new_defaults_to_non_follow_mode_for_194() {
+        // Regression for #194: the default launcher path MUST return control
+        // to the caller after the session is created. If `follow` defaulted
+        // back to true, `clawhip tmux new` would once again block for the
+        // session lifetime and expose callers to false-negative SIGKILL.
+        let cli = Cli::parse_from([
+            "clawhip",
+            "tmux",
+            "new",
+            "-s",
+            "issue-194",
+            "--",
+            "codex",
+        ]);
+
+        let Commands::Tmux { command } = cli.command.expect("tmux command") else {
+            panic!("expected tmux command");
+        };
+        let TmuxCommands::New(args) = command else {
+            panic!("expected tmux new command");
+        };
+
+        assert!(!args.follow, "follow must default to false after #194");
+    }
+
+    #[test]
+    fn parses_tmux_new_with_explicit_follow_flag() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "tmux",
+            "new",
+            "-s",
+            "issue-194",
+            "--follow",
+            "--",
+            "codex",
+        ]);
+
+        let Commands::Tmux { command } = cli.command.expect("tmux command") else {
+            panic!("expected tmux command");
+        };
+        let TmuxCommands::New(args) = command else {
+            panic!("expected tmux new command");
+        };
+
+        assert!(args.follow);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1076,15 +1076,7 @@ mod tests {
         // to the caller after the session is created. If `follow` defaulted
         // back to true, `clawhip tmux new` would once again block for the
         // session lifetime and expose callers to false-negative SIGKILL.
-        let cli = Cli::parse_from([
-            "clawhip",
-            "tmux",
-            "new",
-            "-s",
-            "issue-194",
-            "--",
-            "codex",
-        ]);
+        let cli = Cli::parse_from(["clawhip", "tmux", "new", "-s", "issue-194", "--", "codex"]);
 
         let Commands::Tmux { command } = cli.command.expect("tmux command") else {
             panic!("expected tmux command");

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -778,8 +778,15 @@ mod tests {
                     .send(String::from_utf8_lossy(&buf[..n]).to_string())
                     .await
                     .unwrap();
+                // connection: close prevents reqwest's default keep-alive
+                // from reusing the TCP stream. The collector calls accept()
+                // per request, so pooling the connection causes the 2nd
+                // request under load to hit a dead stream and the collector
+                // to hang on accept() forever (flake root-cause, see #194).
                 stream
-                    .write_all(b"HTTP/1.1 204 No Content\r\ncontent-length: 0\r\n\r\n")
+                    .write_all(
+                        b"HTTP/1.1 204 No Content\r\nconnection: close\r\ncontent-length: 0\r\n\r\n",
+                    )
                     .await
                     .unwrap();
             }

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1070,8 +1070,12 @@ mod tests {
                 let mut buf = vec![0_u8; 4096];
                 let n = stream.read(&mut buf).await.unwrap();
                 requests.push(String::from_utf8_lossy(&buf[..n]).to_string());
+                // connection: close prevents reqwest from reusing the TCP
+                // stream — the mock server calls accept() per request, so
+                // keep-alive pooling causes the 2nd request to go to a dead
+                // connection under load (flake root-cause, see #194).
                 let response = format!(
-                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{}",
                     body.len(),
                     body
                 );

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -19,13 +19,19 @@ use crate::source::tmux::{
 pub async fn run(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
     launch_session(&args).await?;
     let monitor_args = TmuxMonitorArgs::from_new_args(&args, config);
-    let monitor = register_and_start_monitor(monitor_args, config).await?;
 
-    if args.attach {
-        attach_session(&args.session).await?;
+    if args.follow {
+        let monitor = register_and_start_monitor(monitor_args, config).await?;
+        if args.attach {
+            attach_session(&args.session).await?;
+        }
+        monitor.await??;
+    } else {
+        register_for_daemon_monitoring(monitor_args, config).await?;
+        if args.attach {
+            attach_session(&args.session).await?;
+        }
     }
-
-    monitor.await??;
     Ok(())
 }
 
@@ -104,21 +110,21 @@ impl From<&TmuxWatchArgs> for TmuxMonitorArgs {
     }
 }
 
-impl From<TmuxMonitorArgs> for RegisteredTmuxSession {
-    fn from(value: TmuxMonitorArgs) -> Self {
-        Self {
-            session: value.session,
-            channel: value.channel,
-            mention: value.mention,
-            routing: value.routing,
-            keywords: value.keywords,
-            keyword_window_secs: value.keyword_window_secs,
-            stale_minutes: value.stale_minutes,
-            format: value.format.map(Into::into),
-            registered_at: value.registered_at,
-            registration_source: value.registration_source,
-            parent_process: value.parent_process,
-            active_wrapper_monitor: true,
+impl TmuxMonitorArgs {
+    fn into_registration(self, active_wrapper_monitor: bool) -> RegisteredTmuxSession {
+        RegisteredTmuxSession {
+            session: self.session,
+            channel: self.channel,
+            mention: self.mention,
+            routing: self.routing,
+            keywords: self.keywords,
+            keyword_window_secs: self.keyword_window_secs,
+            stale_minutes: self.stale_minutes,
+            format: self.format.map(Into::into),
+            registered_at: self.registered_at,
+            registration_source: self.registration_source,
+            parent_process: self.parent_process,
+            active_wrapper_monitor,
         }
     }
 }
@@ -217,7 +223,7 @@ async fn register_and_start_monitor(
     config: &AppConfig,
 ) -> Result<tokio::task::JoinHandle<Result<()>>> {
     let client = DaemonClient::from_config(config);
-    let registration: RegisteredTmuxSession = args.into();
+    let registration = args.into_registration(true);
     eprintln!("{}", format_watch_audit_log(&registration));
     client.register_tmux(&registration).await?;
 
@@ -225,6 +231,24 @@ async fn register_and_start_monitor(
     Ok(tokio::spawn(async move {
         monitor_registered_session(registration, monitor_client).await
     }))
+}
+
+/// Register the freshly-launched tmux session so the daemon's own poll loop
+/// takes over monitoring, then return without blocking. This is the default
+/// path for `clawhip tmux new`: callers see the wrapper exit with success as
+/// soon as the session exists and is registered, instead of the wrapper
+/// staying alive for the entire session lifetime and exposing the caller to
+/// false-negative SIGKILL surfaces when the launcher/supervisor later kills
+/// it (issue #194).
+async fn register_for_daemon_monitoring(
+    args: TmuxMonitorArgs,
+    config: &AppConfig,
+) -> Result<()> {
+    let client = DaemonClient::from_config(config);
+    let registration = args.into_registration(false);
+    eprintln!("{}", format_watch_audit_log(&registration));
+    client.register_tmux(&registration).await?;
+    Ok(())
 }
 
 async fn launch_session(args: &TmuxNewArgs) -> Result<()> {
@@ -493,6 +517,7 @@ mod tests {
             stale_minutes: 10,
             format: None,
             attach: false,
+            follow: false,
             retry_enter: true,
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
@@ -522,6 +547,7 @@ mod tests {
             stale_minutes: 10,
             format: None,
             attach: false,
+            follow: false,
             retry_enter: true,
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
@@ -547,6 +573,7 @@ mod tests {
             stale_minutes: 10,
             format: None,
             attach: false,
+            follow: false,
             retry_enter: true,
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
@@ -593,7 +620,7 @@ mod tests {
 
     #[test]
     fn registered_tmux_session_from_monitor_args_keeps_audit_metadata() {
-        let registration: RegisteredTmuxSession = TmuxMonitorArgs {
+        let registration = TmuxMonitorArgs {
             session: "issue-105".into(),
             channel: Some("alerts".into()),
             mention: None,
@@ -609,7 +636,7 @@ mod tests {
                 name: Some("bash".into()),
             }),
         }
-        .into();
+        .into_registration(true);
 
         assert_eq!(registration.registered_at, "2026-04-02T00:00:00Z");
         assert!(matches!(
@@ -617,6 +644,40 @@ mod tests {
             RegistrationSource::CliNew
         ));
         assert_eq!(registration.parent_process.unwrap().pid, 99);
+        assert!(
+            registration.active_wrapper_monitor,
+            "into_registration(true) should mark the session as wrapper-monitored"
+        );
+    }
+
+    #[test]
+    fn into_registration_false_lets_daemon_take_over_monitoring() {
+        // Regression for #194: when --follow is not set, clawhip tmux new
+        // exits right after launch and hands off monitoring to the daemon.
+        // The registration MUST report active_wrapper_monitor=false so the
+        // daemon's poll_tmux loop picks it up instead of skipping it as a
+        // wrapper-owned session.
+        let registration = TmuxMonitorArgs {
+            session: "issue-194".into(),
+            channel: Some("alerts".into()),
+            mention: None,
+            routing: RoutingMetadata::default(),
+            keywords: vec!["error".into()],
+            keyword_window_secs: 30,
+            stale_minutes: 10,
+            format: None,
+            registered_at: "2026-04-10T00:00:00Z".into(),
+            registration_source: RegistrationSource::CliNew,
+            parent_process: None,
+        }
+        .into_registration(false);
+
+        assert!(
+            !registration.active_wrapper_monitor,
+            "follow=false path must register with active_wrapper_monitor=false \
+             so the daemon resumes monitoring after the wrapper exits"
+        );
+        assert_eq!(registration.session, "issue-194");
     }
 
     #[test]
@@ -662,6 +723,7 @@ mod tests {
             stale_minutes: 10,
             format: None,
             attach: false,
+            follow: false,
             retry_enter: true,
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
@@ -706,6 +768,7 @@ mod tests {
             stale_minutes: 10,
             format: None,
             attach: false,
+            follow: false,
             retry_enter: true,
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
@@ -764,6 +827,7 @@ mod tests {
             stale_minutes: 10,
             format: None,
             attach: false,
+            follow: false,
             retry_enter: true,
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -240,10 +240,7 @@ async fn register_and_start_monitor(
 /// staying alive for the entire session lifetime and exposing the caller to
 /// false-negative SIGKILL surfaces when the launcher/supervisor later kills
 /// it (issue #194).
-async fn register_for_daemon_monitoring(
-    args: TmuxMonitorArgs,
-    config: &AppConfig,
-) -> Result<()> {
+async fn register_for_daemon_monitoring(args: TmuxMonitorArgs, config: &AppConfig) -> Result<()> {
     let client = DaemonClient::from_config(config);
     let registration = args.into_registration(false);
     eprintln!("{}", format_watch_audit_log(&registration));


### PR DESCRIPTION
## Summary

- `clawhip tmux new` now exits with success immediately after creating the tmux session and registering it with the daemon, instead of blocking for the entire session lifetime
- Registration uses `active_wrapper_monitor=false` so the daemon's `TmuxSource::poll_tmux` loop takes over monitoring — no orphaned sessions if the wrapper is killed
- New `--follow` flag preserves the old in-wrapper monitor (1s polling) for users who want it

## Root cause

`tmux_wrapper::run()` awaited a long-lived monitor task (`monitor.await??`) after successful session creation. Callers that spawned `clawhip tmux new` as a launcher either hung forever or got SIGKILL'd after session creation, surfacing false "Exec failed ... signal SIGKILL" launch failures. The wrapper also registered with `active_wrapper_monitor: true`, so when the wrapper died, the daemon skipped monitoring that session entirely.

## Changes

- **`src/cli.rs`**: Add `--follow` flag to `TmuxNewArgs` (default `false`) + 2 parser tests
- **`src/tmux_wrapper.rs`**: Split `run()` into follow vs. exit-after-launch paths; add `register_for_daemon_monitoring()` for the default path; refactor `into_registration(bool)` to accept explicit `active_wrapper_monitor` flag + regression test

## Test plan

- [x] `tmux_new_defaults_to_non_follow_mode_for_194` — asserts `follow` defaults to `false`
- [x] `parses_tmux_new_with_explicit_follow_flag` — asserts `--follow` parses correctly
- [x] `into_registration_false_lets_daemon_take_over_monitoring` — asserts `active_wrapper_monitor=false` when follow is off
- [x] `registered_tmux_session_from_monitor_args_keeps_audit_metadata` — existing test updated, confirms `active_wrapper_monitor=true` when follow is on
- [x] All 14 tmux_wrapper tests pass; 355/357 total (2 pre-existing flaky dispatch timeout tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)