### PR TITLE
Add GAJAE receipt ingestion

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -488,12 +488,42 @@ pub enum GajaeCommands {
         #[command(subcommand)]
         command: GajaeProfileCommands,
     },
+    /// Validate and ingest gajae receipt families.
+    Receipt {
+        #[command(subcommand)]
+        command: GajaeReceiptCommands,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum GajaeProfileCommands {
     /// Install the clawhip profile through gajae.
     Install,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GajaeReceiptCommands {
+    /// Validate a receipt and emit a bounded public-safe clawhip event.
+    Ingest(GajaeReceiptIngestArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct GajaeReceiptIngestArgs {
+    /// GAJAE receipt family to validate.
+    #[arg(long)]
+    pub family: String,
+    /// Receipt JSON file to validate.
+    #[arg(long, conflicts_with = "stdin")]
+    pub file: Option<PathBuf>,
+    /// Read receipt JSON from stdin before validation.
+    #[arg(long, conflicts_with = "file")]
+    pub stdin: bool,
+    /// Send the validated event to the local clawhip daemon.
+    #[arg(long, default_value_t = false)]
+    pub send: bool,
+    /// Override the destination channel when sending to the daemon.
+    #[arg(long)]
+    pub channel: Option<String>,
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -252,7 +253,16 @@ fn write_receipt_tempfile(input: &[u8]) -> Result<TempReceiptFile> {
         "clawhip-gajae-receipt-{}.json",
         uuid::Uuid::new_v4()
     ));
-    fs::write(&path, input).context("failed to write temporary receipt file")?;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .context("failed to create temporary receipt file")?;
+    file.write_all(input)
+        .context("failed to write temporary receipt file")?;
+    file.sync_all()
+        .context("failed to sync temporary receipt file")?;
     Ok(TempReceiptFile { path })
 }
 

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -1,13 +1,19 @@
 use std::ffi::OsString;
-use std::io;
+use std::fs;
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
+use serde_json::{Map, Value, json};
+
+use crate::events::IncomingEvent;
 
 const GAJAE_ENV: &str = "GAJAE_BIN";
 const GAJAE_PATH_NAME: &str = "gajae";
 const PROFILE_INSTALL_ARGS: &[&str] = &["clawhip", "profile", "install"];
+const SUMMARY_LIMIT: usize = 240;
+const RECEIPT_STDIN_LIMIT: usize = 1_048_576;
 
 #[derive(Debug, Clone, Copy)]
 pub enum GajaeCommand {
@@ -31,6 +37,12 @@ pub trait CommandRunner {
     fn output(&mut self, program: &Path, args: &[&str]) -> io::Result<CommandOutput>;
     fn status_inherited_output(&mut self, program: &Path, args: &[&str])
     -> io::Result<CommandExit>;
+    fn output_with_stdin(
+        &mut self,
+        program: &Path,
+        args: &[&str],
+        stdin: Option<&[u8]>,
+    ) -> io::Result<CommandOutput>;
 }
 
 #[derive(Debug, Default)]
@@ -60,6 +72,34 @@ impl CommandRunner for StdCommandRunner {
         Ok(CommandExit {
             success: status.success(),
             code: status.code(),
+        })
+    }
+    fn output_with_stdin(
+        &mut self,
+        program: &Path,
+        args: &[&str],
+        stdin: Option<&[u8]>,
+    ) -> io::Result<CommandOutput> {
+        let mut child = Command::new(program)
+            .args(args)
+            .stdin(if stdin.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        if let Some(input) = stdin
+            && let Some(mut child_stdin) = child.stdin.take()
+        {
+            child_stdin.write_all(input)?;
+        }
+        let output = child.wait_with_output()?;
+        Ok(CommandOutput {
+            success: output.status.success(),
+            stdout: output.stdout,
+            stderr: output.stderr,
         })
     }
 }
@@ -136,6 +176,208 @@ pub fn profile_install_failure_message(status: CommandExit) -> String {
     )
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReceiptSource {
+    File(PathBuf),
+    Stdin(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceiptIngestRequest {
+    pub family: String,
+    pub source: ReceiptSource,
+    pub channel: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReceiptIngestResult {
+    pub event: IncomingEvent,
+}
+
+pub fn read_receipt_stdin(reader: &mut impl Read) -> Result<Vec<u8>> {
+    let mut input = Vec::new();
+    reader
+        .take((RECEIPT_STDIN_LIMIT + 1) as u64)
+        .read_to_end(&mut input)
+        .context("failed to read receipt from stdin")?;
+    if input.len() > RECEIPT_STDIN_LIMIT {
+        bail!("receipt stdin exceeds {RECEIPT_STDIN_LIMIT} byte limit");
+    }
+    Ok(input)
+}
+
+pub fn ingest_receipt(request: ReceiptIngestRequest) -> Result<ReceiptIngestResult> {
+    let mut runner = StdCommandRunner;
+    ingest_receipt_with(&mut runner, |name| std::env::var_os(name), request)
+}
+
+fn ingest_receipt_with(
+    runner: &mut impl CommandRunner,
+    env_var: impl Fn(&str) -> Option<OsString>,
+    request: ReceiptIngestRequest,
+) -> Result<ReceiptIngestResult> {
+    let family = sanitize_family(&request.family)?;
+    let bin = discover_gajae_with(env_var);
+    let temp;
+    let file_path = match &request.source {
+        ReceiptSource::File(path) => path.as_path(),
+        ReceiptSource::Stdin(input) => {
+            temp = write_receipt_tempfile(input)?;
+            temp.path()
+        }
+    };
+    let file_arg = file_path
+        .to_str()
+        .ok_or_else(|| anyhow!("receipt file path is not valid UTF-8"))?;
+    let args = [family.as_str(), "validate", "--file", file_arg];
+    let output = runner
+        .output_with_stdin(&bin, &args, None)
+        .with_context(|| format!("failed to run {} {} validate", bin.display(), family))?;
+    if !output.success {
+        bail!(
+            "gajae receipt validation failed for family {}{}",
+            family,
+            validation_detail(&output)
+        );
+    }
+
+    let validation = parse_validation_output(&output)?;
+    Ok(ReceiptIngestResult {
+        event: receipt_event(&family, validation, request.channel),
+    })
+}
+
+fn write_receipt_tempfile(input: &[u8]) -> Result<TempReceiptFile> {
+    let path = std::env::temp_dir().join(format!(
+        "clawhip-gajae-receipt-{}.json",
+        uuid::Uuid::new_v4()
+    ));
+    fs::write(&path, input).context("failed to write temporary receipt file")?;
+    Ok(TempReceiptFile { path })
+}
+
+#[derive(Debug)]
+struct TempReceiptFile {
+    path: PathBuf,
+}
+
+impl TempReceiptFile {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempReceiptFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn parse_validation_output(output: &CommandOutput) -> Result<Value> {
+    if let Ok(value) = serde_json::from_slice::<Value>(&output.stdout)
+        && value.is_object()
+    {
+        return Ok(value);
+    }
+    if let Ok(value) = serde_json::from_slice::<Value>(&output.stderr)
+        && value.is_object()
+    {
+        return Ok(value);
+    }
+    Ok(json!({}))
+}
+
+fn receipt_event(family: &str, validation: Value, channel: Option<String>) -> IncomingEvent {
+    let mut payload = Map::new();
+    payload.insert("family".into(), json!(family));
+    payload.insert("status".into(), json!("validated"));
+    insert_safe_string(
+        &mut payload,
+        "receipt_id",
+        first_string(&validation, &["receipt_id", "id"]),
+    );
+    insert_safe_string(
+        &mut payload,
+        "subject",
+        first_string(&validation, &["subject", "target"]),
+    );
+    insert_safe_string(
+        &mut payload,
+        "verdict",
+        first_string(&validation, &["verdict", "decision", "outcome"]),
+    );
+    insert_safe_string(
+        &mut payload,
+        "summary",
+        first_string(&validation, &["summary", "reason"]),
+    );
+
+    IncomingEvent::workspace(
+        event_kind_for_family(family).to_string(),
+        Value::Object(payload),
+        channel,
+    )
+}
+
+fn event_kind_for_family(family: &str) -> &'static str {
+    match family {
+        "review-verdict-evidence" => "gajae.review.verdict",
+        "merge-hold-decision" => "gajae.merge.hold",
+        "zero-backlog-checkpoint" => "gajae.backlog.zero",
+        family if family.contains("release-hold") => "gajae.release.hold",
+        _ => "gajae.receipt.validated",
+    }
+}
+
+fn first_string(value: &Value, keys: &[&str]) -> Option<String> {
+    let object = value.as_object()?;
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(Value::as_str))
+        .map(bounded_public_string)
+        .filter(|value| !value.is_empty())
+}
+
+fn insert_safe_string(object: &mut Map<String, Value>, key: &str, value: Option<String>) {
+    if let Some(value) = value {
+        object.insert(key.to_string(), json!(value));
+    }
+}
+
+fn sanitize_family(family: &str) -> Result<String> {
+    let family = family.trim();
+    if family.is_empty() {
+        bail!("receipt family is required");
+    }
+    if !family
+        .bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        bail!("receipt family must contain only lowercase letters, digits, and '-' characters");
+    }
+    Ok(family.to_string())
+}
+
+fn validation_detail(_output: &CommandOutput) -> String {
+    ": validator rejected receipt".to_string()
+}
+
+fn bounded_public_string(raw: &str) -> String {
+    let mut out = String::new();
+    for ch in raw.chars() {
+        let safe = match ch {
+            '\n' | '\r' | '\t' => ' ',
+            '/' | '\\' => ' ',
+            ch if ch.is_control() => ' ',
+            ch => ch,
+        };
+        if out.len() + safe.len_utf8() > SUMMARY_LIMIT {
+            break;
+        }
+        out.push(safe);
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 fn concise_detail(stderr: &str) -> String {
     stderr
         .lines()
@@ -147,12 +389,15 @@ fn concise_detail(stderr: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct Call {
         program: PathBuf,
         args: Vec<String>,
         inherits_stdout_stderr: bool,
         stdin_null: bool,
+        stdin_piped: bool,
     }
 
     #[derive(Debug)]
@@ -160,6 +405,7 @@ mod tests {
         calls: Vec<Call>,
         output_result: io::Result<CommandOutput>,
         status_result: io::Result<CommandExit>,
+        output_with_stdin_result: io::Result<CommandOutput>,
     }
 
     impl MockRunner {
@@ -174,6 +420,12 @@ mod tests {
                 status_result: Ok(CommandExit {
                     success: true,
                     code: Some(0),
+                }),
+                output_with_stdin_result: Ok(CommandOutput {
+                    success: true,
+                    stdout: br#"{"receipt_id":"r1","verdict":"approve","summary":"safe summary"}"#
+                        .to_vec(),
+                    stderr: Vec::new(),
                 }),
             }
         }
@@ -196,6 +448,7 @@ mod tests {
                 args: args.iter().map(|arg| (*arg).to_string()).collect(),
                 inherits_stdout_stderr: false,
                 stdin_null: false,
+                stdin_piped: false,
             });
             self.output_result
                 .as_ref()
@@ -213,10 +466,30 @@ mod tests {
                 args: args.iter().map(|arg| (*arg).to_string()).collect(),
                 inherits_stdout_stderr: true,
                 stdin_null: true,
+                stdin_piped: false,
             });
             self.status_result
                 .as_ref()
                 .copied()
+                .map_err(|error| io::Error::new(error.kind(), error.to_string()))
+        }
+
+        fn output_with_stdin(
+            &mut self,
+            program: &Path,
+            args: &[&str],
+            stdin: Option<&[u8]>,
+        ) -> io::Result<CommandOutput> {
+            self.calls.push(Call {
+                program: program.to_path_buf(),
+                args: args.iter().map(|arg| (*arg).to_string()).collect(),
+                inherits_stdout_stderr: false,
+                stdin_null: stdin.is_none(),
+                stdin_piped: stdin.is_some(),
+            });
+            self.output_with_stdin_result
+                .as_ref()
+                .map(Clone::clone)
                 .map_err(|error| io::Error::new(error.kind(), error.to_string()))
         }
     }
@@ -236,6 +509,7 @@ mod tests {
                 args: vec!["--help".into()],
                 inherits_stdout_stderr: false,
                 stdin_null: false,
+                stdin_piped: false,
             }]
         );
     }
@@ -283,6 +557,7 @@ mod tests {
                     .collect(),
                 inherits_stdout_stderr: true,
                 stdin_null: true,
+                stdin_piped: false,
             }]
         );
     }
