### PR TITLE
Defer stale replay payloads before restart redispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.45", features = ["full"] }
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }
 uuid = { version = "1", features = ["v4"] }
 toml = "0.8"
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
@@ -9,6 +10,7 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router as AxumRouter};
 use serde_json::{Value, json};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::sync::{RwLock, mpsc};
 
 use crate::Result;
@@ -32,6 +34,23 @@ use crate::source::{
 use crate::update::{self, SharedPendingUpdate};
 
 const EVENT_QUEUE_CAPACITY: usize = 256;
+const STALE_NATIVE_REPLAY_GRACE: Duration = Duration::from_secs(5 * 60);
+const STALE_NATIVE_REPLAY_REASON: &str = "stale_replay";
+const NATIVE_REPLAY_TIMESTAMP_POINTERS: &[&str] = &[
+    "/event_timestamp",
+    "/timestamp",
+    "/observed_at",
+    "/created_at",
+    "/event_payload/event_timestamp",
+    "/event_payload/timestamp",
+];
+const EVENT_REPLAY_TIMESTAMP_POINTERS: &[&str] = &[
+    "/first_seen_at",
+    "/event_timestamp",
+    "/timestamp",
+    "/observed_at",
+    "/created_at",
+];
 
 #[derive(Clone)]
 struct AppState {
@@ -200,6 +219,15 @@ async fn post_event(
     State(state): State<AppState>,
     Json(event): Json<IncomingEvent>,
 ) -> impl IntoResponse {
+    let canonical_kind = event.canonical_kind();
+    if let Some(defer) = stale_replay_defer(
+        canonical_kind,
+        &event.payload,
+        EVENT_REPLAY_TIMESTAMP_POINTERS,
+    ) {
+        return stale_replay_defer_response(canonical_kind, &defer);
+    }
+
     accept_event(&state, normalize_event(event)).await
 }
 
@@ -231,6 +259,10 @@ async fn post_native_hook(
             .into_response();
     }
 
+    if let Some(defer) = stale_native_replay_defer(&event, &payload) {
+        return stale_replay_defer_response(&event.kind, &defer);
+    }
+
     accept_event(&state, event).await
 }
 
@@ -240,6 +272,107 @@ fn native_hook_should_drop(event: &IncomingEvent) -> bool {
         .get(NATIVE_NORMALIZATION_OUTCOME_FIELD)
         .and_then(Value::as_str)
         == Some(NATIVE_NON_GIT_OUTCOME)
+}
+
+#[derive(Debug, Clone)]
+struct NativeReplayDefer {
+    reason: &'static str,
+    timestamp: String,
+    age: Duration,
+}
+
+fn stale_native_replay_defer(
+    event: &IncomingEvent,
+    raw_payload: &Value,
+) -> Option<NativeReplayDefer> {
+    stale_replay_defer(
+        event.canonical_kind(),
+        raw_payload,
+        NATIVE_REPLAY_TIMESTAMP_POINTERS,
+    )
+}
+
+fn stale_replay_defer(
+    kind: &str,
+    raw_payload: &Value,
+    timestamp_pointers: &[&str],
+) -> Option<NativeReplayDefer> {
+    if !is_replay_sensitive_native_kind(kind) {
+        return None;
+    }
+
+    let timestamp = replay_timestamp(raw_payload, timestamp_pointers)?;
+    let observed_at = parse_native_replay_timestamp(&timestamp)?;
+    let now = OffsetDateTime::now_utc();
+    let age = now - observed_at;
+    let age = age.try_into().ok()?;
+
+    (age > STALE_NATIVE_REPLAY_GRACE).then_some(NativeReplayDefer {
+        reason: STALE_NATIVE_REPLAY_REASON,
+        timestamp,
+        age,
+    })
+}
+
+fn is_replay_sensitive_native_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "tool.pre" | "tool.post" | "session.prompt-submitted" | "session.stopped"
+    )
+}
+
+fn replay_timestamp(raw_payload: &Value, pointers: &[&str]) -> Option<String> {
+    pointers
+        .iter()
+        .find_map(|pointer| timestamp_string(raw_payload.pointer(pointer)))
+}
+
+fn stale_replay_defer_response(kind: &str, defer: &NativeReplayDefer) -> axum::response::Response {
+    eprintln!(
+        "clawhip deferred stale replay: type={} reason={} timestamp={} age_secs={}",
+        kind,
+        defer.reason,
+        defer.timestamp,
+        defer.age.as_secs()
+    );
+    (
+        StatusCode::ACCEPTED,
+        Json(json!({
+            "ok": true,
+            "type": kind,
+            "deferred": true,
+            "quarantined": true,
+            "reason": defer.reason,
+            "timestamp": defer.timestamp,
+            "age_secs": defer.age.as_secs(),
+        })),
+    )
+        .into_response()
+}
+
+fn timestamp_string(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) => {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn parse_native_replay_timestamp(value: &str) -> Option<OffsetDateTime> {
+    if let Ok(parsed) = OffsetDateTime::parse(value, &Rfc3339) {
+        return Some(parsed);
+    }
+
+    let integer = value.trim().parse::<i64>().ok()?;
+    let unix_seconds = if integer.unsigned_abs() >= 10_000_000_000 {
+        integer / 1000
+    } else {
+        integer
+    };
+    OffsetDateTime::from_unix_timestamp(unix_seconds).ok()
 }
 
 async fn accept_event(state: &AppState, event: IncomingEvent) -> axum::response::Response {
@@ -532,6 +665,87 @@ mod tests {
     use tempfile::tempdir;
     use tokio::time::{Duration, timeout};
 
+    fn native_hook_test_state() -> (AppState, mpsc::Receiver<IncomingEvent>) {
+        let (tx, rx) = mpsc::channel(8);
+        (
+            AppState {
+                config: Arc::new(AppConfig::default()),
+                port: 25294,
+                tx,
+                tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+                pending_update: update::new_shared_pending_update(),
+            },
+            rx,
+        )
+    }
+
+    fn git_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let git = std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git init");
+        assert!(
+            git.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&git.stderr)
+        );
+        dir
+    }
+
+    fn stale_rfc3339() -> String {
+        (OffsetDateTime::now_utc() - time::Duration::hours(1))
+            .format(&Rfc3339)
+            .expect("format stale timestamp")
+    }
+
+    fn fresh_rfc3339() -> String {
+        OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .expect("format fresh timestamp")
+    }
+
+    fn native_payload(repo: &std::path::Path, event_name: &str) -> Value {
+        json!({
+            "provider": "codex",
+            "event_name": event_name,
+            "directory": repo,
+            "cwd": repo,
+            "event_payload": {
+                "session_id": "sess-213",
+                "tool_name": "Bash",
+                "cwd": repo
+            }
+        })
+    }
+
+    async fn post_native_payload(payload: Value) -> (Value, mpsc::Receiver<IncomingEvent>) {
+        let (state, rx) = native_hook_test_state();
+        let response = post_native_hook(State(state), Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response_json: Value = serde_json::from_slice(&body).unwrap();
+        (response_json, rx)
+    }
+
+    fn insert_timestamp_at_path(payload: &mut Value, path: &[&str], value: String) {
+        let mut current = payload;
+        for key in &path[..path.len() - 1] {
+            current = current
+                .as_object_mut()
+                .expect("object")
+                .entry((*key).to_string())
+                .or_insert_with(|| json!({}));
+        }
+        current
+            .as_object_mut()
+            .expect("object")
+            .insert(path[path.len() - 1].to_string(), Value::String(value));
+    }
+
     #[test]
     fn health_payload_includes_version_and_token_source() {
         let mut config = AppConfig::default();
@@ -624,6 +838,71 @@ mod tests {
             .await
             .expect("rendered event");
         assert!(rendered.contains("check open PRs"));
+    }
+
+    #[tokio::test]
+    async fn post_event_defers_stale_tool_replay_before_normalization_and_enqueue() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+            pending_update: update::new_shared_pending_update(),
+        };
+        let event = IncomingEvent {
+            kind: "tool.post".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "first_seen_at": stale_rfc3339(),
+                "tool": "codex",
+                "summary": "old replay"
+            }),
+        };
+
+        let response = post_event(State(state), Json(event)).await.into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let response_json: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(response_json["ok"], json!(true));
+        assert_eq!(response_json["type"], json!("tool.post"));
+        assert_eq!(response_json["deferred"], json!(true));
+        assert_eq!(response_json["quarantined"], json!(true));
+        assert_eq!(response_json["reason"], json!(STALE_NATIVE_REPLAY_REASON));
+        assert!(rx.try_recv().is_err(), "stale replay should not enqueue");
+    }
+
+    #[tokio::test]
+    async fn post_event_preserves_fresh_tool_payload_with_first_seen_at() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+            pending_update: update::new_shared_pending_update(),
+        };
+        let event = IncomingEvent {
+            kind: "tool.post".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "first_seen_at": fresh_rfc3339(),
+                "tool": "codex",
+                "summary": "fresh"
+            }),
+        };
+
+        let response = post_event(State(state), Json(event)).await.into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let queued = rx.recv().await.expect("queued event");
+        assert_eq!(queued.kind, "tool.post");
     }
 
     #[tokio::test]
