### PR TITLE
docs(pr-flow): add internal PR format gate helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@ Expected install path:
 Use:
 - `docs/live-verification.md`
 - `scripts/live-verify-default-presets.sh`
+- `scripts/internal-pr-format-gate.sh` for cheap local format gating before internal PR create/update flows
 
 Required live sign-off presets:
 - issue opened
@@ -818,3 +819,19 @@ clawhip native hook ... # provider-native hook thin client
 clawhip tmux ...        # thin client / wrapper surface
 clawhip plugin list     # list installed/bundled shell-hook plugins
 ```
+
+## Internal PR fast-path
+
+Before opening or updating an internal PR from a Rust worktree, run:
+
+```bash
+scripts/internal-pr-format-gate.sh
+```
+
+If you already know the tree just needs formatting, auto-fix first:
+
+```bash
+scripts/internal-pr-format-gate.sh --fix
+```
+
+This catches the cheapest class of red CI (`cargo fmt` only) locally before PR create/update churn.

--- a/scripts/internal-pr-format-gate.sh
+++ b/scripts/internal-pr-format-gate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/internal-pr-format-gate.sh
+  scripts/internal-pr-format-gate.sh --fix
+
+Purpose:
+  Cheap local guard for internal Rust PR flows. Refuses to continue when
+  formatting is dirty, so format-only CI failures are caught before PR
+  create/update churn.
+
+Behavior:
+  - default: runs `cargo fmt --all -- --check`
+  - --fix: runs `cargo fmt --all`, then re-checks
+USAGE
+}
+
+fix=0
+case "${1:-}" in
+  "") ;;
+  --fix) fix=1 ;;
+  -h|--help) usage; exit 0 ;;
+  *)
+    echo "unknown arg: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo not found on PATH" >&2
+  exit 1
+fi
+
+if [ ! -f Cargo.toml ]; then
+  echo "Cargo.toml not found in $(pwd); run this from a Rust repo root/worktree" >&2
+  exit 1
+fi
+
+if [ "$fix" -eq 1 ]; then
+  echo "[clawhip] auto-fixing format with cargo fmt --all"
+  cargo fmt --all
+fi
+
+if cargo fmt --all -- --check; then
+  echo "[clawhip] format gate passed"
+  exit 0
+fi
+
+cat >&2 <<'MSG'
+[clawhip] format gate failed
+- Run: cargo fmt --all
+- Re-run: scripts/internal-pr-format-gate.sh
+- Or auto-fix: scripts/internal-pr-format-gate.sh --fix
+Refusing to continue internal PR flow with a known format-only red CI path.
+MSG
+exit 1


### PR DESCRIPTION
## Summary
- add a cheap local helper script for internal Rust PR flows that runs `cargo fmt --all -- --check` before PR create/update churn
- support `--fix` for the common format-only red CI case
- document the helper in the README internal PR fast-path

## Verification
- scripts/internal-pr-format-gate.sh --help
- scripts/internal-pr-format-gate.sh

Closes #204