### PR TITLE
Add GAJAE profile route inspection

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -499,6 +499,45 @@ pub enum GajaeCommands {
 pub enum GajaeProfileCommands {
     /// Install the clawhip profile through gajae.
     Install,
+    /// Inspect the installed GAJAE clawhip route profile without executing routes.
+    Inspect(GajaeProfileFileArgs),
+    /// Explain which GAJAE route would match an event without executing it.
+    Explain(GajaeProfileExplainArgs),
+    /// Validate a GAJAE route profile apply plan; live apply is approval-gated.
+    Apply(GajaeProfileApplyArgs),
+}
+
+#[derive(Debug, Clone, Default, Args)]
+pub struct GajaeProfileFileArgs {
+    /// Read this profile/routes file instead of auto-discovering the installed GAJAE profile.
+    #[arg(long)]
+    pub file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct GajaeProfileExplainArgs {
+    /// Read this profile/routes file instead of auto-discovering the installed GAJAE profile.
+    #[arg(long)]
+    pub file: Option<PathBuf>,
+    /// GAJAE event name to explain, e.g. github.pr.opened.
+    #[arg(long)]
+    pub event: String,
+    /// Optional repository label to include in the explanation report.
+    #[arg(long)]
+    pub repo: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Args)]
+pub struct GajaeProfileApplyArgs {
+    /// Read this profile/routes file instead of auto-discovering the installed GAJAE profile.
+    #[arg(long)]
+    pub file: Option<PathBuf>,
+    /// Validate and explain the apply plan without executing commands.
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+    /// Placeholder approval gate for future live apply support; does not enable execution yet.
+    #[arg(long, default_value_t = false)]
+    pub approve: bool,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -1330,6 +1369,75 @@ mod tests {
         };
 
         assert!(matches!(command, GajaeProfileCommands::Install));
+    }
+
+    #[test]
+    fn parses_gajae_profile_inspect_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "gajae",
+            "profile",
+            "inspect",
+            "--file",
+            "routes.yml",
+        ]);
+
+        let Commands::Gajae { command } = cli.command.expect("gajae command") else {
+            panic!("expected gajae command");
+        };
+        let GajaeCommands::Profile { command } = command else {
+            panic!("expected gajae profile command");
+        };
+        let GajaeProfileCommands::Inspect(args) = command else {
+            panic!("expected gajae profile inspect command");
+        };
+
+        assert_eq!(args.file, Some(PathBuf::from("routes.yml")));
+    }
+
+    #[test]
+    fn parses_gajae_profile_explain_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "gajae",
+            "profile",
+            "explain",
+            "--event",
+            "github.pr.opened",
+            "--repo",
+            "clawhip",
+        ]);
+
+        let Commands::Gajae { command } = cli.command.expect("gajae command") else {
+            panic!("expected gajae command");
+        };
+        let GajaeCommands::Profile { command } = command else {
+            panic!("expected gajae profile command");
+        };
+        let GajaeProfileCommands::Explain(args) = command else {
+            panic!("expected gajae profile explain command");
+        };
+
+        assert_eq!(args.event, "github.pr.opened");
+        assert_eq!(args.repo.as_deref(), Some("clawhip"));
+    }
+
+    #[test]
+    fn parses_gajae_profile_apply_dry_run_subcommand() {
+        let cli = Cli::parse_from(["clawhip", "gajae", "profile", "apply", "--dry-run"]);
+
+        let Commands::Gajae { command } = cli.command.expect("gajae command") else {
+            panic!("expected gajae command");
+        };
+        let GajaeCommands::Profile { command } = command else {
+            panic!("expected gajae profile command");
+        };
+        let GajaeProfileCommands::Apply(args) = command else {
+            panic!("expected gajae profile apply command");
+        };
+
+        assert!(args.dry_run);
+        assert!(!args.approve);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -519,7 +519,7 @@ pub struct GajaeProfileExplainArgs {
     /// Read this profile/routes file instead of auto-discovering the installed GAJAE profile.
     #[arg(long)]
     pub file: Option<PathBuf>,
-    /// GAJAE event name to explain, e.g. github.pr.opened.
+    /// GAJAE event name to explain, e.g. github.pr-status-changed.
     #[arg(long)]
     pub event: String,
     /// Optional repository label to include in the explanation report.
@@ -1403,7 +1403,7 @@ mod tests {
             "profile",
             "explain",
             "--event",
-            "github.pr.opened",
+            "github.pr-status-changed",
             "--repo",
             "clawhip",
         ]);
@@ -1418,7 +1418,7 @@ mod tests {
             panic!("expected gajae profile explain command");
         };
 
-        assert_eq!(args.event, "github.pr.opened");
+        assert_eq!(args.event, "github.pr-status-changed");
         assert_eq!(args.repo.as_deref(), Some("clawhip"));
     }
 

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Read, Write};
@@ -15,10 +16,381 @@ const GAJAE_PATH_NAME: &str = "gajae";
 const PROFILE_INSTALL_ARGS: &[&str] = &["clawhip", "profile", "install"];
 const SUMMARY_LIMIT: usize = 240;
 const RECEIPT_STDIN_LIMIT: usize = 1_048_576;
