### PR TITLE
Make clawhip Tokio worker count configurable at startup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use std::io::Read;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
@@ -31,6 +32,13 @@ impl Cli {
             .clone()
             .unwrap_or_else(crate::config::default_config_path)
     }
+
+    pub fn runtime_worker_threads(&self) -> Option<usize> {
+        match self.command.as_ref() {
+            Some(Commands::Start { worker_threads, .. }) => worker_threads.map(NonZeroUsize::get),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -40,6 +48,9 @@ pub enum Commands {
     Start {
         #[arg(long)]
         port: Option<u16>,
+        /// Override the Tokio worker thread count for the daemon runtime.
+        #[arg(long)]
+        worker_threads: Option<NonZeroUsize>,
     },
     /// Check daemon health/status.
     Status,
@@ -707,6 +718,22 @@ mod tests {
     use crate::event::compat::from_incoming_event;
     use clap::CommandFactory;
     use clap::error::ErrorKind;
+
+    #[test]
+    fn parses_start_subcommand_with_worker_threads_override() {
+        let cli = Cli::parse_from(["clawhip", "start", "--worker-threads", "2"]);
+
+        let Commands::Start {
+            port,
+            worker_threads,
+        } = cli.command.expect("start command")
+        else {
+            panic!("expected start command");
+        };
+
+        assert_eq!(port, None);
+        assert_eq!(worker_threads, Some(NonZeroUsize::new(2).unwrap()));
+    }
 
     #[test]
     fn parses_emit_subcommand_with_top_level_fields() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod update;
 use std::sync::Arc;
 
 use clap::Parser;
+use tokio::runtime::Builder;
 
 use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs, GitCommands,
@@ -46,12 +47,29 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub type DynError = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, DynError>;
 
-#[tokio::main]
-async fn main() {
-    if let Err(error) = real_main().await {
+fn main() {
+    let cli = Cli::parse();
+    let runtime = match build_runtime(&cli) {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("clawhip error: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(error) = runtime.block_on(real_main(cli)) {
         eprintln!("clawhip error: {error}");
         std::process::exit(1);
     }
+}
+
+fn build_runtime(cli: &Cli) -> Result<tokio::runtime::Runtime> {
+    let mut builder = Builder::new_multi_thread();
+    builder.enable_all();
+    if let Some(worker_threads) = cli.runtime_worker_threads() {
+        builder.worker_threads(worker_threads);
+    }
+    Ok(builder.build()?)
 }
 
 fn prepare_event(event: IncomingEvent) -> Result<IncomingEvent> {
@@ -60,14 +78,16 @@ fn prepare_event(event: IncomingEvent) -> Result<IncomingEvent> {
     Ok(event)
 }
 
-async fn real_main() -> Result<()> {
-    let cli = Cli::parse();
+async fn real_main(cli: Cli) -> Result<()> {
     let config_path = cli.config_path();
     let config = Arc::new(AppConfig::load_or_default(&config_path)?);
     let cron_state_path = crate::cron::default_state_path(&config_path);
 
-    match cli.command.unwrap_or(Commands::Start { port: None }) {
-        Commands::Start { port } => daemon::run(config, port, cron_state_path).await,
+    match cli.command.unwrap_or(Commands::Start {
+        port: None,
+        worker_threads: None,
+    }) {
+        Commands::Start { port, .. } => daemon::run(config, port, cron_state_path).await,
         Commands::Status => {
             let client = DaemonClient::from_config(config.as_ref());
             let health = client.health().await?;

--- a/tests/runtime_config.rs
+++ b/tests/runtime_config.rs
@@ -1,0 +1,22 @@
+#[test]
+fn runtime_is_configured_from_cli_worker_threads_flag() {
+    let main_rs = include_str!("../src/main.rs");
+    let cli_rs = include_str!("../src/cli.rs");
+
+    assert!(
+        cli_rs.contains("worker_threads: Option<NonZeroUsize>"),
+        "expected Start command to expose an optional worker_threads CLI flag"
+    );
+    assert!(
+        main_rs.contains("Builder::new_multi_thread()"),
+        "expected clawhip to build the Tokio runtime explicitly"
+    );
+    assert!(
+        main_rs.contains(".worker_threads(worker_threads)"),
+        "expected runtime builder to honor the CLI worker_threads override"
+    );
+    assert!(
+        !main_rs.contains("#[tokio::main(flavor = \"multi_thread\", worker_threads = 2)]"),
+        "runtime should no longer hardcode two worker threads"
+    );
+}


### PR DESCRIPTION
## Summary

- replace the hardcoded Tokio runtime macro configuration with an explicit runtime builder
- add `clawhip start --worker-threads <N>` so operators can tune worker count per process launch
- add regression coverage for the CLI flag and explicit runtime builder path

## Why

The previous PR hardcoded two worker threads, but the actual requirement is runtime configurability at process start. This keeps the default behavior when no override is supplied while allowing systemd or operators to set a host-appropriate worker count explicitly.

## Verification

- `cargo +1.89.0 fmt --check`
- `cargo +1.89.0 check`
- `cargo +1.89.0 clippy --all-targets --all-features -- -D warnings`
- `cargo +1.89.0 test`