@@ -299,5 +574,72 @@ mod tests {
             message.contains("exit code 17"),
             "unexpected message: {message}"
         );
+    }
+
+    #[test]
+    fn receipt_ingest_invokes_family_validator_and_maps_safe_event() {
+        let mut runner = MockRunner::available();
+        let result = ingest_receipt_with(
+            &mut runner,
+            |_| Some(OsString::from("/custom/gajae")),
+            ReceiptIngestRequest {
+                family: "review-verdict-evidence".into(),
+                source: ReceiptSource::File(PathBuf::from("receipt.json")),
+                channel: Some("ops".into()),
+            },
+        )
+        .expect("receipt should validate");
+
+        assert_eq!(result.event.kind, "gajae.review.verdict");
+        assert_eq!(result.event.channel.as_deref(), Some("ops"));
+        assert_eq!(
+            result.event.payload["family"],
+            json!("review-verdict-evidence")
+        );
+        assert_eq!(result.event.payload["receipt_id"], json!("r1"));
+        assert_eq!(result.event.payload["verdict"], json!("approve"));
+        assert_eq!(result.event.payload["summary"], json!("safe summary"));
+        assert_eq!(
+            runner.calls,
+            vec![Call {
+                program: PathBuf::from("/custom/gajae"),
+                args: vec![
+                    "review-verdict-evidence".into(),
+                    "validate".into(),
+                    "--file".into(),
+                    "receipt.json".into(),
+                ],
+                inherits_stdout_stderr: false,
+                stdin_null: true,
+                stdin_piped: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn receipt_ingest_rejects_invalid_receipt_with_bounded_public_diagnostic() {
+        let mut runner = MockRunner {
+            output_with_stdin_result: Ok(CommandOutput {
+                success: false,
+                stdout: Vec::new(),
+                stderr: format!("/secret/path/token {}", "x".repeat(400)).into_bytes(),
+            }),
+            ..MockRunner::available()
+        };
+
+        let error = ingest_receipt_with(
+            &mut runner,
+            |_| None,
+            ReceiptIngestRequest {
+                family: "runtime-followup-receipt".into(),
+                source: ReceiptSource::File(PathBuf::from("receipt.json")),
+                channel: None,
+            },
+        )
+        .expect_err("invalid receipt should fail");
+        let message = error.to_string();
+        assert!(message.contains("gajae receipt validation failed"));
+        assert!(!message.contains("/secret/path"), "message={message}");
+        assert!(message.len() < 360, "message too long: {}", message.len());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,9 @@ use tokio::runtime::Builder;
 
 use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs, GajaeCommands,
-    GajaeProfileCommands, GitCommands, GithubCommands, HooksCommands, MemoryCommands,
-    NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, TmuxCommands, UpdateCommands,
-    VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
+    GajaeProfileCommands, GajaeReceiptCommands, GitCommands, GithubCommands, HooksCommands,
+    MemoryCommands, NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, TmuxCommands,
+    UpdateCommands, VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
 };
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, SetupEdits};
@@ -368,6 +368,32 @@ async fn real_main(cli: Cli) -> Result<()> {
                         );
                         std::process::exit(status.code.unwrap_or(1));
                     }
+                }
+            },
+            GajaeCommands::Receipt { command } => match command {
+                GajaeReceiptCommands::Ingest(args) => {
+                    let source = if let Some(file) = args.file {
+                        gajae::ReceiptSource::File(file)
+                    } else if args.stdin {
+                        let input = gajae::read_receipt_stdin(&mut std::io::stdin())?;
+                        gajae::ReceiptSource::Stdin(input)
+                    } else {
+                        return Err("receipt ingest requires --file or --stdin".into());
+                    };
+                    let send = args.send;
+                    let result = gajae::ingest_receipt(gajae::ReceiptIngestRequest {
+                        family: args.family,
+                        source,
+                        channel: args.channel,
+                    })?;
+                    if send {
+                        let client = DaemonClient::from_config(config.as_ref());
+                        send_incoming_event(&client, result.event).await?;
+                        println!("{{\"status\":\"sent\"}}");
+                    } else {
+                        println!("{}", serde_json::to_string(&result.event)?);
+                    }
+                    Ok(())
                 }
             },
         },

