### PR TITLE
Fix release manifest JSON parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,8 +314,6 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
-    outputs:
-      val: ${{ steps.host.outputs.manifest }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -360,15 +358,22 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
       - name: Create GitHub Release
         env:
-          PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
-          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
+        shell: bash
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          set -euo pipefail
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          prerelease_flag=()
+          if jq -e '.announcement_is_prerelease == true' dist-manifest.json > /dev/null; then
+            prerelease_flag=(--prerelease)
+          fi
+
+          announcement_title="$(jq -er '.announcement_title' dist-manifest.json)"
+
+          # Write and read notes from a file to avoid quoting breaking things
+          jq -er '.announcement_github_body' dist-manifest.json > "$RUNNER_TEMP/notes.txt"
+
+          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" "${prerelease_flag[@]}" --title "$announcement_title" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
   # Publish to crates.io
   publish-crates:


### PR DESCRIPTION
## Summary
- fixes the release workflow's GitHub Release step to read announcement fields from `dist-manifest.json` in bash with `jq`
- avoids parsing the host step output with GitHub `fromJson(...)`, which can fail before the shell step runs when the captured output is empty/invalid
- removes the now-unused host job output

Fixes #244.

## Verification
- `python3` YAML parse of `.github/workflows/release.yml`
- Extracted `Create GitHub Release` shell body and ran it with fixture dist manifests for both prerelease and non-prerelease paths, using a stub `gh`
- `gh workflow view release.yml --yaml` parse check
- `cargo dist generate --check` attempted, but `cargo-dist` is not installed in this worktree (`cargo: no such command: dist`)

## Follow-up
- The failed v0.6.9 release workflow still needs to be rerun after this lands.
