### PR TITLE
fix(dispatch): distinguish drop-by-design from misconfig in error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+- Changed: Distinguish drop-by-design from operator misconfig in dispatcher error
+  handling. Events that match no route emit `event_dropped`/`route_none` telemetry
+  silently (no stderr noise). Routes that match but have no usable target now emit
+  the new `route_target_missing` reason code AND retain the legacy `eprintln!` so
+  configuration drift remains visible. New typed error `router::NoRouteTarget`
+  carries `route_matched: bool` so the dispatcher can branch without parsing
+  strings.
+
 ## 0.6.8 - 2026-05-08
 
 ### Highlights

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -13,7 +13,7 @@ use crate::native_observability::{
     with_native_observability,
 };
 use crate::render::Renderer;
-use crate::router::{ResolvedDelivery, Router};
+use crate::router::{NoRouteTarget, ResolvedDelivery, Router};
 use crate::sink::{Sink, SinkMessage, SinkTarget, SinkTelemetry};
 use crate::telemetry;
 
@@ -135,22 +135,32 @@ impl Dispatcher {
             }
             Err(error) => {
                 let error_message = error.to_string();
-                self.emit_dispatch_failure(
-                    &event,
-                    telemetry::reason::ROUTE_NONE,
-                    None,
-                    error_message.clone(),
-                );
+                let typed = error.downcast_ref::<NoRouteTarget>();
+                let reason = match typed {
+                    Some(t) if t.route_matched => telemetry::reason::ROUTE_TARGET_MISSING,
+                    _ => telemetry::reason::ROUTE_NONE,
+                };
+                self.emit_dispatch_failure(&event, reason, None, error_message.clone());
                 self.observe_native_route_outcome(
                     &event,
                     provenance.as_ref(),
                     None,
                     Some(error_message),
                 );
-                eprintln!(
-                    "clawhip dispatcher failed to resolve {}: {error}",
-                    event.canonical_kind()
+                // Drop-by-design (no route matched, no target) is intent, not failure —
+                // structured telemetry already emitted above; suppress legacy stderr noise.
+                // Misconfigured routes (route matched but target missing) keep the eprintln
+                // because they reflect operator config drift that warrants attention.
+                let drop_by_design = matches!(
+                    typed,
+                    Some(t) if !t.route_matched
                 );
+                if !drop_by_design {
+                    eprintln!(
+                        "clawhip dispatcher failed to resolve {}: {error}",
+                        event.canonical_kind()
+                    );
+                }
                 return;
             }
         };
@@ -175,22 +185,28 @@ impl Dispatcher {
             }
             Err(error) => {
                 let error_message = error.to_string();
-                self.emit_dispatch_failure(
-                    &event,
-                    telemetry::reason::ROUTE_NONE,
-                    None,
-                    error_message.clone(),
-                );
+                let typed = error.downcast_ref::<NoRouteTarget>();
+                let reason = match typed {
+                    Some(t) if t.route_matched => telemetry::reason::ROUTE_TARGET_MISSING,
+                    _ => telemetry::reason::ROUTE_NONE,
+                };
+                self.emit_dispatch_failure(&event, reason, None, error_message.clone());
                 self.observe_native_route_outcome(
                     &event,
                     provenance.as_ref(),
                     None,
                     Some(error_message),
                 );
-                eprintln!(
-                    "clawhip dispatcher failed to resolve {}: {error}",
-                    event.canonical_kind()
+                let drop_by_design = matches!(
+                    typed,
+                    Some(t) if !t.route_matched
                 );
+                if !drop_by_design {
+                    eprintln!(
+                        "clawhip dispatcher failed to resolve {}: {error}",
+                        event.canonical_kind()
+                    );
+                }
                 return;
             }
         };

--- a/src/router.rs
+++ b/src/router.rs
@@ -33,6 +33,30 @@ pub enum RouteTraceResult {
     None,
 }
 
