### PR TITLE
ci: use gajae self-hosted linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,45 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Ensure native build tools
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing+=("$tool")
+            fi
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "Native build tools already available"
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt_get=(apt-get)
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            apt_get=(sudo apt-get)
+          else
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            exit 1
+          fi
+
+          "${apt_get[@]}" update
+          "${apt_get[@]}" install -y --no-install-recommends build-essential xz-utils
+
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::Required tool '$tool' is still missing after apt install."
+              exit 1
+            fi
+          done
       - run: cargo check
 
   test:
@@ -28,6 +67,45 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Ensure native build tools
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing+=("$tool")
+            fi
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "Native build tools already available"
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt_get=(apt-get)
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            apt_get=(sudo apt-get)
+          else
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            exit 1
+          fi
+
+          "${apt_get[@]}" update
+          "${apt_get[@]}" install -y --no-install-recommends build-essential xz-utils
+
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::Required tool '$tool' is still missing after apt install."
+              exit 1
+            fi
+          done
       - run: cargo test
 
   clippy:
@@ -40,6 +118,45 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Ensure native build tools
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing+=("$tool")
+            fi
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "Native build tools already available"
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt_get=(apt-get)
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            apt_get=(sudo apt-get)
+          else
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            exit 1
+          fi
+
+          "${apt_get[@]}" update
+          "${apt_get[@]}" install -y --no-install-recommends build-essential xz-utils
+
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::Required tool '$tool' is still missing after apt install."
+              exit 1
+            fi
+          done
       - run: cargo clippy -- -D warnings
 
   fmt:
@@ -51,6 +168,45 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - name: Ensure native build tools
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing+=("$tool")
+            fi
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "Native build tools already available"
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt_get=(apt-get)
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            apt_get=(sudo apt-get)
+          else
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            exit 1
+          fi
+
+          "${apt_get[@]}" update
+          "${apt_get[@]}" install -y --no-install-recommends build-essential xz-utils
+
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::Required tool '$tool' is still missing after apt install."
+              exit 1
+            fi
+          done
       - run: cargo fmt --all -- --check
 
   build:
@@ -62,6 +218,45 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Ensure native build tools
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing+=("$tool")
+            fi
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "Native build tools already available"
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt_get=(apt-get)
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            apt_get=(sudo apt-get)
+          else
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            exit 1
+          fi
+
+          "${apt_get[@]}" update
+          "${apt_get[@]}" install -y --no-install-recommends build-essential xz-utils
+
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::Required tool '$tool' is still missing after apt install."
+              exit 1
+            fi
+          done
       - run: cargo build --release
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -21,7 +22,8 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -30,7 +32,8 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -41,7 +44,8 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -52,7 +56,8 @@ jobs:
   build:
     name: Build
     needs: [check, test, clippy, fmt]
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,45 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Ensure native build tools
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing+=("$tool")
+            fi
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "Native build tools already available"
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt_get=(apt-get)
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            apt_get=(sudo apt-get)
+          else
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            exit 1
+          fi
+
+          "${apt_get[@]}" update
+          "${apt_get[@]}" install -y --no-install-recommends build-essential xz-utils
+
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::Required tool '$tool' is still missing after apt install."
+              exit 1
+            fi
+          done
       - name: Build clawhip (release preflight needs the binary)
         run: cargo build --release
       - name: Release consistency preflight
@@ -78,6 +117,45 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Ensure native build tools
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing+=("$tool")
+            fi
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "Native build tools already available"
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt_get=(apt-get)
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            apt_get=(sudo apt-get)
+          else
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            exit 1
+          fi
+
+          "${apt_get[@]}" update
+          "${apt_get[@]}" install -y --no-install-recommends build-essential xz-utils
+
+          for tool in cc make xz; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              echo "::error::Required tool '$tool' is still missing after apt install."
+              exit 1
+            fi
+          done
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Fail fast if tag/Cargo.toml/Cargo.lock/CHANGELOG are out of sync.
   preflight:
-    runs-on: "ubuntu-22.04"
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     if: ${{ !github.event.pull_request }}
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +65,7 @@ jobs:
     needs:
       - preflight
     if: ${{ always() && (needs.preflight.result == 'success' || needs.preflight.result == 'skipped') }}
-    runs-on: "ubuntu-22.04"
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -182,7 +182,8 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-22.04"
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -233,7 +234,7 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-22.04"
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -296,7 +297,7 @@ jobs:
       - plan
       - host
     if: ${{ always() && needs.host.result == 'success' && needs.plan.outputs.publishing == 'true' }}
-    runs-on: "ubuntu-22.04"
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
@@ -320,7 +321,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-22.04"
+    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
       - name: Ensure native build tools
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
   plan:
     needs:
       - preflight
-    if: ${{ always() && (needs.preflight.result == 'success' || needs.preflight.result == 'skipped') }}
+    if: ${{ always() && (needs.preflight.result == 'success' || needs.preflight.result == 'skipped') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
     outputs:
       val: ${{ steps.plan.outputs.manifest }}


### PR DESCRIPTION
Switch Linux GitHub Actions jobs from GitHub-hosted Ubuntu runners to the trusted gajae self-hosted runner label. macOS/Windows jobs are left unchanged. External fork PRs are excluded at job level before using the self-hosted runner.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*