### PR TITLE
Fix tmux keyword stale scrollback false positives

### DIFF
--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -119,7 +119,7 @@ fn collect_keyword_hits_from_lines(
         for (keyword, lower_keyword) in &normalized_keywords {
             if lower_line.contains(lower_keyword) {
                 if is_negated_default_failure_match(lower_keyword, &lower_line)
-                    || is_default_review_marker_prose(lower_keyword, line)
+                    || is_instruction_or_search_review_marker_prose(lower_keyword, line)
                 {
                     continue;
                 }
@@ -184,20 +184,26 @@ fn is_negated_default_failure_match(lower_keyword: &str, lower_line: &str) -> bo
     }
 }
 
-fn is_default_review_marker_prose(lower_keyword: &str, line: &str) -> bool {
+fn is_instruction_or_search_review_marker_prose(lower_keyword: &str, line: &str) -> bool {
     if !matches!(lower_keyword, "blocker" | "request_changes" | "approve") {
         return false;
     }
 
-    let trimmed = line.trim();
-    let normalized = trimmed.to_ascii_lowercase();
+    let normalized = line.trim().to_ascii_lowercase();
     if normalized == lower_keyword {
         return false;
     }
-    !normalized
-        .strip_prefix(lower_keyword)
-        .map(|suffix| suffix.starts_with(':'))
-        .unwrap_or(false)
+
+    // Only suppress obvious instruction/search prose that mentions the review
+    // marker as text to look for. Fresh verdict prose such as
+    // "Final verdict APPROVE with evidence" or "I found a BLOCKER..." must
+    // still alert; stale prompt/search scrollback is handled by the appended
+    // output boundary before this filter runs.
+    normalized.contains("end with")
+        || normalized.contains("search ")
+        || normalized.contains("query ")
+        || normalized.contains("keywords")
+        || normalized.contains("using ralph until")
 }
 
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {
@@ -434,7 +440,7 @@ ISSUE2843_PR_READY";
     }
 
     #[test]
-    fn collect_keyword_hits_suppresses_default_marker_prose_but_keeps_custom_markers() {
+    fn collect_keyword_hits_suppresses_instruction_marker_prose_but_keeps_custom_markers() {
         let hits = collect_keyword_hits(
             "armed",
             "armed
@@ -452,6 +458,39 @@ ISSUE2843_PR_READY",
                 provenance: None,
             }]
         );
+    }
+
+    #[test]
+    fn collect_keyword_hits_alerts_on_fresh_review_verdict_prose() {
+        let hits = collect_keyword_hits_with_provenance(
+            "armed",
+            "armed
+Final verdict APPROVE with evidence
+REQUEST_CHANGES with evidence
+I found a BLOCKER in tmux cursor handling",
+            &["APPROVE".into(), "REQUEST_CHANGES".into(), "BLOCKER".into()],
+            KeywordMatchProvenance {
+                pane_id: "%11".into(),
+                pane_name: "0.0".into(),
+                cursor: None,
+                source: KeywordMatchSource::FreshOutput,
+            },
+        );
+
+        assert_eq!(
+            hits.iter().map(|hit| hit.line.as_str()).collect::<Vec<_>>(),
+            vec![
+                "Final verdict APPROVE with evidence",
+                "REQUEST_CHANGES with evidence",
+                "I found a BLOCKER in tmux cursor handling",
+            ]
+        );
+        assert_eq!(hits[0].keyword, "APPROVE");
+        assert_eq!(hits[0].provenance.as_ref().unwrap().cursor, Some(2));
+        assert_eq!(hits[1].keyword, "REQUEST_CHANGES");
+        assert_eq!(hits[1].provenance.as_ref().unwrap().cursor, Some(3));
+        assert_eq!(hits[2].keyword, "BLOCKER");
+        assert_eq!(hits[2].provenance.as_ref().unwrap().cursor, Some(4));
     }
 
     #[test]

--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -68,7 +68,14 @@ impl PendingKeywordHits {
 
 #[cfg(test)]
 pub fn collect_keyword_hits(previous: &str, current: &str, keywords: &[String]) -> Vec<KeywordHit> {
-    collect_keyword_hits_from_lines(appended_lines(previous, current), keywords, None)
+    collect_keyword_hits_from_lines(
+        appended_lines_with_cursors(previous, current)
+            .into_iter()
+            .map(|(_, line)| (None, line))
+            .collect(),
+        keywords,
+        None,
+    )
 }
 
 pub fn collect_keyword_hits_with_provenance(
@@ -78,14 +85,17 @@ pub fn collect_keyword_hits_with_provenance(
     provenance: KeywordMatchProvenance,
 ) -> Vec<KeywordHit> {
     collect_keyword_hits_from_lines(
-        appended_lines(previous, current),
+        appended_lines_with_cursors(previous, current)
+            .into_iter()
+            .map(|(cursor, line)| (Some(cursor), line))
+            .collect(),
         keywords,
         Some(provenance),
     )
 }
 
 fn collect_keyword_hits_from_lines(
-    lines: Vec<&str>,
+    lines: Vec<(Option<usize>, &str)>,
     keywords: &[String],
     provenance: Option<KeywordMatchProvenance>,
 ) -> Vec<KeywordHit> {
@@ -100,7 +110,7 @@ fn collect_keyword_hits_from_lines(
     let mut seen = HashSet::new();
     let mut hits = Vec::new();
 
-    for line in lines {
+    for (line_cursor, line) in lines {
         if should_ignore_launcher_line(line) {
             continue;
         }
@@ -119,7 +129,12 @@ fn collect_keyword_hits_from_lines(
                     hits.push(KeywordHit {
                         keyword: key.0,
                         line: key.1,
-                        provenance: provenance.clone(),
+                        provenance: provenance.clone().map(|mut provenance| {
+                            if let Some(cursor) = line_cursor {
+                                provenance.cursor = Some(cursor);
+                            }
+                            provenance
+                        }),
                     });
                 }
             }
@@ -221,12 +236,17 @@ fn should_ignore_launcher_line(line: &str) -> bool {
         .any(|pattern| trimmed.contains(pattern))
 }
 
-fn appended_lines<'a>(previous: &'a str, current: &'a str) -> Vec<&'a str> {
+fn appended_lines_with_cursors<'a>(previous: &'a str, current: &'a str) -> Vec<(usize, &'a str)> {
     let previous_lines = previous.lines().collect::<Vec<_>>();
     let current_lines = current.lines().collect::<Vec<_>>();
     let overlap = overlapping_suffix_prefix_len(&previous_lines, &current_lines);
 
-    current_lines.into_iter().skip(overlap).collect()
+    current_lines
+        .into_iter()
+        .enumerate()
+        .skip(overlap)
+        .map(|(index, line)| (index + 1, line))
+        .collect()
 }
 
 fn overlapping_suffix_prefix_len(previous: &[&str], current: &[&str]) -> usize {
@@ -431,6 +451,78 @@ ISSUE2843_PR_READY",
                 line: "ISSUE2843_PR_READY".into(),
                 provenance: None,
             }]
+        );
+    }
+
+    #[test]
+    fn collect_keyword_hits_treats_existing_prompt_and_search_markers_as_existing_buffer() {
+        // Regression for #220 / Discord message 1502008605518594172:
+        // markers present in the user's initial prompt and search/query text
+        // are registration-time scrollback, not fresh model output.
+        let previous = "Welcome
+End with PR_READY #220 and summary
+Search keywords.*...PR_READY";
+        let current = "Welcome
+End with PR_READY #220 and summary
+Search keywords.*...PR_READY
+still running";
+
+        let hits = collect_keyword_hits(previous, current, &["PR_READY".into()]);
+
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn collect_keyword_hits_suppresses_existing_prompt_search_but_keeps_fresh_custom_marker() {
+        let previous = "Welcome
+End with PR_READY #220 and summary
+Search keywords.*...PR_READY";
+        let current = "Welcome
+End with PR_READY #220 and summary
+Search keywords.*...PR_READY
+still running
+PR_READY #220";
+
+        let hits = collect_keyword_hits_with_provenance(
+            previous,
+            current,
+            &["PR_READY".into()],
+            KeywordMatchProvenance {
+                pane_id: "%9".into(),
+                pane_name: "0.0".into(),
+                cursor: None,
+                source: KeywordMatchSource::FreshOutput,
+            },
+        );
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].line, "PR_READY #220");
+        assert_eq!(hits[0].provenance.as_ref().unwrap().cursor, Some(5));
+    }
+
+    #[test]
+    fn collect_keyword_hits_keeps_exact_cursor_for_fresh_custom_marker() {
+        let hits = collect_keyword_hits_with_provenance(
+            "boot",
+            "boot
+working
+ISSUE220_PR_READY",
+            &["ISSUE220_PR_READY".into()],
+            KeywordMatchProvenance {
+                pane_id: "%7".into(),
+                pane_name: "0.0".into(),
+                cursor: None,
+                source: KeywordMatchSource::FreshOutput,
+            },
+        );
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].keyword, "ISSUE220_PR_READY");
+        assert_eq!(hits[0].line, "ISSUE220_PR_READY");
+        assert_eq!(hits[0].provenance.as_ref().unwrap().cursor, Some(3));
+        assert_eq!(
+            hits[0].provenance.as_ref().unwrap().source,
+            KeywordMatchSource::FreshOutput
         );
     }
 

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -263,21 +263,24 @@ impl Renderer for DefaultRenderer {
             ) => serde_json::to_string_pretty(payload)?,
 
             ("tmux.keyword", MessageFormat::Compact) => format!(
-                "tmux:{} matched '{}' => {}",
+                "tmux:{} matched '{}' => {}{}",
                 string_field(payload, "session")?,
                 string_field(payload, "keyword")?,
-                string_field(payload, "line")?
+                string_field(payload, "line")?,
+                tmux_keyword_provenance_suffix(payload)
             ),
             ("tmux.keyword", MessageFormat::Alert) => format!(
-                "🚨 tmux session {} hit keyword '{}': {}",
+                "🚨 tmux session {} hit keyword '{}': {}{}",
                 string_field(payload, "session")?,
                 string_field(payload, "keyword")?,
-                string_field(payload, "line")?
+                string_field(payload, "line")?,
+                tmux_keyword_provenance_suffix(payload)
             ),
             ("tmux.keyword", MessageFormat::Inline) => format!(
-                "[tmux:{}] {}",
+                "[tmux:{}] {}{}",
                 string_field(payload, "session")?,
-                string_field(payload, "line")?
+                string_field(payload, "line")?,
+                tmux_keyword_provenance_suffix(payload)
             ),
             ("tmux.keyword", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
 
@@ -731,6 +734,31 @@ fn render_aggregated_git_commit(payload: &Value, format: &MessageFormat) -> Resu
     Ok(Some(lines.join("\n")))
 }
 