+/// Returned when a sink lookup ends with no usable target. Carries
+/// `route_matched` so the dispatcher can distinguish "no route matched"
+/// (drop-by-design) from "route matched but target missing" (operator
+/// misconfiguration). Both still surface a stable `Display` message for
+/// backward-compatible logging.
+#[derive(Debug, Clone)]
+pub struct NoRouteTarget {
+    /// Canonical event kind that failed to resolve (e.g. `"tool.post"`,
+    /// `"github.push"`). Stored on the typed error so downcast consumers
+    /// can inspect it without parsing the Display message.
+    #[allow(dead_code)]
+    pub event_kind: String,
+    pub route_matched: bool,
+    pub message: String,
+}
+
+impl std::fmt::Display for NoRouteTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for NoRouteTarget {}
+
 impl RouteTraceResult {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -365,8 +389,10 @@ impl Router {
                         .or_else(|| event.channel.clone())
                         .or_else(|| self.config.defaults.channel.clone())
                 }
-                .ok_or_else(|| {
-                    format!("no channel configured for event {}", event.canonical_kind())
+                .ok_or_else(|| NoRouteTarget {
+                    event_kind: event.canonical_kind().to_string(),
+                    route_matched: route.is_some(),
+                    message: format!("no channel configured for event {}", event.canonical_kind()),
                 })?;
 
                 Ok(SinkTarget::DiscordChannel(channel))
@@ -375,10 +401,14 @@ impl Router {
                 .and_then(RouteRule::slack_webhook_target)
                 .map(|webhook| SinkTarget::SlackWebhook(webhook.to_string()))
                 .ok_or_else(|| {
-                    format!(
-                        "no Slack webhook configured for event {}",
-                        event.canonical_kind()
-                    )
+                    NoRouteTarget {
+                        event_kind: event.canonical_kind().to_string(),
+                        route_matched: route.is_some(),
+                        message: format!(
+                            "no Slack webhook configured for event {}",
+                            event.canonical_kind()
+                        ),
+                    }
                     .into()
                 }),
             other => Err(format!(
@@ -774,6 +804,71 @@ mod tests {
                 .await
                 .unwrap(),
             "🚨 wake up"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_no_route_target_with_route_matched_false_when_unrouted() {
+        // No defaults.channel, no routes -> nothing matches, target_for fails
+        // and the typed error reports route_matched: false (drop-by-design).
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: None,
+                channel_name: None,
+                format: MessageFormat::Compact,
+            },
+            routes: vec![],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::custom(None, "unrouted".into());
+
+        let err = router.resolve(&event).await.unwrap_err();
+        let typed = err
+            .downcast_ref::<NoRouteTarget>()
+            .expect("error should be NoRouteTarget");
+        assert!(
+            !typed.route_matched,
+            "no route matched the event — route_matched must be false"
+        );
+        assert_eq!(typed.event_kind, "custom");
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_no_route_target_with_route_matched_true_when_route_lacks_channel() {
+        // A route matches but neither it nor defaults supplies a channel ->
+        // typed error reports route_matched: true (operator misconfig).
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: None,
+                channel_name: None,
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "custom".into(),
+                sink: "discord".into(),
+                filter: Default::default(),
+                channel: None,
+                channel_name: None,
+                webhook: None,
+                slack_webhook: None,
+                mention: None,
+                allow_dynamic_tokens: false,
+                format: None,
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent::custom(None, "misconfigured".into());
+
+        let err = router.resolve(&event).await.unwrap_err();
+        let typed = err
+            .downcast_ref::<NoRouteTarget>()
+            .expect("error should be NoRouteTarget");
+        assert!(
+            typed.route_matched,
+            "route matched but had no target — route_matched must be true"
         );
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -33,6 +33,7 @@ pub mod reason {
     pub const ROUTE_MATCHED: &str = "route_matched";
     pub const ROUTE_FALLBACK: &str = "route_fallback";
     pub const ROUTE_NONE: &str = "route_none";
+    pub const ROUTE_TARGET_MISSING: &str = "route_target_missing";
     pub const ROUTINE_BATCH_DEFERRED: &str = "routine_batch_deferred";
     pub const ROUTINE_BATCH_FLUSHED: &str = "routine_batch_flushed";
     pub const RENDER_FAILED: &str = "render_failed";


### PR DESCRIPTION
# Distinguish drop-by-design from misconfig in dispatcher error handling

## Summary

When `Router::resolve()` fails with no usable sink target, the dispatcher
currently emits identical `eprintln!` and `route_none` telemetry for two
operationally-distinct cases:

1. **Drop by design** — no route matched the event, no defaults configured.
   The operator did not configure delivery for this event type. Logging this
   as a failure floods stderr with intent-as-error noise.
2. **Misconfiguration** — a route matched but its target (channel/webhook) is
   missing. This is real config drift the operator should see.

This PR threads a typed error (`router::NoRouteTarget`) through `target_for()`
so the dispatcher can branch on `route_matched: bool`. Drop-by-design now
emits structured telemetry only (the new `route_target_missing` reason is
reserved for the misconfig case); legacy `eprintln!` is suppressed for
drop-by-design while preserved for misconfig.

## Problem

Originating downstream incident: a single deployment accumulated a 274 MB
`daemon.error.log` over ~3 weeks because Pre/PostToolUse provider-native hooks
generated `tool.*` events that no `[[routes]]` consumed. The events resolved
to "no channel configured" `Err`, the dispatcher logged each as a delivery
failure via `eprintln!`, and the volume swamped real failures (Discord 4xx,
DLQ-bury entries) in the same log.

The behavior is correct in isolation — events without a route SHOULD be
dropped. The bug is treating the drop as a failure for logging purposes.

## Solution

### `router.rs`

- New `pub struct NoRouteTarget { event_kind, route_matched, message }`
  implements `std::error::Error` and `Display`. The `Display` impl returns
  the same string the previous `format!()` produced, so any external log
  scrapers that grep on the message text continue to work.
- `target_for()`'s Discord and Slack arms now construct `NoRouteTarget` with
  `route_matched: route.is_some()` instead of bare `String` errors.
- The "unsupported sink" arm is unchanged — that's a genuine config error
  (typo in `sink = ...`), not a drop-by-design case.

### `dispatch.rs`

Both `deliver_event()` and `resolve_and_dispatch()` now `downcast_ref` the
error to `NoRouteTarget`:

| `route_matched` | Telemetry reason | Legacy `eprintln!` |
|---|---|---|
| `false` (no route matched the event) | `route_none` | suppressed (drop-by-design) |
| `true` (route matched, target missing) | `route_target_missing` (new) | preserved (misconfig) |
| Error is not `NoRouteTarget` | `route_none` (preserved default) | preserved |

### `telemetry.rs`

- Adds `pub const ROUTE_TARGET_MISSING: &str = "route_target_missing"` to
  `reason::`. No new dependencies; matches the existing module convention.

## Testing

- New: `resolve_returns_no_route_target_with_route_matched_false_when_unrouted`
  — empty config, custom event, asserts `route_matched == false`.
- New: `resolve_returns_no_route_target_with_route_matched_true_when_route_lacks_channel`
  — single Discord route with no channel, asserts `route_matched == true`.
- Full `cargo test` suite: **447 passed, 2 failed** — failures are
  pre-existing macOS-environment issues (`/private/var` path canonicalization
  in source/git tests, tmux session prefix heuristics) unrelated to this
  change. Same baseline produces the same 2 failures on `dev` HEAD without
  this PR applied.

## CI gates verified locally

- `cargo build` ✅ (no warnings)
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test` ✅ (vs baseline, +2 new passing tests, no regressions)

## Breaking changes

None. The error message text is preserved verbatim through `Display`. Anyone
reading the structured telemetry stream sees a new `route_target_missing`
reason code only in cases that previously emitted `route_none` for what was
actually a misconfigured route — i.e. higher signal, not different shape.

## Out of scope

- Doesn't change route-matching semantics. A route that doesn't match still
  doesn't match.
- Doesn't add a `pub` surface to `NoRouteTarget` for external crates — it's
  internal to the binary and consumed via `anyhow::Error::downcast_ref`.
- Doesn't touch the `"unsupported sink"` arm; that error class is unrelated
  to drop-by-design.
