### PR TITLE
Alert on native ask-tool question requests

### DIFF
--- a/docs/event-contract-v1.md
+++ b/docs/event-contract-v1.md
@@ -21,6 +21,18 @@ clawhip v1 supports exactly these five provider-native events:
 
 Provider-specific extras are out of scope for v1.
 
+## Additive question-request bridge
+
+Within the frozen shared event family, clawhip treats `PreToolUse`/`PostToolUse` calls to
+explicit ask-user tools as operator question requests. The bridge maps ask-tool identifiers
+(`ask`, `ask_user`, `ask_user_question`, `AskUserQuestion`, `askuserquestion`) to the
+`question.requested` route key, which canonicalizes to `session.blocked` for existing routes.
+
+The bridge is intentionally allowlist-based: normal prose, prompts containing `?`, and unrelated
+tools do not become question alerts. For public safety, normalized question events expose only a
+bounded `summary`/`question_summary`; raw tool input and tool response bodies are omitted from the
+normalized `payload`/`event_payload` copies.
+
 ## Supported ingress
 
 The public local ingress for shared provider-native payloads is:
@@ -48,6 +60,7 @@ After clawhip normalizes a provider payload, these base routing fields are the v
 | `tool_name` | tool events | Tool identifier for pre/post tool hooks. |
 | `command` | tool events | Command context when a provider supplies it. |
 | `summary` | no | Short human-readable context. |
+| `question_summary` | question bridge only | Bounded, public-safe ask-tool question summary. |
 | `event_timestamp` | no | Timestamp preserved from provider input when available. |
 
 ## Augmentation rules

--- a/docs/native-event-contract.md
+++ b/docs/native-event-contract.md
@@ -25,6 +25,28 @@ v1 intentionally supports only the five events shared by Codex and Claude:
 Provider-specific extra events stay out of the shared route surface until clawhip adopts them
 explicitly.
 
+### Question-request bridge
+
+`PreToolUse` and `PostToolUse` payloads whose `tool_name` is an explicit ask-user tool are
+normalized as a `question.requested` route key and delivered through the existing
+`session.blocked` alert semantics. Supported ask-tool names are matched by identifier, not by
+message prose:
+
+- `ask`
+- `ask_user`
+- `ask_user_question`
+- `AskUserQuestion`
+- `askuserquestion`
+
+This covers Codex/OMX-compatible hooks, Pi/GJC ask tools, and Claude Code's
+`askuserquestion` tool without treating arbitrary question marks as alerts.
+
+Question alerts are public-safe by default. clawhip exposes only bounded `summary`,
+`question`, and `question_summary` fields derived from common tool-input keys such as
+`question`, `prompt`, or `message`; control characters and newlines are collapsed and the
+summary is truncated. The original ask tool input/response is not retained in the normalized
+`payload`/`event_payload` copies for question alerts.
+
 ## Preferred ingress
 
 Use the generic provider-native thin client:
@@ -54,6 +76,7 @@ fields for routing:
 - `tool_name`
 - `command`
 - `summary`
+- `question_summary` (question-request bridge only)
 - `event_timestamp`
 
 ### Notes

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1353,6 +1353,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn post_native_hook_queues_ask_tool_as_session_blocked() {
+        let repo = git_repo();
+        let mut payload = native_payload(repo.path(), "PreToolUse");
+        payload["provider"] = json!("claude-code");
+        payload["event_payload"]["tool_name"] = json!("askuserquestion");
+        payload["event_payload"]["tool_input"] = json!({
+            "question": "Need operator approval?\nDo not dump the full transcript."
+        });
+
+        let (response_json, mut rx) = post_native_payload(payload).await;
+        assert_eq!(response_json["ok"], json!(true));
+        assert_eq!(response_json["type"], json!("session.blocked"));
+
+        let queued = rx.recv().await.expect("queued event");
+        assert_eq!(queued.kind, "session.blocked");
+        assert_eq!(queued.payload["tool"], json!("claude-code"));
+        assert_eq!(queued.payload["agent_name"], json!("claude-code"));
+        assert_eq!(queued.payload["route_key"], json!("question.requested"));
+        assert_eq!(
+            queued.payload["summary"],
+            json!("Need operator approval? Do not dump the full transcript.")
+        );
+        assert_eq!(queued.payload["event_payload"]["redacted"], json!(true));
+        assert!(queued.payload["event_payload"].get("tool_input").is_none());
+    }
+
+    #[tokio::test]
     async fn post_native_hook_rejects_unsupported_event() {
         let (tx, _rx) = mpsc::channel(1);
         let state = AppState {

--- a/src/events.rs
+++ b/src/events.rs
@@ -2055,4 +2055,32 @@ mod tests {
             assert_eq!(event.payload["normalized_event"], json!(expected_status));
         }
     }
+
+    #[test]
+    fn normalize_event_maps_question_requested_to_session_blocked() {
+        let event = normalize_event(IncomingEvent {
+            kind: "question.requested".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "tool": "codex",
+                "agent_name": "codex",
+                "session_id": "sess-234",
+                "repo_name": "clawhip",
+                "tool_name": "ask_user_question",
+                "route_key": "question.requested",
+                "question_summary": "Approve the deploy?",
+                "summary": "Approve the deploy?"
+            }),
+        });
+
+        assert_eq!(event.kind, "session.blocked");
+        assert_eq!(event.payload["raw_event"], json!("question.requested"));
+        assert_eq!(event.payload["contract_event"], json!("session.blocked"));
+        assert_eq!(event.payload["status"], json!("blocked"));
+        assert_eq!(event.payload["normalized_event"], json!("blocked"));
+        assert_eq!(event.payload["summary"], json!("Approve the deploy?"));
+    }
 }

