### PR TITLE
Fix tmux keyword watcher noise

### DIFF
--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -16,6 +16,20 @@ const LAUNCHER_NOISE_PATTERNS: &[&str] = &[
 pub struct KeywordHit {
     pub keyword: String,
     pub line: String,
+    pub provenance: Option<KeywordMatchProvenance>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeywordMatchProvenance {
+    pub pane_id: String,
+    pub pane_name: String,
+    pub cursor: Option<usize>,
+    pub source: KeywordMatchSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeywordMatchSource {
+    FreshOutput,
 }
 
 #[derive(Debug, Clone)]
@@ -52,7 +66,29 @@ impl PendingKeywordHits {
     }
 }
 
+#[cfg(test)]
 pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) -> Vec<KeywordHit> {
+    collect_keyword_hits_from_lines(appended_lines(previous, current), keywords, None)
+}
+
+pub fn collect_keyword_hits_with_provenance(
+    previous: &str,
+    current: &str,
+    keywords: &[String],
+    provenance: KeywordMatchProvenance,
+) -> Vec<KeywordHit> {
+    collect_keyword_hits_from_lines(
+        appended_lines(previous, current),
+        keywords,
+        Some(provenance),
+    )
+}
+
+fn collect_keyword_hits_from_lines(
+    lines: Vec<&str>,
+    keywords: &[String],
+    provenance: Option<KeywordMatchProvenance>,
+) -> Vec<KeywordHit> {
     if keywords.is_empty() {
         return Vec::new();
     }
@@ -64,7 +100,7 @@ pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) 
     let mut seen = HashSet::new();
     let mut hits = Vec::new();
 
-    for line in appended_lines(previous, current) {
+    for line in lines {
         if should_ignore_launcher_line(line) {
             continue;
         }
@@ -72,11 +108,18 @@ pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) 
         let lower_line = line.to_ascii_lowercase();
         for (keyword, lower_keyword) in &normalized_keywords {
             if lower_line.contains(lower_keyword) {
+                if is_negated_default_failure_match(lower_keyword, &lower_line)
+                    || is_default_review_marker_prose(lower_keyword, line)
+                {
+                    continue;
+                }
+
                 let key = (keyword.clone(), line.to_string());
                 if seen.insert(key.clone()) {
                     hits.push(KeywordHit {
                         keyword: key.0,
                         line: key.1,
+                        provenance: provenance.clone(),
                     });
                 }
             }
@@ -84,6 +127,92 @@ pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) 
     }
 
     hits
+}
+
+fn is_negated_default_failure_match(lower_keyword: &str, lower_line: &str) -> bool {
+    match lower_keyword {
+        "error" | "errors" => contains_any(
+            lower_line,
+            &[
+                "0 error",
+                "0 errors",
+                "zero error",
+                "zero errors",
+                "no error",
+                "no errors",
+                "without error",
+                "without errors",
+            ],
+        ),
+        "fail" | "fails" | "failed" | "failure" | "failures" => contains_any(
+            lower_line,
+            &[
+                "0 fail",
+                "0 fails",
+                "0 failure",
+                "0 failures",
+                "zero fail",
+                "zero fails",
+                "zero failure",
+                "zero failures",
+                "no fail",
+                "no fails",
+                "no failure",
+                "no failures",
+                "without fail",
+                "without fails",
+                "without failure",
+                "without failures",
+            ],
+        ),
+        _ => false,
+    }
+}
+
+fn is_default_review_marker_prose(lower_keyword: &str, line: &str) -> bool {
+    if !matches!(lower_keyword, "blocker" | "request_changes" | "approve") {
+        return false;
+    }
+
+    let trimmed = line.trim();
+    let normalized = trimmed.to_ascii_lowercase();
+    if normalized == lower_keyword {
+        return false;
+    }
+    normalized
+        .strip_prefix(lower_keyword)
+        .map(|suffix| suffix.starts_with(':'))
+        .unwrap_or(false)
+        == false
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles
+        .iter()
+        .any(|needle| contains_bounded(haystack, needle))
+}
+
+fn contains_bounded(haystack: &str, needle: &str) -> bool {
+    let mut search_start = 0;
+    while let Some(relative_start) = haystack[search_start..].find(needle) {
+        let start = search_start + relative_start;
+        let end = start + needle.len();
+        let before_is_word = haystack[..start]
+            .chars()
+            .next_back()
+            .map(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+            .unwrap_or(false);
+        let after_is_word = haystack[end..]
+            .chars()
+            .next()
+            .map(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+            .unwrap_or(false);
+        if !before_is_word && !after_is_word {
+            return true;
+        }
+        search_start = end;
+    }
+    false
 }
 
 fn should_ignore_launcher_line(line: &str) -> bool {
@@ -131,10 +260,12 @@ mod tests {
                 KeywordHit {
                     keyword: "error".into(),
                     line: "error: failed".into(),
+                    provenance: None,
                 },
                 KeywordHit {
                     keyword: "error".into(),
                     line: "ERROR: FAILED".into(),
+                    provenance: None,
                 },
             ]
         );
@@ -153,6 +284,7 @@ mod tests {
             vec![KeywordHit {
                 keyword: "error".into(),
                 line: "error: failed".into(),
+                provenance: None,
             }]
         );
     }
@@ -170,6 +302,7 @@ mod tests {
             vec![KeywordHit {
                 keyword: "error".into(),
                 line: "error: failed".into(),
+                provenance: None,
             }]
         );
     }