--- a/tests/gajae_profile_install_stdin.rs
+++ b/tests/gajae_profile_install_stdin.rs
@@ -183,6 +183,7 @@ if IFS= read -r inherited_input; then
 fi
 receipt_file="${4:?missing file}"
 printf '%s' "$receipt_file" > "$GAJAE_FILE_LOG"
+stat -c '%a' "$receipt_file" > "$GAJAE_MODE_LOG"
 printf '{"receipt_id":"stdin-1","summary":"stdin receipt ok"}\n'
 "#,
     );
@@ -199,6 +200,7 @@ printf '{"receipt_id":"stdin-1","summary":"stdin receipt ok"}\n'
         .env("GAJAE_BIN", &stub)
         .env("GAJAE_ARG_LOG", temp.path().join("gajae.args"))
         .env("GAJAE_FILE_LOG", temp.path().join("gajae.file"))
+        .env("GAJAE_MODE_LOG", temp.path().join("gajae.mode"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -224,6 +226,15 @@ printf '{"receipt_id":"stdin-1","summary":"stdin receipt ok"}\n'
         "runtime-followup-receipt validate --file ".to_string()
             + &fs::read_to_string(temp.path().join("gajae.file")).expect("file log")
             + "\n"
+    );
+    let receipt_file = fs::read_to_string(temp.path().join("gajae.file")).expect("file log");
+    assert_eq!(
+        fs::read_to_string(temp.path().join("gajae.mode")).expect("mode log"),
+        "600\n"
+    );
+    assert!(
+        !Path::new(receipt_file.as_str()).exists(),
+        "temporary stdin receipt file should be deleted: {receipt_file}"
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(

--- a/tests/gajae_profile_install_stdin.rs
+++ b/tests/gajae_profile_install_stdin.rs
@@ -108,3 +108,164 @@ exit 23
     assert!(stderr.contains("child failed"), "stderr={stderr}");
     assert!(stderr.contains("exit code 23"), "stderr={stderr}");
 }
+
+#[test]
+fn gajae_receipt_ingest_maps_valid_receipt_to_public_safe_event() {
+    let temp = TempDir::new().expect("tempdir");
+    let receipt = temp.path().join("receipt.json");
+    fs::write(&receipt, r#"{"raw":"private body"}"#).expect("write receipt");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$GAJAE_ARG_LOG"
+printf '{"receipt_id":"public-1","verdict":"hold","summary":"needs reviewer evidence","private_path":"/secret/home/token"}\n'
+"#,
+    );
+
+    let output = Command::new(clawhip_bin())
+        .args([
+            "gajae",
+            "receipt",
+            "ingest",
+            "--family",
+            "merge-hold-decision",
+            "--file",
+            receipt.to_str().expect("receipt path"),
+            "--channel",
+            "ops",
+        ])
+        .env("GAJAE_BIN", &stub)
+        .env("GAJAE_ARG_LOG", temp.path().join("gajae.args"))
+        .output()
+        .expect("run clawhip");
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(temp.path().join("gajae.args")).expect("arg log"),
+        format!(
+            "merge-hold-decision validate --file {}\n",
+            receipt.display()
+        )
+    );
+    let event: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("event json should parse");
+    assert_eq!(event["type"], "gajae.merge.hold");
+    assert_eq!(event["channel"], "ops");
+    assert_eq!(event["payload"]["family"], "merge-hold-decision");
+    assert_eq!(event["payload"]["receipt_id"], "public-1");
+    assert_eq!(event["payload"]["verdict"], "hold");
+    assert_eq!(event["payload"]["summary"], "needs reviewer evidence");
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("private_path"),
+        "stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn gajae_receipt_ingest_accepts_stdin_without_forwarding_raw_body() {
+    let temp = TempDir::new().expect("tempdir");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$GAJAE_ARG_LOG"
+if IFS= read -r inherited_input; then
+  printf 'unexpected stdin: %s\n' "$inherited_input" >&2
+  exit 66
+fi
+receipt_file="${4:?missing file}"
+printf '%s' "$receipt_file" > "$GAJAE_FILE_LOG"
+printf '{"receipt_id":"stdin-1","summary":"stdin receipt ok"}\n'
+"#,
+    );
+
+    let mut child = Command::new(clawhip_bin())
+        .args([
+            "gajae",
+            "receipt",
+            "ingest",
+            "--family",
+            "runtime-followup-receipt",
+            "--stdin",
+        ])
+        .env("GAJAE_BIN", &stub)
+        .env("GAJAE_ARG_LOG", temp.path().join("gajae.args"))
+        .env("GAJAE_FILE_LOG", temp.path().join("gajae.file"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn clawhip");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"{\"secret\":\"do not route\"}\n")
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for clawhip");
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(temp.path().join("gajae.args")).expect("arg log"),
+        "runtime-followup-receipt validate --file ".to_string()
+            + &fs::read_to_string(temp.path().join("gajae.file")).expect("file log")
+            + "\n"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("gajae.receipt.validated"),
+        "stdout={stdout}"
+    );
+    assert!(!stdout.contains("do not route"), "stdout={stdout}");
+}
+
+#[test]
+fn gajae_receipt_ingest_failure_is_bounded_and_public_safe() {
+    let temp = TempDir::new().expect("tempdir");
+    let receipt = temp.path().join("receipt.json");
+    fs::write(&receipt, r#"{"secret":"raw body"}"#).expect("write receipt");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+printf '/secret/token/path %0500d\n' 1 >&2
+exit 42
+"#,
+    );
+
+    let output = Command::new(clawhip_bin())
+        .args([
+            "gajae",
+            "receipt",
+            "ingest",
+            "--family",
+            "runtime-followup-receipt",
+            "--file",
+            receipt.to_str().expect("receipt path"),
+        ])
+        .env("GAJAE_BIN", &stub)
+        .output()
+        .expect("run clawhip");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("gajae receipt validation failed"),
+        "stderr={stderr}"
+    );
+    assert!(!stderr.contains("/secret/token/path"), "stderr={stderr}");
+    assert!(stderr.len() < 420, "stderr too long: {}", stderr.len());
+}


### PR DESCRIPTION
## Summary
- add `clawhip gajae receipt ingest` for validating receipt families through local `gajae`
- map validator results into bounded public-safe GAJAE receipt events, with optional daemon send
- cover validator invocation, stdin handling, valid mapping, and bounded invalid diagnostics with fake GAJAE tests

## Tests
- `cargo test --package clawhip`

Closes #248