### PR TITLE
Fix #214 logging telemetry upgrade

### DIFF
--- a/src/core/circuit_breaker.rs
+++ b/src/core/circuit_breaker.rs
@@ -7,6 +7,12 @@ pub enum CircuitState {
     HalfOpen,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CircuitTransition {
+    pub from: &'static str,
+    pub to: &'static str,
+}
+
 #[derive(Debug, Clone)]
 pub struct CircuitBreaker {
     state: CircuitState,
@@ -26,26 +32,39 @@ impl CircuitBreaker {
         }
     }
 
-    pub fn allow_request(&mut self) -> bool {
+    pub fn allow_request(&mut self) -> (bool, Option<CircuitTransition>) {
         match self.state {
-            CircuitState::Closed | CircuitState::HalfOpen => true,
+            CircuitState::Closed | CircuitState::HalfOpen => (true, None),
             CircuitState::Open { opened_at } => {
                 if opened_at.elapsed() >= self.cooldown {
+                    let previous = self.state_name();
                     self.state = CircuitState::HalfOpen;
-                    true
+                    (
+                        true,
+                        Some(CircuitTransition {
+                            from: previous,
+                            to: self.state_name(),
+                        }),
+                    )
                 } else {
-                    false
+                    (false, None)
                 }
             }
         }
     }
 
-    pub fn record_success(&mut self) {
+    pub fn record_success(&mut self) -> Option<CircuitTransition> {
         self.consecutive_failures = 0;
+        let previous = self.state_name();
         self.state = CircuitState::Closed;
+        (previous != self.state_name()).then_some(CircuitTransition {
+            from: previous,
+            to: self.state_name(),
+        })
     }
 
-    pub fn record_failure(&mut self) {
+    pub fn record_failure(&mut self) -> Option<CircuitTransition> {
+        let previous = self.state_name();
         match self.state {
             CircuitState::Closed => {
                 self.consecutive_failures += 1;
@@ -62,6 +81,10 @@ impl CircuitBreaker {
             }
             CircuitState::Open { .. } => {}
         }
+        (previous != self.state_name()).then_some(CircuitTransition {
+            from: previous,
+            to: self.state_name(),
+        })
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -84,10 +107,10 @@ mod tests {
         let mut breaker = CircuitBreaker::new(3, Duration::from_secs(60));
         breaker.record_failure();
         breaker.record_failure();
-        assert!(breaker.allow_request());
+        assert!(breaker.allow_request().0);
         breaker.record_failure();
         assert_eq!(breaker.state_name(), "open");
-        assert!(!breaker.allow_request());
+        assert!(!breaker.allow_request().0);
     }
 
     #[test]
@@ -95,7 +118,7 @@ mod tests {
         let mut breaker = CircuitBreaker::new(1, Duration::from_millis(1));
         breaker.record_failure();
         std::thread::sleep(Duration::from_millis(5));
-        assert!(breaker.allow_request());
+        assert!(breaker.allow_request().0);
         assert_eq!(breaker.state_name(), "half-open");
     }
 
@@ -104,8 +127,25 @@ mod tests {
         let mut breaker = CircuitBreaker::new(1, Duration::from_millis(1));
         breaker.record_failure();
         std::thread::sleep(Duration::from_millis(5));
-        assert!(breaker.allow_request());
+        assert!(breaker.allow_request().0);
         breaker.record_success();
         assert_eq!(breaker.state_name(), "closed");
+    }
+
+    #[test]
+    fn reports_state_transitions() {
+        let mut breaker = CircuitBreaker::new(1, Duration::from_millis(1));
+        let opened = breaker.record_failure().expect("open transition");
+        assert_eq!(opened.from, "closed");
+        assert_eq!(opened.to, "open");
+
+        std::thread::sleep(Duration::from_millis(5));
+        let half_open = breaker.allow_request().1.expect("half-open transition");
+        assert_eq!(half_open.from, "open");
+        assert_eq!(half_open.to, "half-open");
+
+        let closed = breaker.record_success().expect("close transition");
+        assert_eq!(closed.from, "half-open");
+        assert_eq!(closed.to, "closed");
     }
 }

--- a/src/core/dlq.rs
+++ b/src/core/dlq.rs
@@ -11,6 +11,12 @@ pub struct DlqEntry {
     pub format: String,
     pub content: String,
     pub payload: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_bytes: Option<usize>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -47,8 +53,12 @@ mod tests {
             format: "compact".into(),
             content: "msg".into(),
             payload: json!({"repo":"clawhip"}),
+            correlation_id: Some("corr-1".into()),
+            content_bytes: Some(3),
+            payload_bytes: Some(18),
         });
         assert_eq!(dlq.entries().len(), 1);
         assert_eq!(dlq.entries()[0].payload["repo"], "clawhip");
+        assert_eq!(dlq.entries()[0].correlation_id.as_deref(), Some("corr-1"));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -31,6 +31,7 @@ use crate::source::{
     GitHubSource, GitSource, RegisteredTmuxSession, SharedTmuxRegistry, Source, TmuxSource,
     WorkspaceSource, list_active_tmux_registrations,
 };
+use crate::telemetry;
 use crate::update::{self, SharedPendingUpdate};
 
 const EVENT_QUEUE_CAPACITY: usize = 256;
@@ -69,6 +70,10 @@ pub async fn run(
     config.validate()?;
     let token_source = config.discord_token_source();
     println!("clawhip v{VERSION} starting (token_source: {token_source})");
+    telemetry::emit(daemon_record(
+        telemetry::reason::DAEMON_STARTUP,
+        json!({"version": VERSION, "token_source": token_source}),
+    ));
 
     let mut sinks: HashMap<String, Box<dyn Sink>> = HashMap::new();
     sinks.insert(
@@ -140,10 +145,15 @@ pub async fn run(
     });
     let addr: SocketAddr = format!("{}:{}", config.daemon.bind_host, port).parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
+    let local_addr = listener.local_addr()?;
     println!(
         "clawhip daemon v{VERSION} listening on http://{} (token_source: {token_source})",
-        listener.local_addr()?
+        local_addr
     );
+    telemetry::emit(daemon_record(
+        telemetry::reason::DAEMON_LISTENING,
+        json!({"version": VERSION, "addr": local_addr.to_string(), "token_source": token_source}),
+    ));
     axum::serve(listener, app).await?;
     Ok(())
 }
@@ -155,7 +165,17 @@ where
     let source_name = source.name().to_string();
     tokio::spawn(async move {
         println!("clawhip source '{}' starting", source_name);
+        telemetry::emit(source_lifecycle_record(
+            telemetry::reason::SOURCE_START,
+            &source_name,
+            None,
+        ));
         if let Err(error) = source.run(tx.clone()).await {
+            telemetry::emit(source_lifecycle_record(
+                telemetry::reason::SOURCE_STOPPED,
+                &source_name,
+                Some(error.to_string()),
+            ));
             eprintln!("clawhip source '{}' stopped: {error}", source_name);
             if let Err(alert_error) = tx
                 .send(source_failure_alert_event(&source_name, &error.to_string()))
@@ -184,6 +204,50 @@ fn source_failure_alert_event(source_name: &str, error_message: &str) -> Incomin
     }
 
     event
+}
+
+fn daemon_record(reason_code: &str, details: Value) -> serde_json::Map<String, Value> {
+    let mut record = telemetry::record(
+        telemetry::event_name::DAEMON_PHASE,
+        reason_code,
+        format!("daemon:{reason_code}"),
+    );
+    record.insert("details".to_string(), details);
+    record
+}
+
+fn source_lifecycle_record(
+    reason_code: &str,
+    source_name: &str,
+    error: Option<String>,
+) -> serde_json::Map<String, Value> {
+    let event_name = if reason_code == telemetry::reason::SOURCE_STOPPED {
+        telemetry::event_name::SOURCE_DEGRADED
+    } else {
+        telemetry::event_name::SOURCE_INVENTORY
+    };
+    let mut record = telemetry::record(event_name, reason_code, format!("source:{source_name}"));
+    record.insert("source".to_string(), json!(source_name));
+    if let Some(error) = error {
+        record.insert("error".to_string(), json!(error));
+    }
+    record
+}
+
+fn event_record(
+    event_name: &str,
+    reason_code: &str,
+    event: &IncomingEvent,
+    details: Value,
+) -> serde_json::Map<String, Value> {
+    let mut record = telemetry::record(
+        event_name,
+        reason_code,
+        telemetry::correlation_id_for_event(event),
+    );
+    record.insert("event_kind".to_string(), json!(event.canonical_kind()));
+    record.insert("details".to_string(), details);
+    record
 }
 
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
@@ -235,6 +299,7 @@ async fn post_native_hook(
     State(state): State<AppState>,
     Json(payload): Json<Value>,
 ) -> impl IntoResponse {
+    let raw_non_git = native_payload_is_non_git(&payload);
     let event = match incoming_event_from_native_hook_json(&payload) {
         Ok(event) => normalize_event(event),
         Err(error) => {
@@ -246,7 +311,13 @@ async fn post_native_hook(
         }
     };
 
-    if native_hook_should_drop(&event) {
+    if raw_non_git || native_hook_should_drop(&event) {
+        telemetry::emit(event_record(
+            telemetry::event_name::EVENT_DROPPED,
+            telemetry::reason::DROP_NON_GIT_NATIVE_HOOK,
+            &event,
+            json!({"dropped": true, "source": "native_hook"}),
+        ));
         return (
             StatusCode::ACCEPTED,
             Json(json!({
@@ -266,10 +337,37 @@ async fn post_native_hook(
     accept_event(&state, event).await
 }
 
+fn native_payload_is_non_git(payload: &Value) -> bool {
+    payload
+        .get(NATIVE_NORMALIZATION_OUTCOME_FIELD)
+        .and_then(Value::as_str)
+        == Some(NATIVE_NON_GIT_OUTCOME)
+        || payload
+            .get("event_payload")
+            .and_then(|payload| payload.get(NATIVE_NORMALIZATION_OUTCOME_FIELD))
+            .and_then(Value::as_str)
+            == Some(NATIVE_NON_GIT_OUTCOME)
+        || payload
+            .get("payload")
+            .and_then(|payload| payload.get(NATIVE_NORMALIZATION_OUTCOME_FIELD))
+            .and_then(Value::as_str)
+            == Some(NATIVE_NON_GIT_OUTCOME)
+}
+
 fn native_hook_should_drop(event: &IncomingEvent) -> bool {
-    event
+    if event
         .payload
         .get(NATIVE_NORMALIZATION_OUTCOME_FIELD)
+        .and_then(Value::as_str)
+        == Some(NATIVE_NON_GIT_OUTCOME)
+    {
+        return true;
+    }
+
+    event
+        .payload
+        .get("payload")
+        .and_then(|payload| payload.get(NATIVE_NORMALIZATION_OUTCOME_FIELD))
         .and_then(Value::as_str)
         == Some(NATIVE_NON_GIT_OUTCOME)
 }
@@ -388,15 +486,23 @@ async fn accept_event(state: &AppState, event: IncomingEvent) -> axum::response:
     };
 
     match enqueue_event(&state.tx, event.clone()).await {
-        Ok(()) => (
-            StatusCode::ACCEPTED,
-            Json(json!({
-                "ok": true,
-                "type": event.kind,
-                "event_id": envelope.id.to_string(),
-            })),
-        )
-            .into_response(),
+        Ok(()) => {
+            telemetry::emit(event_record(
+                telemetry::event_name::EVENT_ACCEPTED,
+                telemetry::reason::ACCEPT_ENQUEUED,
+                &event,
+                json!({"event_id": envelope.id.to_string()}),
+            ));
+            (
+                StatusCode::ACCEPTED,
+                Json(json!({
+                    "ok": true,
+                    "type": event.kind,
+                    "event_id": envelope.id.to_string(),
+                })),
+            )
+                .into_response()
+        }
         Err(error) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({"ok": false, "error": error.to_string()})),
@@ -1176,7 +1282,8 @@ mod tests {
             "provider": "codex",
             "event_name": "SessionStart",
             "directory": dir.path(),
-            "event_payload": {}
+            "event_payload": {},
+            "normalization_outcome": NATIVE_NON_GIT_OUTCOME
         });
 
         let response = post_native_hook(State(state), Json(payload))

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -14,6 +14,7 @@ use crate::core::circuit_breaker::CircuitBreaker;
 use crate::core::dlq::{Dlq, DlqEntry};
 use crate::core::rate_limit::RateLimiter;
 use crate::sink::{SinkMessage, SinkTarget};
+use crate::telemetry;
 
 const MAX_ATTEMPTS: u32 = 3;
 const JITTER_MS: u64 = 50;
@@ -41,6 +42,7 @@ struct DiscordState {
 struct DiscordSendError {
     message: String,
     retry_after: Option<Duration>,
+    status: Option<u16>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -90,8 +92,24 @@ impl DiscordClient {
 
     pub async fn send(&self, target: &SinkTarget, message: &SinkMessage) -> Result<()> {
         let key = target_rate_limit_key(target);
-        if !self.allow_request(&key) {
-            let error = format!("Discord circuit open for {key}");
+        let safe_target = telemetry::safe_target_id(target);
+        let telemetry_ctx = telemetry::TelemetryContext::from_message(message);
+        let (allowed, transition) = self.allow_request(&key);
+        if let Some(transition) = transition {
+            self.emit_circuit_transition(&telemetry_ctx.correlation_id, &safe_target, &transition);
+        }
+        if !allowed {
+            telemetry::emit(discord_record(DiscordTelemetryInput {
+                event_name: telemetry::event_name::DISCORD_SEND_FAILURE,
+                reason_code: telemetry::reason::CIRCUIT_OPEN,
+                correlation_id: &telemetry_ctx.correlation_id,
+                safe_target: &safe_target,
+                message,
+                attempt: Some(MAX_ATTEMPTS),
+                error: Some("circuit-open".to_string()),
+                status: None,
+            }));
+            let error = format!("Discord circuit open for {safe_target}");
             self.record_dlq(target, message, MAX_ATTEMPTS, error.clone());
             return Err(error.into());
         }
@@ -101,6 +119,16 @@ impl DiscordClient {
             if !delay.is_zero() {
                 tokio::time::sleep(delay).await;
             }
+            telemetry::emit(discord_record(DiscordTelemetryInput {
+                event_name: telemetry::event_name::DISCORD_SEND_ATTEMPT,
+                reason_code: telemetry::reason::DISCORD_PRE_SEND,
+                correlation_id: &telemetry_ctx.correlation_id,
+                safe_target: &safe_target,
+                message,
+                attempt: Some(attempt),
+                error: None,
+                status: None,
+            }));
 
             let result = match target {
                 SinkTarget::DiscordChannel(channel_id) => {
@@ -116,25 +144,67 @@ impl DiscordClient {
 
             match result {
                 Ok(()) => {
-                    self.record_success(&key);
+                    if let Some(transition) = self.record_success(&key) {
+                        self.emit_circuit_transition(
+                            &telemetry_ctx.correlation_id,
+                            &safe_target,
+                            &transition,
+                        );
+                    }
+                    telemetry::emit(discord_record(DiscordTelemetryInput {
+                        event_name: telemetry::event_name::DISCORD_SEND_SUCCESS,
+                        reason_code: telemetry::reason::DISCORD_SUCCESS,
+                        correlation_id: &telemetry_ctx.correlation_id,
+                        safe_target: &safe_target,
+                        message,
+                        attempt: Some(attempt),
+                        error: None,
+                        status: None,
+                    }));
                     return Ok(());
                 }
                 Err(error) => {
-                    self.record_failure(&key);
+                    if let Some(transition) = self.record_failure(&key) {
+                        self.emit_circuit_transition(
+                            &telemetry_ctx.correlation_id,
+                            &safe_target,
+                            &transition,
+                        );
+                    }
                     if let Some(retry_after) = error.retry_after
                         && attempt < MAX_ATTEMPTS
                     {
+                        telemetry::emit(discord_record(DiscordTelemetryInput {
+                            event_name: telemetry::event_name::DISCORD_SEND_FAILURE,
+                            reason_code: telemetry::reason::DISCORD_RETRY,
+                            correlation_id: &telemetry_ctx.correlation_id,
+                            safe_target: &safe_target,
+                            message,
+                            attempt: Some(attempt),
+                            error: Some(error.message.clone()),
+                            status: error.status,
+                        }));
                         tokio::time::sleep(retry_after + jitter_for_attempt(attempt)).await;
                         continue;
                     }
 
+                    telemetry::emit(discord_record(DiscordTelemetryInput {
+                        event_name: telemetry::event_name::DISCORD_SEND_FAILURE,
+                        reason_code: telemetry::reason::DISCORD_EXHAUSTED,
+                        correlation_id: &telemetry_ctx.correlation_id,
+                        safe_target: &safe_target,
+                        message,
+                        attempt: Some(attempt),
+                        error: Some(error.message.clone()),
+                        status: error.status,
+                    }));
                     self.record_dlq(target, message, attempt, error.message.clone());
                     return Err(error.message.into());
                 }
             }
         }
 
-        let error = format!("Discord delivery exhausted retries for {key}");
+        let error = format!("Discord delivery exhausted retries for {safe_target}");
         self.record_dlq(target, message, MAX_ATTEMPTS, error.clone());
         Err(error.into())
     }
@@ -208,6 +278,7 @@ impl DiscordClient {
         let client = self.bot_client.as_ref().ok_or_else(|| DiscordSendError {
             message: "missing Discord bot token for channel delivery; configure [providers.discord].token (or legacy [discord].token) or use a route webhook".to_string(),
             retry_after: None,
+            status: None,
         })?;
 
         self.execute_request(
@@ -236,9 +307,10 @@ impl DiscordClient {
         request: reqwest::RequestBuilder,
         label: &str,
     ) -> std::result::Result<(), DiscordSendError> {
-        let response = request.send().await.map_err(|error| DiscordSendError {
-            message: format!("{label} failed: {error}"),
+        let response = request.send().await.map_err(|_error| DiscordSendError {
+            message: format!("{label} failed: transport error"),
             retry_after: None,
+            status: None,
         })?;
 
         if response.status().is_success() {
@@ -250,10 +322,17 @@ impl DiscordClient {
         Err(DiscordSendError {
             message: format!("{label} failed with {status}: {body}"),
             retry_after: parse_retry_after(status, &body),
+            status: Some(status.as_u16()),
         })
     }
 
-    fn allow_request(&self, key: &str) -> bool {
+    fn allow_request(
+        &self,
+        key: &str,
+    ) -> (
+        bool,
+        Option<crate::core::circuit_breaker::CircuitTransition>,
+    ) {
         let mut state = self.state.lock().expect("discord state lock");
         state
             .circuits
@@ -272,7 +351,7 @@ impl DiscordClient {
         state.limiter.delay_for(key)
     }
 
-    fn record_success(&self, key: &str) {
+    fn record_success(&self, key: &str) -> Option<crate::core::circuit_breaker::CircuitTransition> {
         let mut state = self.state.lock().expect("discord state lock");
         state
             .circuits
@@ -283,10 +362,10 @@ impl DiscordClient {
                     Duration::from_secs(CIRCUIT_COOLDOWN_SECS),
                 )
             })
-            .record_success();
+            .record_success()
     }
 
-    fn record_failure(&self, key: &str) {
+    fn record_failure(&self, key: &str) -> Option<crate::core::circuit_breaker::CircuitTransition> {
         let mut state = self.state.lock().expect("discord state lock");
         state
             .circuits
@@ -297,20 +376,54 @@ impl DiscordClient {
                     Duration::from_secs(CIRCUIT_COOLDOWN_SECS),
                 )
             })
-            .record_failure();
+            .record_failure()
+    }
+
+    fn emit_circuit_transition(
+        &self,
+        correlation_id: &str,
+        safe_target: &str,
+        transition: &crate::core::circuit_breaker::CircuitTransition,
+    ) {
+        let mut record = telemetry::record(
+            telemetry::event_name::CIRCUIT_TRANSITION,
+            telemetry::reason::CIRCUIT_TRANSITION,
+            correlation_id.to_string(),
+        );
+        record.insert("target".to_string(), json!(safe_target));
+        record.insert("from".to_string(), json!(transition.from));
+        record.insert("to".to_string(), json!(transition.to));
+        telemetry::emit(record);
     }
 
     fn record_dlq(&self, target: &SinkTarget, message: &SinkMessage, attempts: u32, error: String) {
+        let safe_target = telemetry::safe_target_id(target);
+        let correlation_id =
+            telemetry::correlation_id_for_message(&message.event_kind, &message.payload);
         let entry = DlqEntry {
             original_topic: message.event_kind.clone(),
             retry_count: attempts,
             last_error: error,
-            target: target_rate_limit_key(target),
+            target: safe_target.clone(),
             event_kind: message.event_kind.clone(),
             format: message.format.as_str().to_string(),
             content: message.content.clone(),
             payload: message.payload.clone(),
+            correlation_id: Some(correlation_id.clone()),
+            content_bytes: Some(message.content.len()),
+            payload_bytes: telemetry::payload_bytes(&message.payload),
         };
+
+        telemetry::emit(discord_record(DiscordTelemetryInput {
+            event_name: telemetry::event_name::DLQ_BURY,
+            reason_code: telemetry::reason::DLQ_WRITE,
+            correlation_id: &correlation_id,
+            safe_target: &safe_target,
+            message,
+            attempt: Some(attempts),
+            error: Some(entry.last_error.clone()),
+            status: None,
+        }));
 
         eprintln!(
             "clawhip dlq bury: {}",
@@ -378,6 +491,51 @@ fn target_rate_limit_key(target: &SinkTarget) -> String {
         SinkTarget::DiscordWebhook(webhook_url) => format!("discord:webhook:{webhook_url}"),
         SinkTarget::SlackWebhook(webhook_url) => format!("slack:webhook:{webhook_url}"),
     }
+}
+
+struct DiscordTelemetryInput<'a> {
+    event_name: &'a str,
+    reason_code: &'a str,
+    correlation_id: &'a str,
+    safe_target: &'a str,
+    message: &'a SinkMessage,
+    attempt: Option<u32>,
+    error: Option<String>,
+    status: Option<u16>,
+}
+
+fn discord_record(input: DiscordTelemetryInput<'_>) -> serde_json::Map<String, serde_json::Value> {
+    let mut record = telemetry::record(
+        input.event_name,
+        input.reason_code,
+        input.correlation_id.to_string(),
+    );
+    record.insert("target".to_string(), json!(input.safe_target));
+    record.insert("event_kind".to_string(), json!(input.message.event_kind));
+    record.insert("format".to_string(), json!(input.message.format.as_str()));
+    record.insert(
+        "content_bytes".to_string(),
+        json!(input.message.content.len()),
+    );
+    record.insert(
+        "payload_bytes".to_string(),
+        json!(telemetry::payload_bytes(&input.message.payload)),
+    );
+    if let Some(attempt) = input.attempt {
+        record.insert("attempt".to_string(), json!(attempt));
+    }
+    if let Some(error) = input.error {
+        record.insert("error".to_string(), json!(error));
+    }
+    if let Some(status) = input.status {
+        record.insert("status".to_string(), json!(status));
+    }
+    if let Some(extra) = &input.message.telemetry {
+        record.insert("route_result".to_string(), json!(extra.route_result));
+        record.insert("route_index".to_string(), json!(extra.route_index));
+        record.insert("batch_count".to_string(), json!(extra.batch_count));
+    }
+    record
 }
 
 fn jitter_for_attempt(attempt: u32) -> Duration {
@@ -457,6 +615,7 @@ mod tests {
             format: MessageFormat::Compact,
             content: "hello".into(),
             payload: json!({"session":"ops"}),
+            telemetry: None,
         };
         client
             .send(
@@ -623,7 +782,8 @@ mod tests {
             event_kind: "github.ci-failed".into(),
             format: MessageFormat::Alert,
             content: "boom".into(),
-            payload: json!({"repo":"clawhip"}),
+            payload: json!({"repo":"clawhip", "correlation_id":"corr-214"}),
+            telemetry: None,
         };
         let error = client
             .send(
@@ -638,5 +798,40 @@ mod tests {
         assert_eq!(dlq.len(), 1);
         assert_eq!(dlq[0].payload["repo"], "clawhip");
         assert_eq!(dlq[0].retry_count, 3);
+        assert!(dlq[0].target.starts_with("discord:webhook:"));
+        assert!(!dlq[0].target.contains(&format!("http://{addr}/webhook")));
+        assert_eq!(dlq[0].correlation_id.as_deref(), Some("corr-214"));
+        assert_eq!(dlq[0].content_bytes, Some(4));
+        assert!(dlq[0].payload_bytes.is_some());
+    }
+
+    #[test]
+    fn record_dlq_redacts_target_and_preserves_correlation() {
+        let client = DiscordClient::from_config(Arc::new(AppConfig::default())).unwrap();
+        let message = SinkMessage {
+            event_kind: "github.ci-failed".into(),
+            format: MessageFormat::Alert,
+            content: "boom".into(),
+            payload: json!({"repo":"clawhip", "correlation_id":"corr-214"}),
+            telemetry: None,
+        };
+        let target = SinkTarget::DiscordWebhook(
+            "https://discord.com/api/webhooks/123456/secret-token".into(),
+        );
+
+        client.record_dlq(&target, &message, 3, "failed".into());
+
+        let dlq = client.dlq_entries();
+        assert_eq!(dlq.len(), 1);
+        assert!(
+            dlq[0]
+                .target
+                .starts_with("discord:webhook:discord.com/redacted/")
+        );
+        assert!(!dlq[0].target.contains("123456"));
+        assert!(!dlq[0].target.contains("secret-token"));
+        assert_eq!(dlq[0].correlation_id.as_deref(), Some("corr-214"));
+        assert_eq!(dlq[0].content_bytes, Some(4));
+        assert!(dlq[0].payload_bytes.is_some());
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -7,10 +7,11 @@ use tokio::sync::mpsc;
 
 use crate::Result;
 use crate::core::timer_wheel::{DelayedEntry, TimerWheel};
-use crate::events::IncomingEvent;
+use crate::events::{IncomingEvent, normalize_event};
 use crate::render::Renderer;
 use crate::router::{ResolvedDelivery, Router};
-use crate::sink::{Sink, SinkMessage, SinkTarget};
+use crate::sink::{Sink, SinkMessage, SinkTarget, SinkTelemetry};
+use crate::telemetry;
 
 const DEFAULT_BATCH_TICK: Duration = Duration::from_secs(1);
 
@@ -69,6 +70,7 @@ impl Dispatcher {
                 maybe_event = self.rx.recv() => {
                     match maybe_event {
                         Some(event) => {
+                            let event = normalize_event(event);
                             let now_ms = now_ms();
                             self.flush_due_batches(now_ms).await?;
                             if self.is_ci_event(&event) {
@@ -116,6 +118,12 @@ impl Dispatcher {
         let deliveries = match self.router.resolve(&event).await {
             Ok(deliveries) => deliveries,
             Err(error) => {
+                self.emit_dispatch_failure(
+                    &event,
+                    telemetry::reason::ROUTE_NONE,
+                    None,
+                    error.to_string(),
+                );
                 eprintln!(
                     "clawhip dispatcher failed to resolve {}: {error}",
                     event.canonical_kind()
@@ -125,6 +133,7 @@ impl Dispatcher {
         };
 
         for delivery in deliveries {
+            self.emit_route_trace(&event, &delivery);
             self.send_delivery(&event, &delivery).await;
         }
     }
@@ -133,6 +142,12 @@ impl Dispatcher {
         let deliveries = match self.router.resolve(&event).await {
             Ok(deliveries) => deliveries,
             Err(error) => {
+                self.emit_dispatch_failure(
+                    &event,
+                    telemetry::reason::ROUTE_NONE,
+                    None,
+                    error.to_string(),
+                );
                 eprintln!(
                     "clawhip dispatcher failed to resolve {}: {error}",
                     event.canonical_kind()
@@ -142,9 +157,13 @@ impl Dispatcher {
         };
 
         for delivery in deliveries {
-            if self.should_batch_routine_delivery(&event, &delivery)
-                && let Some(routine_batcher) = self.routine_batcher.as_mut()
-            {
+            self.emit_route_trace(&event, &delivery);
+            if self.should_batch_routine_delivery(&event, &delivery) {
+                self.emit_routine_deferred(&event, &delivery);
+                let Some(routine_batcher) = self.routine_batcher.as_mut() else {
+                    self.send_delivery(&event, &delivery).await;
+                    continue;
+                };
                 routine_batcher.observe(
                     QueuedRoutineDelivery {
                         event: event.clone(),
@@ -161,6 +180,12 @@ impl Dispatcher {
 
     async fn send_delivery(&self, event: &IncomingEvent, delivery: &ResolvedDelivery) {
         let Some(sink) = self.sinks.get(delivery.sink.as_str()) else {
+            self.emit_dispatch_failure(
+                event,
+                telemetry::reason::SINK_MISSING,
+                Some(delivery),
+                format!("missing sink '{}'", delivery.sink),
+            );
             eprintln!(
                 "clawhip dispatcher missing sink '{}' for target {:?}",
                 delivery.sink, delivery.target
@@ -175,6 +200,12 @@ impl Dispatcher {
         {
             Ok(content) => content,
             Err(error) => {
+                self.emit_dispatch_failure(
+                    event,
+                    telemetry::reason::RENDER_FAILED,
+                    Some(delivery),
+                    error.to_string(),
+                );
                 eprintln!(
                     "clawhip dispatcher failed to render {} for {}/ {:?}: {error}",
                     event.canonical_kind(),
@@ -193,6 +224,7 @@ impl Dispatcher {
                 format: delivery.format.clone(),
                 content,
                 payload: event.payload.clone(),
+                telemetry: Some(sink_telemetry_for(event, delivery, None)),
             },
         )
         .await;
@@ -208,6 +240,12 @@ impl Dispatcher {
         }
 
         let Some(sink) = self.sinks.get(first.delivery.sink.as_str()) else {
+            self.emit_dispatch_failure(
+                &first.event,
+                telemetry::reason::SINK_MISSING,
+                Some(&first.delivery),
+                format!("missing sink '{}'", first.delivery.sink),
+            );
             eprintln!(
                 "clawhip dispatcher missing sink '{}' for batched target {:?}",
                 first.delivery.sink, first.delivery.target
@@ -228,6 +266,12 @@ impl Dispatcher {
                     event_kinds.push(item.event.canonical_kind().to_string());
                 }
                 Err(error) => {
+                    self.emit_dispatch_failure(
+                        &item.event,
+                        telemetry::reason::RENDER_FAILED,
+                        Some(&item.delivery),
+                        error.to_string(),
+                    );
                     eprintln!(
                         "clawhip dispatcher failed to render batched {} for {}/ {:?}: {error}",
                         item.event.canonical_kind(),
@@ -242,6 +286,7 @@ impl Dispatcher {
             return;
         }
 
+        self.emit_routine_flushed(first, contents.len());
         self.send_sink_message(
             sink.as_ref(),
             &first.delivery.target,
@@ -253,7 +298,13 @@ impl Dispatcher {
                     "batched": true,
                     "count": contents.len(),
                     "event_kinds": event_kinds,
+                    "correlation_id": telemetry::correlation_id_for_event(&first.event),
                 }),
+                telemetry: Some(sink_telemetry_for(
+                    &first.event,
+                    &first.delivery,
+                    Some(contents.len()),
+                )),
             },
         )
         .await;
@@ -261,11 +312,109 @@ impl Dispatcher {
 
     async fn send_sink_message(&self, sink: &dyn Sink, target: &SinkTarget, message: SinkMessage) {
         if let Err(error) = sink.send(target, &message).await {
+            let mut record = telemetry::record(
+                telemetry::event_name::DISPATCH_FAILURE,
+                telemetry::reason::SINK_SEND_FAILED,
+                telemetry::correlation_id_for_message(&message.event_kind, &message.payload),
+            );
+            record.insert(
+                "target".to_string(),
+                json!(telemetry::safe_target_id(target)),
+            );
+            record.insert("event_kind".to_string(), json!(message.event_kind));
+            record.insert("error".to_string(), json!(error.to_string()));
+            telemetry::emit(record);
             eprintln!(
                 "clawhip dispatcher delivery failed to {:?}: {error}",
                 target
             );
         }
+    }
+
+    fn emit_route_trace(&self, event: &IncomingEvent, delivery: &ResolvedDelivery) {
+        let mut record = telemetry::record(
+            telemetry::event_name::ROUTE_TRACE,
+            delivery.trace.result.reason_code(),
+            telemetry::correlation_id_for_event(event),
+        );
+        record.insert("event_kind".to_string(), json!(event.canonical_kind()));
+        record.insert(
+            "route_result".to_string(),
+            json!(delivery.trace.result.as_str()),
+        );
+        record.insert(
+            "route_index".to_string(),
+            json!(delivery.trace.matched_route_index),
+        );
+        record.insert(
+            "event_pattern".to_string(),
+            json!(delivery.trace.event_pattern),
+        );
+        record.insert("filter_keys".to_string(), json!(delivery.trace.filter_keys));
+        record.insert("target".to_string(), json!(delivery.trace.target));
+        telemetry::emit(record);
+    }
+
+    fn emit_routine_deferred(&self, event: &IncomingEvent, delivery: &ResolvedDelivery) {
+        let mut record = telemetry::record(
+            telemetry::event_name::ROUTINE_DEFERRED,
+            telemetry::reason::ROUTINE_BATCH_DEFERRED,
+            telemetry::correlation_id_for_event(event),
+        );
+        record.insert("event_kind".to_string(), json!(event.canonical_kind()));
+        record.insert("target".to_string(), json!(delivery.trace.target));
+        record.insert(
+            "route_result".to_string(),
+            json!(delivery.trace.result.as_str()),
+        );
+        telemetry::emit(record);
+    }
+
+    fn emit_routine_flushed(&self, first: &QueuedRoutineDelivery, count: usize) {
+        let mut record = telemetry::record(
+            telemetry::event_name::ROUTINE_FLUSHED,
+            telemetry::reason::ROUTINE_BATCH_FLUSHED,
+            telemetry::correlation_id_for_event(&first.event),
+        );
+        record.insert(
+            "event_kind".to_string(),
+            json!(first.event.canonical_kind()),
+        );
+        record.insert("target".to_string(), json!(first.delivery.trace.target));
+        record.insert(
+            "route_result".to_string(),
+            json!(first.delivery.trace.result.as_str()),
+        );
+        record.insert("batch_count".to_string(), json!(count));
+        telemetry::emit(record);
+    }
+
+    fn emit_dispatch_failure(
+        &self,
+        event: &IncomingEvent,
+        reason_code: &str,
+        delivery: Option<&ResolvedDelivery>,
+        error: String,
+    ) {
+        let mut record = telemetry::record(
+            telemetry::event_name::DISPATCH_FAILURE,
+            reason_code,
+            telemetry::correlation_id_for_event(event),
+        );
+        record.insert("event_kind".to_string(), json!(event.canonical_kind()));
+        record.insert("error".to_string(), json!(error));
+        if let Some(delivery) = delivery {
+            record.insert("target".to_string(), json!(delivery.trace.target));
+            record.insert(
+                "route_result".to_string(),
+                json!(delivery.trace.result.as_str()),
+            );
+            record.insert(
+                "route_index".to_string(),
+                json!(delivery.trace.matched_route_index),
+            );
+        }
+        telemetry::emit(record);
     }
 
     fn should_batch_routine_delivery(
@@ -277,6 +426,20 @@ impl Dispatcher {
             && delivery.sink == "discord"
             && !self.is_ci_event(event)
             && !should_bypass_routine_batch(event)
+    }
+}
+
+fn sink_telemetry_for(
+    event: &IncomingEvent,
+    delivery: &ResolvedDelivery,
+    batch_count: Option<usize>,
+) -> SinkTelemetry {
+    SinkTelemetry {
+        correlation_id: telemetry::correlation_id_for_event(event),
+        route_result: Some(delivery.trace.result.as_str().to_string()),
+        route_index: delivery.trace.matched_route_index,
+        target: delivery.trace.target.clone(),
+        batch_count,
     }
 }
 

--- a/src/hooks/prompt_deliver.rs
+++ b/src/hooks/prompt_deliver.rs
@@ -134,6 +134,12 @@ pub async fn run(args: DeliverArgs) -> Result<()> {
 pub async fn deliver(config: &PromptDeliverConfig) -> Result<DeliveryResult> {
     let mut pane = resolve_target_pane(&config.session).await?;
     let hook_setup = detect_hook_setup(&pane.cwd)?;
+    if hook_setup.install_scope == HookDetectionScope::Global
+        && pane.cwd.exists()
+        && infer_worktree_root(&pane.cwd).is_none()
+    {
+        return Err(non_repo_delivery_error(&pane.cwd));
+    }
     let provider = ensure_provider_ready(&mut pane, &hook_setup, config).await?;
     let effective_workdir = effective_workdir(&hook_setup, &pane.cwd)?;
     let marker_path = effective_workdir.join(PROMPT_SUBMIT_MARKER);
@@ -245,11 +251,15 @@ fn detect_hook_setup(cwd: &Path) -> Result<HookSetup> {
         return Ok(setup);
     }
 
-    Err(format!(
+    Err(non_repo_delivery_error(cwd))
+}
+
+fn non_repo_delivery_error(cwd: &Path) -> crate::DynError {
+    format!(
         "refusing delivery: '{}' is not inside a repo/workdir with prompt-submit-aware hook setup, and no global ~/.codex / ~/.claude clawhip hook install was detected",
         cwd.display()
     )
-    .into())
+    .into()
 }
 
 fn hook_setup_at(root: &Path, install_scope: HookDetectionScope) -> Option<HookSetup> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod router;
 mod sink;
 mod slack;
 mod source;
+mod telemetry;
 mod tmux_wrapper;
 mod update;
 

--- a/src/native_hooks.rs
+++ b/src/native_hooks.rs
@@ -65,15 +65,26 @@ pub fn incoming_event_from_native_hook_json(
     );
     let worktree_path = first_string(payload, &["/worktree_path", "/context/worktree_path"])
         .or_else(|| directory.clone());
+    let explicit_normalization_outcome = first_string(
+        payload,
+        &[
+            "/normalization_outcome",
+            "/context/normalization_outcome",
+            "/event_payload/normalization_outcome",
+            "/payload/normalization_outcome",
+        ],
+    );
     let repo_path = first_string(payload, &["/repo_path", "/context/repo_path"]).or_else(|| {
         worktree_path
             .as_deref()
             .and_then(infer_repo_root)
             .map(|path| path.to_string_lossy().into_owned())
     });
-    let normalization_outcome = repo_path
-        .is_none()
-        .then(|| NATIVE_NON_GIT_OUTCOME.to_string());
+    let normalization_outcome = explicit_normalization_outcome.or_else(|| {
+        repo_path
+            .is_none()
+            .then(|| NATIVE_NON_GIT_OUTCOME.to_string())
+    });
     let project_metadata = load_effective_project_metadata(
         payload,
         repo_path.as_deref(),
@@ -181,12 +192,6 @@ pub fn incoming_event_from_native_hook_json(
         "normalized_event".into(),
         json!(normalized_event_label(canonical_kind)),
     );
-    if let Some(normalization_outcome) = normalization_outcome {
-        normalized.insert(
-            NATIVE_NORMALIZATION_OUTCOME_FIELD.into(),
-            json!(normalization_outcome),
-        );
-    }
     normalized.insert("event_payload".into(), event_payload);
     normalized.insert("payload".into(), payload.clone());
 
@@ -198,6 +203,12 @@ pub fn incoming_event_from_native_hook_json(
     }
     if let Some(repo_path) = repo_path {
         normalized.insert("repo_path".into(), json!(repo_path));
+    }
+    if let Some(normalization_outcome) = normalization_outcome {
+        normalized.insert(
+            NATIVE_NORMALIZATION_OUTCOME_FIELD.into(),
+            json!(normalization_outcome),
+        );
     }
     if let Some(repo_name) = repo_name {
         normalized.insert("repo_name".into(), json!(repo_name));

--- a/src/router.rs
+++ b/src/router.rs
@@ -15,6 +15,41 @@ use crate::sink::Sink;
 #[cfg(test)]
 use crate::sink::SinkMessage;
 use crate::sink::SinkTarget;
+use crate::telemetry;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteTrace {
+    pub result: RouteTraceResult,
+    pub matched_route_index: Option<usize>,
+    pub event_pattern: Option<String>,
+    pub filter_keys: Vec<String>,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteTraceResult {
+    Matched,
+    Fallback,
+    None,
+}
+
+impl RouteTraceResult {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Matched => "matched",
+            Self::Fallback => "fallback",
+            Self::None => "none",
+        }
+    }
+
+    pub fn reason_code(self) -> &'static str {
+        match self {
+            Self::Matched => telemetry::reason::ROUTE_MATCHED,
+            Self::Fallback => telemetry::reason::ROUTE_FALLBACK,
+            Self::None => telemetry::reason::ROUTE_NONE,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedDelivery {
@@ -24,6 +59,7 @@ pub struct ResolvedDelivery {
     pub mention: Option<String>,
     pub template: Option<String>,
     pub allow_dynamic_tokens: bool,
+    pub trace: RouteTrace,
 }
 
 pub struct Router {
@@ -48,6 +84,7 @@ impl Router {
                 format: delivery.format.clone(),
                 content,
                 payload: event.payload.clone(),
+                telemetry: None,
             };
             if let Err(error) = sink.send(&delivery.target, &message).await {
                 eprintln!(
@@ -61,16 +98,22 @@ impl Router {
     }
 
     pub async fn resolve(&self, event: &IncomingEvent) -> Result<Vec<ResolvedDelivery>> {
-        let routes = self.routes_for(event);
-        let routes = if routes.is_empty() {
-            vec![None]
-        } else {
-            routes.into_iter().map(Some).collect()
-        };
-        let mut deliveries = Vec::with_capacity(routes.len());
+        let context = event.template_context();
+        let matched_routes =
+            matching_routes_for(&self.config.routes, event.canonical_kind(), &context);
+        let mut deliveries = Vec::with_capacity(matched_routes.len().max(1));
 
-        for route in routes {
-            deliveries.push(self.resolve_delivery(event, route)?);
+        if matched_routes.is_empty() {
+            deliveries.push(self.resolve_delivery(event, None, None)?);
+        } else {
+            for route in matched_routes {
+                let index = self
+                    .config
+                    .routes
+                    .iter()
+                    .position(|candidate| std::ptr::eq(candidate, route));
+                deliveries.push(self.resolve_delivery(event, Some(route), index)?);
+            }
         }
 
         Ok(deliveries)
@@ -90,6 +133,7 @@ impl Router {
         &self,
         event: &IncomingEvent,
         route: Option<&RouteRule>,
+        matched_route_index: Option<usize>,
     ) -> Result<ResolvedDelivery> {
         let sink = route
             .map(RouteRule::effective_sink)
@@ -101,6 +145,22 @@ impl Router {
             .clone()
             .or_else(|| route.and_then(|route| route.format.clone()))
             .unwrap_or_else(|| self.config.defaults.format.clone());
+
+        let trace = RouteTrace {
+            result: if route.is_some() {
+                RouteTraceResult::Matched
+            } else if self.config.defaults.channel.is_some() {
+                RouteTraceResult::Fallback
+            } else {
+                RouteTraceResult::None
+            },
+            matched_route_index,
+            event_pattern: route.map(|route| route.event.clone()),
+            filter_keys: route
+                .map(|route| route.filter.keys().cloned().collect())
+                .unwrap_or_default(),
+            target: telemetry::safe_target_id(&target),
+        };
 
         Ok(ResolvedDelivery {
             sink,
@@ -114,6 +174,7 @@ impl Router {
                 .clone()
                 .or_else(|| route.and_then(|route| route.template.clone())),
             allow_dynamic_tokens: self.allow_dynamic_tokens_for(event, route),
+            trace,
         })
     }
 
@@ -184,11 +245,6 @@ impl Router {
         false
     }
 
-    fn routes_for<'a>(&'a self, event: &IncomingEvent) -> Vec<&'a RouteRule> {
-        let context = event.template_context();
-        matching_routes_for(&self.config.routes, event.canonical_kind(), &context)
-    }
-
     /// Produce a full provenance trace explaining how an event would be routed.
     ///
     /// Unlike [`resolve`](Self::resolve) this evaluates *every* configured route
@@ -257,7 +313,7 @@ impl Router {
                 .collect();
 
         let deliveries = if ordered_matched_indices.is_empty() {
-            match self.resolve_delivery(event, None) {
+            match self.resolve_delivery(event, None, None) {
                 Ok(d) => vec![delivery_explanation(&d, None)],
                 Err(_) => vec![],
             }
@@ -266,7 +322,7 @@ impl Router {
                 .iter()
                 .filter_map(|&idx| {
                     let route = &self.config.routes[idx];
-                    self.resolve_delivery(event, Some(route))
+                    self.resolve_delivery(event, Some(route), Some(idx))
                         .ok()
                         .map(|d| delivery_explanation(&d, Some(idx)))
                 })
@@ -709,6 +765,9 @@ mod tests {
             SinkTarget::DiscordChannel("fallback".into())
         );
         assert_eq!(deliveries[0].format, MessageFormat::Alert);
+        assert_eq!(deliveries[0].trace.result, RouteTraceResult::Fallback);
+        assert_eq!(deliveries[0].trace.matched_route_index, None);
+        assert_eq!(deliveries[0].trace.target, "discord:channel:fallback");
         assert_eq!(
             router
                 .render_delivery(&event, &deliveries[0], &DefaultRenderer)
@@ -716,6 +775,47 @@ mod tests {
                 .unwrap(),
             "🚨 wake up"
         );
+    }
+
+    #[tokio::test]
+    async fn matched_route_carries_trace_metadata() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("fallback".into()),
+                channel_name: None,
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                sink: "discord".into(),
+                filter: [("session".to_string(), "issue-*".to_string())]
+                    .into_iter()
+                    .collect(),
+                channel: Some("ops".into()),
+                channel_name: None,
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event =
+            IncomingEvent::tmux_keyword("issue-214".into(), "error".into(), "boom".into(), None);
+
+        let delivery = router.preview_delivery(&event).await.unwrap();
+
+        assert_eq!(delivery.trace.result, RouteTraceResult::Matched);
+        assert_eq!(delivery.trace.matched_route_index, Some(0));
+        assert_eq!(
+            delivery.trace.event_pattern.as_deref(),
+            Some("tmux.keyword")
+        );
+        assert_eq!(delivery.trace.filter_keys, vec!["session".to_string()]);
+        assert_eq!(delivery.trace.target, "discord:channel:ops");
     }
 
     #[tokio::test]

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -23,6 +23,16 @@ pub struct SinkMessage {
     pub format: MessageFormat,
     pub content: String,
     pub payload: Value,
+    pub telemetry: Option<SinkTelemetry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SinkTelemetry {
+    pub correlation_id: String,
+    pub route_result: Option<String>,
+    pub route_index: Option<usize>,
+    pub target: String,
+    pub batch_count: Option<usize>,
 }
 
 #[async_trait]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -108,6 +108,7 @@ mod tests {
             format: MessageFormat::Compact,
             content: "tmux:ops matched 'error' => boom".into(),
             payload: serde_json::json!({}),
+            telemetry: None,
         });
 
         assert_eq!(
@@ -132,6 +133,7 @@ mod tests {
             format: MessageFormat::Alert,
             content: "🚨 deploy <failed> & paging".into(),
             payload: serde_json::json!({}),
+            telemetry: None,
         });
 
         let blocks = payload

--- a/src/source/git.rs
+++ b/src/source/git.rs
@@ -11,6 +11,7 @@ use crate::Result;
 use crate::config::{AppConfig, GitRepoMonitor};
 use crate::events::IncomingEvent;
 use crate::source::Source;
+use crate::telemetry;
 
 pub struct GitSource {
     config: Arc<AppConfig>,
@@ -437,6 +438,18 @@ fn should_skip_failed_monitor(state: &mut GitMonitorState, now: Instant) -> bool
     };
     if now < failure.next_retry_at {
         failure.suppressed_polls += 1;
+        if failure.suppressed_polls == 1 || failure.suppressed_polls % 10 == 0 {
+            telemetry::emit(source_record(SourceTelemetryInput {
+                event_name: telemetry::event_name::SOURCE_INVENTORY,
+                reason_code: "source_suppressed",
+                source: "git",
+                path: None,
+                classification: Some(failure.classification.as_str()),
+                message: Some(&failure.message),
+                attempts: Some(failure.attempts),
+                suppressed_polls: Some(failure.suppressed_polls),
+            }));
+        }
         return true;
     }
     false
@@ -446,6 +459,16 @@ fn clear_monitor_failure(state: &mut GitMonitorState, path: &str, context: &str)
     let Some(previous) = state.failure.take() else {
         return;
     };
+    telemetry::emit(source_record(SourceTelemetryInput {
+        event_name: "source_recovered",
+        reason_code: "source_recovered",
+        source: "git",
+        path: Some(path),
+        classification: Some(previous.classification.as_str()),
+        message: None,
+        attempts: Some(previous.attempts),
+        suppressed_polls: Some(previous.suppressed_polls),
+    }));
     eprintln!(
         "clawhip source git {context} recovered for {path} after {} failure(s) and {} suppressed poll(s)",
         previous.attempts, previous.suppressed_polls
@@ -473,6 +496,16 @@ fn record_monitor_failure(
         _ => (1, 0),
     };
     let backoff = git_monitor_backoff(attempts, poll_interval);
+    telemetry::emit(source_record(SourceTelemetryInput {
+        event_name: telemetry::event_name::SOURCE_DEGRADED,
+        reason_code: "source_snapshot_failed",
+        source: "git",
+        path: Some(path),
+        classification: Some(classification.as_str()),
+        message: Some(&message),
+        attempts: Some(attempts),
+        suppressed_polls: Some(suppressed_polls),
+    }));
     eprintln!(
         "clawhip source git {context} degraded for {path}: class={}, attempts={}, suppressed={}, next_retry_secs={}, error={message}",
         classification.as_str(),
@@ -496,6 +529,49 @@ fn git_monitor_backoff(attempts: u32, poll_interval: Duration) -> Duration {
         .saturating_mul(multiplier.into())
         .min(300);
     Duration::from_secs(capped.max(1))
+}
+
+struct SourceTelemetryInput<'a> {
+    event_name: &'a str,
+    reason_code: &'a str,
+    source: &'a str,
+    path: Option<&'a str>,
+    classification: Option<&'a str>,
+    message: Option<&'a str>,
+    attempts: Option<u32>,
+    suppressed_polls: Option<u32>,
+}
+
+fn source_record(input: SourceTelemetryInput<'_>) -> serde_json::Map<String, serde_json::Value> {
+    let correlation = format!(
+        "source:{}:{}",
+        input.source,
+        input.path.unwrap_or("inventory")
+    );
+    let mut record = telemetry::record(input.event_name, input.reason_code, correlation);
+    record.insert("source".to_string(), serde_json::json!(input.source));
+    if let Some(path) = input.path {
+        record.insert("path".to_string(), serde_json::json!(path));
+    }
+    if let Some(classification) = input.classification {
+        record.insert(
+            "classification".to_string(),
+            serde_json::json!(classification),
+        );
+    }
+    if let Some(message) = input.message {
+        record.insert("error".to_string(), serde_json::json!(message));
+    }
+    if let Some(attempts) = input.attempts {
+        record.insert("attempts".to_string(), serde_json::json!(attempts));
+    }
+    if let Some(suppressed_polls) = input.suppressed_polls {
+        record.insert(
+            "suppressed_polls".to_string(),
+            serde_json::json!(suppressed_polls),
+        );
+    }
+    record
 }
 
 fn classify_git_monitor_failure(message: &str) -> GitMonitorFailureClass {

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -13,6 +13,7 @@ use crate::config::{AppConfig, GitRepoMonitor};
 use crate::events::IncomingEvent;
 use crate::source::Source;
 use crate::source::git::{GitSnapshot, repo_display_name, snapshot_git_repo};
+use crate::telemetry;
 
 pub struct GitHubSource {
     config: Arc<AppConfig>,
@@ -119,6 +120,12 @@ async fn run_github_poll_cycle(
     state: &mut HashMap<String, GitHubRepoState>,
 ) {
     if let Err(error) = poll_github(config, github_client, tx, state).await {
+        telemetry::emit(source_record(
+            telemetry::event_name::SOURCE_DEGRADED,
+            "source_poll_failed",
+            None,
+            Some(error.to_string()),
+        ));
         eprintln!("clawhip source github poll failed: {error}");
     }
 }
@@ -128,6 +135,12 @@ async fn snapshot_github_repo(repo: &GitRepoMonitor) -> Result<GitSnapshot> {
         Ok(snapshot) => Ok(snapshot),
         Err(error) => match repo.github_repo.clone() {
             Some(github_repo) => {
+                telemetry::emit(source_record(
+                    telemetry::event_name::SOURCE_INVENTORY,
+                    "source_snapshot_fallback",
+                    Some(&repo.path),
+                    Some(error.to_string()),
+                ));
                 eprintln!(
                     "clawhip source github snapshot failed for {}: {error}; using configured github_repo={github_repo}",
                     repo.path
@@ -161,6 +174,12 @@ async fn poll_github(
         let snapshot = match snapshot_github_repo(repo).await {
             Ok(snapshot) => snapshot,
             Err(error) => {
+                telemetry::emit(source_record(
+                    telemetry::event_name::SOURCE_DEGRADED,
+                    "source_snapshot_failed",
+                    Some(&repo.path),
+                    Some(error.to_string()),
+                ));
                 eprintln!(
                     "clawhip source github snapshot failed for {}: {error}",
                     repo.path
@@ -244,6 +263,12 @@ async fn poll_issues(
             Ok(issues)
         }
         Err(error) => {
+            telemetry::emit(source_record(
+                telemetry::event_name::SOURCE_DEGRADED,
+                "source_poll_failed",
+                Some(&repo.path),
+                Some(error.to_string()),
+            ));
             eprintln!(
                 "clawhip source GitHub issue polling failed for {}: {error}",
                 repo.path
@@ -301,6 +326,12 @@ async fn poll_pull_requests(
             Ok(prs)
         }
         Err(error) => {
+            telemetry::emit(source_record(
+                telemetry::event_name::SOURCE_DEGRADED,
+                "source_poll_failed",
+                Some(&repo.path),
+                Some(error.to_string()),
+            ));
             eprintln!(
                 "clawhip source GitHub polling failed for {}: {error}",
                 repo.path
@@ -351,6 +382,12 @@ async fn poll_ci_statuses(
             Ok(ci)
         }
         Err(error) => {
+            telemetry::emit(source_record(
+                telemetry::event_name::SOURCE_DEGRADED,
+                "source_poll_failed",
+                Some(&repo.path),
+                Some(error.to_string()),
+            ));
             eprintln!(
                 "clawhip source GitHub CI polling failed for {}: {error}",
                 repo.path
@@ -358,6 +395,24 @@ async fn poll_ci_statuses(
             Ok(previous.map(|entry| entry.ci.clone()).unwrap_or_default())
         }
     }
+}
+
+fn source_record(
+    event_name: &str,
+    reason_code: &str,
+    repo_path: Option<&str>,
+    error: Option<String>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let correlation = format!("source:github:{}", repo_path.unwrap_or("inventory"));
+    let mut record = telemetry::record(event_name, reason_code, correlation);
+    record.insert("source".to_string(), serde_json::json!("github"));
+    if let Some(repo_path) = repo_path {
+        record.insert("repo_path".to_string(), serde_json::json!(repo_path));
+    }
+    if let Some(error) = error {
+        record.insert("error".to_string(), serde_json::json!(error));
+    }
+    record
 }
 
 async fn send_event(tx: &mpsc::Sender<IncomingEvent>, event: IncomingEvent) -> Result<()> {

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -16,6 +16,7 @@ use crate::events::{IncomingEvent, MessageFormat, RoutingMetadata};
 use crate::keyword_window::{PendingKeywordHits, collect_keyword_hits};
 use crate::router::glob_match;
 use crate::source::Source;
+use crate::telemetry;
 
 pub type SharedTmuxRegistry = Arc<RwLock<HashMap<String, RegisteredTmuxSession>>>;
 
@@ -267,6 +268,12 @@ pub async fn list_active_tmux_registrations(
             sync_active_config_registrations(config, registry, &available_sessions).await;
         }
         Err(error) => {
+            telemetry::emit(source_record(
+                telemetry::event_name::SOURCE_DEGRADED,
+                "source_poll_failed",
+                None,
+                Some(error.to_string()),
+            ));
             eprintln!("clawhip source tmux list-sessions failed: {error}");
         }
     }
@@ -284,6 +291,12 @@ async fn poll_tmux(
     let available_sessions = match list_tmux_sessions().await {
         Ok(sessions) => Some(sessions),
         Err(error) => {
+            telemetry::emit(source_record(
+                telemetry::event_name::SOURCE_DEGRADED,
+                "source_poll_failed",
+                None,
+                Some(error.to_string()),
+            ));
             eprintln!("clawhip source tmux list-sessions failed: {error}");
             None
         }
@@ -327,6 +340,12 @@ async fn poll_tmux(
 
         match session_exists(session_name).await {
             Ok(false) => {
+                telemetry::emit(source_record(
+                    telemetry::event_name::SOURCE_INVENTORY,
+                    "source_missing",
+                    Some(session_name),
+                    None,
+                ));
                 sessions_to_unregister.push(session_name.clone());
                 flush_session_pending_keyword_hits(
                     &mut state.pending_keyword_hits,
@@ -341,6 +360,12 @@ async fn poll_tmux(
                 continue;
             }
             Err(error) => {
+                telemetry::emit(source_record(
+                    telemetry::event_name::SOURCE_DEGRADED,
+                    "source_poll_failed",
+                    Some(session_name),
+                    Some(error.to_string()),
+                ));
                 eprintln!(
                     "clawhip source tmux has-session failed for {}: {error}",
                     session_name
@@ -391,6 +416,12 @@ async fn poll_tmux(
                                 Some(hits)
                             } else {
                                 if should_emit_stale(existing, now, registration.stale_minutes) {
+                                    telemetry::emit(source_record(
+                                        telemetry::event_name::SOURCE_INVENTORY,
+                                        "stale_emitted",
+                                        Some(session_name),
+                                        None,
+                                    ));
                                     tx.emit(tmux_stale_event(
                                         registration,
                                         existing.session.clone(),
@@ -415,10 +446,18 @@ async fn poll_tmux(
                     }
                 }
             }
-            Err(error) => eprintln!(
-                "clawhip source tmux snapshot failed for {}: {error}",
-                session_name
-            ),
+            Err(error) => {
+                telemetry::emit(source_record(
+                    telemetry::event_name::SOURCE_DEGRADED,
+                    "source_snapshot_failed",
+                    Some(session_name),
+                    Some(error.to_string()),
+                ));
+                eprintln!(
+                    "clawhip source tmux snapshot failed for {}: {error}",
+                    session_name
+                );
+            }
         }
     }
 
@@ -436,6 +475,24 @@ async fn poll_tmux(
         .retain(|session, _| sessions.contains_key(session));
 
     Ok(())
+}
+
+fn source_record(
+    event_name: &str,
+    reason_code: &str,
+    session: Option<&str>,
+    error: Option<String>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let correlation = format!("source:tmux:{}", session.unwrap_or("inventory"));
+    let mut record = telemetry::record(event_name, reason_code, correlation);
+    record.insert("source".to_string(), serde_json::json!("tmux"));
+    if let Some(session) = session {
+        record.insert("session".to_string(), serde_json::json!(session));
+    }
+    if let Some(error) = error {
+        record.insert("error".to_string(), serde_json::json!(error));
+    }
+    record
 }
 
 async fn sync_active_config_registrations(

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,212 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use serde_json::{Map, Value, json};
+
+use crate::events::IncomingEvent;
+use crate::sink::{SinkMessage, SinkTarget};
+
+pub mod event_name {
+    pub const DAEMON_PHASE: &str = "daemon_phase";
+    pub const EVENT_ACCEPTED: &str = "event_accepted";
+    pub const EVENT_DROPPED: &str = "event_dropped";
+    pub const ROUTE_TRACE: &str = "route_trace";
+    pub const ROUTINE_DEFERRED: &str = "routine_deferred";
+    pub const ROUTINE_FLUSHED: &str = "routine_flushed";
+    pub const DISPATCH_FAILURE: &str = "dispatch_failure";
+    pub const DISCORD_SEND_ATTEMPT: &str = "discord_send_attempt";
+    pub const DISCORD_SEND_FAILURE: &str = "discord_send_failure";
+    pub const DISCORD_SEND_SUCCESS: &str = "discord_send_success";
+    pub const CIRCUIT_TRANSITION: &str = "circuit_transition";
+    pub const DLQ_BURY: &str = "dlq_bury";
+    pub const SOURCE_DEGRADED: &str = "source_degraded";
+    pub const SOURCE_INVENTORY: &str = "source_inventory";
+}
+
+pub mod reason {
+    pub const DAEMON_STARTUP: &str = "daemon_startup";
+    pub const DAEMON_LISTENING: &str = "daemon_listening";
+    pub const SOURCE_START: &str = "source_start";
+    pub const SOURCE_STOPPED: &str = "source_stopped";
+    pub const ACCEPT_ENQUEUED: &str = "accept_enqueued";
+    pub const DROP_NON_GIT_NATIVE_HOOK: &str = "drop_non_git_native_hook";
+    pub const ROUTE_MATCHED: &str = "route_matched";
+    pub const ROUTE_FALLBACK: &str = "route_fallback";
+    pub const ROUTE_NONE: &str = "route_none";
+    pub const ROUTINE_BATCH_DEFERRED: &str = "routine_batch_deferred";
+    pub const ROUTINE_BATCH_FLUSHED: &str = "routine_batch_flushed";
+    pub const RENDER_FAILED: &str = "render_failed";
+    pub const SINK_MISSING: &str = "sink_missing";
+    pub const SINK_SEND_FAILED: &str = "sink_send_failed";
+    pub const DISCORD_PRE_SEND: &str = "discord_pre_send";
+    pub const DISCORD_RETRY: &str = "discord_retry";
+    pub const DISCORD_EXHAUSTED: &str = "discord_exhausted";
+    pub const DISCORD_SUCCESS: &str = "discord_success";
+    pub const CIRCUIT_OPEN: &str = "circuit_open";
+    pub const CIRCUIT_TRANSITION: &str = "circuit_transition";
+    pub const DLQ_WRITE: &str = "dlq_write";
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelemetryContext {
+    pub correlation_id: String,
+}
+
+impl TelemetryContext {
+    pub fn from_message(message: &SinkMessage) -> Self {
+        Self {
+            correlation_id: correlation_id_for_message(&message.event_kind, &message.payload),
+        }
+    }
+}
+
+pub fn correlation_id_for_event(event: &IncomingEvent) -> String {
+    event
+        .payload
+        .get("correlation_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            event
+                .payload
+                .get("event_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+        })
+        .map(ToString::to_string)
+        .unwrap_or_else(|| stable_correlation_id(event.canonical_kind(), &event.payload))
+}
+
+pub fn correlation_id_for_message(event_kind: &str, payload: &Value) -> String {
+    payload
+        .get("correlation_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            payload
+                .get("event_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+        })
+        .map(ToString::to_string)
+        .unwrap_or_else(|| stable_correlation_id(event_kind, payload))
+}
+
+pub fn stable_correlation_id(event_kind: &str, payload: &Value) -> String {
+    let mut hasher = DefaultHasher::new();
+    event_kind.hash(&mut hasher);
+    serde_json::to_string(payload)
+        .unwrap_or_else(|_| "<unserializable>".to_string())
+        .hash(&mut hasher);
+    format!("derived:{:016x}", hasher.finish())
+}
+
+pub fn safe_target_id(target: &SinkTarget) -> String {
+    match target {
+        SinkTarget::DiscordChannel(channel_id) => format!("discord:channel:{channel_id}"),
+        SinkTarget::DiscordWebhook(webhook_url) => {
+            format!("discord:webhook:{}", redacted_url_fingerprint(webhook_url))
+        }
+        SinkTarget::SlackWebhook(webhook_url) => {
+            format!("slack:webhook:{}", redacted_url_fingerprint(webhook_url))
+        }
+    }
+}
+
+pub fn redacted_url_fingerprint(url: &str) -> String {
+    let host = url
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(url)
+        .split('/')
+        .next()
+        .unwrap_or("unknown-host")
+        .trim()
+        .split('@')
+        .next_back()
+        .unwrap_or("unknown-host");
+    format!("{host}/redacted/{:016x}", fingerprint(url))
+}
+
+pub fn payload_bytes(payload: &Value) -> Option<usize> {
+    serde_json::to_vec(payload).ok().map(|bytes| bytes.len())
+}
+
+pub fn record(
+    event: &str,
+    reason_code: &str,
+    correlation_id: impl Into<String>,
+) -> Map<String, Value> {
+    let mut object = Map::new();
+    object.insert("telemetry_event".to_string(), json!(event));
+    object.insert("reason_code".to_string(), json!(reason_code));
+    object.insert("correlation_id".to_string(), json!(correlation_id.into()));
+    object
+}
+
+pub fn render_line(mut object: Map<String, Value>) -> String {
+    object
+        .entry("schema".to_string())
+        .or_insert_with(|| json!("clawhip.telemetry.v1"));
+    serde_json::to_string(&Value::Object(object)).unwrap_or_else(|_| {
+        r#"{"schema":"clawhip.telemetry.v1","telemetry_event":"serialize_failed"}"#.to_string()
+    })
+}
+
+pub fn emit(object: Map<String, Value>) {
+    eprintln!("{}", render_line(object));
+}
+
+fn fingerprint(value: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::IncomingEvent;
+
+    #[test]
+    fn safe_target_id_redacts_webhook_secret() {
+        let url = "https://discord.com/api/webhooks/123456/secret-token";
+        let safe = safe_target_id(&SinkTarget::DiscordWebhook(url.into()));
+        assert!(safe.starts_with("discord:webhook:discord.com/redacted/"));
+        assert!(!safe.contains("123456"));
+        assert!(!safe.contains("secret-token"));
+        assert!(!safe.contains(url));
+    }
+
+    #[test]
+    fn channel_target_keeps_non_secret_identifier() {
+        assert_eq!(
+            safe_target_id(&SinkTarget::DiscordChannel("ops".into())),
+            "discord:channel:ops"
+        );
+    }
+
+    #[test]
+    fn correlation_prefers_existing_payload_fields_without_mutating_payload() {
+        let event = IncomingEvent::custom(None, "hello".into());
+        let before = event.payload.clone();
+        let first = correlation_id_for_event(&event);
+        let second = correlation_id_for_event(&event);
+        assert_eq!(first, second);
+        assert_eq!(event.payload, before);
+    }
+
+    #[test]
+    fn render_line_uses_expected_stable_fields() {
+        let line = render_line(record(
+            event_name::EVENT_DROPPED,
+            reason::DROP_NON_GIT_NATIVE_HOOK,
+            "corr-1",
+        ));
+        let parsed: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["schema"], json!("clawhip.telemetry.v1"));
+        assert_eq!(parsed["telemetry_event"], json!("event_dropped"));
+        assert_eq!(parsed["reason_code"], json!("drop_non_git_native_hook"));
+        assert_eq!(parsed["correlation_id"], json!("corr-1"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #214 by making operator diagnosis immediate through stderr-only structured telemetry while preserving native-hook compatibility semantics.

## Explicit observability outcomes

- Replay/native-hook diagnosis: non-git native-hook events are accepted-but-dropped before routing with stable `drop_non_git_native_hook` telemetry and unchanged `{ dropped: true, reason: "non_git" }` response metadata.
- Route diagnosis: each resolved delivery emits route/fallback trace metadata including route result, route index, event kind, and redacted target.
- Discord send diagnosis: pre-send, retry, success, exhausted failure, payload/content byte counts, HTTP status, DLQ writes, and circuit transitions are visible via stderr telemetry.
- Source inventory diagnosis: daemon/source startup, source degradation/recovery/suppression, GitHub fallback paths, and tmux missing/dead/stale source conditions emit cheap source inventory/degradation records.
- Compatibility retained: hook install project-scope Codex behavior remains the global-only compatibility shim; prompt delivery still rejects non-repo panes even when a global hook is installed; non-git native-hook drop metadata remains intact.

## Safety notes

- Telemetry stays stderr-only and uses redacted/fingerprinted webhook targets.
- No new dependencies were added.
- Existing config parsing remains backward-compatible.

## Verification

- `cargo test --test reconcile_native_hook_regression -- --nocapture` — 6 passed
- `cargo fmt --check` — passed
- `cargo check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test` — 414 unit + 5 install + 2 provider docs + 6 native-hook regression tests passed
