### PR TITLE
Add GAJAE CLI bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,7 +900,20 @@ clawhip agent ...       # thin client agent lifecycle event
 clawhip native hook ... # provider-native hook thin client
 clawhip tmux ...        # thin client / wrapper surface
 clawhip plugin list     # list installed/bundled shell-hook plugins
+clawhip gajae status    # check local GAJAE CLI bridge availability
 ```
+
+
+## GAJAE CLI bridge
+
+`clawhip gajae` provides a small Rust CLI bridge for local GAJAE dogfooding:
+
+```bash
+clawhip gajae status
+clawhip gajae profile install
+```
+
+`status` discovers GAJAE from `GAJAE_BIN` first, then the `gajae` executable on `PATH`, and verifies it by running `gajae --help`. `profile install` forwards to `gajae clawhip profile install` with stdout/stderr attached so GAJAE owns the profile update flow.
 
 ## Internal PR fast-path
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,11 @@ pub enum Commands {
     /// Shows which routes match, which filters pass/fail, and where the
     /// event would be delivered — useful for debugging config.
     Explain(ExplainArgs),
+    /// Bridge to the local gajae CLI.
+    Gajae {
+        #[command(subcommand)]
+        command: GajaeCommands,
+    },
     /// Release consistency checks.
     Release {
         #[command(subcommand)]
@@ -472,6 +477,23 @@ impl NativeHookArgs {
         }
         Ok(serde_json::from_str(trimmed)?)
     }
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GajaeCommands {
+    /// Check whether gajae is available.
+    Status,
+    /// Manage gajae-installed clawhip profiles.
+    Profile {
+        #[command(subcommand)]
+        command: GajaeProfileCommands,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GajaeProfileCommands {
+    /// Install the clawhip profile through gajae.
+    Install,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -1252,6 +1274,32 @@ mod tests {
         };
 
         assert!(args.follow);
+    }
+
+    #[test]
+    fn parses_gajae_status_subcommand() {
+        let cli = Cli::parse_from(["clawhip", "gajae", "status"]);
+
+        let Commands::Gajae { command } = cli.command.expect("gajae command") else {
+            panic!("expected gajae command");
+        };
+
+        assert!(matches!(command, GajaeCommands::Status));
+    }
+
+    #[test]
+    fn parses_gajae_profile_install_subcommand() {
+        let cli = Cli::parse_from(["clawhip", "gajae", "profile", "install"]);
+
+        let Commands::Gajae { command } = cli.command.expect("gajae command") else {
+            panic!("expected gajae command");
+        };
+
+        let GajaeCommands::Profile { command } = command else {
+            panic!("expected gajae profile command");
+        };
+
+        assert!(matches!(command, GajaeProfileCommands::Install));
     }
 
     #[test]

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 
 const GAJAE_ENV: &str = "GAJAE_BIN";
 const GAJAE_PATH_NAME: &str = "gajae";
@@ -12,7 +12,6 @@ const PROFILE_INSTALL_ARGS: &[&str] = &["clawhip", "profile", "install"];
 #[derive(Debug, Clone, Copy)]
 pub enum GajaeCommand {
     Status,
-    ProfileInstall,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,7 +29,8 @@ pub struct CommandExit {
 
 pub trait CommandRunner {
     fn output(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandOutput>;
-    fn status_inherited(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandExit>;
+    fn status_inherited_output(&mut self, program: &Path, args: &[&str])
+    -> io::Result<CommandExit>;
 }
 
 #[derive(Debug, Default)]
@@ -46,9 +46,14 @@ impl CommandRunner for StdCommandRunner {
         })
     }
 
-    fn status_inherited(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandExit> {
+    fn status_inherited_output(
+        &mut self,
+        program: &Path,
+        args: &[&str],
+    ) -> io::Result<CommandExit> {
         let status = Command::new(program)
             .args(args)
+            .stdin(Stdio::null())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .status()?;
@@ -63,9 +68,6 @@ pub fn run(command: GajaeCommand) -> Result<()> {
     let mut runner = StdCommandRunner;
     match command {
         GajaeCommand::Status => run_status_with(&mut runner, |name| std::env::var_os(name)),
-        GajaeCommand::ProfileInstall => {
-            run_profile_install_with(&mut runner, |name| std::env::var_os(name))
-        }
     }
 }
 
@@ -101,13 +103,18 @@ fn run_status_with(
     }
 }
 
+pub fn run_profile_install() -> Result<CommandExit> {
+    let mut runner = StdCommandRunner;
+    run_profile_install_with(&mut runner, |name| std::env::var_os(name))
+}
+
 fn run_profile_install_with(
     runner: &mut impl CommandRunner,
     env_var: impl Fn(&str) -> Option<OsString>,
-) -> Result<()> {
+) -> Result<CommandExit> {
     let bin = discover_gajae_with(env_var);
     let status = runner
-        .status_inherited(&bin, PROFILE_INSTALL_ARGS)
+        .status_inherited_output(&bin, PROFILE_INSTALL_ARGS)
         .with_context(|| {
             format!(
                 "failed to run {} {}",
@@ -116,17 +123,17 @@ fn run_profile_install_with(
             )
         })?;
 
-    if status.success {
-        Ok(())
-    } else {
-        Err(anyhow!(
-            "gajae clawhip profile install failed{}",
-            status
-                .code
-                .map(|code| format!(" with exit code {code}"))
-                .unwrap_or_else(|| " without an exit code".to_string())
-        ))
-    }
+    Ok(status)
+}
+
+pub fn profile_install_failure_message(status: CommandExit) -> String {
+    format!(
+        "gajae clawhip profile install failed{}",
+        status
+            .code
+            .map(|code| format!(" with exit code {code}"))
+            .unwrap_or_else(|| " without an exit code".to_string())
+    )
 }
 
 fn concise_detail(stderr: &str) -> String {
@@ -144,7 +151,8 @@ mod tests {
     struct Call {
         program: PathBuf,
         args: Vec<String>,
-        inherited: bool,
+        inherits_stdout_stderr: bool,
+        stdin_null: bool,
     }
 
     #[derive(Debug)]
@@ -186,7 +194,8 @@ mod tests {
             self.calls.push(Call {
                 program: program.to_path_buf(),
                 args: args.iter().map(|arg| (*arg).to_string()).collect(),
-                inherited: false,
+                inherits_stdout_stderr: false,
+                stdin_null: false,
             });
             self.output_result
                 .as_ref()
@@ -194,11 +203,16 @@ mod tests {
                 .map_err(|error| io::Error::new(error.kind(), error.to_string()))
         }
 
-        fn status_inherited(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandExit> {
+        fn status_inherited_output(
+            &mut self,
+            program: &Path,
+            args: &[&str],
+        ) -> io::Result<CommandExit> {
             self.calls.push(Call {
                 program: program.to_path_buf(),
                 args: args.iter().map(|arg| (*arg).to_string()).collect(),
-                inherited: true,
+                inherits_stdout_stderr: true,
+                stdin_null: true,
             });
             self.status_result
                 .as_ref()
@@ -220,7 +234,8 @@ mod tests {
             vec![Call {
                 program: PathBuf::from("/custom/gajae"),
                 args: vec!["--help".into()],
-                inherited: false,
+                inherits_stdout_stderr: false,
+                stdin_null: false,
             }]
         );
     }
@@ -253,9 +268,10 @@ mod tests {
     }
 
     #[test]
-    fn profile_install_constructs_expected_args_and_inherits_stdio() {
+    fn profile_install_constructs_expected_args_inherits_output_and_closes_stdin() {
         let mut runner = MockRunner::available();
-        run_profile_install_with(&mut runner, |_| None).expect("install should pass");
+        let status = run_profile_install_with(&mut runner, |_| None).expect("install should run");
+        assert!(status.success);
 
         assert_eq!(
             runner.calls,
@@ -265,7 +281,8 @@ mod tests {
                     .iter()
                     .map(|arg| (*arg).to_string())
                     .collect(),
-                inherited: true,
+                inherits_stdout_stderr: true,
+                stdin_null: true,
             }]
         );
     }
@@ -273,11 +290,14 @@ mod tests {
     #[test]
     fn profile_install_fails_on_nonzero_status() {
         let mut runner = MockRunner::failing_status(17);
-        let error = run_profile_install_with(&mut runner, |_| None).expect_err("nonzero fails");
+        let status =
+            run_profile_install_with(&mut runner, |_| None).expect("nonzero still reports status");
+        assert_eq!(status.code, Some(17));
 
+        let message = profile_install_failure_message(status);
         assert!(
-            error.to_string().contains("exit code 17"),
-            "unexpected error: {error}"
+            message.contains("exit code 17"),
+            "unexpected message: {message}"
         );
     }
 }

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -1,0 +1,283 @@
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, anyhow, bail};
+
+const GAJAE_ENV: &str = "GAJAE_BIN";
+const GAJAE_PATH_NAME: &str = "gajae";
+const PROFILE_INSTALL_ARGS: &[&str] = &["clawhip", "profile", "install"];
+
+#[derive(Debug, Clone, Copy)]
+pub enum GajaeCommand {
+    Status,
+    ProfileInstall,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutput {
+    pub success: bool,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandExit {
+    pub success: bool,
+    pub code: Option<i32>,
+}
+
+pub trait CommandRunner {
+    fn output(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandOutput>;
+    fn status_inherited(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandExit>;
+}
+
+#[derive(Debug, Default)]
+pub struct StdCommandRunner;
+
+impl CommandRunner for StdCommandRunner {
+    fn output(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandOutput> {
+        let output = Command::new(program).args(args).output()?;
+        Ok(CommandOutput {
+            success: output.status.success(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+
+    fn status_inherited(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandExit> {
+        let status = Command::new(program)
+            .args(args)
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()?;
+        Ok(CommandExit {
+            success: status.success(),
+            code: status.code(),
+        })
+    }
+}
+
+pub fn run(command: GajaeCommand) -> Result<()> {
+    let mut runner = StdCommandRunner;
+    match command {
+        GajaeCommand::Status => run_status_with(&mut runner, |name| std::env::var_os(name)),
+        GajaeCommand::ProfileInstall => {
+            run_profile_install_with(&mut runner, |name| std::env::var_os(name))
+        }
+    }
+}
+
+fn discover_gajae_with(env_var: impl Fn(&str) -> Option<OsString>) -> PathBuf {
+    env_var(GAJAE_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(GAJAE_PATH_NAME))
+}
+
+fn run_status_with(
+    runner: &mut impl CommandRunner,
+    env_var: impl Fn(&str) -> Option<OsString>,
+) -> Result<()> {
+    let bin = discover_gajae_with(env_var);
+    match runner.output(&bin, &["--help"]) {
+        Ok(output) if output.success => {
+            println!("gajae available: {}", bin.display());
+            Ok(())
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!(
+                "gajae found at {} but `--help` failed{}",
+                bin.display(),
+                concise_detail(&stderr)
+            );
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            bail!("gajae unavailable: set {GAJAE_ENV} or install `{GAJAE_PATH_NAME}` on PATH")
+        }
+        Err(error) => Err(error).with_context(|| format!("failed to run {} --help", bin.display())),
+    }
+}
+
+fn run_profile_install_with(
+    runner: &mut impl CommandRunner,
+    env_var: impl Fn(&str) -> Option<OsString>,
+) -> Result<()> {
+    let bin = discover_gajae_with(env_var);
+    let status = runner
+        .status_inherited(&bin, PROFILE_INSTALL_ARGS)
+        .with_context(|| {
+            format!(
+                "failed to run {} {}",
+                bin.display(),
+                PROFILE_INSTALL_ARGS.join(" ")
+            )
+        })?;
+
+    if status.success {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "gajae clawhip profile install failed{}",
+            status
+                .code
+                .map(|code| format!(" with exit code {code}"))
+                .unwrap_or_else(|| " without an exit code".to_string())
+        ))
+    }
+}
+
+fn concise_detail(stderr: &str) -> String {
+    stderr
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| format!(": {}", line.trim()))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Call {
+        program: PathBuf,
+        args: Vec<String>,
+        inherited: bool,
+    }
+
+    #[derive(Debug)]
+    struct MockRunner {
+        calls: Vec<Call>,
+        output_result: io::Result<CommandOutput>,
+        status_result: io::Result<CommandExit>,
+    }
+
+    impl MockRunner {
+        fn available() -> Self {
+            Self {
+                calls: Vec::new(),
+                output_result: Ok(CommandOutput {
+                    success: true,
+                    stdout: b"help".to_vec(),
+                    stderr: Vec::new(),
+                }),
+                status_result: Ok(CommandExit {
+                    success: true,
+                    code: Some(0),
+                }),
+            }
+        }
+
+        fn failing_status(code: i32) -> Self {
+            Self {
+                status_result: Ok(CommandExit {
+                    success: false,
+                    code: Some(code),
+                }),
+                ..Self::available()
+            }
+        }
+    }
+
+    impl CommandRunner for MockRunner {
+        fn output(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandOutput> {
+            self.calls.push(Call {
+                program: program.to_path_buf(),
+                args: args.iter().map(|arg| (*arg).to_string()).collect(),
+                inherited: false,
+            });
+            self.output_result
+                .as_ref()
+                .map(Clone::clone)
+                .map_err(|error| io::Error::new(error.kind(), error.to_string()))
+        }
+
+        fn status_inherited(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandExit> {
+            self.calls.push(Call {
+                program: program.to_path_buf(),
+                args: args.iter().map(|arg| (*arg).to_string()).collect(),
+                inherited: true,
+            });
+            self.status_result
+                .as_ref()
+                .copied()
+                .map_err(|error| io::Error::new(error.kind(), error.to_string()))
+        }
+    }
+
+    #[test]
+    fn gajae_status_prefers_gajae_bin_env_override() {
+        let mut runner = MockRunner::available();
+        run_status_with(&mut runner, |name| {
+            (name == GAJAE_ENV).then(|| OsString::from("/custom/gajae"))
+        })
+        .expect("status should pass");
+
+        assert_eq!(
+            runner.calls,
+            vec![Call {
+                program: PathBuf::from("/custom/gajae"),
+                args: vec!["--help".into()],
+                inherited: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn gajae_status_uses_path_name_when_env_is_absent() {
+        let mut runner = MockRunner::available();
+        run_status_with(&mut runner, |_| None).expect("status should pass");
+
+        assert_eq!(runner.calls[0].program, PathBuf::from("gajae"));
+    }
+
+    #[test]
+    fn gajae_status_fails_when_help_exits_nonzero() {
+        let mut runner = MockRunner {
+            output_result: Ok(CommandOutput {
+                success: false,
+                stdout: Vec::new(),
+                stderr: b"usage unavailable".to_vec(),
+            }),
+            ..MockRunner::available()
+        };
+
+        let error = run_status_with(&mut runner, |_| None).expect_err("nonzero help should fail");
+
+        assert!(
+            error.to_string().contains("usage unavailable"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn profile_install_constructs_expected_args_and_inherits_stdio() {
+        let mut runner = MockRunner::available();
+        run_profile_install_with(&mut runner, |_| None).expect("install should pass");
+
+        assert_eq!(
+            runner.calls,
+            vec![Call {
+                program: PathBuf::from("gajae"),
+                args: PROFILE_INSTALL_ARGS
+                    .iter()
+                    .map(|arg| (*arg).to_string())
+                    .collect(),
+                inherited: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn profile_install_fails_on_nonzero_status() {
+        let mut runner = MockRunner::failing_status(17);
+        let error = run_profile_install_with(&mut runner, |_| None).expect_err("nonzero fails");
+
+        assert!(
+            error.to_string().contains("exit code 17"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,7 +357,16 @@ async fn real_main(cli: Cli) -> Result<()> {
             GajaeCommands::Status => Ok(gajae::run(gajae::GajaeCommand::Status)?),
             GajaeCommands::Profile { command } => match command {
                 GajaeProfileCommands::Install => {
-                    Ok(gajae::run(gajae::GajaeCommand::ProfileInstall)?)
+                    let status = gajae::run_profile_install()?;
+                    if status.success {
+                        Ok(())
+                    } else {
+                        eprintln!(
+                            "clawhip error: {}",
+                            gajae::profile_install_failure_message(status)
+                        );
+                        std::process::exit(status.code.unwrap_or(1));
+                    }
                 }
             },
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod dispatch;
 mod dynamic_tokens;
 mod event;
 mod events;
+mod gajae;
 mod gateway_allowlist;
 mod hooks;
 mod keyword_window;
@@ -35,9 +36,10 @@ use clap::Parser;
 use tokio::runtime::Builder;
 
 use crate::cli::{
-    AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs, GitCommands,
-    GithubCommands, HooksCommands, MemoryCommands, NativeCommands, PluginCommands, ReleaseCommands,
-    SetupArgs, TmuxCommands, UpdateCommands, VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
+    AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs, GajaeCommands,
+    GajaeProfileCommands, GitCommands, GithubCommands, HooksCommands, MemoryCommands,
+    NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, TmuxCommands, UpdateCommands,
+    VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
 };
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, SetupEdits};
@@ -350,6 +352,14 @@ async fn real_main(cli: Cli) -> Result<()> {
         },
         Commands::Hooks { command } => match command {
             HooksCommands::Install(args) => hooks::install(args),
+        },
+        Commands::Gajae { command } => match command {
+            GajaeCommands::Status => Ok(gajae::run(gajae::GajaeCommand::Status)?),
+            GajaeCommands::Profile { command } => match command {
+                GajaeProfileCommands::Install => {
+                    Ok(gajae::run(gajae::GajaeCommand::ProfileInstall)?)
+                }
+            },
         },
         Commands::Release { command } => match command {
             ReleaseCommands::Preflight { version, repo } => release_preflight::run(repo, version),

--- a/tests/gajae_profile_install_stdin.rs
+++ b/tests/gajae_profile_install_stdin.rs
@@ -1,0 +1,110 @@
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+fn clawhip_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clawhip")
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write executable");
+    let mut permissions = fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("chmod");
+}
+
+fn gajae_stub(temp: &TempDir, contents: &str) -> std::path::PathBuf {
+    let stub = temp.path().join("gajae");
+    write_executable(&stub, contents);
+    stub
+}
+
+#[test]
+fn gajae_profile_install_does_not_forward_parent_stdin() {
+    let temp = TempDir::new().expect("tempdir");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$GAJAE_ARG_LOG"
+if IFS= read -r inherited_input; then
+  printf 'unexpected stdin: %s\n' "$inherited_input" >&2
+  exit 66
+fi
+printf 'profile installed\n'
+printf 'install diagnostics\n' >&2
+"#,
+    );
+
+    let mut child = Command::new(clawhip_bin())
+        .args(["gajae", "profile", "install"])
+        .env("GAJAE_BIN", &stub)
+        .env("GAJAE_ARG_LOG", temp.path().join("gajae.args"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn clawhip");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"sensitive operator input\n")
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for clawhip");
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(temp.path().join("gajae.args")).expect("arg log"),
+        "clawhip profile install\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "profile installed\n"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "install diagnostics\n"
+    );
+}
+
+#[test]
+fn gajae_profile_install_propagates_child_exit_code() {
+    let temp = TempDir::new().expect("tempdir");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+printf 'child failed\n' >&2
+exit 23
+"#,
+    );
+
+    let output = Command::new(clawhip_bin())
+        .args(["gajae", "profile", "install"])
+        .env("GAJAE_BIN", &stub)
+        .output()
+        .expect("run clawhip");
+
+    assert_eq!(
+        output.status.code(),
+        Some(23),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("child failed"), "stderr={stderr}");
+    assert!(stderr.contains("exit code 23"), "stderr={stderr}");
+}


### PR DESCRIPTION
Closes #229.

## Summary
- Adds top-level `clawhip gajae` CLI group with `status` and `profile install` subcommands.
- Adds a small `src/gajae.rs` subprocess/discovery helper module.
- Documents the GAJAE CLI bridge in README.

## Behavior
- `clawhip gajae status` resolves `GAJAE_BIN` first, then PATH name `gajae`, runs `gajae --help`, and prints concise availability.
- `clawhip gajae profile install` forwards to `gajae clawhip profile install`, inherits stdout/stderr, and fails on nonzero status.

## Validation
- `cargo fmt --check`
- `cargo test gajae` (7 passed)
- `cargo test` (463 unit tests + integration tests passed)
- `git diff --check`
- `GAJAE_BIN=/mnt/offloading/.nvm/versions/node/v25.1.0/bin/gajae cargo run -- gajae status`
  - output: `gajae available: /mnt/offloading/.nvm/versions/node/v25.1.0/bin/gajae`

## Review notes
- Independent code-reviewer lane: APPROVE, no issues.
- Independent architect lane initially returned WATCH for stdin inheritance/test hardening; the final commit removed stdin inheritance, added a forwarded-args constant, and added a negative `status` test. I did not run a second architect lane per instruction to stop waiting when local validation was green.

## Not run
- `clawhip gajae profile install` live smoke, because it may overwrite local config.