@@ -748,6 +1027,138 @@ mod tests {
                 .as_str()
                 .is_some_and(|error| error.contains("unsupported native hook event"))
         );
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_defers_stale_payloads_from_all_trusted_timestamp_paths() {
+        let repo = git_repo();
+        let cases = [
+            vec!["event_timestamp"],
+            vec!["timestamp"],
+            vec!["observed_at"],
+            vec!["created_at"],
+            vec!["event_payload", "event_timestamp"],
+            vec!["event_payload", "timestamp"],
+        ];
+
+        for path in cases {
+            let mut payload = native_payload(repo.path(), "PostToolUse");
+            insert_timestamp_at_path(&mut payload, &path, stale_rfc3339());
+
+            let (response_json, mut rx) = post_native_payload(payload).await;
+            assert_eq!(response_json["ok"], json!(true));
+            assert_eq!(response_json["type"], json!("tool.post"));
+            assert_eq!(response_json["deferred"], json!(true));
+            assert_eq!(response_json["quarantined"], json!(true));
+            assert_eq!(response_json["reason"], json!(STALE_NATIVE_REPLAY_REASON));
+            assert!(
+                rx.try_recv().is_err(),
+                "stale payload at {path:?} should not enqueue"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_defers_all_replay_sensitive_native_kinds() {
+        let repo = git_repo();
+        let cases = [
+            ("PreToolUse", "tool.pre"),
+            ("PostToolUse", "tool.post"),
+            ("UserPromptSubmit", "session.prompt-submitted"),
+            ("Stop", "session.stopped"),
+        ];
+
+        for (event_name, expected_kind) in cases {
+            let mut payload = native_payload(repo.path(), event_name);
+            payload
+                .as_object_mut()
+                .unwrap()
+                .insert("timestamp".into(), Value::String(stale_rfc3339()));
+
+            let (response_json, mut rx) = post_native_payload(payload).await;
+            assert_eq!(response_json["type"], json!(expected_kind));
+            assert_eq!(response_json["deferred"], json!(true));
+            assert!(
+                rx.try_recv().is_err(),
+                "{expected_kind} stale replay should not enqueue"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_stale_session_started_still_enqueues() {
+        let repo = git_repo();
+        let mut payload = native_payload(repo.path(), "SessionStart");
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("timestamp".into(), Value::String(stale_rfc3339()));
+
+        let (response_json, mut rx) = post_native_payload(payload).await;
+        assert_eq!(response_json["type"], json!("session.started"));
+        assert!(response_json.get("deferred").is_none());
+        let queued = rx.recv().await.expect("queued event");
+        assert_eq!(queued.kind, "session.started");
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_preserves_fresh_timestamped_tool_post() {
+        let repo = git_repo();
+        let mut payload = native_payload(repo.path(), "PostToolUse");
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("timestamp".into(), Value::String(fresh_rfc3339()));
+
+        let (response_json, mut rx) = post_native_payload(payload).await;
+        assert_eq!(response_json["type"], json!("tool.post"));
+        assert!(response_json["event_id"].as_str().is_some());
+        let queued = rx.recv().await.expect("queued event");
+        assert_eq!(queued.kind, "tool.post");
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_preserves_timestampless_tool_post() {
+        let repo = git_repo();
+        let payload = native_payload(repo.path(), "PostToolUse");
+
+        let (response_json, mut rx) = post_native_payload(payload).await;
+        assert_eq!(response_json["type"], json!("tool.post"));
+        assert!(response_json["event_id"].as_str().is_some());
+        let queued = rx.recv().await.expect("queued event");
+        assert_eq!(queued.kind, "tool.post");
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_invalid_timestamp_enqueues() {
+        let repo = git_repo();
+        let mut payload = native_payload(repo.path(), "PostToolUse");
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("timestamp".into(), Value::String("not-a-time".into()));
+
+        let (response_json, mut rx) = post_native_payload(payload).await;
+        assert_eq!(response_json["type"], json!("tool.post"));
+        assert!(response_json.get("deferred").is_none());
+        let queued = rx.recv().await.expect("queued event");
+        assert_eq!(queued.kind, "tool.post");
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_does_not_treat_stop_context_last_prompt_at_as_event_timestamp() {
+        let repo = git_repo();
+        let mut payload = native_payload(repo.path(), "Stop");
+        payload.as_object_mut().unwrap().insert(
+            "stop_context".into(),
+            json!({ "last_prompt_at": stale_rfc3339() }),
+        );
+
+        let (response_json, mut rx) = post_native_payload(payload).await;
+        assert_eq!(response_json["type"], json!("session.stopped"));
+        assert!(response_json.get("deferred").is_none());
+        let queued = rx.recv().await.expect("queued event");
+        assert_eq!(queued.kind, "session.stopped");
     }
 
     #[tokio::test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -75,11 +75,7 @@ fn ensure_supported_install_scope(args: &HooksInstallArgs) -> Result<()> {
 
 fn resolve_install_root(args: &HooksInstallArgs) -> Result<PathBuf> {
     match args.scope {
-        HookInstallScope::Project => Ok(args
-            .root
-            .clone()
-            .unwrap_or(std::env::current_dir()?)
-            .canonicalize()?),
+        HookInstallScope::Project => home_dir(),
         HookInstallScope::Global => home_dir(),
     }
 }
@@ -287,8 +283,10 @@ mod tests {
 
     #[test]
     #[serial]
-    fn install_project_scope_writes_codex_hook_file_and_global_bridge() {
+    fn install_project_scope_shims_codex_to_global_bridge_only() {
         let dir = tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo dir");
         let previous_home = std::env::var_os("HOME");
         unsafe {
             std::env::set_var("HOME", dir.path());
@@ -298,7 +296,7 @@ mod tests {
             all: false,
             provider: vec![HookProvider::Codex],
             scope: HookInstallScope::Project,
-            root: Some(dir.path().to_path_buf()),
+            root: Some(repo.clone()),
             force: false,
         })
         .expect("project-scoped codex install should succeed");
@@ -313,11 +311,8 @@ mod tests {
                 .generated_files
                 .contains(&dir.path().join(CODEX_HOOKS_FILE))
         );
-        assert!(
-            report
-                .generated_files
-                .contains(&dir.path().join(CODEX_HOOKS_FILE))
-        );
+        assert!(!repo.join(HOOK_SCRIPT).exists());
+        assert!(!repo.join(CODEX_HOOKS_FILE).exists());
 
         if let Some(previous) = previous_home {
             unsafe {

--- a/src/hooks/prompt_deliver.rs
+++ b/src/hooks/prompt_deliver.rs
@@ -135,8 +135,8 @@ pub async fn deliver(config: &PromptDeliverConfig) -> Result<DeliveryResult> {
     let mut pane = resolve_target_pane(&config.session).await?;
     let hook_setup = detect_hook_setup(&pane.cwd)?;
     let provider = ensure_provider_ready(&mut pane, &hook_setup, config).await?;
-    let marker_path = effective_marker_path(&hook_setup, &pane.cwd);
-    let effective_workdir = effective_workdir(&hook_setup, &pane.cwd);
+    let effective_workdir = effective_workdir(&hook_setup, &pane.cwd)?;
+    let marker_path = effective_workdir.join(PROMPT_SUBMIT_MARKER);
 
     wait_for_tui_ready(&pane.pane_id, config.tui_timeout, config.poll_interval).await?;
 
@@ -642,16 +642,18 @@ fn ensure_global_workdir_marker(marker_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn effective_workdir(hook_setup: &HookSetup, pane_cwd: &Path) -> PathBuf {
+fn effective_workdir(hook_setup: &HookSetup, pane_cwd: &Path) -> Result<PathBuf> {
     if hook_setup.install_scope != HookDetectionScope::Global {
-        return hook_setup.workdir.clone();
+        return Ok(hook_setup.workdir.clone());
     }
 
-    infer_worktree_root(pane_cwd).unwrap_or_else(|| pane_cwd.to_path_buf())
-}
-
-fn effective_marker_path(hook_setup: &HookSetup, pane_cwd: &Path) -> PathBuf {
-    effective_workdir(hook_setup, pane_cwd).join(PROMPT_SUBMIT_MARKER)
+    infer_worktree_root(pane_cwd).ok_or_else(|| {
+        format!(
+            "refusing delivery: '{}' is not inside a repo/workdir; global hook install is available but prompt delivery requires a git repo/workdir cwd",
+            pane_cwd.display()
+        )
+        .into()
+    })
 }
 
 fn infer_worktree_root(directory: &Path) -> Option<PathBuf> {
@@ -1130,6 +1132,7 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         let workdir = tempdir.path().join("repo");
         let fake_home = tempdir.path().join("home");
+        init_git_repo_for_prompt_delivery_test(&workdir);
         fs::create_dir_all(fake_home.join(".codex")).expect("create codex dir");
         fs::create_dir_all(fake_home.join(".clawhip/hooks")).expect("create hook dir");
         let command = format!(
@@ -1217,6 +1220,7 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         let workdir = tempdir.path().join("repo");
         let fake_home = tempdir.path().join("home");
+        init_git_repo_for_prompt_delivery_test(&workdir);
         fs::create_dir_all(fake_home.join(".codex")).expect("create codex dir");
         fs::create_dir_all(fake_home.join(".clawhip/hooks")).expect("create hook dir");
         let command = format!(
@@ -1302,5 +1306,19 @@ mod tests {
     fn shell_escape_path(path: &Path) -> String {
         let value = path.display().to_string();
         format!("'{}'", value.replace('\'', "'\\''"))
+    }
+
+    fn init_git_repo_for_prompt_delivery_test(path: &Path) {
+        fs::create_dir_all(path).expect("create repo dir");
+        let output = std::process::Command::new("git")
+            .arg("init")
+            .current_dir(path)
+            .output()
+            .expect("run git init");
+        assert!(
+            output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/src/native_hooks.rs
+++ b/src/native_hooks.rs
@@ -71,6 +71,9 @@ pub fn incoming_event_from_native_hook_json(
             .and_then(infer_repo_root)
             .map(|path| path.to_string_lossy().into_owned())
     });
+    let normalization_outcome = repo_path
+        .is_none()
+        .then(|| NATIVE_NON_GIT_OUTCOME.to_string());
     let project_metadata = load_effective_project_metadata(
         payload,
         repo_path.as_deref(),
@@ -178,6 +181,12 @@ pub fn incoming_event_from_native_hook_json(
         "normalized_event".into(),
         json!(normalized_event_label(canonical_kind)),
     );
+    if let Some(normalization_outcome) = normalization_outcome {
+        normalized.insert(
+            NATIVE_NORMALIZATION_OUTCOME_FIELD.into(),
+            json!(normalization_outcome),
+        );
+    }
     normalized.insert("event_payload".into(), event_payload);
     normalized.insert("payload".into(), payload.clone());
 


### PR DESCRIPTION
## Incident

Issue #213 reported that stale tool/hook payloads could be replayed after a daemon restart and then re-delivered into live Discord channels through fallback/default routing and DLQ retry. In practice this caused old `tool.pre` / `tool.post` style events to show up as fresh notifications, including oversized payload churn after restart.

## What changed

- defer/quarantine replay-looking ingress payloads before they reach normal routing:
  - native hook ingress now checks explicit raw timestamps (`event_timestamp`, `timestamp`, `observed_at`, `created_at`, and `event_payload.*` variants)
  - generic `/event` ingress now checks replay metadata such as `first_seen_at` before normalization, covering stale replays that already carry normalized timestamps
- limit the restart-safe guard to replay-sensitive native/session kinds only:
  - `tool.pre`
  - `tool.post`
  - `session.prompt-submitted`
  - `session.stopped`
- preserve legitimate fresh, timestamp-less, invalid-timestamp, and `session.started` traffic
- restore non-git native hook normalization outcome so non-repo payloads are dropped before routing
- restore the existing hook contract expected by regression coverage:
  - Codex `hooks install --scope project` behaves as the global-only compatibility shim again
  - prompt delivery still refuses non-repo/non-workdir panes even when a global hook install exists

## Why this is narrow

The classifier only acts on explicit ingress timestamps and only when the payload age is clearly outside a small grace window. It does **not** recursively inspect unrelated nested fields like stop-context metadata, so fresh live events keep flowing normally.

## Verification

- `cargo test --test reconcile_native_hook_regression -- --nocapture`
- `cargo test post_ -- --nocapture`
- `cargo test -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`

## Risk

Low and localized to ingress replay suppression plus hook install/prompt-delivery compatibility behavior. The main follow-up risk is tuning the stale grace window if real-world hook timestamps arrive later than expected.
