### PR TITLE
Parse release manifest without jq

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,15 +363,23 @@ jobs:
         run: |
           set -euo pipefail
 
+          manifest_values="$RUNNER_TEMP/dist-manifest-values"
+          python3 - <<'PY' > "$manifest_values"
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(Path("dist-manifest.json").read_text())
+          print("true" if manifest.get("announcement_is_prerelease") is True else "false")
+          print(manifest["announcement_title"])
+          Path("${RUNNER_TEMP}/notes.txt").write_text(manifest["announcement_github_body"])
+          PY
+
+          mapfile -t manifest_lines < "$manifest_values"
           prerelease_flag=()
-          if jq -e '.announcement_is_prerelease == true' dist-manifest.json > /dev/null; then
+          if [[ "${manifest_lines[0]}" == "true" ]]; then
             prerelease_flag=(--prerelease)
           fi
-
-          announcement_title="$(jq -er '.announcement_title' dist-manifest.json)"
-
-          # Write and read notes from a file to avoid quoting breaking things
-          jq -er '.announcement_github_body' dist-manifest.json > "$RUNNER_TEMP/notes.txt"
+          announcement_title="${manifest_lines[1]}"
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" "${prerelease_flag[@]}" --title "$announcement_title" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 


### PR DESCRIPTION
## Summary
- removes the jq dependency from the GitHub Release creation step
- parses dist-manifest.json with python3, which is already available on the self-hosted runner
- keeps the runtime manifest parsing fix from #245 while making it work on the actual runner image

Fixes the remaining v0.6.9 release failure after #245.

## Verification
- python3 YAML parse of .github/workflows/release.yml
- git diff --check

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*