@@ -187,6 +320,7 @@ mod tests {
             vec![KeywordHit {
                 keyword: "error".into(),
                 line: "error: real failure".into(),
+                provenance: None,
             }]
         );
     }
@@ -204,6 +338,7 @@ mod tests {
             vec![KeywordHit {
                 keyword: "error".into(),
                 line: "error: real failure".into(),
+                provenance: None,
             }]
         );
     }
@@ -221,6 +356,81 @@ mod tests {
             vec![KeywordHit {
                 keyword: "FAILED".into(),
                 line: "FAILED: actual application failure".into(),
+                provenance: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn collect_keyword_hits_suppresses_negated_default_failure_phrases() {
+        let hits = collect_keyword_hits(
+            "boot",
+            "boot
+0 errors, 0 warnings
+completed without failure
+no errors found
+error: real failure",
+            &["error".into()],
+        );
+
+        assert_eq!(
+            hits,
+            vec![KeywordHit {
+                keyword: "error".into(),
+                line: "error: real failure".into(),
+                provenance: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn negated_failure_suppression_requires_phrase_boundaries() {
+        let hits = collect_keyword_hits(
+            "boot",
+            "boot
+10 errors remain
+20 failures remain",
+            &["error".into(), "failure".into()],
+        );
+
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].line, "10 errors remain");
+        assert_eq!(hits[1].line, "20 failures remain");
+    }
+
+    #[test]
+    fn collect_keyword_hits_ignores_startup_prompt_boundary() {
+        let startup = "Fix issue #220
+End with PR URL or concrete BLOCKER
+ISSUE2843_PR_READY";
+
+        assert!(
+            collect_keyword_hits(
+                startup,
+                startup,
+                &["BLOCKER".into(), "ISSUE2843_PR_READY".into()]
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn collect_keyword_hits_suppresses_default_marker_prose_but_keeps_custom_markers() {
+        let hits = collect_keyword_hits(
+            "armed",
+            "armed
+• Using ralph until PR/ blocker
+End with PR URL or concrete BLOCKER
+ISSUE2843_PR_READY",
+            &["BLOCKER".into(), "ISSUE2843_PR_READY".into()],
+        );
+
+        assert_eq!(
+            hits,
+            vec![KeywordHit {
+                keyword: "ISSUE2843_PR_READY".into(),
+                line: "ISSUE2843_PR_READY".into(),
+                provenance: None,
             }]
         );
     }
@@ -232,15 +442,18 @@ mod tests {
         pending.push(vec![KeywordHit {
             keyword: "error".into(),
             line: "error: failed".into(),
+            provenance: None,
         }]);
         pending.push(vec![
             KeywordHit {
                 keyword: "error".into(),
                 line: "error: failed".into(),
+                provenance: None,
             },
             KeywordHit {
                 keyword: "complete".into(),
                 line: "complete".into(),
+                provenance: None,
             },
         ]);
 
@@ -250,10 +463,12 @@ mod tests {
                 KeywordHit {
                     keyword: "error".into(),
                     line: "error: failed".into(),
+                    provenance: None,
                 },
                 KeywordHit {
                     keyword: "complete".into(),
                     line: "complete".into(),
+                    provenance: None,
                 },
             ]
         );

--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -179,11 +179,10 @@ fn is_default_review_marker_prose(lower_keyword: &str, line: &str) -> bool {
     if normalized == lower_keyword {
         return false;
     }
-    normalized
+    !normalized
         .strip_prefix(lower_keyword)
         .map(|suffix| suffix.starts_with(':'))
         .unwrap_or(false)
-        == false
 }
 
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -13,7 +13,10 @@ use crate::Result;
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, TmuxSessionMonitor};
 use crate::events::{IncomingEvent, MessageFormat, RoutingMetadata};
-use crate::keyword_window::{PendingKeywordHits, collect_keyword_hits};
+use crate::keyword_window::{
+    KeywordHit, KeywordMatchProvenance, KeywordMatchSource, PendingKeywordHits,
+    collect_keyword_hits_with_provenance,
+};
 use crate::router::glob_match;
 use crate::source::Source;
 use crate::telemetry;
@@ -224,10 +227,16 @@ pub async fn monitor_registered_session(
                 Some(existing) => {
                     existing.pane_dead = pane.pane_dead;
                     if existing.content_hash != hash {
-                        let hits = collect_keyword_hits(
+                        let hits = collect_keyword_hits_with_provenance(
                             &existing.snapshot,
                             &pane.content,
                             &registration.keywords,
+                            KeywordMatchProvenance {
+                                pane_id: pane.pane_id.clone(),
+                                pane_name: pane.pane_name.clone(),
+                                cursor: Some(pane.content.lines().count()),
+                                source: KeywordMatchSource::FreshOutput,
+                            },
                         );
                         push_pending_keyword_hits(&mut pending_keyword_hits, now, hits);
 
@@ -403,10 +412,16 @@ async fn poll_tmux(
                         Some(existing) => {
                             existing.pane_dead = pane.pane_dead;
                             if existing.content_hash != hash {
-                                let hits = collect_keyword_hits(
+                                let hits = collect_keyword_hits_with_provenance(
                                     &existing.snapshot,
                                     &pane.content,
                                     &registration.keywords,
+                                    KeywordMatchProvenance {
+                                        pane_id: pane.pane_id.clone(),
+                                        pane_name: pane.pane_name.clone(),
+                                        cursor: Some(pane.content.lines().count()),
+                                        source: KeywordMatchSource::FreshOutput,
+                                    },
                                 );
                                 existing.pane_name = pane.pane_name;
                                 existing.snapshot = pane.content;
@@ -667,12 +682,19 @@ fn should_emit_stale(pane: &TmuxPaneState, now: Instant, stale_minutes: u64) -> 
 fn tmux_keyword_event(
     registration: &RegisteredTmuxSession,
     session: String,
-    hits: Vec<(String, String)>,
+    hits: Vec<KeywordHit>,
 ) -> IncomingEvent {
     let event = if hits.len() <= 1 {
         match hits.into_iter().next() {
-            Some((keyword, line)) => {
-                IncomingEvent::tmux_keyword(session, keyword, line, registration.channel.clone())
+            Some(hit) => {
+                let mut event = IncomingEvent::tmux_keyword(
+                    session,
+                    hit.keyword,
+                    hit.line,
+                    registration.channel.clone(),
+                );
+                add_keyword_hit_provenance(&mut event.payload, hit.provenance.as_ref());
+                event
             }
             None => IncomingEvent::tmux_keyword(
                 session,
@@ -681,14 +703,90 @@ fn tmux_keyword_event(
                 registration.channel.clone(),
             ),
         }
+    } else if hits.iter().all(|hit| hit.provenance.is_none()) {
+        IncomingEvent::tmux_keywords(
+            session,
+            hits.into_iter()
+                .map(|hit| (hit.keyword, hit.line))
+                .collect(),
+            registration.channel.clone(),
+        )
     } else {
-        IncomingEvent::tmux_keywords(session, hits, registration.channel.clone())
+        let hit_payloads = hits
+            .into_iter()
+            .map(|hit| {
+                let mut payload = serde_json::json!({
+                    "keyword": hit.keyword,
+                    "line": hit.line,
+                });
+                add_keyword_hit_provenance(&mut payload, hit.provenance.as_ref());
+                payload
+            })
+            .collect::<Vec<_>>();
+        tmux_keyword_event_from_hit_payloads(session, registration.channel.clone(), hit_payloads)
     };
 
     event
         .with_routing_metadata(&registration.routing)
         .with_mention(registration.mention.clone())
         .with_format(registration.format.clone())
+}
+
+fn tmux_keyword_event_from_hit_payloads(
+    session: String,
+    channel: Option<String>,
+    hit_payloads: Vec<serde_json::Value>,
+) -> IncomingEvent {
+    let hit_count = hit_payloads.len();
+    let first_keyword = hit_payloads
+        .first()
+        .and_then(|hit| hit.get("keyword"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let first_line = hit_payloads
+        .first()
+        .and_then(|hit| hit.get("line"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    IncomingEvent {
+        kind: "tmux.keyword".to_string(),
+        channel,
+        mention: None,
+        format: None,
+        template: None,
+        payload: serde_json::json!({
+            "session": session,
+            "keyword": first_keyword,
+            "line": first_line,
+            "hit_count": hit_count,
+            "hits": hit_payloads,
+        }),
+    }
+}
+
+fn add_keyword_hit_provenance(
+    payload: &mut serde_json::Value,
+    provenance: Option<&KeywordMatchProvenance>,
+) {
+    let Some(provenance) = provenance else {
+        return;
+    };
+    let Some(object) = payload.as_object_mut() else {
+        return;
+    };
+
+    object.insert("pane_id".to_string(), serde_json::json!(provenance.pane_id));
+    object.insert(
+        "pane_name".to_string(),
+        serde_json::json!(provenance.pane_name),
+    );
+    if let Some(cursor) = provenance.cursor {
+        object.insert("cursor".to_string(), serde_json::json!(cursor));
+    }
+    object.insert("source".to_string(), serde_json::json!("fresh-output"));
 }
 
 fn tmux_stale_event(
@@ -729,11 +827,7 @@ async fn flush_pending_keyword_hits<E: EventEmitter>(
     let Some(pending) = pending_keyword_hits.take() else {
         return Ok(());
     };
-    let hits = pending
-        .into_hits()
-        .into_iter()
-        .map(|hit| (hit.keyword, hit.line))
-        .collect::<Vec<_>>();
+    let hits = pending.into_hits();
     if hits.is_empty() {
         return Ok(());
     }
@@ -911,7 +1005,7 @@ pub fn current_timestamp_rfc3339() -> String {
 mod tests {
     use super::*;
     use crate::event::{EventBody, compat::from_incoming_event};
-    use crate::keyword_window::KeywordHit;
+    use crate::keyword_window::{KeywordHit, collect_keyword_hits};
 
     fn registration(keywords: Vec<&str>) -> RegisteredTmuxSession {
         RegisteredTmuxSession {
@@ -927,6 +1021,14 @@ mod tests {
             registration_source: RegistrationSource::ConfigMonitor,
             parent_process: None,
             active_wrapper_monitor: false,
+        }
+    }
+
+    fn keyword_hit(keyword: &str, line: &str) -> KeywordHit {
+        KeywordHit {
+            keyword: keyword.into(),
+            line: line.into(),
+            provenance: None,
         }
     }
 
@@ -954,7 +1056,7 @@ PR created #7",
         let event = tmux_keyword_event(
             &registration,
             "issue-24".into(),
-            vec![("error".into(), "boom".into())],
+            vec![keyword_hit("error", "boom")],
         );
 
         assert_eq!(event.channel.as_deref(), Some("alerts"));
@@ -964,6 +1066,30 @@ PR created #7",
         assert_eq!(event.payload["keyword"], "error");
         assert_eq!(event.payload["line"], "boom");
         assert_eq!(event.payload["hit_count"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn tmux_keyword_event_includes_match_provenance() {
+        let registration = registration(vec!["error"]);
+        let event = tmux_keyword_event(
+            &registration,
+            "issue-24".into(),
+            vec![KeywordHit {
+                keyword: "error".into(),
+                line: "error: failed".into(),
+                provenance: Some(KeywordMatchProvenance {
+                    pane_id: "%3".into(),
+                    pane_name: "0.1".into(),
+                    cursor: Some(42),
+                    source: KeywordMatchSource::FreshOutput,
+                }),
+            }],
+        );
+
+        assert_eq!(event.payload["pane_id"], "%3");
+        assert_eq!(event.payload["pane_name"], "0.1");
+        assert_eq!(event.payload["cursor"], 42);
+        assert_eq!(event.payload["source"], "fresh-output");
     }
 
     #[test]
@@ -979,7 +1105,7 @@ PR created #7",
         let event = tmux_keyword_event(
             &registration,
             "clawhip-issue-152".into(),
-            vec![("error".into(), "boom".into())],
+            vec![keyword_hit("error", "boom")],
         );
 
         assert_eq!(event.payload["project"], "clawhip");
@@ -999,8 +1125,8 @@ PR created #7",
             &registration,
             "issue-24".into(),
             vec![
-                ("error".into(), "boom".into()),
-                ("complete".into(), "done".into()),
+                keyword_hit("error", "boom"),
+                keyword_hit("complete", "done"),
             ],
         );
 
@@ -1183,14 +1309,17 @@ PR created #7",
                 KeywordHit {
                     keyword: "error".into(),
                     line: "error: failed".into(),
+                    provenance: None,
                 },
                 KeywordHit {
                     keyword: "error".into(),
                     line: "error: failed".into(),
+                    provenance: None,
                 },
                 KeywordHit {
                     keyword: "complete".into(),
                     line: "complete".into(),
+                    provenance: None,
                 },
             ]);
             pending
@@ -1230,6 +1359,7 @@ PR created #7",
             pending.push(vec![KeywordHit {
                 keyword: "error".into(),
                 line: "boom".into(),
+                provenance: None,
             }]);
             pending
         });
@@ -1332,6 +1462,7 @@ error: failed";
             vec![KeywordHit {
                 keyword: "error".into(),
                 line: "error: failed".into(),
+                provenance: None,
             }],
         );
         push_session_pending_keyword_hits(
@@ -1342,10 +1473,12 @@ error: failed";
                 KeywordHit {
                     keyword: "error".into(),
                     line: "error: failed".into(),
+                    provenance: None,
                 },
                 KeywordHit {
                     keyword: "complete".into(),
                     line: "build complete".into(),
+                    provenance: None,
                 },
             ],
         );
@@ -1390,6 +1523,7 @@ error: failed";
             vec![KeywordHit {
                 keyword: "error".into(),
                 line: "error: failed".into(),
+                provenance: None,
             }],
         );
 


### PR DESCRIPTION
## Summary
- track tmux keyword hits as fresh-output matches with pane/cursor provenance in alert payloads
- suppress stale startup/prompt text regressions and obvious negated default failure phrases like `0 errors`, `no errors`, and `without error`
- suppress prose matches for default review markers like `BLOCKER` while preserving explicit fresh custom markers

## Verification
- cargo fmt --check
- cargo check
- cargo test

Fixes #220