### PR TITLE
Add gateway allowlist verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,6 +758,28 @@ Discord thread targets:
 - Diagnostics and binding verification only reference configured IDs and status
   outcomes; clawhip does not list or dump private channel/thread inventories.
 
+## Gateway allowlist diagnostics
+
+When clawhip sends through a local Clawdbot gateway, route channel IDs must also
+be present in the gateway's Discord allowlist. Check that boundary with:
+
+```bash
+clawhip config verify-gateway-allowlist
+clawhip config verify-gateway-allowlist --gateway-config ~/.clawdbot/clawdbot.json
+clawhip config verify-gateway-allowlist --json
+```
+
+The default gateway config path is `~/.clawdbot/clawdbot.json` when `HOME` is
+available; use `--gateway-config <path>` for any other local file. The command
+reads only `channels.discord.guilds[*].channels.<channel_id>.allow = true`,
+compares it with clawhip's configured Discord channel destinations, and exits
+non-zero when any destination is missing or not explicitly allowed.
+
+Output is public-safe by design: text and JSON reports include counts, clawhip
+source labels, and channel IDs only. They do not dump gateway tokens, webhook
+URLs, raw config payloads, or unrelated gateway fields. Webhooks, Slack routes,
+localfile routes, and thread-only targets are outside this allowlist check.
+
 ## Dynamic token contract
 
 Only for routes with:
@@ -870,6 +892,7 @@ Required live sign-off presets:
 clawhip                 # start daemon
 clawhip status          # daemon health
 clawhip config          # bounded preset editor / config inspection
+clawhip config verify-gateway-allowlist  # check Clawdbot gateway allowlist coverage
 clawhip send ...        # thin client custom event
 clawhip github ...      # thin client GitHub event
 clawhip git ...         # thin client git event

--- a/src/binding_verify.rs
+++ b/src/binding_verify.rs
@@ -41,6 +41,7 @@ pub enum BindingSource {
     Route { index: usize },
     GitMonitor { index: usize },
     TmuxMonitor { index: usize },
+    WorkspaceMonitor { index: usize },
 }
 
 impl fmt::Display for BindingSource {
@@ -50,6 +51,7 @@ impl fmt::Display for BindingSource {
             Self::Route { index } => write!(f, "routes[{}]", index + 1),
             Self::GitMonitor { index } => write!(f, "monitors.git.repos[{}]", index + 1),
             Self::TmuxMonitor { index } => write!(f, "monitors.tmux.sessions[{}]", index + 1),
+            Self::WorkspaceMonitor { index } => write!(f, "monitors.workspace[{}]", index + 1),
         }
     }
 }