+const DEFAULT_ROUTES_PATH: &str = ".clawhip/gajae.routes.yml";
+const DEFAULT_RUNTIME_DIR: &str = ".gajae/runtime";
+const PROFILE_FILE_NAME: &str = "clawhip-profile.yml";
+const SUPPORTED_EVENTS: &[&str] = &[
+    "github.issue.opened",
+    "github.issue.comment",
+    "github.pr.opened",
+    "github.pr.synchronize",
+    "github.check.failed",
+    "session.completed",
+    "session.stale",
+    "heartbeat",
+];
 
 #[derive(Debug, Clone, Copy)]
 pub enum GajaeCommand {
     Status,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ProfileInspectOptions {
+    pub file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProfileExplainOptions {
+    pub file: Option<PathBuf>,
+    pub event: String,
+    pub repo: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ProfileApplyOptions {
+    pub file: Option<PathBuf>,
+    pub dry_run: bool,
+    pub approve: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GajaeRouteProfile {
+    source: PathBuf,
+    name: Option<String>,
+    routes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RouteValidation {
+    unknown_events: Vec<String>,
+    unsupported_commands: Vec<(String, String)>,
+}
+
+impl RouteValidation {
+    fn is_clean(&self) -> bool {
+        self.unknown_events.is_empty() && self.unsupported_commands.is_empty()
+    }
+}
+
+pub fn run_profile_inspect(options: ProfileInspectOptions) -> Result<()> {
+    let profile = load_profile(options.file.as_deref())?;
+    let validation = validate_profile(&profile);
+    println!(
+        "GAJAE clawhip profile: {}",
+        profile.name.as_deref().unwrap_or("unknown")
+    );
+    println!("source: {}", profile.source.display());
+    println!("routes: {}", profile.routes.len());
+    for (event, command) in &profile.routes {
+        println!("- {event}: {command}");
+    }
+    print_validation(&validation);
+    if validation.is_clean() {
+        Ok(())
+    } else {
+        bail!("GAJAE profile validation failed")
+    }
+}
+
+pub fn run_profile_explain(options: ProfileExplainOptions) -> Result<()> {
+    let profile = load_profile(options.file.as_deref())?;
+    let validation = validate_profile(&profile);
+    if !SUPPORTED_EVENTS.contains(&options.event.as_str()) {
+        bail!("unknown GAJAE event name: {}", options.event);
+    }
+    if !validation.is_clean() {
+        print_validation(&validation);
+        bail!("GAJAE profile validation failed")
+    }
+
+    println!("event: {}", options.event);
+    if let Some(repo) = options.repo.as_deref() {
+        println!("repo: {repo}");
+    }
+    match profile.routes.get(&options.event) {
+        Some(command) => {
+            println!("match: yes");
+            println!("route command: {command}");
+            println!("action: explain-only; command not executed");
+            Ok(())
+        }
+        None => {
+            println!("match: no");
+            println!("action: explain-only; no command executed");
+            Ok(())
+        }
+    }
+}
+
+pub fn run_profile_apply(options: ProfileApplyOptions) -> Result<()> {
+    if !options.dry_run {
+        if options.approve {
+            bail!(
+                "live GAJAE profile apply is approval-gated and not implemented by this safe inspector"
+            );
+        }
+        bail!("refusing live GAJAE profile apply; rerun with --dry-run to inspect safely");
+    }
+
+    let profile = load_profile(options.file.as_deref())?;
+    let validation = validate_profile(&profile);
+    println!("GAJAE profile apply dry-run");
+    println!("source: {}", profile.source.display());
+    println!("would inspect routes: {}", profile.routes.len());
+    println!("would execute commands: 0");
+    print_validation(&validation);
+    if validation.is_clean() {
+        println!("dry-run result: supported; live apply still requires a separate approval gate");
+        Ok(())
+    } else {
+        bail!("GAJAE profile dry-run detected unsupported route entries")
+    }
+}
+
+fn load_profile(explicit_file: Option<&Path>) -> Result<GajaeRouteProfile> {
+    let source = match explicit_file {
+        Some(path) => path.to_path_buf(),
+        None => discover_profile_path()?,
+    };
+    let contents = fs::read_to_string(&source).with_context(|| {
+        format!(
+            "failed to read GAJAE profile route file {}",
+            source.display()
+        )
+    })?;
+    parse_profile(&contents, source)
+}
+
+fn discover_profile_path() -> Result<PathBuf> {
+    let routes = PathBuf::from(DEFAULT_ROUTES_PATH);
+    if routes.is_file() {
+        return Ok(routes);
+    }
+
+    let runtime_dir = Path::new(DEFAULT_RUNTIME_DIR);
+    if runtime_dir.is_dir() {
+        let mut candidates = Vec::new();
+        for entry in
+            fs::read_dir(runtime_dir).context("failed to inspect GAJAE runtime directory")?
+        {
+            let entry = entry.context("failed to inspect GAJAE runtime entry")?;
+            let candidate = entry.path().join(PROFILE_FILE_NAME);
+            if candidate.is_file() {
+                candidates.push(candidate);
+            }
+        }
+        candidates.sort();
+        if let Some(candidate) = candidates.into_iter().next() {
+            return Ok(candidate);
+        }
+    }
+
+    bail!(
+        "GAJAE clawhip profile not found; expected {DEFAULT_ROUTES_PATH} or {DEFAULT_RUNTIME_DIR}/*/{PROFILE_FILE_NAME}"
+    )
+}
+
+fn parse_profile(contents: &str, source: PathBuf) -> Result<GajaeRouteProfile> {
+    let mut name = None;
+    let mut routes = BTreeMap::new();
+    let mut top_level = None::<String>;
+    let mut in_routes = false;
+    let mut route_event = None::<String>;
+    let mut parent_stack: Vec<(usize, String)> = Vec::new();
+
+    for (index, raw_line) in contents.lines().enumerate() {
+        let line_number = index + 1;
+        let without_comment = raw_line
+            .split_once('#')
+            .map_or(raw_line, |(before, _)| before);
+        if without_comment.trim().is_empty() {
+            continue;
+        }
+        if without_comment.trim_start().starts_with('-') {
+            continue;
+        }
+        let indent = without_comment.chars().take_while(|ch| *ch == ' ').count();
+        if indent != raw_line.len() - raw_line.trim_start_matches(' ').len() || indent % 2 != 0 {
+            bail!("invalid GAJAE profile syntax at line {line_number}");
+        }
+        let trimmed = without_comment.trim();
+        let Some((key, value)) = trimmed.split_once(':') else {
+            bail!("invalid GAJAE profile syntax at line {line_number}");
+        };
+        let key = key.trim();
+        if key.is_empty() || key.contains(char::is_whitespace) {
+            bail!("invalid GAJAE profile key at line {line_number}");
+        }
+        let value = clean_scalar(value.trim());
+
+        while parent_stack
+            .last()
+            .is_some_and(|(level, _)| *level >= indent)
+        {
+            parent_stack.pop();
+        }
+        if value.is_none() {
+            parent_stack.push((indent, key.to_string()));
+        }
+        let parent = parent_stack.last().map(|(_, key)| key.as_str());
+
+        if indent == 0 {
+            top_level = Some(key.to_string());
+            in_routes = key == "routes";
+            route_event = None;
+            validate_top_level_key(key, source.as_path(), line_number)?;
+            if key == "profile" || key == "name" {
+                name = value;
+            }
+            continue;
+        }
+
+        if matches!(top_level.as_deref(), Some("clawhipProfile")) && indent == 2 {
+            validate_clawhip_profile_key(key, line_number)?;
+            in_routes = key == "routes";
+            route_event = None;
+            if key == "name" {
+                name = value;
+            }
+            continue;
+        }
+
+        if in_routes {
+            if indent == routes_indent(top_level.as_deref()) {
+                route_event = Some(key.to_string());
+                if let Some(command) = value {
+                    routes.insert(key.to_string(), command);
+                }
+                continue;
+            }
+            if key == "command" {
+                let event = route_event.clone().ok_or_else(|| {
+                    anyhow::anyhow!("invalid GAJAE profile route command at line {line_number}")
+                })?;
+                let command = value.ok_or_else(|| {
+                    anyhow::anyhow!("invalid GAJAE profile route command at line {line_number}")
+                })?;
+                routes.insert(event, command);
+                continue;
+            }
+            bail!("unsupported GAJAE profile route key at line {line_number}");
+        }
+
+        if matches!(parent, Some("safety" | "followUp" | "gajae")) {
+            continue;
+        }
+    }
+
+    if routes.is_empty() {
+        bail!("GAJAE profile contains no routes");
+    }
+
+    Ok(GajaeRouteProfile {
+        source,
+        name,
+        routes,
+    })
+}
+
+fn clean_scalar(value: &str) -> Option<String> {
+    if value.is_empty() {
+        return None;
+    }
+    let cleaned = value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|value| value.strip_suffix('\''))
+        })
+        .unwrap_or(value);
+    Some(cleaned.to_string())
+}
+
+fn routes_indent(top_level: Option<&str>) -> usize {
+    if matches!(top_level, Some("clawhipProfile")) {
+        4
+    } else {
+        2
+    }
+}
+
+fn validate_top_level_key(key: &str, source: &Path, line_number: usize) -> Result<()> {
+    let profile_file = source.file_name().and_then(|name| name.to_str()) == Some(PROFILE_FILE_NAME);
+    let allowed = if profile_file {
+        matches!(
+            key,
+            "runtime"
+                | "category"
+                | "displayName"
+                | "gajae"
+                | "clawhipProfile"
+                | "safety"
+                | "operatorConnectionsRequiredLater"
+                | "name"
+                | "description"
+                | "routesFile"
+                | "followUp"
+                | "routes"
+                | "profile"
+        )
+    } else {
+        matches!(key, "profile" | "routes")
+    };
+    if allowed {
+        Ok(())
+    } else {
+        bail!("unsupported GAJAE profile key `{key}` at line {line_number}")
+    }
+}
+
+fn validate_clawhip_profile_key(key: &str, line_number: usize) -> Result<()> {
+    if matches!(
+        key,
+        "name" | "description" | "routesFile" | "safety" | "followUp" | "routes"
+    ) {
+        Ok(())
+    } else {
+        bail!("unsupported GAJAE clawhipProfile key `{key}` at line {line_number}")
+    }
+}
+
+fn validate_profile(profile: &GajaeRouteProfile) -> RouteValidation {
+    let mut unknown_events = Vec::new();
+    let mut unsupported_commands = Vec::new();
+    for (event, command) in &profile.routes {
+        if !SUPPORTED_EVENTS.contains(&event.as_str()) {
+            unknown_events.push(event.clone());
+        }
+        if !command_matches_event(command, event) {
+            unsupported_commands.push((event.clone(), command.clone()));
+        }
+    }
+    RouteValidation {
+        unknown_events,
+        unsupported_commands,
+    }
+}
+
+fn command_matches_event(command: &str, event: &str) -> bool {
+    command == format!("gajae handle {event}")
+        || command == format!("gajae runtime handle --router clawhip --event {event}")
+}
+
+fn print_validation(validation: &RouteValidation) {
+    if validation.is_clean() {
+        println!("validation: ok");
+        return;
+    }
+    println!("validation: failed");
+    for event in &validation.unknown_events {
+        println!("unknown event: {event}");
+    }
+    for (event, _) in &validation.unsupported_commands {
+        println!("unsupported command for event: {event}");
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -502,6 +874,105 @@ mod tests {
                 .map(Clone::clone)
                 .map_err(|error| io::Error::new(error.kind(), error.to_string()))
         }
+    }
+
+    #[test]
+    fn profile_parser_loads_routes_file_and_validates_supported_commands() {
+        let profile = parse_profile(
+            r#"
+profile: gajae
+routes:
+  github.pr.opened:
+    command: gajae handle github.pr.opened
+  heartbeat:
+    command: gajae runtime handle --router clawhip --event heartbeat
+"#,
+            PathBuf::from(".clawhip/gajae.routes.yml"),
+        )
+        .expect("profile should parse");
+
+        assert_eq!(profile.name.as_deref(), Some("gajae"));
+        assert_eq!(profile.routes.len(), 2);
+        assert!(validate_profile(&profile).is_clean());
+    }
+
+    #[test]
+    fn profile_parser_loads_nested_clawhip_profile_routes() {
+        let profile = parse_profile(
+            r#"
+runtime: hermes
+clawhipProfile:
+  name: gajae
+  routes:
+    github.issue.opened:
+      command: gajae handle github.issue.opened
+safety:
+  liveClawhipEnablement: false
+"#,
+            PathBuf::from(".gajae/runtime/hermes/clawhip-profile.yml"),
+        )
+        .expect("nested profile should parse");
+
+        assert_eq!(profile.name.as_deref(), Some("gajae"));
+        assert_eq!(
+            profile
+                .routes
+                .get("github.issue.opened")
+                .map(String::as_str),
+            Some("gajae handle github.issue.opened")
+        );
+        assert!(validate_profile(&profile).is_clean());
+    }
+
+    #[test]
+    fn profile_validation_detects_unknown_events_and_unsupported_commands() {
+        let profile = parse_profile(
+            r#"
+routes:
+  github.pr.closed:
+    command: gajae handle github.pr.closed
+  github.pr.opened:
+    command: rm -rf /tmp/example
+"#,
+            PathBuf::from(".clawhip/gajae.routes.yml"),
+        )
+        .expect("profile should parse before semantic validation");
+
+        let validation = validate_profile(&profile);
+        assert_eq!(validation.unknown_events, vec!["github.pr.closed"]);
+        assert_eq!(validation.unsupported_commands.len(), 1);
+        assert_eq!(validation.unsupported_commands[0].0, "github.pr.opened");
+    }
+
+    #[test]
+    fn malformed_profile_error_is_sanitized_without_raw_input() {
+        let raw_secret = "routes:\n  github.pr.opened command: secret-token-123\n";
+        let error = parse_profile(raw_secret, PathBuf::from(".clawhip/gajae.routes.yml"))
+            .expect_err("malformed profile should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("line 2"), "unexpected message: {message}");
+        assert!(
+            !message.contains("secret-token-123"),
+            "leaked raw input: {message}"
+        );
+        assert!(
+            !message.contains("github.pr.opened command"),
+            "leaked raw input: {message}"
+        );
+    }
+
+    #[test]
+    fn route_file_rejects_unknown_top_level_key_without_raw_value() {
+        let error = parse_profile(
+            "routes:\n  heartbeat:\n    command: gajae handle heartbeat\nprivate: secret-token-123\n",
+            PathBuf::from(".clawhip/gajae.routes.yml"),
+        )
+        .expect_err("unknown key should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("unsupported GAJAE profile key `private`"));
+        assert!(!message.contains("secret-token-123"));
     }
 
     #[test]

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -21,14 +21,35 @@ const DEFAULT_RUNTIME_DIR: &str = ".gajae/runtime";
 const PROFILE_FILE_NAME: &str = "clawhip-profile.yml";
 const MAX_PROFILE_BYTES: usize = 256 * 1024;
 const SUPPORTED_EVENTS: &[&str] = &[
-    "github.issue.opened",
-    "github.issue.comment",
-    "github.pr.opened",
-    "github.pr.synchronize",
-    "github.check.failed",
-    "session.completed",
-    "session.stale",
-    "heartbeat",
+    "github.issue-opened",
+    "github.issue-commented",
+    "github.issue-closed",
+    "github.pr-status-changed",
+    "github.release-published",
+    "github.release-prereleased",
+    "github.release-edited",
+    "github.ci-started",
+    "github.ci-failed",
+    "github.ci-passed",
+    "github.ci-cancelled",
+    "session.started",
+    "session.blocked",
+    "session.finished",
+    "session.failed",
+    "session.retry-needed",
+    "session.pr-created",
+    "session.test-started",
+    "session.test-finished",
+    "session.test-failed",
+    "session.handoff-needed",
+    "session.prompt-submitted",
+    "session.prompt-delivered",
+    "session.prompt-delivery-failed",
+    "session.stopped",
+    "tool.pre",
+    "tool.post",
+    "tmux.keyword",
+    "tmux.stale",
 ];
 
 #[derive(Debug, Clone, Copy)]
@@ -85,7 +106,8 @@ pub fn run_profile_inspect(options: ProfileInspectOptions) -> Result<()> {
     println!("source: {}", profile.source.display());
     println!("routes: {}", profile.routes.len());
     for (event, command) in &profile.routes {
-        println!("- {event}: {command}");
+        println!("- {event}:");
+        println!("  command: {}", summarize_route_command(command, event));
     }
     print_validation(&validation);
     if validation.is_clean() {
@@ -113,7 +135,10 @@ pub fn run_profile_explain(options: ProfileExplainOptions) -> Result<()> {
     match profile.routes.get(&options.event) {
         Some(command) => {
             println!("match: yes");
-            println!("route command: {command}");
+            println!(
+                "route command: {}",
+                summarize_route_command(command, &options.event)
+            );
             println!("action: explain-only; command not executed");
             Ok(())
         }
@@ -484,6 +509,14 @@ fn validate_profile(profile: &GajaeRouteProfile) -> RouteValidation {
 fn command_matches_event(command: &str, event: &str) -> bool {
     command == format!("gajae handle {event}")
         || command == format!("gajae runtime handle --router clawhip --event {event}")
+}
+
+fn summarize_route_command(command: &str, event: &str) -> &'static str {
+    if command_matches_event(command, event) {
+        "supported GAJAE handler (command redacted)"
+    } else {
+        "unsupported command (redacted)"
+    }
 }
 
 fn print_validation(validation: &RouteValidation) {
@@ -990,10 +1023,10 @@ mod tests {
             r#"
 profile: gajae
 routes:
-  github.pr.opened:
-    command: gajae handle github.pr.opened
-  heartbeat:
-    command: gajae runtime handle --router clawhip --event heartbeat
+  github.pr-status-changed:
+    command: gajae handle github.pr-status-changed
+  session.started:
+    command: gajae runtime handle --router clawhip --event session.started
 "#,
             PathBuf::from(".clawhip/gajae.routes.yml"),
         )
@@ -1012,8 +1045,8 @@ runtime: hermes
 clawhipProfile:
   name: gajae
   routes:
-    github.issue.opened:
-      command: gajae handle github.issue.opened
+    github.issue-opened:
+      command: gajae handle github.issue-opened
 safety:
   liveClawhipEnablement: false
 "#,
@@ -1025,9 +1058,9 @@ safety:
         assert_eq!(
             profile
                 .routes
-                .get("github.issue.opened")
+                .get("github.issue-opened")
                 .map(String::as_str),
-            Some("gajae handle github.issue.opened")
+            Some("gajae handle github.issue-opened")
         );
         assert!(validate_profile(&profile).is_clean());
     }
@@ -1055,8 +1088,8 @@ clawhipProfile:
             &routes_path,
             r#"
 routes:
-  heartbeat:
-    command: gajae handle heartbeat
+  session.started:
+    command: gajae handle session.started
 "#,
         )
         .expect("write routes");
@@ -1066,8 +1099,8 @@ routes:
 
         assert_eq!(profile.name.as_deref(), Some("gajae"));
         assert_eq!(
-            profile.routes.get("heartbeat").map(String::as_str),
-            Some("gajae handle heartbeat")
+            profile.routes.get("session.started").map(String::as_str),
+            Some("gajae handle session.started")
         );
         assert_eq!(profile.source, routes_path);
         assert!(validate_profile(&profile).is_clean());
@@ -1081,7 +1114,7 @@ routes:
         fs::write(
             &profile_path,
             format!(
-                "routes:\n  heartbeat:\n    command: gajae handle heartbeat\n# {}\n",
+                "routes:\n  session.started:\n    command: gajae handle session.started\n# {}\n",
                 "secret-token-123".repeat(MAX_PROFILE_BYTES / 16)
             ),
         )
@@ -1117,7 +1150,7 @@ clawhipProfile:
         fs::write(
             &routes_path,
             format!(
-                "routes:\n  heartbeat:\n    command: gajae handle heartbeat\n# {}\n",
+                "routes:\n  session.started:\n    command: gajae handle session.started\n# {}\n",
                 "secret-token-123".repeat(MAX_PROFILE_BYTES / 16)
             ),
         )
@@ -1137,9 +1170,9 @@ clawhipProfile:
         let error = parse_profile(
             r#"
 routes:
-  - event: github.issue.opened
-  heartbeat:
-    command: gajae handle heartbeat
+  - event: github.issue-opened
+  session.started:
+    command: gajae handle session.started
 "#,
             PathBuf::from(".clawhip/gajae.routes.yml"),
         )
@@ -1148,7 +1181,7 @@ routes:
 
         assert!(message.contains("list-style route entry"));
         assert!(message.contains("line 3"));
-        assert!(!message.contains("github.issue.opened"));
+        assert!(!message.contains("github.issue-opened"));
     }
 
     #[test]
@@ -1158,7 +1191,7 @@ routes:
 runtime: hermes
 clawhipProfile:
   routes:
-    - event: github.issue.opened
+    - event: github.issue-opened
 "#,
             PathBuf::from(".gajae/runtime/hermes/clawhip-profile.yml"),
         )
@@ -1167,7 +1200,7 @@ clawhipProfile:
 
         assert!(message.contains("list-style route entry"));
         assert!(message.contains("line 5"));
-        assert!(!message.contains("github.issue.opened"));
+        assert!(!message.contains("github.issue-opened"));
     }
 
     #[test]
@@ -1175,16 +1208,16 @@ clawhipProfile:
         let error = parse_profile(
             r#"
 routes:
-  github.issue.opened:
-  heartbeat:
-    command: gajae handle heartbeat
+  github.issue-opened:
+  session.started:
+    command: gajae handle session.started
 "#,
             PathBuf::from(".clawhip/gajae.routes.yml"),
         )
         .expect_err("missing command should fail");
         let message = error.to_string();
 
-        assert!(message.contains("github.issue.opened"));
+        assert!(message.contains("github.issue-opened"));
         assert!(message.contains("missing command"));
     }
 
@@ -1195,7 +1228,7 @@ routes:
 routes:
   github.pr.closed:
     command: gajae handle github.pr.closed
-  github.pr.opened:
+  github.pr-status-changed:
     command: rm -rf /tmp/example
 "#,
             PathBuf::from(".clawhip/gajae.routes.yml"),
@@ -1205,12 +1238,84 @@ routes:
         let validation = validate_profile(&profile);
         assert_eq!(validation.unknown_events, vec!["github.pr.closed"]);
         assert_eq!(validation.unsupported_commands.len(), 1);
-        assert_eq!(validation.unsupported_commands[0].0, "github.pr.opened");
+        assert_eq!(
+            validation.unsupported_commands[0].0,
+            "github.pr-status-changed"
+        );
+    }
+
+    #[test]
+    fn profile_validation_accepts_current_events_and_rejects_stale_dotted_events() {
+        let current = parse_profile(
+            r#"
+routes:
+  github.issue-opened:
+    command: gajae handle github.issue-opened
+  github.issue-commented:
+    command: gajae handle github.issue-commented
+  github.issue-closed:
+    command: gajae handle github.issue-closed
+  github.pr-status-changed:
+    command: gajae handle github.pr-status-changed
+  session.started:
+    command: gajae handle session.started
+  session.blocked:
+    command: gajae handle session.blocked
+  session.finished:
+    command: gajae handle session.finished
+  tmux.stale:
+    command: gajae handle tmux.stale
+"#,
+            PathBuf::from(".clawhip/gajae.routes.yml"),
+        )
+        .expect("current profile should parse");
+        assert!(validate_profile(&current).is_clean());
+
+        let stale = parse_profile(
+            r#"
+routes:
+  github.issue.opened:
+    command: gajae handle github.issue.opened
+  github.pr.opened:
+    command: gajae handle github.pr.opened
+  session.completed:
+    command: gajae handle session.completed
+  session.stale:
+    command: gajae handle session.stale
+"#,
+            PathBuf::from(".clawhip/gajae.routes.yml"),
+        )
+        .expect("stale profile should parse before semantic validation");
+        assert_eq!(
+            validate_profile(&stale).unknown_events,
+            vec![
+                "github.issue.opened",
+                "github.pr.opened",
+                "session.completed",
+                "session.stale",
+            ]
+        );
+    }
+
+    #[test]
+    fn profile_command_summary_redacts_raw_command_details() {
+        let event = "github.issue-opened";
+        let secret_command = "gajae handle github.issue-opened --token secret-token-123 --webhook https://hooks.example/secret --path /home/operator/private";
+
+        assert_eq!(
+            summarize_route_command("gajae handle github.issue-opened", event),
+            "supported GAJAE handler (command redacted)"
+        );
+        let summary = summarize_route_command(secret_command, event);
+        assert_eq!(summary, "unsupported command (redacted)");
+        assert!(!summary.contains("secret-token-123"));
+        assert!(!summary.contains("https://hooks.example/secret"));
+        assert!(!summary.contains("/home/operator/private"));
     }
 
     #[test]
     fn malformed_profile_error_is_sanitized_without_raw_input() {
-        let raw_secret = "routes:\n  github.pr.opened command: secret-token-123\n";
+        let raw_secret = "routes:\n  github.pr-status-changed command: secret-token-123\n";
         let error = parse_profile(raw_secret, PathBuf::from(".clawhip/gajae.routes.yml"))
             .expect_err("malformed profile should fail");
         let message = error.to_string();
@@ -1221,7 +1326,7 @@ routes:
             "leaked raw input: {message}"
         );
         assert!(
-            !message.contains("github.pr.opened command"),
+            !message.contains("github.pr-status-changed command"),
             "leaked raw input: {message}"
         );
     }
@@ -1229,7 +1334,7 @@ routes:
     #[test]
     fn route_file_rejects_unknown_top_level_key_without_raw_value() {
         let error = parse_profile(
-            "routes:\n  heartbeat:\n    command: gajae handle heartbeat\nprivate: secret-token-123\n",
+            "routes:\n  session.started:\n    command: gajae handle session.started\nprivate: secret-token-123\n",
             PathBuf::from(".clawhip/gajae.routes.yml"),
         )
         .expect_err("unknown key should fail");

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -58,6 +58,7 @@ pub struct ProfileApplyOptions {
 struct GajaeRouteProfile {
     source: PathBuf,
     name: Option<String>,
+    routes_file: Option<PathBuf>,
     routes: BTreeMap<String, String>,
 }
 
@@ -149,6 +150,13 @@ pub fn run_profile_apply(options: ProfileApplyOptions) -> Result<()> {
 }
 
 fn load_profile(explicit_file: Option<&Path>) -> Result<GajaeRouteProfile> {
+    load_profile_from_cwd(
+        explicit_file,
+        &std::env::current_dir().context("failed to inspect current directory")?,
+    )
+}
+
+fn load_profile_from_cwd(explicit_file: Option<&Path>, cwd: &Path) -> Result<GajaeRouteProfile> {
     let source = match explicit_file {
         Some(path) => path.to_path_buf(),
         None => discover_profile_path()?,
@@ -159,7 +167,66 @@ fn load_profile(explicit_file: Option<&Path>) -> Result<GajaeRouteProfile> {
             source.display()
         )
     })?;
-    parse_profile(&contents, source)
+    let profile = parse_profile(&contents, source)?;
+    if !profile.routes.is_empty() {
+        return Ok(profile);
+    }
+
+    let Some(routes_file) = profile.routes_file.as_deref() else {
+        return Ok(profile);
+    };
+    let routes_source = resolve_routes_file(routes_file, profile.source.as_path(), cwd)?;
+    let routes_contents = fs::read_to_string(&routes_source).with_context(|| {
+        format!(
+            "failed to read referenced GAJAE routes file {}",
+            routes_source.display()
+        )
+    })?;
+    let mut routes_profile = parse_profile(&routes_contents, routes_source)?;
+    if routes_profile.name.is_none() {
+        routes_profile.name = profile.name;
+    }
+    Ok(routes_profile)
+}
+
+fn resolve_routes_file(routes_file: &Path, source: &Path, cwd: &Path) -> Result<PathBuf> {
+    let cwd = cwd
+        .canonicalize()
+        .context("failed to inspect current directory")?;
+    let mut candidates = Vec::new();
+    if routes_file.is_absolute() {
+        candidates.push(routes_file.to_path_buf());
+    } else {
+        candidates.push(cwd.join(routes_file));
+        if let Some(parent) = source.parent() {
+            let candidate = parent.join(routes_file);
+            if !candidates.iter().any(|path| path == &candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+
+    let mut escaped = false;
+    for candidate in candidates {
+        if !candidate.is_file() {
+            continue;
+        }
+        let canonical = candidate.canonicalize().with_context(|| {
+            format!(
+                "failed to inspect referenced GAJAE routes file {}",
+                candidate.display()
+            )
+        })?;
+        if canonical.starts_with(&cwd) {
+            return Ok(candidate);
+        }
+        escaped = true;
+    }
+
+    if escaped {
+        bail!("referenced GAJAE routes file is outside the current workspace");
+    }
+    bail!("referenced GAJAE routes file not found")
 }
 
 fn discover_profile_path() -> Result<PathBuf> {
@@ -197,6 +264,8 @@ fn parse_profile(contents: &str, source: PathBuf) -> Result<GajaeRouteProfile> {
     let mut top_level = None::<String>;
     let mut in_routes = false;
     let mut route_event = None::<String>;
+    let mut route_missing_command = None::<(String, usize)>;
+    let mut routes_file = None::<PathBuf>;
     let mut parent_stack: Vec<(usize, String)> = Vec::new();
 
     for (index, raw_line) in contents.lines().enumerate() {
@@ -236,31 +305,51 @@ fn parse_profile(contents: &str, source: PathBuf) -> Result<GajaeRouteProfile> {
         let parent = parent_stack.last().map(|(_, key)| key.as_str());
 
         if indent == 0 {
+            ensure_route_has_command(&route_missing_command)?;
             top_level = Some(key.to_string());
             in_routes = key == "routes";
             route_event = None;
+            route_missing_command = None;
             validate_top_level_key(key, source.as_path(), line_number)?;
             if key == "profile" || key == "name" {
-                name = value;
+                name = value.clone();
+            }
+            if key == "routesFile" {
+                let value = value.ok_or_else(|| {
+                    anyhow::anyhow!("invalid GAJAE routesFile at line {line_number}")
+                })?;
+                routes_file = Some(PathBuf::from(value));
             }
             continue;
         }
 
         if matches!(top_level.as_deref(), Some("clawhipProfile")) && indent == 2 {
+            ensure_route_has_command(&route_missing_command)?;
             validate_clawhip_profile_key(key, line_number)?;
             in_routes = key == "routes";
             route_event = None;
+            route_missing_command = None;
             if key == "name" {
-                name = value;
+                name = value.clone();
+            }
+            if key == "routesFile" {
+                let value = value.ok_or_else(|| {
+                    anyhow::anyhow!("invalid GAJAE routesFile at line {line_number}")
+                })?;
+                routes_file = Some(PathBuf::from(value));
             }
             continue;
         }
 
         if in_routes {
             if indent == routes_indent(top_level.as_deref()) {
+                ensure_route_has_command(&route_missing_command)?;
                 route_event = Some(key.to_string());
                 if let Some(command) = value {
                     routes.insert(key.to_string(), command);
+                    route_missing_command = None;
+                } else {
+                    route_missing_command = Some((key.to_string(), line_number));
                 }
                 continue;
             }
@@ -271,6 +360,7 @@ fn parse_profile(contents: &str, source: PathBuf) -> Result<GajaeRouteProfile> {
                 let command = value.ok_or_else(|| {
                     anyhow::anyhow!("invalid GAJAE profile route command at line {line_number}")
                 })?;
+                route_missing_command = None;
                 routes.insert(event, command);
                 continue;
             }
@@ -281,16 +371,25 @@ fn parse_profile(contents: &str, source: PathBuf) -> Result<GajaeRouteProfile> {
             continue;
         }
     }
+    ensure_route_has_command(&route_missing_command)?;
 
-    if routes.is_empty() {
+    if routes.is_empty() && routes_file.is_none() {
         bail!("GAJAE profile contains no routes");
     }
 
     Ok(GajaeRouteProfile {
         source,
         name,
+        routes_file,
         routes,
     })
+}
+
+fn ensure_route_has_command(route_missing_command: &Option<(String, usize)>) -> Result<()> {
+    if let Some((event, line_number)) = route_missing_command {
+        bail!("GAJAE profile route `{event}` missing command at line {line_number}");
+    }
+    Ok(())
 }
 
 fn clean_scalar(value: &str) -> Option<String> {
@@ -772,6 +871,7 @@ fn concise_detail(stderr: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+    use tempfile::tempdir;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct Call {
@@ -922,6 +1022,65 @@ safety:
             Some("gajae handle github.issue.opened")
         );
         assert!(validate_profile(&profile).is_clean());
+    }
+
+    #[test]
+    fn profile_loader_follows_clawhip_profile_routes_file_from_cwd() {
+        let temp = tempdir().expect("tempdir");
+        let profile_path = temp
+            .path()
+            .join(".gajae/runtime/hermes/clawhip-profile.yml");
+        fs::create_dir_all(profile_path.parent().expect("profile parent")).expect("profile dir");
+        let routes_path = temp.path().join(".clawhip/gajae.routes.yml");
+        fs::create_dir_all(routes_path.parent().expect("routes parent")).expect("routes dir");
+        fs::write(
+            &profile_path,
+            r#"
+runtime: hermes
+clawhipProfile:
+  name: gajae
+  routesFile: .clawhip/gajae.routes.yml
+"#,
+        )
+        .expect("write profile");
+        fs::write(
+            &routes_path,
+            r#"
+routes:
+  heartbeat:
+    command: gajae handle heartbeat
+"#,
+        )
+        .expect("write routes");
+
+        let profile = load_profile_from_cwd(Some(profile_path.as_path()), temp.path())
+            .expect("profile should load referenced routes");
+
+        assert_eq!(profile.name.as_deref(), Some("gajae"));
+        assert_eq!(
+            profile.routes.get("heartbeat").map(String::as_str),
+            Some("gajae handle heartbeat")
+        );
+        assert_eq!(profile.source, routes_path);
+        assert!(validate_profile(&profile).is_clean());
+    }
+
+    #[test]
+    fn profile_parser_rejects_missing_command_route_even_with_valid_route() {
+        let error = parse_profile(
+            r#"
+routes:
+  github.issue.opened:
+  heartbeat:
+    command: gajae handle heartbeat
+"#,
+            PathBuf::from(".clawhip/gajae.routes.yml"),
+        )
+        .expect_err("missing command should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("github.issue.opened"));
+        assert!(message.contains("missing command"));
     }
 
     #[test]

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -19,6 +19,7 @@ const RECEIPT_STDIN_LIMIT: usize = 1_048_576;
 const DEFAULT_ROUTES_PATH: &str = ".clawhip/gajae.routes.yml";
 const DEFAULT_RUNTIME_DIR: &str = ".gajae/runtime";
 const PROFILE_FILE_NAME: &str = "clawhip-profile.yml";
+const MAX_PROFILE_BYTES: usize = 256 * 1024;
 const SUPPORTED_EVENTS: &[&str] = &[
     "github.issue.opened",
     "github.issue.comment",
@@ -161,12 +162,7 @@ fn load_profile_from_cwd(explicit_file: Option<&Path>, cwd: &Path) -> Result<Gaj
         Some(path) => path.to_path_buf(),
         None => discover_profile_path()?,
     };
-    let contents = fs::read_to_string(&source).with_context(|| {
-        format!(
-            "failed to read GAJAE profile route file {}",
-            source.display()
-        )
-    })?;
+    let contents = read_bounded_profile(&source, "GAJAE profile route file")?;
     let profile = parse_profile(&contents, source)?;
     if !profile.routes.is_empty() {
         return Ok(profile);
@@ -176,17 +172,26 @@ fn load_profile_from_cwd(explicit_file: Option<&Path>, cwd: &Path) -> Result<Gaj
         return Ok(profile);
     };
     let routes_source = resolve_routes_file(routes_file, profile.source.as_path(), cwd)?;
-    let routes_contents = fs::read_to_string(&routes_source).with_context(|| {
-        format!(
-            "failed to read referenced GAJAE routes file {}",
-            routes_source.display()
-        )
-    })?;
+    let routes_contents = read_bounded_profile(&routes_source, "referenced GAJAE routes file")?;
     let mut routes_profile = parse_profile(&routes_contents, routes_source)?;
     if routes_profile.name.is_none() {
         routes_profile.name = profile.name;
     }
     Ok(routes_profile)
+}
+
+fn read_bounded_profile(path: &Path, description: &str) -> Result<String> {
+    let file = fs::File::open(path)
+        .with_context(|| format!("failed to read {description} {}", path.display()))?;
+    let mut bytes = Vec::new();
+    file.take((MAX_PROFILE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read {description} {}", path.display()))?;
+    if bytes.len() > MAX_PROFILE_BYTES {
+        bail!("{description} exceeds maximum size of {MAX_PROFILE_BYTES} bytes");
+    }
+    String::from_utf8(bytes)
+        .with_context(|| format!("{description} {} is not valid UTF-8", path.display()))
 }
 
 fn resolve_routes_file(routes_file: &Path, source: &Path, cwd: &Path) -> Result<PathBuf> {
@@ -276,14 +281,17 @@ fn parse_profile(contents: &str, source: PathBuf) -> Result<GajaeRouteProfile> {
         if without_comment.trim().is_empty() {
             continue;
         }
-        if without_comment.trim_start().starts_with('-') {
-            continue;
-        }
         let indent = without_comment.chars().take_while(|ch| *ch == ' ').count();
         if indent != raw_line.len() - raw_line.trim_start_matches(' ').len() || indent % 2 != 0 {
             bail!("invalid GAJAE profile syntax at line {line_number}");
         }
         let trimmed = without_comment.trim();
+        if trimmed.starts_with('-') {
+            if in_routes && indent >= routes_indent(top_level.as_deref()) {
+                bail!("unsupported GAJAE list-style route entry at line {line_number}");
+            }
+            continue;
+        }
         let Some((key, value)) = trimmed.split_once(':') else {
             bail!("invalid GAJAE profile syntax at line {line_number}");
         };
@@ -1063,6 +1071,103 @@ routes:
         );
         assert_eq!(profile.source, routes_path);
         assert!(validate_profile(&profile).is_clean());
+    }
+
+    #[test]
+    fn profile_loader_rejects_oversized_primary_profile_without_raw_contents() {
+        let temp = tempdir().expect("tempdir");
+        let profile_path = temp.path().join(".clawhip/gajae.routes.yml");
+        fs::create_dir_all(profile_path.parent().expect("profile parent")).expect("profile dir");
+        fs::write(
+            &profile_path,
+            format!(
+                "routes:\n  heartbeat:\n    command: gajae handle heartbeat\n# {}\n",
+                "secret-token-123".repeat(MAX_PROFILE_BYTES / 16)
+            ),
+        )
+        .expect("write oversized profile");
+
+        let error = load_profile_from_cwd(Some(profile_path.as_path()), temp.path())
+            .expect_err("oversized primary profile should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("exceeds maximum size"));
+        assert!(!message.contains("secret-token-123"));
+    }
+
+    #[test]
+    fn profile_loader_rejects_oversized_referenced_routes_without_raw_contents() {
+        let temp = tempdir().expect("tempdir");
+        let profile_path = temp
+            .path()
+            .join(".gajae/runtime/hermes/clawhip-profile.yml");
+        fs::create_dir_all(profile_path.parent().expect("profile parent")).expect("profile dir");
+        let routes_path = temp.path().join(".clawhip/gajae.routes.yml");
+        fs::create_dir_all(routes_path.parent().expect("routes parent")).expect("routes dir");
+        fs::write(
+            &profile_path,
+            r#"
+runtime: hermes
+clawhipProfile:
+  name: gajae
+  routesFile: .clawhip/gajae.routes.yml
+"#,
+        )
+        .expect("write profile");
+        fs::write(
+            &routes_path,
+            format!(
+                "routes:\n  heartbeat:\n    command: gajae handle heartbeat\n# {}\n",
+                "secret-token-123".repeat(MAX_PROFILE_BYTES / 16)
+            ),
+        )
+        .expect("write oversized routes");
+
+        let error = load_profile_from_cwd(Some(profile_path.as_path()), temp.path())
+            .expect_err("oversized referenced routes should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("referenced GAJAE routes file"));
+        assert!(message.contains("exceeds maximum size"));
+        assert!(!message.contains("secret-token-123"));
+    }
+
+    #[test]
+    fn profile_parser_rejects_list_style_route_entries() {
+        let error = parse_profile(
+            r#"
+routes:
+  - event: github.issue.opened
+  heartbeat:
+    command: gajae handle heartbeat
+"#,
+            PathBuf::from(".clawhip/gajae.routes.yml"),
+        )
+        .expect_err("list-style routes should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("list-style route entry"));
+        assert!(message.contains("line 3"));
+        assert!(!message.contains("github.issue.opened"));
+    }
+
+    #[test]
+    fn profile_parser_rejects_nested_list_style_route_entries() {
+        let error = parse_profile(
+            r#"
+runtime: hermes
+clawhipProfile:
+  routes:
+    - event: github.issue.opened
+"#,
+            PathBuf::from(".gajae/runtime/hermes/clawhip-profile.yml"),
+        )
+        .expect_err("nested list-style routes should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("list-style route entry"));
+        assert!(message.contains("line 5"));
+        assert!(!message.contains("github.issue.opened"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,6 +369,25 @@ async fn real_main(cli: Cli) -> Result<()> {
                         std::process::exit(status.code.unwrap_or(1));
                     }
                 }
+                GajaeProfileCommands::Inspect(args) => {
+                    Ok(gajae::run_profile_inspect(gajae::ProfileInspectOptions {
+                        file: args.file,
+                    })?)
+                }
+                GajaeProfileCommands::Explain(args) => {
+                    Ok(gajae::run_profile_explain(gajae::ProfileExplainOptions {
+                        file: args.file,
+                        event: args.event,
+                        repo: args.repo,
+                    })?)
+                }
+                GajaeProfileCommands::Apply(args) => {
+                    Ok(gajae::run_profile_apply(gajae::ProfileApplyOptions {
+                        file: args.file,
+                        dry_run: args.dry_run,
+                        approve: args.approve,
+                    })?)
+                }
             },
             GajaeCommands::Receipt { command } => match command {
                 GajaeReceiptCommands::Ingest(args) => {

--- a/tests/gajae_profile_install_stdin.rs
+++ b/tests/gajae_profile_install_stdin.rs
@@ -280,3 +280,195 @@ exit 42
     assert!(!stderr.contains("/secret/token/path"), "stderr={stderr}");
     assert!(stderr.len() < 420, "stderr too long: {}", stderr.len());
 }
+
+#[test]
+fn gajae_profile_inspect_accepts_current_events_and_rejects_stale_dotted_events() {
+    let temp = TempDir::new().expect("tempdir");
+    let current_profile = temp.path().join("current.yml");
+    fs::write(
+        &current_profile,
+        r#"
+routes:
+  github.issue-opened:
+    command: gajae handle github.issue-opened
+  github.issue-commented:
+    command: gajae handle github.issue-commented
+  github.issue-closed:
+    command: gajae handle github.issue-closed
+  github.pr-status-changed:
+    command: gajae handle github.pr-status-changed
+  session.started:
+    command: gajae handle session.started
+  session.blocked:
+    command: gajae handle session.blocked
+  session.finished:
+    command: gajae handle session.finished
+"#,
+    )
+    .expect("write current profile");
+
+    let output = Command::new(clawhip_bin())
+        .args([
+            "--config",
+            temp.path().join("config.toml").to_str().expect("utf8 path"),
+            "gajae",
+            "profile",
+            "inspect",
+            "--file",
+            current_profile.to_str().expect("utf8 path"),
+        ])
+        .output()
+        .expect("inspect current profile");
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stale_profile = temp.path().join("stale.yml");
+    fs::write(
+        &stale_profile,
+        r#"
+routes:
+  github.issue.opened:
+    command: gajae handle github.issue.opened
+  github.pr.opened:
+    command: gajae handle github.pr.opened
+  session.completed:
+    command: gajae handle session.completed
+  session.stale:
+    command: gajae handle session.stale
+"#,
+    )
+    .expect("write stale profile");
+
+    let output = Command::new(clawhip_bin())
+        .args([
+            "--config",
+            temp.path().join("config.toml").to_str().expect("utf8 path"),
+            "gajae",
+            "profile",
+            "inspect",
+            "--file",
+            stale_profile.to_str().expect("utf8 path"),
+        ])
+        .output()
+        .expect("inspect stale profile");
+    assert!(
+        !output.status.success(),
+        "stale profile unexpectedly passed"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("unknown event: github.issue.opened"));
+    assert!(stdout.contains("unknown event: github.pr.opened"));
+    assert!(stdout.contains("unknown event: session.completed"));
+    assert!(stdout.contains("unknown event: session.stale"));
+}
+
+#[test]
+fn gajae_profile_inspect_and_explain_success_summarize_supported_commands() {
+    let temp = TempDir::new().expect("tempdir");
+    let profile = temp.path().join("profile.yml");
+    let config = temp.path().join("config.toml");
+    fs::write(
+        &profile,
+        r#"
+routes:
+  github.issue-opened:
+    command: gajae handle github.issue-opened
+"#,
+    )
+    .expect("write profile");
+
+    for command in ["inspect", "explain"] {
+        let mut args = vec![
+            "--config",
+            config.to_str().expect("utf8 path"),
+            "gajae",
+            "profile",
+            command,
+            "--file",
+            profile.to_str().expect("utf8 path"),
+        ];
+        if command == "explain" {
+            args.push("--event");
+            args.push("github.issue-opened");
+        }
+
+        let output = Command::new(clawhip_bin())
+            .args(args)
+            .output()
+            .expect("run profile command");
+        assert!(
+            output.status.success(),
+            "stdout={}\nstderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("supported GAJAE handler (command redacted)"));
+        assert!(!stdout.contains("gajae handle github.issue-opened"));
+    }
+}
+
+#[test]
+fn gajae_profile_inspect_and_explain_redact_route_command_details() {
+    let temp = TempDir::new().expect("tempdir");
+    let profile = temp.path().join("profile.yml");
+    let config = temp.path().join("config.toml");
+    fs::write(
+        &profile,
+        r#"
+routes:
+  github.issue-opened:
+    command: gajae handle github.issue-opened --token secret-token-123 --webhook https://hooks.example/secret --path /home/operator/private
+"#,
+    )
+    .expect("write profile");
+
+    for command in ["inspect", "explain"] {
+        let mut args = vec![
+            "--config",
+            config.to_str().expect("utf8 path"),
+            "gajae",
+            "profile",
+            command,
+            "--file",
+            profile.to_str().expect("utf8 path"),
+        ];
+        if command == "explain" {
+            args.push("--event");
+            args.push("github.issue-opened");
+        }
+
+        let output = Command::new(clawhip_bin())
+            .args(args)
+            .output()
+            .expect("run profile command");
+        assert!(
+            !output.status.success(),
+            "secret-bearing command should fail validation"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = format!("{stdout}\n{stderr}");
+        assert!(combined.contains("unsupported command for event: github.issue-opened"));
+        assert!(
+            !combined.contains("secret-token-123"),
+            "leaked token: {combined}"
+        );
+        assert!(
+            !combined.contains("https://hooks.example/secret"),
+            "leaked webhook URL: {combined}"
+        );
+        assert!(
+            !combined.contains("/home/operator/private"),
+            "leaked private path: {combined}"
+        );
+        assert!(
+            !combined.contains("gajae handle github.issue-opened --token"),
+            "leaked raw command: {combined}"
+        );
+    }
+}


### PR DESCRIPTION
Summary
- Add GAJAE profile inspect, explain, and apply --dry-run CLI surfaces.
- Parse installed or explicit GAJAE route profiles and validate supported event-to-command mappings without executing routes.
- Keep live apply approval-gated and refused by this safe inspector.

Tests
- cargo fmt --check
- cargo test gajae:: --package clawhip
- cargo test --package clawhip

GJC fallback evidence
- GJC owner session was previously launched, but gjc harness submit failed with session_not_found.
- OMX/Codex fallback evidence is authorized and captured by the successful local formatter and test runs above.

Closes #249

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*