+fn tmux_keyword_provenance_suffix(payload: &Value) -> String {
+    let mut parts = Vec::new();
+    if let Some(pane_id) = payload.get("pane_id").and_then(Value::as_str) {
+        let pane_name = payload.get("pane_name").and_then(Value::as_str);
+        match pane_name {
+            Some(pane_name) if !pane_name.is_empty() => {
+                parts.push(format!("pane {pane_id}/{pane_name}"));
+            }
+            _ => parts.push(format!("pane {pane_id}")),
+        }
+    }
+    if let Some(cursor) = payload.get("cursor").and_then(Value::as_u64) {
+        parts.push(format!("cursor {cursor}"));
+    }
+    if let Some(source) = payload.get("source").and_then(Value::as_str) {
+        parts.push(source.to_string());
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join(", "))
+    }
+}
+
 fn render_aggregated_tmux_keyword(
     payload: &Value,
     format: &MessageFormat,
@@ -754,7 +782,10 @@ fn render_aggregated_tmux_keyword(
             if keyword.is_empty() || line.is_empty() {
                 None
             } else {
-                Some(format!("'{keyword}': {line}"))
+                Some(format!(
+                    "'{keyword}': {line}{}",
+                    tmux_keyword_provenance_suffix(hit)
+                ))
             }
         })
         .collect::<Vec<_>>();