@@ -86,7 +88,8 @@ pub fn collect_bindings(config: &AppConfig) -> Vec<ChannelBinding> {
 
     // routes
     for (index, route) in config.routes.iter().enumerate() {
-        if let Some(channel) = route.channel.as_deref()
+        if route.effective_sink() == "discord"
+            && let Some(channel) = route.channel.as_deref()
             && !channel.is_empty()
         {
             let label = if route.filter.is_empty() {
@@ -141,6 +144,20 @@ pub fn collect_bindings(config: &AppConfig) -> Vec<ChannelBinding> {
                 expected_name: session.channel_name.clone(),
                 source: BindingSource::TmuxMonitor { index },
                 label: format!("tmux:{}", session.session),
+            });
+        }
+    }
+
+    // workspace monitors
+    for (index, workspace) in config.monitors.workspace.iter().enumerate() {
+        if let Some(channel) = workspace.channel.as_deref()
+            && !channel.is_empty()
+        {
+            bindings.push(ChannelBinding {
+                channel_id: channel.to_string(),
+                expected_name: None,
+                source: BindingSource::WorkspaceMonitor { index },
+                label: format!("workspace:{}", workspace.path),
             });
         }
     }
@@ -321,7 +338,7 @@ mod tests {
 
     use crate::config::{
         DefaultsConfig, GitMonitorConfig, GitRepoMonitor, MonitorConfig, RouteRule,
-        TmuxMonitorConfig, TmuxSessionMonitor,
+        TmuxMonitorConfig, TmuxSessionMonitor, WorkspaceMonitor,
     };
 
     fn config_with_routes(routes: Vec<RouteRule>) -> AppConfig {
@@ -449,6 +466,29 @@ mod tests {
         let bindings = collect_bindings(&config);
         assert_eq!(bindings.len(), 1);
         assert_eq!(bindings[0].label, "tmux:issue-42");
+    }
+
+    #[test]
+    fn collects_workspace_monitor_binding() {
+        let config = AppConfig {
+            monitors: MonitorConfig {
+                workspace: vec![WorkspaceMonitor {
+                    path: "/workspace".into(),
+                    channel: Some("555".into()),
+                    ..WorkspaceMonitor::default()
+                }],
+                ..MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let bindings = collect_bindings(&config);
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].channel_id, "555");
+        assert_eq!(
+            bindings[0].source,
+            BindingSource::WorkspaceMonitor { index: 0 }
+        );
+        assert_eq!(bindings[0].label, "workspace:/workspace");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -249,6 +249,18 @@ pub struct VerifyBindingsArgs {
     pub json: bool,
 }
 
+#[derive(Debug, Clone, Default, Args)]
+pub struct VerifyGatewayAllowlistArgs {
+    /// Path to the local Clawdbot gateway JSON config.
+    ///
+    /// Defaults to ~/.clawdbot/clawdbot.json when HOME is available.
+    #[arg(long = "gateway-config")]
+    pub gateway_config: Option<PathBuf>,
+    /// Emit machine-readable JSON instead of the human-readable text report.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
 impl EmitArgs {
     pub fn into_event(self) -> crate::Result<crate::events::IncomingEvent> {
         let mut channel = None;
@@ -710,6 +722,12 @@ pub enum ConfigCommand {
     /// then queries the Discord API to confirm each channel exists and (optionally)
     /// matches the `channel_name` hint set alongside the ID.
     VerifyBindings(VerifyBindingsArgs),
+    /// Verify clawhip channel destinations are allowed by the local Clawdbot gateway config.
+    ///
+    /// Reads only the public-safe gateway channel allowlist shape and reports
+    /// channel IDs plus clawhip source labels; never dumps gateway tokens,
+    /// webhooks, payloads, or unrelated config fields.
+    VerifyGatewayAllowlist(VerifyGatewayAllowlistArgs),
 }
 
 #[cfg(test)]
@@ -1028,6 +1046,29 @@ mod tests {
             panic!("expected verify-bindings");
         };
         assert!(!args.json);
+    }
+
+    #[test]
+    fn parses_config_verify_gateway_allowlist_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "config",
+            "verify-gateway-allowlist",
+            "--gateway-config",
+            "/tmp/clawdbot.json",
+            "--json",
+        ]);
+        let Some(Commands::Config {
+            command: Some(ConfigCommand::VerifyGatewayAllowlist(args)),
+        }) = cli.command
+        else {
+            panic!("expected verify-gateway-allowlist");
+        };
+        assert_eq!(
+            args.gateway_config.as_deref(),
+            Some(std::path::Path::new("/tmp/clawdbot.json"))
+        );
+        assert!(args.json);
     }
 
     #[test]

--- a/src/gateway_allowlist.rs
+++ b/src/gateway_allowlist.rs
@@ -1,0 +1,440 @@
+//! Gateway allowlist coverage diagnostics.
+//!
+//! This is a local, read-only preflight for the clawhip -> Clawdbot gateway
+//! boundary. It compares clawhip's configured Discord channel destinations
+//! against the public-safe channel allowlist shape used by Clawdbot:
+//!
+//! `channels.discord.guilds[*].channels.<channel_id>.allow = true`
+//!
+//! The report intentionally carries only channel IDs plus clawhip source labels;
+//! it never serializes the gateway config, tokens, webhooks, or payload fields.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::binding_verify::{BindingSource, collect_bindings};
+use crate::config::AppConfig;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAllowlistVerdict {
+    pub channel_id: String,
+    pub source: BindingSource,
+    pub label: String,
+    pub gateway_status: GatewayAllowlistStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayAllowlistStatus {
+    Allowed,
+    NotAllowed,
+}
+
+impl GatewayAllowlistStatus {
+    fn is_ok(self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatewayAllowlistReport {
+    pub checked_count: usize,
+    pub allowed_count: usize,
+    pub missing_count: usize,
+    pub verdicts: Vec<GatewayAllowlistVerdict>,
+}
+
+impl GatewayAllowlistReport {
+    pub fn all_ok(&self) -> bool {
+        self.verdicts
+            .iter()
+            .all(|entry| entry.gateway_status.is_ok())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GatewayAllowlist {
+    allowed_channels: BTreeSet<String>,
+}
+
+impl GatewayAllowlist {
+    pub fn from_json_str(contents: &str) -> Result<Self, String> {
+        let value: Value = serde_json::from_str(contents)
+            .map_err(|error| format!("failed to parse gateway config JSON: {error}"))?;
+        Ok(Self::from_json_value(&value))
+    }
+
+    fn from_json_value(value: &Value) -> Self {
+        let mut allowed_channels = BTreeSet::new();
+        let Some(guilds) = value
+            .get("channels")
+            .and_then(|channels| channels.get("discord"))
+            .and_then(|discord| discord.get("guilds"))
+            .and_then(Value::as_object)
+        else {
+            return Self { allowed_channels };
+        };
+
+        for guild in guilds.values() {
+            let Some(channels) = guild.get("channels").and_then(Value::as_object) else {
+                continue;
+            };
+            for (channel_id, channel_config) in channels {
+                if channel_config
+                    .get("allow")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    allowed_channels.insert(channel_id.clone());
+                }
+            }
+        }
+
+        Self { allowed_channels }
+    }
+
+    fn contains(&self, channel_id: &str) -> bool {
+        self.allowed_channels.contains(channel_id)
+    }
+}
+
+pub fn default_gateway_config_path() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".clawdbot").join("clawdbot.json"))
+}
+
+pub fn verify(config: &AppConfig, gateway: &GatewayAllowlist) -> GatewayAllowlistReport {
+    let bindings = collect_bindings(config);
+    let mut verdicts = Vec::with_capacity(bindings.len());
+
+    for binding in bindings {
+        let gateway_status = if gateway.contains(&binding.channel_id) {
+            GatewayAllowlistStatus::Allowed
+        } else {
+            GatewayAllowlistStatus::NotAllowed
+        };
+        verdicts.push(GatewayAllowlistVerdict {
+            channel_id: binding.channel_id,
+            source: binding.source,
+            label: binding.label,
+            gateway_status,
+        });
+    }
+
+    let checked_count = verdicts.len();
+    let allowed_count = verdicts
+        .iter()
+        .filter(|entry| entry.gateway_status.is_ok())
+        .count();
+    let missing_count = checked_count - allowed_count;
+
+    GatewayAllowlistReport {
+        checked_count,
+        allowed_count,
+        missing_count,
+        verdicts,
+    }
+}
+
+pub fn verify_from_path(
+    config: &AppConfig,
+    gateway_config_path: &Path,
+) -> Result<GatewayAllowlistReport, String> {
+    let contents = fs::read_to_string(gateway_config_path).map_err(|error| {
+        format!(
+            "failed to read gateway config {}: {error}. Pass --gateway-config <path> to use a different local Clawdbot config.",
+            gateway_config_path.display()
+        )
+    })?;
+    let gateway = GatewayAllowlist::from_json_str(&contents)?;
+    Ok(verify(config, &gateway))
+}
+
+impl fmt::Display for GatewayAllowlistReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.verdicts.is_empty() {
+            writeln!(
+                f,
+                "No Discord channel destinations found in clawhip config."
+            )?;
+            return Ok(());
+        }
+
+        for entry in &self.verdicts {
+            let tag = if entry.gateway_status.is_ok() {
+                "ok"
+            } else {
+                "FAIL"
+            };
+            let status = match entry.gateway_status {
+                GatewayAllowlistStatus::Allowed => "allowed by gateway",
+                GatewayAllowlistStatus::NotAllowed => "NOT ALLOWED by gateway",
+            };
+            writeln!(
+                f,
+                "[{tag:>4}] {} -> {} ({}) -- {status}",
+                entry.source, entry.channel_id, entry.label
+            )?;
+        }
+
+        writeln!(f)?;
+        if self.missing_count == 0 {
+            writeln!(
+                f,
+                "{} gateway allowlist binding(s) checked, all allowed.",
+                self.checked_count
+            )?;
+        } else {
+            writeln!(
+                f,
+                "{} gateway allowlist binding(s) checked: {} allowed, {} missing.",
+                self.checked_count, self.allowed_count, self.missing_count
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    use crate::config::{
+        AppConfig, DefaultsConfig, GitMonitorConfig, GitRepoMonitor, MonitorConfig, RouteRule,
+        TmuxMonitorConfig, TmuxSessionMonitor, WorkspaceMonitor,
+    };
+
+    fn gateway_json(channel_entries: &str) -> String {
+        format!(
+            r#"{{
+  "token": "gateway-secret-token",
+  "privatePayload": {{ "doNotLeak": "private-value" }},
+  "channels": {{
+    "discord": {{
+      "groupPolicy": "allowlist",
+      "guilds": {{
+        "*": {{
+          "channels": {{
+            {channel_entries}
+          }}
+        }}
+      }}
+    }}
+  }}
+}}"#
+        )
+    }
+
+    fn config_with_route(channel: &str) -> AppConfig {
+        let mut filter = BTreeMap::new();
+        filter.insert("repo".to_string(), "clawhip".to_string());
+        AppConfig {
+            routes: vec![RouteRule {
+                event: "github.*".into(),
+                filter,
+                channel: Some(channel.into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        }
+    }
+
+    #[test]
+    fn allowed_channel_reports_ok() {
+        let config = config_with_route("111");
+        let gateway =
+            GatewayAllowlist::from_json_str(&gateway_json(r#""111": { "allow": true }"#)).unwrap();
+
+        let report = verify(&config, &gateway);
+
+        assert!(report.all_ok());
+        assert_eq!(report.checked_count, 1);
+        assert_eq!(report.allowed_count, 1);
+        assert_eq!(report.missing_count, 0);
+        assert_eq!(
+            report.verdicts[0].gateway_status,
+            GatewayAllowlistStatus::Allowed
+        );
+    }
+
+    #[test]
+    fn missing_allowlist_channel_fails() {
+        let config = config_with_route("222");
+        let gateway =
+            GatewayAllowlist::from_json_str(&gateway_json(r#""111": { "allow": true }"#)).unwrap();
+
+        let report = verify(&config, &gateway);
+
+        assert!(!report.all_ok());
+        assert_eq!(report.checked_count, 1);
+        assert_eq!(report.allowed_count, 0);
+        assert_eq!(report.missing_count, 1);
+        assert_eq!(
+            report.verdicts[0].gateway_status,
+            GatewayAllowlistStatus::NotAllowed
+        );
+    }
+
+    #[test]
+    fn allow_false_and_missing_allow_are_not_allowed() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("111".into()),
+                ..DefaultsConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "github.*".into(),
+                channel: Some("222".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let gateway = GatewayAllowlist::from_json_str(&gateway_json(
+            r#""111": { "allow": false }, "222": { "name": "missing-allow" }"#,
+        ))
+        .unwrap();
+
+        let report = verify(&config, &gateway);
+
+        assert!(!report.all_ok());
+        assert_eq!(report.missing_count, 2);
+    }
+
+    #[test]
+    fn text_and_json_do_not_dump_gateway_secrets_or_config_payloads() {
+        let mut config = config_with_route("333");
+        config.routes[0].channel_name = Some("do-not-render-channel-name-hint".into());
+        let gateway = GatewayAllowlist::from_json_str(&gateway_json(
+            r#""333": { "allow": true, "token": "nested-secret" }"#,
+        ))
+        .unwrap();
+        let report = verify(&config, &gateway);
+
+        let text = report.to_string();
+        let json = serde_json::to_string(&report).unwrap();
+
+        for rendered in [text, json] {
+            assert!(rendered.contains("333"));
+            assert!(rendered.contains("github.*"));
+            assert!(!rendered.contains("gateway-secret-token"));
+            assert!(!rendered.contains("nested-secret"));
+            assert!(!rendered.contains("private-value"));
+            assert!(!rendered.contains("privatePayload"));
+            assert!(!rendered.contains("groupPolicy"));
+            assert!(!rendered.contains("do-not-render-channel-name-hint"));
+            assert!(!rendered.contains("expected_name"));
+        }
+    }
+
+    #[test]
+    fn absent_gateway_config_returns_friendly_error() {
+        let config = AppConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing-clawdbot.json");
+
+        let error = verify_from_path(&config, &missing).unwrap_err();
+
+        assert!(error.contains("failed to read gateway config"));
+        assert!(error.contains("--gateway-config <path>"));
+    }
+
+    #[test]
+    fn route_default_and_monitor_sources_are_reported() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("100".into()),
+                ..DefaultsConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "github.*".into(),
+                channel: Some("200".into()),
+                ..RouteRule::default()
+            }],
+            monitors: MonitorConfig {
+                git: GitMonitorConfig {
+                    repos: vec![GitRepoMonitor {
+                        path: "/repo".into(),
+                        name: Some("repo-label".into()),
+                        channel: Some("300".into()),
+                        ..GitRepoMonitor::default()
+                    }],
+                },
+                tmux: TmuxMonitorConfig {
+                    sessions: vec![TmuxSessionMonitor {
+                        session: "session-label".into(),
+                        channel: Some("400".into()),
+                        ..TmuxSessionMonitor::default()
+                    }],
+                },
+                workspace: vec![WorkspaceMonitor {
+                    path: "/workspace".into(),
+                    channel: Some("500".into()),
+                    ..WorkspaceMonitor::default()
+                }],
+                ..MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let gateway = GatewayAllowlist::from_json_str(&gateway_json(
+            r#""100": { "allow": true }, "200": { "allow": true }, "300": { "allow": true }, "400": { "allow": true }, "500": { "allow": true }"#,
+        ))
+        .unwrap();
+
+        let report = verify(&config, &gateway);
+        let text = report.to_string();
+
+        assert!(report.all_ok());
+        assert!(text.contains("defaults.channel -> 100"));
+        assert!(text.contains("routes[1] -> 200"));
+        assert!(text.contains("monitors.git.repos[1] -> 300"));
+        assert!(text.contains("monitors.tmux.sessions[1] -> 400"));
+        assert!(text.contains("monitors.workspace[1] -> 500"));
+        assert!(text.contains("repo-label"));
+        assert!(text.contains("tmux:session-label"));
+        assert!(text.contains("workspace:/workspace"));
+    }
+
+    #[test]
+    fn non_discord_targets_and_threads_are_skipped() {
+        let config = AppConfig {
+            routes: vec![
+                RouteRule {
+                    event: "discord-webhook".into(),
+                    webhook: Some("https://discord.com/api/webhooks/secret".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "slack".into(),
+                    sink: "slack".into(),
+                    slack_webhook: Some("https://hooks.slack.test/secret".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "local".into(),
+                    sink: "localfile".into(),
+                    local_path: Some("/tmp/out".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "thread".into(),
+                    thread: Some("999".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+        let gateway = GatewayAllowlist::from_json_str(&gateway_json(""))
+            .expect("gateway shape parses even without allowed channels");
+
+        let report = verify(&config, &gateway);
+
+        assert!(report.verdicts.is_empty());
+        assert!(report.all_ok());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod dispatch;
 mod dynamic_tokens;
 mod event;
 mod events;
+mod gateway_allowlist;
 mod hooks;
 mod keyword_window;
 mod lifecycle;
@@ -36,7 +37,7 @@ use tokio::runtime::Builder;
 use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs, GitCommands,
     GithubCommands, HooksCommands, MemoryCommands, NativeCommands, PluginCommands, ReleaseCommands,
-    SetupArgs, TmuxCommands, UpdateCommands, VerifyBindingsArgs,
+    SetupArgs, TmuxCommands, UpdateCommands, VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
 };
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, SetupEdits};
@@ -317,6 +318,9 @@ async fn real_main(cli: Cli) -> Result<()> {
                 Ok(())
             }
             ConfigCommand::VerifyBindings(args) => run_verify_bindings(config, args).await,
+            ConfigCommand::VerifyGatewayAllowlist(args) => {
+                run_verify_gateway_allowlist(config, args)
+            }
         },
         Commands::Plugin { command } => match command {
             PluginCommands::List => {
@@ -504,6 +508,31 @@ async fn run_verify_bindings(config: Arc<AppConfig>, args: VerifyBindingsArgs) -
     }
 
     if !audit.all_ok() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn run_verify_gateway_allowlist(
+    config: Arc<AppConfig>,
+    args: VerifyGatewayAllowlistArgs,
+) -> Result<()> {
+    let gateway_config_path = match args.gateway_config {
+        Some(path) => path,
+        None => gateway_allowlist::default_gateway_config_path().ok_or_else(|| {
+            "could not resolve default gateway config path; pass --gateway-config <path>"
+                .to_string()
+        })?,
+    };
+    let report = gateway_allowlist::verify_from_path(&config, &gateway_config_path)?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{report}");
+    }
+
+    if !report.all_ok() {
         std::process::exit(1);
     }
     Ok(())


### PR DESCRIPTION
Closes #228. Adds a public-safe config diagnostic for clawhip route channels missing from the Clawdbot gateway allowlist.

Validation:
- cargo fmt --check
- cargo test gateway_allowlist -- --nocapture
- cargo test binding_verify -- --nocapture
- cargo test parses_config_verify_gateway_allowlist_subcommand -- --nocapture
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*