### PR TITLE
Expire dead tmux watches before stale alerts

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -599,6 +599,7 @@ async fn accept_event(state: &AppState, event: IncomingEvent) -> axum::response:
 
     match enqueue_event(&state.tx, event.clone()).await {
         Ok(()) => {
+            expire_terminal_tmux_registration(state, &event).await;
             telemetry::emit(event_record(
                 telemetry::event_name::EVENT_ACCEPTED,
                 telemetry::reason::ACCEPT_ENQUEUED,
@@ -628,6 +629,55 @@ async fn accept_event(state: &AppState, event: IncomingEvent) -> axum::response:
                 .into_response()
         }
     }
+}
+
+async fn expire_terminal_tmux_registration(state: &AppState, event: &IncomingEvent) {
+    if !is_terminal_session_event(event.canonical_kind()) {
+        return;
+    }
+
+    let candidates = terminal_session_candidates(&event.payload);
+    if candidates.is_empty() {
+        return;
+    }
+
+    let mut registry = state.tmux_registry.write().await;
+    for session in candidates {
+        if registry.remove(&session).is_some() {
+            telemetry::emit(tmux_terminal_expiry_record(&session));
+        }
+    }
+}
+
+fn is_terminal_session_event(kind: &str) -> bool {
+    matches!(
+        kind,
+        "session.finished" | "session.stopped" | "session.pr-created"
+    )
+}
+
+fn tmux_terminal_expiry_record(session: &str) -> serde_json::Map<String, Value> {
+    let mut record = telemetry::record(
+        telemetry::event_name::SOURCE_INVENTORY,
+        "terminal_session_expired",
+        format!("source:tmux:{session}"),
+    );
+    record.insert("source".to_string(), json!("tmux"));
+    record.insert("session".to_string(), json!(session));
+    record
+}
+
+fn terminal_session_candidates(payload: &Value) -> Vec<String> {
+    let mut candidates = Vec::new();
+    for key in ["session", "session_name", "session_id", "agent_name"] {
+        if let Some(value) = payload.get(key).and_then(Value::as_str) {
+            let value = value.trim();
+            if !value.is_empty() && !candidates.iter().any(|candidate| candidate == value) {
+                candidates.push(value.to_string());
+            }
+        }
+    }
+    candidates
 }
 
 async fn register_tmux(
@@ -905,6 +955,26 @@ mod tests {
         )
     }
 
+    fn tmux_registration(session: &str) -> RegisteredTmuxSession {
+        RegisteredTmuxSession {
+            session: session.into(),
+            channel: Some("alerts".into()),
+            mention: Some("<@123>".into()),
+            routing: RoutingMetadata::default(),
+            keywords: vec!["error".into()],
+            keyword_window_secs: 30,
+            stale_minutes: 15,
+            format: None,
+            registered_at: "2026-04-02T00:00:00Z".into(),
+            registration_source: RegistrationSource::CliWatch,
+            parent_process: Some(ParentProcessInfo {
+                pid: 4242,
+                name: Some("codex".into()),
+            }),
+            active_wrapper_monitor: true,
+        }
+    }
+
     fn git_repo() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");
         let git = std::process::Command::new("git")
@@ -970,6 +1040,97 @@ mod tests {
             .as_object_mut()
             .expect("object")
             .insert(path[path.len() - 1].to_string(), Value::String(value));
+    }
+
+    #[tokio::test]
+    async fn accepted_terminal_session_event_expires_matching_tmux_registration() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        registry
+            .write()
+            .await
+            .insert("issue-221".into(), tmux_registration("issue-221"));
+        registry
+            .write()
+            .await
+            .insert("still-active".into(), tmux_registration("still-active"));
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: registry.clone(),
+            pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
+        };
+
+        let response = accept_event(
+            &state,
+            IncomingEvent {
+                kind: "session.finished".into(),
+                channel: None,
+                mention: None,
+                format: None,
+                template: None,
+                payload: json!({
+                    "agent_name": "issue-221",
+                    "session": "issue-221",
+                    "session_id": "issue-221",
+                    "status": "finished"
+                }),
+            },
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert_eq!(
+            rx.recv().await.expect("queued event").kind,
+            "session.finished"
+        );
+        let registry = registry.read().await;
+        assert!(!registry.contains_key("issue-221"));
+        assert!(registry.contains_key("still-active"));
+    }
+
+    #[tokio::test]
+    async fn accepted_non_terminal_session_event_preserves_tmux_registration() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        registry
+            .write()
+            .await
+            .insert("issue-221".into(), tmux_registration("issue-221"));
+        let state = AppState {
+            config: Arc::new(AppConfig::default()),
+            port: 25294,
+            tx,
+            tmux_registry: registry.clone(),
+            pending_update: update::new_shared_pending_update(),
+            native_observability: new_shared_native_hook_observability(),
+        };
+
+        let response = accept_event(
+            &state,
+            IncomingEvent {
+                kind: "session.blocked".into(),
+                channel: None,
+                mention: None,
+                format: None,
+                template: None,
+                payload: json!({
+                    "agent_name": "issue-221",
+                    "session": "issue-221",
+                    "status": "blocked"
+                }),
+            },
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert_eq!(
+            rx.recv().await.expect("queued event").kind,
+            "session.blocked"
+        );
+        assert!(registry.read().await.contains_key("issue-221"));
     }
 
     #[test]

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -184,6 +184,16 @@ pub async fn monitor_registered_session(
 
     loop {
         let now = Instant::now();
+        if !session_exists(&registration.session).await? {
+            telemetry::emit(source_record(
+                telemetry::event_name::SOURCE_INVENTORY,
+                "source_missing",
+                Some(&registration.session),
+                None,
+            ));
+            break;
+        }
+
         flush_pending_keyword_hits(
             &mut pending_keyword_hits,
             &registration,
@@ -195,20 +205,6 @@ pub async fn monitor_registered_session(
         )
         .await?;
 
-        if !session_exists(&registration.session).await? {
-            flush_pending_keyword_hits(
-                &mut pending_keyword_hits,
-                &registration,
-                &client,
-                &registration.session,
-                now,
-                Duration::from_secs(registration.keyword_window_secs.max(1)),
-                true,
-            )
-            .await?;
-            break;
-        }
-
         let panes_snapshot = snapshot_tmux_session(&registration.session).await?;
         let mut active_panes = HashSet::new();
 
@@ -217,6 +213,10 @@ pub async fn monitor_registered_session(
             let pane_key = pane.pane_id.clone();
             let hash = content_hash(&pane.content);
             let latest_line = last_nonempty_line(&pane.content);
+
+            if pane.pane_dead {
+                pending_keyword_hits = None;
+            }
 
             match panes.get_mut(&pane_key) {
                 None => {
@@ -236,17 +236,21 @@ pub async fn monitor_registered_session(
                 Some(existing) => {
                     existing.pane_dead = pane.pane_dead;
                     if existing.content_hash != hash {
-                        let hits = collect_keyword_hits_with_provenance(
-                            &existing.snapshot,
-                            &pane.content,
-                            &registration.keywords,
-                            KeywordMatchProvenance {
-                                pane_id: pane.pane_id.clone(),
-                                pane_name: pane.pane_name.clone(),
-                                cursor: None,
-                                source: KeywordMatchSource::FreshOutput,
-                            },
-                        );
+                        let hits = if pane.pane_dead {
+                            Vec::new()
+                        } else {
+                            collect_keyword_hits_with_provenance(
+                                &existing.snapshot,
+                                &pane.content,
+                                &registration.keywords,
+                                KeywordMatchProvenance {
+                                    pane_id: pane.pane_id.clone(),
+                                    pane_name: pane.pane_name.clone(),
+                                    cursor: None,
+                                    source: KeywordMatchSource::FreshOutput,
+                                },
+                            )
+                        };
                         push_pending_keyword_hits(&mut pending_keyword_hits, now, hits);
 
                         existing.session = pane.session;
@@ -346,15 +350,6 @@ async fn poll_tmux(
         }
 
         let now = Instant::now();
-        flush_session_pending_keyword_hits(
-            &mut state.pending_keyword_hits,
-            session_name,
-            registration,
-            tx,
-            now,
-            false,
-        )
-        .await?;
 
         match session_exists(session_name).await {
             Ok(false) => {
@@ -365,15 +360,7 @@ async fn poll_tmux(
                     None,
                 ));
                 sessions_to_unregister.push(session_name.clone());
-                flush_session_pending_keyword_hits(
-                    &mut state.pending_keyword_hits,
-                    session_name,
-                    registration,
-                    tx,
-                    now,
-                    true,
-                )
-                .await?;
+                state.pending_keyword_hits.remove(session_name);
                 state.panes.retain(|_, pane| pane.session != *session_name);
                 continue;
             }
@@ -393,6 +380,16 @@ async fn poll_tmux(
             Ok(true) => {}
         }
 
+        flush_session_pending_keyword_hits(
+            &mut state.pending_keyword_hits,
+            session_name,
+            registration,
+            tx,
+            now,
+            false,
+        )
+        .await?;
+
         match snapshot_tmux_session(session_name).await {
             Ok(panes) => {
                 for pane in panes {
@@ -401,6 +398,10 @@ async fn poll_tmux(
                     let now = Instant::now();
                     let hash = content_hash(&pane.content);
                     let latest_line = last_nonempty_line(&pane.content);
+
+                    if pane.pane_dead {
+                        state.pending_keyword_hits.remove(session_name);
+                    }
 
                     let hits = match state.panes.get_mut(&pane_key) {
                         None => {
@@ -421,17 +422,21 @@ async fn poll_tmux(
                         Some(existing) => {
                             existing.pane_dead = pane.pane_dead;
                             if existing.content_hash != hash {
-                                let hits = collect_keyword_hits_with_provenance(
-                                    &existing.snapshot,
-                                    &pane.content,
-                                    &registration.keywords,
-                                    KeywordMatchProvenance {
-                                        pane_id: pane.pane_id.clone(),
-                                        pane_name: pane.pane_name.clone(),
-                                        cursor: None,
-                                        source: KeywordMatchSource::FreshOutput,
-                                    },
-                                );
+                                let hits = if pane.pane_dead {
+                                    Vec::new()
+                                } else {
+                                    collect_keyword_hits_with_provenance(
+                                        &existing.snapshot,
+                                        &pane.content,
+                                        &registration.keywords,
+                                        KeywordMatchProvenance {
+                                            pane_id: pane.pane_id.clone(),
+                                            pane_name: pane.pane_name.clone(),
+                                            cursor: None,
+                                            source: KeywordMatchSource::FreshOutput,
+                                        },
+                                    )
+                                };
                                 existing.pane_name = pane.pane_name;
                                 existing.snapshot = pane.content;
                                 existing.content_hash = hash;


### PR DESCRIPTION
## Summary\n- expire registered tmux watches when accepted terminal session events identify the watched session\n- stop flushing pending tmux keyword windows after sessions disappear or panes become dead\n- add focused daemon regressions for terminal expiry vs non-terminal preservation\n\nCloses #221\n\n## Validation\n- cargo fmt --check\n- cargo test accepted_terminal_session_event_expires_matching_tmux_registration -- --nocapture\n- cargo test accepted_non_terminal_session_event_preserves_tmux_registration -- --nocapture\n- cargo test tmux -- --nocapture\n- cargo test\n- cargo clippy --all-targets --all-features -- -D warnings