@@ -883,6 +914,29 @@ mod tests {
             .render(&event, &MessageFormat::Compact)
             .unwrap();
         assert_eq!(rendered, "git:repo@main 1234567 ship it");
+    }
+
+    #[test]
+    fn renders_tmux_keyword_provenance_when_present() {
+        let mut event = IncomingEvent::tmux_keyword(
+            "issue-220".into(),
+            "ERROR_READY".into(),
+            "ERROR_READY".into(),
+            None,
+        );
+        event.payload["pane_id"] = json!("%3");
+        event.payload["pane_name"] = json!("0.1");
+        event.payload["cursor"] = json!(42);
+        event.payload["source"] = json!("fresh-output");
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Alert)
+            .unwrap();
+
+        assert_eq!(
+            rendered,
+            "🚨 tmux session issue-220 hit keyword 'ERROR_READY': ERROR_READY (pane %3/0.1, cursor 42, fresh-output)"
+        );
     }
 
     #[test]

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -234,7 +234,7 @@ pub async fn monitor_registered_session(
                             KeywordMatchProvenance {
                                 pane_id: pane.pane_id.clone(),
                                 pane_name: pane.pane_name.clone(),
-                                cursor: Some(pane.content.lines().count()),
+                                cursor: None,
                                 source: KeywordMatchSource::FreshOutput,
                             },
                         );
@@ -419,7 +419,7 @@ async fn poll_tmux(
                                     KeywordMatchProvenance {
                                         pane_id: pane.pane_id.clone(),
                                         pane_name: pane.pane_name.clone(),
-                                        cursor: Some(pane.content.lines().count()),
+                                        cursor: None,
                                         source: KeywordMatchSource::FreshOutput,
                                     },
                                 );


### PR DESCRIPTION
## Summary
- keep tmux keyword alerts anchored to appended fresh output and attach exact matched-line cursor provenance instead of only the final pane length
- render provenance in tmux keyword alerts (pane id/name, cursor, fresh-output) so alert/log context shows where the match came from
- preserve explicit fresh custom markers while suppressing existing prompt/search scrollback matches and negated default failure phrases like `0 errors`, `no errors`, and `without error`

## Regression coverage
- prompt marker already in existing buffer does not alert
- concrete dogfood repro: Discord message 1502008605518594172 in #townhall matched PR_READY from the initial prompt text `End with PR_READY #220 and summary` and search/query text `Search keywords.*...PR_READY`; tests now cover those prompt/search scrollback markers as existing buffer and confirm only a subsequent fresh `PR_READY #220` emits
- `0 errors` remains suppressed for the default `error` keyword
- fresh custom marker after watch start still alerts and carries cursor/provenance

## Tests
- `cargo test keyword_window`
- `cargo test source::tmux`
- `cargo test tmux_keyword`
- `cargo test renders_tmux_keyword_provenance_when_present`
- `cargo test tmux_keyword_events_aggregate_multi_hit_windows`

Fixes #220