--- a/src/native_hooks.rs
+++ b/src/native_hooks.rs
@@ -46,7 +46,7 @@ pub fn incoming_event_from_native_hook_json(
         ],
     )
     .ok_or_else(|| "missing native hook event name".to_string())?;
-    let canonical_kind = map_shared_event(&event_name)
+    let mut canonical_kind = map_shared_event(&event_name)
         .ok_or_else(|| format!("unsupported native hook event '{event_name}'"))?;
 
     let directory = first_string(
@@ -180,6 +180,10 @@ pub fn incoming_event_from_native_hook_json(
         .cloned()
         .or_else(|| payload.get("payload").cloned())
         .unwrap_or_else(|| json!({}));
+    let question_request = detect_question_request(&event_name, tool_name.as_deref(), payload);
+    if question_request.is_some() {
+        canonical_kind = "question.requested";
+    }
 
     let mut normalized = Map::new();
     normalized.insert("provider".into(), json!(provider.clone()));
@@ -192,8 +196,30 @@ pub fn incoming_event_from_native_hook_json(
         "normalized_event".into(),
         json!(normalized_event_label(canonical_kind)),
     );
-    normalized.insert("event_payload".into(), event_payload);
-    normalized.insert("payload".into(), payload.clone());
+    if let Some(question_request) = &question_request {
+        normalized.insert(
+            "event_payload".into(),
+            safe_question_payload(&event_payload, question_request),
+        );
+        normalized.insert(
+            "payload".into(),
+            safe_question_payload(payload, question_request),
+        );
+        normalized.insert("route_key".into(), json!("question.requested"));
+        normalized.insert("question".into(), json!(question_request.summary.clone()));
+        normalized.insert(
+            "question_summary".into(),
+            json!(question_request.summary.clone()),
+        );
+        normalized.insert("summary".into(), json!(question_request.summary.clone()));
+        normalized.insert(
+            "question_source".into(),
+            json!(question_request.source.clone()),
+        );
+    } else {
+        normalized.insert("event_payload".into(), event_payload);
+        normalized.insert("payload".into(), payload.clone());
+    }
 
     if let Some(directory) = directory {
         normalized.insert("directory".into(), json!(directory));
@@ -745,9 +771,198 @@ fn normalized_event_label(kind: &str) -> &str {
         "session.started" => "started",
         "tool.pre" => "pre-tool-use",
         "tool.post" => "post-tool-use",
+        "question.requested" => "question.requested",
         "session.prompt-submitted" => "prompt-submitted",
         "session.stopped" => "stop",
         _ => kind,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QuestionRequest {
+    source: String,
+    summary: String,
+}
+
+fn detect_question_request(
+    event_name: &str,
+    tool_name: Option<&str>,
+    payload: &Value,
+) -> Option<QuestionRequest> {
+    let event = event_name.trim().to_ascii_lowercase().replace('-', "");
+    if event != "pretooluse" && event != "posttooluse" {
+        return None;
+    }
+
+    let tool_name = tool_name?;
+    if !is_question_tool_name(tool_name) {
+        return None;
+    }
+
+    let summary = first_string(
+        payload,
+        &[
+            "/tool_input/question",
+            "/tool_input/prompt",
+            "/tool_input/message",
+            "/tool_input/query",
+            "/tool_input/input",
+            "/event_payload/tool_input/question",
+            "/event_payload/tool_input/prompt",
+            "/event_payload/tool_input/message",
+            "/event_payload/tool_input/query",
+            "/event_payload/tool_input/input",
+            "/payload/tool_input/question",
+            "/payload/tool_input/prompt",
+            "/payload/tool_input/message",
+            "/payload/tool_input/query",
+            "/payload/tool_input/input",
+            "/event_payload/question",
+            "/event_payload/prompt",
+            "/event_payload/message",
+            "/payload/question",
+            "/payload/prompt",
+            "/payload/message",
+        ],
+    )
+    .map(|value| public_safe_summary(&value, 160))
+    .filter(|value| !value.is_empty())
+    .unwrap_or_else(|| format!("operator question requested via {tool_name}"));
+
+    Some(QuestionRequest {
+        source: "ask-tool".to_string(),
+        summary,
+    })
+}
+
+fn is_question_tool_name(tool_name: &str) -> bool {
+    let normalized = tool_name
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+
+    matches!(
+        normalized.as_str(),
+        "ask" | "askuser" | "askuserquestion" | "askquestion" | "userquestion"
+    )
+}
+
+fn public_safe_summary(value: &str, max_chars: usize) -> String {
+    let collapsed = value
+        .chars()
+        .map(|ch| {
+            if ch.is_control() || ch == '\n' || ch == '\r' || ch == '\t' {
+                ' '
+            } else {
+                ch
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    truncate_chars(&collapsed, max_chars)
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+
+    let keep = max_chars.saturating_sub(1);
+    let mut truncated = value.chars().take(keep).collect::<String>();
+    truncated.push('…');
+    truncated
+}
+
+fn safe_question_payload(payload: &Value, question_request: &QuestionRequest) -> Value {
+    let mut safe = Map::new();
+    copy_safe_payload_string(&mut safe, payload, "provider", &["/provider"]);
+    copy_safe_payload_string(&mut safe, payload, "source", &["/source"]);
+    copy_safe_payload_string(
+        &mut safe,
+        payload,
+        "event_name",
+        &[
+            "/event_name",
+            "/event",
+            "/hook_event_name",
+            "/hookEventName",
+        ],
+    );
+    copy_safe_payload_string(
+        &mut safe,
+        payload,
+        "tool_name",
+        &[
+            "/tool_name",
+            "/toolName",
+            "/event_payload/tool_name",
+            "/event_payload/toolName",
+        ],
+    );
+    copy_safe_payload_string(
+        &mut safe,
+        payload,
+        "session_id",
+        &[
+            "/session_id",
+            "/sessionId",
+            "/event_payload/session_id",
+            "/event_payload/sessionId",
+        ],
+    );
+    copy_safe_payload_string(&mut safe, payload, "turn_id", &["/turn_id", "/turnId"]);
+    copy_safe_payload_string(
+        &mut safe,
+        payload,
+        "repo_path",
+        &["/repo_path", "/context/repo_path"],
+    );
+    copy_safe_payload_string(
+        &mut safe,
+        payload,
+        "worktree_path",
+        &["/worktree_path", "/context/worktree_path"],
+    );
+    copy_safe_payload_string(
+        &mut safe,
+        payload,
+        "repo_name",
+        &["/repo_name", "/context/repo_name"],
+    );
+    copy_safe_payload_string(
+        &mut safe,
+        payload,
+        "project",
+        &["/project", "/project_name", "/projectName"],
+    );
+    copy_safe_payload_string(&mut safe, payload, "directory", &["/directory", "/cwd"]);
+    copy_safe_payload_string(&mut safe, payload, "model", &["/model", "/context/model"]);
+    safe.insert(
+        "question_summary".to_string(),
+        json!(question_request.summary.clone()),
+    );
+    safe.insert(
+        "question_source".to_string(),
+        json!(question_request.source.clone()),
+    );
+    safe.insert("redacted".to_string(), json!(true));
+    safe.entry("redaction_reason".to_string())
+        .or_insert_with(|| json!("question request payload omitted"));
+    Value::Object(safe)
+}
+
+fn copy_safe_payload_string(
+    safe: &mut Map<String, Value>,
+    payload: &Value,
+    key: &str,
+    pointers: &[&str],
+) {
+    if let Some(value) = first_string(payload, pointers) {
+        safe.insert(key.to_string(), json!(public_safe_summary(&value, 160)));
     }
 }
 
@@ -1065,6 +1280,101 @@ mod tests {
             assert_eq!(event.payload["provider"], json!(provider));
             assert_eq!(event.payload["repo_name"], json!("clawhip"));
         }
+    }
+
+    #[test]
+    fn maps_supported_ask_tool_events_to_question_requested() {
+        let cases = [
+            ("codex", "PreToolUse", "ask"),
+            ("gjc", "PreToolUse", "ask_user"),
+            ("pi", "PostToolUse", "ask_user_question"),
+            ("claude-code", "PreToolUse", "askuserquestion"),
+            ("claude-code", "PreToolUse", "AskUserQuestion"),
+        ];
+
+        for (provider, event_name, tool_name) in cases {
+            let event = incoming_event_from_native_hook_json(&json!({
+                "provider": provider,
+                "directory": "/repo/clawhip",
+                "event_name": event_name,
+                "session_id": "sess-234",
+                "event_payload": {
+                    "tool_name": tool_name,
+                    "tool_input": {
+                        "question": "Should I continue?\nThis second line should collapse."
+                    }
+                }
+            }))
+            .expect("event");
+
+            assert_eq!(event.kind, "question.requested", "{provider}:{tool_name}");
+            assert_eq!(event.payload["route_key"], json!("question.requested"));
+            assert_eq!(event.payload["session_id"], json!("sess-234"));
+            assert_eq!(event.payload["repo_name"], json!("clawhip"));
+            assert_eq!(event.payload["tool_name"], json!(tool_name));
+            assert_eq!(
+                event.payload["summary"],
+                json!("Should I continue? This second line should collapse.")
+            );
+            assert_eq!(
+                event.payload["event_payload"]["redacted"],
+                json!(true),
+                "raw ask payload should not survive in event_payload"
+            );
+            assert!(
+                event.payload["event_payload"].get("tool_input").is_none(),
+                "tool_input should be omitted from public-safe question payload"
+            );
+            assert!(
+                event.payload["payload"].get("tool_input").is_none(),
+                "top-level raw tool_input should be omitted from public-safe payload"
+            );
+        }
+    }
+
+    #[test]
+    fn question_request_summary_is_public_safe_and_bounded() {
+        let long_question = format!("{}{}", "A".repeat(200), "\nsecret-ish second line");
+        let event = incoming_event_from_native_hook_json(&json!({
+            "provider": "codex",
+            "directory": "/repo/clawhip",
+            "event_name": "PreToolUse",
+            "tool_name": "ask_user_question",
+            "tool_input": {
+                "prompt": long_question
+            }
+        }))
+        .expect("event");
+
+        let summary = event.payload["summary"].as_str().expect("summary");
+        assert_eq!(event.kind, "question.requested");
+        assert!(summary.chars().count() <= 160);
+        assert!(summary.ends_with('…'));
+        assert!(!summary.contains('\n'));
+    }
+
+    #[test]
+    fn does_not_map_question_marks_or_normal_tools_to_question_requested() {
+        let prose_question = incoming_event_from_native_hook_json(&json!({
+            "provider": "codex",
+            "directory": "/repo/clawhip",
+            "event_name": "UserPromptSubmit",
+            "prompt": "Can you run tests?"
+        }))
+        .expect("event");
+        assert_eq!(prose_question.kind, "session.prompt-submitted");
+
+        let normal_tool = incoming_event_from_native_hook_json(&json!({
+            "provider": "codex",
+            "directory": "/repo/clawhip",
+            "event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "printf 'continue?'"
+            }
+        }))
+        .expect("event");
+        assert_eq!(normal_tool.kind, "tool.pre");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bridge allowlisted native ask-user tool hooks (`ask`, `ask_user`, `ask_user_question`, `AskUserQuestion`, `askuserquestion`) into `question.requested` / existing `session.blocked` semantics
- preserve provider/session/repo/tool metadata while redacting raw ask payload copies and exposing only bounded public-safe question summaries
- document the question-request bridge and add regression coverage for Codex, Pi/GJC, Claude Code positives plus prose/normal-tool negatives

Closes #234

## Verification
- `cargo fmt`
- `cargo test question_request -- --nocapture`
- `cargo test ask_tool -- --nocapture`
- `cargo test question_requested -- --nocapture`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

— Codex (OpenAI)