### PR TITLE
Add native hook ingress observability

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -24,6 +24,10 @@ use crate::native_hooks::{
     NATIVE_NON_GIT_OUTCOME, NATIVE_NORMALIZATION_OUTCOME_FIELD,
     incoming_event_from_native_hook_json,
 };
+use crate::native_observability::{
+    SharedNativeHookObservability, is_native_hook_event, native_event_telemetry_fields,
+    new_shared_native_hook_observability, snapshot_shared, with_native_observability,
+};
 use crate::render::{DefaultRenderer, Renderer};
 use crate::router::Router;
 use crate::sink::{DiscordSink, Sink, SlackSink};
@@ -60,6 +64,7 @@ struct AppState {
     tx: mpsc::Sender<IncomingEvent>,
     tmux_registry: SharedTmuxRegistry,
     pending_update: SharedPendingUpdate,
+    native_observability: SharedNativeHookObservability,
 }
 
 pub async fn run(
@@ -85,9 +90,11 @@ pub async fn run(
     let router = Router::new(config.clone());
     let tmux_registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
     let (tx, rx) = mpsc::channel(EVENT_QUEUE_CAPACITY);
+    let native_observability = new_shared_native_hook_observability();
 
     let ci_batch_window = config.dispatch.ci_batch_window();
     let routine_batch_window = config.dispatch.routine_batch_window();
+    let dispatcher_native_observability = native_observability.clone();
     tokio::spawn(async move {
         let mut dispatcher = Dispatcher::new(
             rx,
@@ -96,6 +103,7 @@ pub async fn run(
             sinks,
             ci_batch_window,
             routine_batch_window,
+            dispatcher_native_observability,
         );
         if let Err(error) = dispatcher.run().await {
             eprintln!("clawhip dispatcher stopped: {error}");
@@ -142,6 +150,7 @@ pub async fn run(
         tx,
         tmux_registry,
         pending_update,
+        native_observability,
     });
     let addr: SocketAddr = format!("{}:{}", config.daemon.bind_host, port).parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
@@ -252,14 +261,21 @@ fn event_record(
 
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let registered = state.tmux_registry.read().await.len();
+    let native_hooks = snapshot_shared(&state.native_observability);
     Json(health_payload(
         state.config.as_ref(),
         state.port,
         registered,
+        native_hooks,
     ))
 }
 
-fn health_payload(config: &AppConfig, port: u16, registered_tmux_sessions: usize) -> Value {
+fn health_payload(
+    config: &AppConfig,
+    port: u16,
+    registered_tmux_sessions: usize,
+    native_hooks: Value,
+) -> Value {
     json!({
         "ok": true,
         "version": VERSION,
@@ -272,6 +288,7 @@ fn health_payload(config: &AppConfig, port: u16, registered_tmux_sessions: usize
         "configured_workspace_monitors": config.monitors.workspace.len(),
         "configured_cron_jobs": config.cron.jobs.len(),
         "registered_tmux_sessions": registered_tmux_sessions,
+        "native_hooks": native_hooks,
     })
 }
 
@@ -300,9 +317,67 @@ async fn post_native_hook(
     Json(payload): Json<Value>,
 ) -> impl IntoResponse {
     let raw_non_git = native_payload_is_non_git(&payload);
+    with_native_observability(&state.native_observability, |observability| {
+        observability.observe_received_raw(&payload);
+    });
+    eprintln!(
+        "clawhip native hook received: provider={} event={} repo={} session={}",
+        raw_native_field(
+            &payload,
+            &["/provider", "/source/provider", "/context/provider"],
+        ),
+        raw_native_field(
+            &payload,
+            &[
+                "/event_name",
+                "/event",
+                "/hook_event_name",
+                "/hookEventName",
+            ],
+        ),
+        raw_native_field(
+            &payload,
+            &[
+                "/repo_name",
+                "/context/repo_name",
+                "/project",
+                "/project_name",
+            ],
+        ),
+        raw_native_field(
+            &payload,
+            &[
+                "/session_id",
+                "/sessionId",
+                "/context/session_id",
+                "/event_payload/session_id",
+            ],
+        ),
+    );
+
     let event = match incoming_event_from_native_hook_json(&payload) {
         Ok(event) => normalize_event(event),
         Err(error) => {
+            with_native_observability(&state.native_observability, |observability| {
+                observability.observe_dropped_raw(&payload, "normalization_failed");
+            });
+            eprintln!(
+                "clawhip native hook dropped: provider={} event={} reason=normalization_failed error={}",
+                raw_native_field(
+                    &payload,
+                    &["/provider", "/source/provider", "/context/provider"],
+                ),
+                raw_native_field(
+                    &payload,
+                    &[
+                        "/event_name",
+                        "/event",
+                        "/hook_event_name",
+                        "/hookEventName",
+                    ],
+                ),
+                error
+            );
             return (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"ok": false, "error": error.to_string()})),
@@ -311,6 +386,10 @@ async fn post_native_hook(
         }
     };
 
+    with_native_observability(&state.native_observability, |observability| {
+        observability.observe_normalized(&event);
+    });
+
     if raw_non_git || native_hook_should_drop(&event) {
         telemetry::emit(event_record(
             telemetry::event_name::EVENT_DROPPED,
@@ -318,6 +397,14 @@ async fn post_native_hook(
             &event,
             json!({"dropped": true, "source": "native_hook"}),
         ));
+        with_native_observability(&state.native_observability, |observability| {
+            observability.observe_dropped(&event, NATIVE_NON_GIT_OUTCOME);
+        });
+        eprintln!(
+            "clawhip native hook dropped: {} reason={}",
+            native_event_telemetry_fields(&event),
+            NATIVE_NON_GIT_OUTCOME
+        );
         return (
             StatusCode::ACCEPTED,
             Json(json!({
@@ -331,6 +418,15 @@ async fn post_native_hook(
     }
 
     if let Some(defer) = stale_native_replay_defer(&event, &payload) {
+        with_native_observability(&state.native_observability, |observability| {
+            observability.observe_deferred(&event, defer.reason);
+        });
+        eprintln!(
+            "clawhip native hook deferred: {} reason={} age_secs={}",
+            native_event_telemetry_fields(&event),
+            defer.reason,
+            defer.age.as_secs()
+        );
         return stale_replay_defer_response(&event.kind, &defer);
     }
 
@@ -352,6 +448,16 @@ fn native_payload_is_non_git(payload: &Value) -> bool {
             .and_then(|payload| payload.get(NATIVE_NORMALIZATION_OUTCOME_FIELD))
             .and_then(Value::as_str)
             == Some(NATIVE_NON_GIT_OUTCOME)
+}
+
+fn raw_native_field(payload: &Value, pointers: &[&str]) -> String {
+    pointers
+        .iter()
+        .find_map(|pointer| payload.pointer(pointer).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
 }
 
 fn native_hook_should_drop(event: &IncomingEvent) -> bool {
@@ -477,6 +583,11 @@ async fn accept_event(state: &AppState, event: IncomingEvent) -> axum::response:
     let envelope = match from_incoming_event(&event) {
         Ok(envelope) => envelope,
         Err(error) => {
+            if is_native_hook_event(&event) {
+                with_native_observability(&state.native_observability, |observability| {
+                    observability.observe_dropped(&event, "validation_error");
+                });
+            }
             return (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"ok": false, "error": error.to_string()})),
@@ -503,11 +614,18 @@ async fn accept_event(state: &AppState, event: IncomingEvent) -> axum::response:
             )
                 .into_response()
         }
-        Err(error) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"ok": false, "error": error.to_string()})),
-        )
-            .into_response(),
+        Err(error) => {
+            if is_native_hook_event(&event) {
+                with_native_observability(&state.native_observability, |observability| {
+                    observability.observe_dropped(&event, "queue_unavailable");
+                });
+            }
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"ok": false, "error": error.to_string()})),
+            )
+                .into_response()
+        }
     }
 }
 
@@ -780,6 +898,7 @@ mod tests {
                 tx,
                 tmux_registry: Arc::new(RwLock::new(HashMap::new())),
                 pending_update: update::new_shared_pending_update(),
+                native_observability: new_shared_native_hook_observability(),
             },
             rx,
         )
@@ -860,7 +979,12 @@ mod tests {
         config.monitors.tmux.sessions.push(Default::default());
         config.monitors.workspace.push(Default::default());
 
-        let payload = health_payload(&config, 25294, 3);
+        let payload = health_payload(
+            &config,
+            25294,
+            3,
+            snapshot_shared(&new_shared_native_hook_observability()),
+        );
 
         assert_eq!(payload["ok"], Value::Bool(true));
         assert_eq!(payload["version"], Value::String(VERSION.to_string()));
@@ -870,6 +994,7 @@ mod tests {
         assert_eq!(payload["configured_tmux_monitors"], Value::from(1));
         assert_eq!(payload["configured_workspace_monitors"], Value::from(1));
         assert_eq!(payload["registered_tmux_sessions"], Value::from(3));
+        assert!(payload["native_hooks"]["totals"]["received"].is_number());
     }
 
     #[tokio::test]
@@ -955,6 +1080,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
         let event = IncomingEvent {
             kind: "tool.post".into(),
@@ -991,6 +1117,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
         let event = IncomingEvent {
             kind: "tool.post".into(),
@@ -1020,6 +1147,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
         let event = IncomingEvent::agent_started(
             "worker-1".into(),
@@ -1053,6 +1181,124 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn post_native_hook_observability_counts_accepted_event() {
+        let repo = git_repo();
+        let payload = native_payload(repo.path(), "SessionStart");
+        let (tx, mut rx) = mpsc::channel(1);
+        let observability = new_shared_native_hook_observability();
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+            pending_update: update::new_shared_pending_update(),
+            native_observability: observability.clone(),
+        };
+
+        let response = post_native_hook(State(state), Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let queued = rx.recv().await.expect("queued event");
+        assert_eq!(queued.kind, "session.started");
+
+        let snapshot = snapshot_shared(&observability);
+        assert_eq!(snapshot["totals"]["received"], json!(1));
+        assert_eq!(snapshot["totals"]["normalized"], json!(1));
+        assert_eq!(snapshot["recent_groups"][0]["provider"], json!("codex"));
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_observability_counts_rejected_event() {
+        let (tx, _rx) = mpsc::channel(1);
+        let observability = new_shared_native_hook_observability();
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+            pending_update: update::new_shared_pending_update(),
+            native_observability: observability.clone(),
+        };
+        let payload = json!({"provider": "codex", "event_name": "Bogus"});
+
+        let response = post_native_hook(State(state), Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let snapshot = snapshot_shared(&observability);
+        assert_eq!(snapshot["totals"]["received"], json!(1));
+        assert_eq!(snapshot["totals"]["dropped"], json!(1));
+        assert_eq!(snapshot["reasons"]["normalization_failed"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_observability_counts_non_git_drop() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let observability = new_shared_native_hook_observability();
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+            pending_update: update::new_shared_pending_update(),
+            native_observability: observability.clone(),
+        };
+        let dir = tempdir().expect("tempdir");
+        let payload = json!({
+            "provider": "codex",
+            "event_name": "SessionStart",
+            "directory": dir.path(),
+            "event_payload": {}
+        });
+
+        let response = post_native_hook(State(state), Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(rx.try_recv().is_err());
+
+        let snapshot = snapshot_shared(&observability);
+        assert_eq!(snapshot["totals"]["received"], json!(1));
+        assert_eq!(snapshot["totals"]["normalized"], json!(1));
+        assert_eq!(snapshot["totals"]["dropped"], json!(1));
+        assert_eq!(snapshot["reasons"]["non_git"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn post_native_hook_observability_counts_stale_defer() {
+        let repo = git_repo();
+        let mut payload = native_payload(repo.path(), "PostToolUse");
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("timestamp".into(), Value::String(stale_rfc3339()));
+        let (tx, mut rx) = mpsc::channel(1);
+        let observability = new_shared_native_hook_observability();
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+            pending_update: update::new_shared_pending_update(),
+            native_observability: observability.clone(),
+        };
+
+        let response = post_native_hook(State(state), Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(rx.try_recv().is_err());
+
+        let snapshot = snapshot_shared(&observability);
+        assert_eq!(snapshot["totals"]["received"], json!(1));
+        assert_eq!(snapshot["totals"]["normalized"], json!(1));
+        assert_eq!(snapshot["totals"]["deferred"], json!(1));
+        assert_eq!(snapshot["reasons"]["stale_replay"], json!(1));
+    }
+
+    #[tokio::test]
     async fn post_native_hook_accepts_codex_payload_and_queues_normalized_event() {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo = temp.path().join("clawhip");
@@ -1074,6 +1320,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
         let payload = json!({
             "provider": "codex",
@@ -1113,6 +1360,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
         let payload = json!({
             "provider": "claude-code",
@@ -1276,6 +1524,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
         let dir = tempdir().expect("tempdir");
         let payload = json!({
@@ -1329,6 +1578,7 @@ mod tests {
             tx,
             tmux_registry: registry,
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
 
         let response = list_tmux(State(state)).await.into_response();
@@ -1363,6 +1613,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
 
         let response = update_status(State(state)).await.into_response();
@@ -1391,6 +1642,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: pending,
+            native_observability: new_shared_native_hook_observability(),
         };
 
         let response = update_status(State(state)).await.into_response();
@@ -1412,6 +1664,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
 
         let response = approve_update(State(state)).await.into_response();
@@ -1445,6 +1698,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: pending.clone(),
+            native_observability: new_shared_native_hook_observability(),
         };
 
         let response = dismiss_update(State(state)).await.into_response();
@@ -1466,6 +1720,7 @@ mod tests {
             tx,
             tmux_registry: Arc::new(RwLock::new(HashMap::new())),
             pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
         };
 
         let response = dismiss_update(State(state)).await.into_response();

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -8,6 +8,10 @@ use tokio::sync::mpsc;
 use crate::Result;
 use crate::core::timer_wheel::{DelayedEntry, TimerWheel};
 use crate::events::{IncomingEvent, normalize_event};
+use crate::native_observability::{
+    SharedNativeHookObservability, is_native_hook_event, native_event_telemetry_fields,
+    with_native_observability,
+};
 use crate::render::Renderer;
 use crate::router::{ResolvedDelivery, Router};
 use crate::sink::{Sink, SinkMessage, SinkTarget, SinkTelemetry};
@@ -23,6 +27,7 @@ pub struct Dispatcher {
     ci_batcher: GitHubCiBatcher,
     routine_batcher: Option<RoutineDeliveryBatcher>,
     batch_tick: Duration,
+    native_observability: SharedNativeHookObservability,
 }
 
 impl Dispatcher {
@@ -33,6 +38,7 @@ impl Dispatcher {
         sinks: HashMap<String, Box<dyn Sink>>,
         ci_batch_window: Duration,
         routine_batch_window: Option<Duration>,
+        native_observability: SharedNativeHookObservability,
     ) -> Self {
         Self {
             rx,
@@ -42,6 +48,7 @@ impl Dispatcher {
             ci_batcher: GitHubCiBatcher::new(ci_batch_window),
             routine_batcher: routine_batch_window.map(RoutineDeliveryBatcher::new),
             batch_tick: DEFAULT_BATCH_TICK,
+            native_observability,
         }
     }
 
@@ -115,14 +122,30 @@ impl Dispatcher {
     }
 
     async fn deliver_event(&self, event: IncomingEvent) {
+        let provenance = is_native_hook_event(&event).then(|| self.router.explain(&event));
         let deliveries = match self.router.resolve(&event).await {
-            Ok(deliveries) => deliveries,
+            Ok(deliveries) => {
+                self.observe_native_route_outcome(
+                    &event,
+                    provenance.as_ref(),
+                    Some(deliveries.len()),
+                    None,
+                );
+                deliveries
+            }
             Err(error) => {
+                let error_message = error.to_string();
                 self.emit_dispatch_failure(
                     &event,
                     telemetry::reason::ROUTE_NONE,
                     None,
-                    error.to_string(),
+                    error_message.clone(),
+                );
+                self.observe_native_route_outcome(
+                    &event,
+                    provenance.as_ref(),
+                    None,
+                    Some(error_message),
                 );
                 eprintln!(
                     "clawhip dispatcher failed to resolve {}: {error}",
@@ -139,14 +162,30 @@ impl Dispatcher {
     }
 
     async fn resolve_and_dispatch(&mut self, event: IncomingEvent, now_ms: u64) {
+        let provenance = is_native_hook_event(&event).then(|| self.router.explain(&event));
         let deliveries = match self.router.resolve(&event).await {
-            Ok(deliveries) => deliveries,
+            Ok(deliveries) => {
+                self.observe_native_route_outcome(
+                    &event,
+                    provenance.as_ref(),
+                    Some(deliveries.len()),
+                    None,
+                );
+                deliveries
+            }
             Err(error) => {
+                let error_message = error.to_string();
                 self.emit_dispatch_failure(
                     &event,
                     telemetry::reason::ROUTE_NONE,
                     None,
-                    error.to_string(),
+                    error_message.clone(),
+                );
+                self.observe_native_route_outcome(
+                    &event,
+                    provenance.as_ref(),
+                    None,
+                    Some(error_message),
                 );
                 eprintln!(
                     "clawhip dispatcher failed to resolve {}: {error}",
@@ -176,6 +215,44 @@ impl Dispatcher {
 
             self.send_delivery(&event, &delivery).await;
         }
+    }
+
+    fn observe_native_route_outcome(
+        &self,
+        event: &IncomingEvent,
+        provenance: Option<&crate::provenance::Provenance>,
+        delivery_count: Option<usize>,
+        error: Option<String>,
+    ) {
+        if !is_native_hook_event(event) {
+            return;
+        }
+
+        let route_kind = match (delivery_count, provenance) {
+            (Some(0), _) | (None, _) => "unresolved",
+            (Some(_), Some(provenance))
+                if provenance
+                    .deliveries
+                    .iter()
+                    .any(|delivery| delivery.matched_route_index.is_some()) =>
+            {
+                "explicit_route"
+            }
+            (Some(_), _) => "default_route",
+        };
+
+        let count = delivery_count.unwrap_or_default();
+        with_native_observability(&self.native_observability, |observability| {
+            observability.observe_routed(event, count, route_kind);
+        });
+
+        eprintln!(
+            "clawhip native hook routed: {} route={} deliveries={} error={}",
+            native_event_telemetry_fields(event),
+            route_kind,
+            count,
+            error.as_deref().unwrap_or("none")
+        );
     }
 
     async fn send_delivery(&self, event: &IncomingEvent, delivery: &ResolvedDelivery) {
@@ -873,6 +950,7 @@ mod tests {
 
     use super::*;
     use crate::config::{AppConfig, RouteRule};
+    use crate::native_observability::new_shared_native_hook_observability;
     use crate::render::DefaultRenderer;
     use crate::sink::{DiscordSink, SlackSink};
 
@@ -890,7 +968,111 @@ mod tests {
             sinks,
             Duration::from_secs(30),
             None,
+            new_shared_native_hook_observability(),
         )
+    }
+
+    fn native_dispatch_event(kind: &str) -> IncomingEvent {
+        IncomingEvent {
+            kind: kind.into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "provider": "codex",
+                "hook_event_name": "SessionStart",
+                "repo_name": "clawhip",
+                "repo_path": "/tmp/clawhip",
+                "worktree_path": "/tmp/clawhip",
+                "session_id": "sess-route"
+            }),
+        }
+    }
+
+    fn dispatcher_with_observability(
+        config: AppConfig,
+        observability: crate::native_observability::SharedNativeHookObservability,
+    ) -> Dispatcher {
+        let (_tx, rx) = mpsc::channel(1);
+        Dispatcher::new(
+            rx,
+            Router::new(Arc::new(config)),
+            Box::new(DefaultRenderer),
+            HashMap::new(),
+            Duration::from_secs(30),
+            None,
+            observability,
+        )
+    }
+
+    #[tokio::test]
+    async fn native_route_observability_counts_explicit_route() {
+        let observability = new_shared_native_hook_observability();
+        let mut config = AppConfig::default();
+        config.routes.push(RouteRule {
+            event: "session.started".into(),
+            channel: Some("ops".into()),
+            ..RouteRule::default()
+        });
+        let mut dispatcher = dispatcher_with_observability(config, observability.clone());
+
+        dispatcher
+            .resolve_and_dispatch(native_dispatch_event("session.started"), now_ms())
+            .await;
+
+        let snapshot = crate::native_observability::snapshot_shared(&observability);
+        assert_eq!(snapshot["totals"]["routed"], json!(1));
+        assert_eq!(snapshot["reasons"]["explicit_route"], json!(1));
+        assert_eq!(snapshot["recent_groups"][0]["routed"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn native_route_observability_counts_default_route() {
+        let observability = new_shared_native_hook_observability();
+        let mut config = AppConfig::default();
+        config.defaults.channel = Some("default".into());
+        let mut dispatcher = dispatcher_with_observability(config, observability.clone());
+
+        dispatcher
+            .resolve_and_dispatch(native_dispatch_event("session.started"), now_ms())
+            .await;
+
+        let snapshot = crate::native_observability::snapshot_shared(&observability);
+        assert_eq!(snapshot["totals"]["routed"], json!(1));
+        assert_eq!(snapshot["reasons"]["default_route"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn native_route_observability_counts_unresolved_route() {
+        let observability = new_shared_native_hook_observability();
+        let mut dispatcher =
+            dispatcher_with_observability(AppConfig::default(), observability.clone());
+
+        dispatcher
+            .resolve_and_dispatch(native_dispatch_event("session.started"), now_ms())
+            .await;
+
+        let snapshot = crate::native_observability::snapshot_shared(&observability);
+        assert_eq!(snapshot["totals"]["routed"], json!(0));
+        assert_eq!(snapshot["totals"]["unresolved"], json!(1));
+        assert_eq!(snapshot["reasons"]["unresolved"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn route_observability_ignores_non_native_events() {
+        let observability = new_shared_native_hook_observability();
+        let mut config = AppConfig::default();
+        config.defaults.channel = Some("default".into());
+        let mut dispatcher = dispatcher_with_observability(config, observability.clone());
+
+        dispatcher
+            .resolve_and_dispatch(IncomingEvent::custom(None, "hello".into()), now_ms())
+            .await;
+
+        let snapshot = crate::native_observability::snapshot_shared(&observability);
+        assert_eq!(snapshot["totals"]["routed"], json!(0));
+        assert!(snapshot["recent_groups"].as_array().unwrap().is_empty());
     }
 
     async fn spawn_webhook_collector(
@@ -1543,6 +1725,7 @@ mod tests {
             HashMap::new(),
             Duration::from_secs(90),
             None,
+            new_shared_native_hook_observability(),
         );
 
         assert_eq!(dispatcher.ci_batcher.window, Duration::from_secs(90));
@@ -1630,6 +1813,7 @@ mod tests {
             sinks,
             Duration::from_secs(config.dispatch.ci_batch_window_secs),
             config.dispatch.routine_batch_window(),
+            new_shared_native_hook_observability(),
         );
 
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod keyword_window;
 mod lifecycle;
 mod memory;
 mod native_hooks;
+mod native_observability;
 mod plugins;
 mod provenance;
 mod release_preflight;

--- a/src/native_hooks.rs
+++ b/src/native_hooks.rs
@@ -1179,7 +1179,7 @@ mod tests {
         let fake_clawhip = fake_bin.join("clawhip");
         std::fs::write(
             &fake_clawhip,
-            "#!/bin/sh\necho 'fake native hook bridge failure' >&2\nexit 7\n",
+            "#!/bin/sh\ncat >/dev/null\necho 'fake native hook bridge failure' >&2\nexit 7\n",
         )
         .expect("write fake clawhip");
         let mut fake_perms = std::fs::metadata(&fake_clawhip)

--- a/src/native_observability.rs
+++ b/src/native_observability.rs
@@ -1,0 +1,648 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+
+use crate::events::IncomingEvent;
+
+const MAX_NATIVE_OBSERVABILITY_GROUPS: usize = 256;
+const MAX_NATIVE_OBSERVABILITY_SESSIONS: usize = 256;
+const MAX_NATIVE_OBSERVABILITY_SAMPLES: usize = 32;
+const MAX_NATIVE_MISMATCHES: usize = 32;
+
+pub type SharedNativeHookObservability = Arc<Mutex<NativeHookObservability>>;
+
+pub fn new_shared_native_hook_observability() -> SharedNativeHookObservability {
+    Arc::new(Mutex::new(NativeHookObservability::default()))
+}
+
+#[derive(Debug, Default)]
+pub struct NativeHookObservability {
+    totals: Totals,
+    reason_counts: HashMap<String, u64>,
+    groups: HashMap<GroupKey, GroupStats>,
+    sessions: HashMap<SessionKey, SessionStats>,
+    samples: VecDeque<Sample>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct Totals {
+    received: u64,
+    normalized: u64,
+    dropped: u64,
+    deferred: u64,
+    routed: u64,
+    unresolved: u64,
+    route_deliveries: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct GroupKey {
+    provider: String,
+    event_kind: String,
+    repo: String,
+    repo_path: String,
+    worktree_path: String,
+    session_id: String,
+}
+
+#[derive(Debug, Default, Clone)]
+struct GroupStats {
+    received: u64,
+    normalized: u64,
+    dropped: u64,
+    deferred: u64,
+    routed: u64,
+    unresolved: u64,
+    route_deliveries: u64,
+    last_seen_unix: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SessionKey {
+    provider: String,
+    repo: String,
+    repo_path: String,
+    worktree_path: String,
+    session_id: String,
+}
+
+#[derive(Debug, Default, Clone)]
+struct SessionStats {
+    tool_events: u64,
+    session_events: u64,
+    last_tool_event_unix: Option<u64>,
+    last_session_event_unix: Option<u64>,
+    first_mismatch_unix: Option<u64>,
+    last_seen_unix: u64,
+}
+
+#[derive(Debug, Clone)]
+struct Sample {
+    outcome: &'static str,
+    reason: Option<String>,
+    key: GroupKey,
+    delivery_count: Option<usize>,
+    observed_at_unix: u64,
+}
+
+impl NativeHookObservability {
+    pub fn observe_received_raw(&mut self, payload: &Value) {
+        let now = now_unix();
+        self.totals.received += 1;
+        let key = GroupKey::from_raw(payload);
+        let group = self.group_mut(key.clone(), now);
+        group.received += 1;
+        self.push_sample(Sample {
+            outcome: "received",
+            reason: None,
+            key,
+            delivery_count: None,
+            observed_at_unix: now,
+        });
+    }
+
+    pub fn observe_normalized(&mut self, event: &IncomingEvent) {
+        let now = now_unix();
+        self.totals.normalized += 1;
+        let key = GroupKey::from_event(event);
+        let group = self.group_mut(key.clone(), now);
+        group.normalized += 1;
+        self.observe_session_event(&key, event.canonical_kind(), now);
+        self.push_sample(Sample {
+            outcome: "normalized",
+            reason: None,
+            key,
+            delivery_count: None,
+            observed_at_unix: now,
+        });
+    }
+
+    pub fn observe_dropped_raw(&mut self, payload: &Value, reason: impl Into<String>) {
+        let reason = reason.into();
+        let now = now_unix();
+        self.totals.dropped += 1;
+        *self.reason_counts.entry(reason.clone()).or_default() += 1;
+        let key = GroupKey::from_raw(payload);
+        let group = self.group_mut(key.clone(), now);
+        group.dropped += 1;
+        self.push_sample(Sample {
+            outcome: "dropped",
+            reason: Some(reason),
+            key,
+            delivery_count: None,
+            observed_at_unix: now,
+        });
+    }
+
+    pub fn observe_dropped(&mut self, event: &IncomingEvent, reason: impl Into<String>) {
+        let reason = reason.into();
+        let now = now_unix();
+        self.totals.dropped += 1;
+        *self.reason_counts.entry(reason.clone()).or_default() += 1;
+        let key = GroupKey::from_event(event);
+        let group = self.group_mut(key.clone(), now);
+        group.dropped += 1;
+        self.push_sample(Sample {
+            outcome: "dropped",
+            reason: Some(reason),
+            key,
+            delivery_count: None,
+            observed_at_unix: now,
+        });
+    }
+
+    pub fn observe_deferred(&mut self, event: &IncomingEvent, reason: impl Into<String>) {
+        let reason = reason.into();
+        let now = now_unix();
+        self.totals.deferred += 1;
+        *self.reason_counts.entry(reason.clone()).or_default() += 1;
+        let key = GroupKey::from_event(event);
+        let group = self.group_mut(key.clone(), now);
+        group.deferred += 1;
+        self.push_sample(Sample {
+            outcome: "deferred",
+            reason: Some(reason),
+            key,
+            delivery_count: None,
+            observed_at_unix: now,
+        });
+    }
+
+    pub fn observe_routed(
+        &mut self,
+        event: &IncomingEvent,
+        delivery_count: usize,
+        route_kind: &str,
+    ) {
+        let now = now_unix();
+        let unresolved = route_kind == "unresolved";
+        if unresolved {
+            self.totals.unresolved += 1;
+        } else {
+            self.totals.routed += 1;
+            self.totals.route_deliveries += delivery_count as u64;
+        }
+        *self
+            .reason_counts
+            .entry(route_kind.to_string())
+            .or_default() += 1;
+        let key = GroupKey::from_event(event);
+        let group = self.group_mut(key.clone(), now);
+        if unresolved {
+            group.unresolved += 1;
+        } else {
+            group.routed += 1;
+            group.route_deliveries += delivery_count as u64;
+        }
+        self.push_sample(Sample {
+            outcome: if unresolved { "unresolved" } else { "routed" },
+            reason: Some(route_kind.to_string()),
+            key,
+            delivery_count: Some(delivery_count),
+            observed_at_unix: now,
+        });
+    }
+
+    pub fn snapshot(&self) -> Value {
+        let mut groups: Vec<_> = self
+            .groups
+            .iter()
+            .map(|(key, stats)| group_snapshot(key, stats))
+            .collect();
+        groups.sort_by(|a, b| {
+            b.get("last_seen_unix")
+                .and_then(Value::as_u64)
+                .cmp(&a.get("last_seen_unix").and_then(Value::as_u64))
+        });
+
+        let mut mismatches: Vec<_> = self
+            .sessions
+            .iter()
+            .filter(|(_, stats)| stats.tool_events > 0 && stats.session_events == 0)
+            .map(|(key, stats)| mismatch_snapshot(key, stats))
+            .collect();
+        mismatches.sort_by(|a, b| {
+            b.get("last_seen_unix")
+                .and_then(Value::as_u64)
+                .cmp(&a.get("last_seen_unix").and_then(Value::as_u64))
+        });
+        mismatches.truncate(MAX_NATIVE_MISMATCHES);
+
+        json!({
+            "totals": {
+                "received": self.totals.received,
+                "normalized": self.totals.normalized,
+                "dropped": self.totals.dropped,
+                "deferred": self.totals.deferred,
+                "routed": self.totals.routed,
+                "unresolved": self.totals.unresolved,
+                "route_deliveries": self.totals.route_deliveries,
+            },
+            "reasons": self.reason_counts,
+            "recent_groups": groups,
+            "recent_mismatches": mismatches,
+            "recent_samples": self.samples.iter().map(sample_snapshot).collect::<Vec<_>>(),
+        })
+    }
+
+    fn observe_session_event(&mut self, key: &GroupKey, event_kind: &str, now: u64) {
+        if !matches!(
+            event_kind,
+            "tool.pre"
+                | "tool.post"
+                | "session.started"
+                | "session.prompt-submitted"
+                | "session.stopped"
+        ) {
+            return;
+        }
+        let session_key = SessionKey::from_group(key);
+        let stats = self.sessions.entry(session_key).or_default();
+        stats.last_seen_unix = now;
+        if matches!(event_kind, "tool.pre" | "tool.post") {
+            stats.tool_events += 1;
+            stats.last_tool_event_unix = Some(now);
+            if stats.session_events == 0 && stats.first_mismatch_unix.is_none() {
+                stats.first_mismatch_unix = Some(now);
+            }
+        } else {
+            stats.session_events += 1;
+            stats.last_session_event_unix = Some(now);
+            stats.first_mismatch_unix = None;
+        }
+        evict_oldest_session_if_needed(&mut self.sessions);
+    }
+
+    fn group_mut(&mut self, key: GroupKey, now: u64) -> &mut GroupStats {
+        if !self.groups.contains_key(&key) && self.groups.len() >= MAX_NATIVE_OBSERVABILITY_GROUPS {
+            evict_oldest_group(&mut self.groups);
+        }
+        let stats = self.groups.entry(key).or_default();
+        stats.last_seen_unix = now;
+        stats
+    }
+
+    fn push_sample(&mut self, sample: Sample) {
+        if self.samples.len() == MAX_NATIVE_OBSERVABILITY_SAMPLES {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(sample);
+    }
+}
+
+pub fn is_native_hook_event(event: &IncomingEvent) -> bool {
+    matches!(
+        event.canonical_kind(),
+        "session.started"
+            | "session.prompt-submitted"
+            | "session.stopped"
+            | "tool.pre"
+            | "tool.post"
+    ) && event.payload.as_object().is_some_and(|payload| {
+        payload.contains_key("provider")
+            && (payload.contains_key("hook_event_name")
+                || payload.contains_key("event_name")
+                || payload.contains_key("normalized_event"))
+    })
+}
+
+pub fn snapshot_shared(observability: &SharedNativeHookObservability) -> Value {
+    observability
+        .lock()
+        .map(|guard| guard.snapshot())
+        .unwrap_or_else(|_| json!({"error": "native hook observability unavailable"}))
+}
+
+pub fn with_native_observability(
+    observability: &SharedNativeHookObservability,
+    update: impl FnOnce(&mut NativeHookObservability),
+) {
+    if let Ok(mut guard) = observability.lock() {
+        update(&mut guard);
+    }
+}
+
+pub fn native_event_telemetry_fields(event: &IncomingEvent) -> String {
+    let key = GroupKey::from_event(event);
+    format!(
+        "provider={} type={} repo={} session={}",
+        key.provider, key.event_kind, key.repo, key.session_id
+    )
+}
+
+fn group_snapshot(key: &GroupKey, stats: &GroupStats) -> Value {
+    json!({
+        "provider": key.provider,
+        "event_kind": key.event_kind,
+        "repo": key.repo,
+        "repo_path": key.repo_path,
+        "worktree_path": key.worktree_path,
+        "session_id": key.session_id,
+        "received": stats.received,
+        "normalized": stats.normalized,
+        "dropped": stats.dropped,
+        "deferred": stats.deferred,
+        "routed": stats.routed,
+        "unresolved": stats.unresolved,
+        "route_deliveries": stats.route_deliveries,
+        "last_seen_unix": stats.last_seen_unix,
+    })
+}
+
+fn mismatch_snapshot(key: &SessionKey, stats: &SessionStats) -> Value {
+    json!({
+        "provider": key.provider,
+        "repo": key.repo,
+        "repo_path": key.repo_path,
+        "worktree_path": key.worktree_path,
+        "session_id": key.session_id,
+        "tool_events": stats.tool_events,
+        "session_events": stats.session_events,
+        "first_mismatch_unix": stats.first_mismatch_unix,
+        "last_tool_event_unix": stats.last_tool_event_unix,
+        "last_seen_unix": stats.last_seen_unix,
+        "summary": "tool events observed without session lifecycle events",
+    })
+}
+
+fn sample_snapshot(sample: &Sample) -> Value {
+    json!({
+        "outcome": sample.outcome,
+        "reason": sample.reason,
+        "provider": sample.key.provider,
+        "event_kind": sample.key.event_kind,
+        "repo": sample.key.repo,
+        "session_id": sample.key.session_id,
+        "delivery_count": sample.delivery_count,
+        "observed_at_unix": sample.observed_at_unix,
+    })
+}
+
+impl GroupKey {
+    fn from_event(event: &IncomingEvent) -> Self {
+        let payload = &event.payload;
+        Self {
+            provider: string_field(payload, &["/provider", "/source", "/tool"])
+                .unwrap_or_else(|| "unknown".into()),
+            event_kind: event.canonical_kind().to_string(),
+            repo: repo_label(payload),
+            repo_path: string_field(payload, &["/repo_path"]).unwrap_or_else(|| "unknown".into()),
+            worktree_path: string_field(payload, &["/worktree_path"])
+                .unwrap_or_else(|| "unknown".into()),
+            session_id: string_field(payload, &["/session_id", "/sessionId"])
+                .unwrap_or_else(|| "unknown".into()),
+        }
+    }
+
+    fn from_raw(payload: &Value) -> Self {
+        let event_kind = string_field(
+            payload,
+            &[
+                "/event_name",
+                "/event",
+                "/hook_event_name",
+                "/hookEventName",
+            ],
+        )
+        .unwrap_or_else(|| "unknown".into());
+        let repo_path = string_field(payload, &["/repo_path", "/context/repo_path"])
+            .unwrap_or_else(|| "unknown".into());
+        let worktree_path = string_field(
+            payload,
+            &[
+                "/worktree_path",
+                "/context/worktree_path",
+                "/directory",
+                "/cwd",
+                "/context/directory",
+                "/context/cwd",
+            ],
+        )
+        .unwrap_or_else(|| "unknown".into());
+        Self {
+            provider: string_field(
+                payload,
+                &["/provider", "/source/provider", "/context/provider"],
+            )
+            .unwrap_or_else(|| "unknown".into()),
+            event_kind,
+            repo: raw_repo_label(payload, &repo_path, &worktree_path),
+            repo_path,
+            worktree_path,
+            session_id: string_field(
+                payload,
+                &[
+                    "/session_id",
+                    "/sessionId",
+                    "/context/session_id",
+                    "/context/sessionId",
+                    "/event_payload/session_id",
+                    "/event_payload/sessionId",
+                ],
+            )
+            .unwrap_or_else(|| "unknown".into()),
+        }
+    }
+}
+
+impl SessionKey {
+    fn from_group(key: &GroupKey) -> Self {
+        Self {
+            provider: key.provider.clone(),
+            repo: key.repo.clone(),
+            repo_path: key.repo_path.clone(),
+            worktree_path: key.worktree_path.clone(),
+            session_id: key.session_id.clone(),
+        }
+    }
+}
+
+fn repo_label(payload: &Value) -> String {
+    string_field(payload, &["/repo_name", "/project"])
+        .or_else(|| string_field(payload, &["/repo_path"]).and_then(|path| basename(&path)))
+        .or_else(|| string_field(payload, &["/worktree_path"]).and_then(|path| basename(&path)))
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn raw_repo_label(payload: &Value, repo_path: &str, worktree_path: &str) -> String {
+    string_field(
+        payload,
+        &[
+            "/repo_name",
+            "/context/repo_name",
+            "/project",
+            "/project_name",
+            "/projectName",
+        ],
+    )
+    .or_else(|| basename(repo_path))
+    .or_else(|| basename(worktree_path))
+    .unwrap_or_else(|| "unknown".into())
+}
+
+fn string_field(payload: &Value, pointers: &[&str]) -> Option<String> {
+    pointers.iter().find_map(|pointer| {
+        payload
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+    })
+}
+
+fn basename(path: &str) -> Option<String> {
+    let trimmed = path.trim().trim_end_matches('/');
+    if trimmed.is_empty() || trimmed == "unknown" {
+        return None;
+    }
+    trimmed
+        .rsplit('/')
+        .next()
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn evict_oldest_group(groups: &mut HashMap<GroupKey, GroupStats>) {
+    if let Some(oldest) = groups
+        .iter()
+        .min_by_key(|(_, stats)| stats.last_seen_unix)
+        .map(|(key, _)| key.clone())
+    {
+        groups.remove(&oldest);
+    }
+}
+
+fn evict_oldest_session_if_needed(sessions: &mut HashMap<SessionKey, SessionStats>) {
+    if sessions.len() <= MAX_NATIVE_OBSERVABILITY_SESSIONS {
+        return;
+    }
+    if let Some(oldest) = sessions
+        .iter()
+        .min_by_key(|(_, stats)| stats.last_seen_unix)
+        .map(|(key, _)| key.clone())
+    {
+        sessions.remove(&oldest);
+    }
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn native_event(kind: &str, session_id: &str) -> IncomingEvent {
+        IncomingEvent {
+            kind: kind.into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "provider": "codex",
+                "hook_event_name": "PostToolUse",
+                "repo_name": "clawhip",
+                "repo_path": "/tmp/clawhip",
+                "worktree_path": "/tmp/clawhip",
+                "session_id": session_id,
+                "payload": { "secret": "must-not-appear" }
+            }),
+        }
+    }
+
+    #[test]
+    fn records_totals_groups_and_samples_without_raw_payload() {
+        let mut obs = NativeHookObservability::default();
+        let event = native_event("tool.post", "sess-1");
+
+        obs.observe_received_raw(&json!({
+            "provider": "codex",
+            "event_name": "PostToolUse",
+            "repo_name": "clawhip",
+            "session_id": "sess-1"
+        }));
+        obs.observe_normalized(&event);
+        obs.observe_routed(&event, 2, "explicit_route");
+
+        let snapshot = obs.snapshot();
+        assert_eq!(snapshot["totals"]["received"], json!(1));
+        assert_eq!(snapshot["totals"]["normalized"], json!(1));
+        assert_eq!(snapshot["totals"]["routed"], json!(1));
+        assert_eq!(snapshot["totals"]["route_deliveries"], json!(2));
+        assert_eq!(snapshot["recent_groups"][0]["provider"], json!("codex"));
+        assert_eq!(snapshot["recent_groups"][0]["session_id"], json!("sess-1"));
+        assert!(!snapshot.to_string().contains("must-not-appear"));
+    }
+
+    #[test]
+    fn mismatch_appears_for_tool_event_and_clears_after_session_event() {
+        let mut obs = NativeHookObservability::default();
+        obs.observe_normalized(&native_event("tool.pre", "sess-2"));
+        assert_eq!(
+            obs.snapshot()["recent_mismatches"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+
+        obs.observe_normalized(&native_event("session.started", "sess-2"));
+        assert!(
+            obs.snapshot()["recent_mismatches"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn dropped_raw_increments_reason_counter() {
+        let mut obs = NativeHookObservability::default();
+        obs.observe_dropped_raw(
+            &json!({"provider": "codex", "event_name": "Bogus"}),
+            "normalization_failed",
+        );
+        let snapshot = obs.snapshot();
+        assert_eq!(snapshot["totals"]["dropped"], json!(1));
+        assert_eq!(snapshot["reasons"]["normalization_failed"], json!(1));
+    }
+
+    #[test]
+    fn group_count_is_bounded() {
+        let mut obs = NativeHookObservability::default();
+        for index in 0..(MAX_NATIVE_OBSERVABILITY_GROUPS + 10) {
+            obs.observe_received_raw(&json!({
+                "provider": "codex",
+                "event_name": "PostToolUse",
+                "repo_name": format!("repo-{index}"),
+            }));
+        }
+        assert_eq!(obs.groups.len(), MAX_NATIVE_OBSERVABILITY_GROUPS);
+    }
+
+    #[test]
+    fn recognizes_only_provider_native_hook_events() {
+        assert!(is_native_hook_event(&native_event(
+            "session.started",
+            "sess-3"
+        )));
+        let generic = IncomingEvent {
+            kind: "session.started".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({"session_id": "sess-3"}),
+        };
+        assert!(!is_native_hook_event(&generic));
+    }
+}


### PR DESCRIPTION
## Summary\n- Add bounded in-memory native hook observability counters for received, normalized, dropped/deferred, routed, and unresolved provider events grouped by provider/event/repo/session.\n- Expose additive native_hooks status JSON through existing daemon health/status surfaces without new CLI or config semantics.\n- Emit structured stderr telemetry at native ingress/drop/defer/route points and add tests for ingress, route outcome, mismatch, and bounds behavior.\n\nFixes #212.\n\n## Verification\n- cargo fmt --check\n- cargo check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test