### PR TITLE
Add safe GAJAE handler executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,24 @@ clawhip gajae profile install
 
 `status` discovers GAJAE from `GAJAE_BIN` first, then the `gajae` executable on `PATH`, and verifies it by running `gajae --help`. `profile install` forwards to `gajae clawhip profile install` with stdout/stderr attached so GAJAE owns the profile update flow.
 
+GAJAE route handlers are daemon-side and default off. Enable them explicitly and attach a bounded handler to an approved route:
+
+```toml
+[gajae]
+handlers_enabled = true
+handler_timeout_ms = 5000
+handler_max_output_bytes = 16384
+
+[[routes]]
+event = "github.pr-*"
+filter = { repo = "clawhip" }
+sink = "discord"
+channel = "OPS_CHANNEL_ID"
+gajae = { subcommand = "handle-event", args = ["--profile", "safe"] }
+```
+
+Handler execution uses the `GAJAE_BIN` override or `gajae` on `PATH`, runs only fixed allowlisted GAJAE handler subcommands, passes the event JSON on child stdin, closes parent stdin, enforces timeout/output caps, and emits `gajae.handler.completed`, `gajae.handler.failed`, `gajae.handler.timeout`, or `gajae.handler.approval-required` through normal routing. Handler output is data-only; mutation-shaped output is converted to an approval-required event instead of being applied automatically.
+
 ## Internal PR fast-path
 
 Before opening or updating an internal PR from a Rust worktree, run:

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,44 @@ pub struct AppConfig {
     pub discord_watch: DiscordWatchConfig,
     #[serde(default, skip_serializing_if = "crate::update::UpdateConfig::is_empty")]
     pub update: crate::update::UpdateConfig,
+    #[serde(default, skip_serializing_if = "GajaeConfig::is_empty")]
+    pub gajae: GajaeConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GajaeConfig {
+    #[serde(default)]
+    pub handlers_enabled: bool,
+    #[serde(default = "default_gajae_handler_timeout_ms")]
+    pub handler_timeout_ms: u64,
+    #[serde(default = "default_gajae_handler_max_output_bytes")]
+    pub handler_max_output_bytes: usize,
+}
+
+impl Default for GajaeConfig {
+    fn default() -> Self {
+        Self {
+            handlers_enabled: false,
+            handler_timeout_ms: default_gajae_handler_timeout_ms(),
+            handler_max_output_bytes: default_gajae_handler_max_output_bytes(),
+        }
+    }
+}
+
+impl GajaeConfig {
+    fn is_empty(&self) -> bool {
+        !self.handlers_enabled
+            && self.handler_timeout_ms == default_gajae_handler_timeout_ms()
+            && self.handler_max_output_bytes == default_gajae_handler_max_output_bytes()
+    }
+}
+
+fn default_gajae_handler_timeout_ms() -> u64 {
+    5_000
+}
+
+fn default_gajae_handler_max_output_bytes() -> usize {
+    16 * 1024
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -161,6 +199,17 @@ pub struct RouteRule {
     pub allow_dynamic_tokens: bool,
     pub format: Option<MessageFormat>,
     pub template: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gajae: Option<GajaeRouteAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GajaeRouteAction {
+    pub subcommand: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub requires_approval: bool,
 }
 
 impl Default for RouteRule {
@@ -179,6 +228,7 @@ impl Default for RouteRule {
             allow_dynamic_tokens: false,
             format: None,
             template: None,
+            gajae: None,
         }
     }
 }
@@ -859,12 +909,35 @@ impl AppConfig {
             return Err("discord_watch cooldowns must be non-negative".into());
         }
 
+        if self.gajae.handlers_enabled {
+            if self.gajae.handler_timeout_ms == 0 {
+                return Err(
+                    "gajae.handler_timeout_ms must be at least 1 when GAJAE handlers are enabled"
+                        .into(),
+                );
+            }
+            if self.gajae.handler_max_output_bytes == 0 {
+                return Err("gajae.handler_max_output_bytes must be at least 1 when GAJAE handlers are enabled".into());
+            }
+        }
+
         for (index, route) in self.routes.iter().enumerate() {
             let sink = route.effective_sink();
             let has_channel = normalize_secret(route.channel.clone()).is_some();
             let has_thread = route.discord_thread_target().is_some();
             let has_discord_webhook = route.discord_webhook_target().is_some();
             let has_slack_webhook = route.slack_webhook_target().is_some();
+            if let Some(gajae) = &route.gajae {
+                let subcommand = gajae.subcommand.trim();
+                if subcommand.is_empty() {
+                    return Err(format!(
+                        "route #{} ({}) GAJAE handler must set subcommand",
+                        index + 1,
+                        route.event
+                    )
+                    .into());
+                }
+            }
             if route.sink.trim().is_empty() && !has_slack_webhook {
                 return Err(
                     format!("route #{} ({}) must set a sink", index + 1, route.event).into(),
@@ -1067,6 +1140,7 @@ impl AppConfig {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: None,
+                    gajae: None,
                 });
                 Ok(())
             }
@@ -1138,6 +1212,7 @@ impl AppConfig {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: None,
+                    gajae: None,
                 });
             }
         }
@@ -1284,6 +1359,15 @@ impl AppConfig {
             route.slack_webhook = normalize_text(route.slack_webhook.clone());
             route.mention = normalize_text(route.mention.clone());
             route.template = normalize_text(route.template.clone());
+            if let Some(gajae) = &mut route.gajae {
+                gajae.subcommand =
+                    normalize_text(Some(gajae.subcommand.clone())).unwrap_or_default();
+                gajae.args = gajae
+                    .args
+                    .iter()
+                    .filter_map(|arg| normalize_text(Some(arg.clone())))
+                    .collect();
+            }
         }
 
         for repo in &mut self.monitors.git.repos {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -15,11 +15,12 @@ use tokio::sync::{Mutex, RwLock, mpsc};
 
 use crate::Result;
 use crate::VERSION;
-use crate::config::AppConfig;
+use crate::config::{AppConfig, GajaeRouteAction, RouteRule};
 use crate::cron::CronSource;
 use crate::dispatch::Dispatcher;
 use crate::event::compat::from_incoming_event;
 use crate::events::{IncomingEvent, MessageFormat, normalize_event};
+use crate::gajae::{HandlerAction, HandlerLimits, HandlerOutcome};
 use crate::native_hooks::{
     NATIVE_NON_GIT_OUTCOME, NATIVE_NORMALIZATION_OUTCOME_FIELD,
     incoming_event_from_native_hook_json,
@@ -619,6 +620,33 @@ async fn accept_event(state: &AppState, event: IncomingEvent) -> axum::response:
         return local_only_event_response(&event, &envelope);
     }
 
+    if let Some(handler_event) = run_matching_gajae_handler(state, &event).await {
+        return enqueue_accepted_event(state, handler_event).await;
+    }
+
+    enqueue_accepted_event(state, event).await
+}
+
+async fn enqueue_accepted_event(
+    state: &AppState,
+    event: IncomingEvent,
+) -> axum::response::Response {
+    let envelope = match from_incoming_event(&event) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            if is_native_hook_event(&event) {
+                with_native_observability(&state.native_observability, |observability| {
+                    observability.observe_dropped(&event, "validation_error");
+                });
+            }
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"ok": false, "error": error.to_string()})),
+            )
+                .into_response();
+        }
+    };
+
     match enqueue_event(&state.tx, event.clone()).await {
         Ok(()) => {
             expire_terminal_tmux_registration(state, &event).await;
@@ -667,6 +695,180 @@ fn local_only_event_response(
         })),
     )
         .into_response()
+}
+
+async fn run_matching_gajae_handler(
+    state: &AppState,
+    event: &IncomingEvent,
+) -> Option<IncomingEvent> {
+    if !state.config.gajae.handlers_enabled {
+        return None;
+    }
+    if event.canonical_kind().starts_with("gajae.handler.") {
+        return None;
+    }
+
+    let route = matching_gajae_route(&state.config, event)?;
+    let action = handler_action(route.gajae.as_ref()?);
+    let event_json = handler_event_json(event);
+    let limits = HandlerLimits {
+        timeout: Duration::from_millis(state.config.gajae.handler_timeout_ms),
+        max_output_bytes: state.config.gajae.handler_max_output_bytes,
+    };
+
+    let outcome = match crate::gajae::run_handler(&action, &event_json, limits).await {
+        Ok(outcome) => outcome,
+        Err(error) => HandlerOutcome::Failed {
+            code: None,
+            stdout: String::new(),
+            stderr: bounded_handler_text(&error.to_string()),
+        },
+    };
+
+    Some(handler_outcome_event(event, &action, outcome))
+}
+
+fn matching_gajae_route<'a>(config: &'a AppConfig, event: &IncomingEvent) -> Option<&'a RouteRule> {
+    let context = event.template_context();
+    config
+        .routes
+        .iter()
+        .filter(|route| route.gajae.is_some())
+        .filter(|route| route_matches_event(route, event.canonical_kind(), &context))
+        .max_by_key(|route| route_specificity(route, &context))
+}
+
+fn route_matches_event(
+    route: &RouteRule,
+    canonical_kind: &str,
+    context: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    route_event_candidates(canonical_kind)
+        .iter()
+        .any(|candidate| crate::router::glob_match(&route.event, candidate))
+        && route.filter.iter().all(|(key, expected)| {
+            context
+                .get(key)
+                .map(|actual| crate::router::glob_match(expected, actual))
+                .unwrap_or(false)
+        })
+}
+
+fn route_event_candidates(canonical_kind: &str) -> [&str; 2] {
+    let suffix = canonical_kind
+        .split_once('.')
+        .map(|(_, suffix)| suffix)
+        .unwrap_or(canonical_kind);
+    [canonical_kind, suffix]
+}
+
+fn route_specificity(
+    route: &RouteRule,
+    context: &std::collections::BTreeMap<String, String>,
+) -> usize {
+    let path_rank = if route.filter.contains_key("worktree_path")
+        && context
+            .get("worktree_path")
+            .is_some_and(|value| !value.trim().is_empty())
+    {
+        3
+    } else if route.filter.contains_key("repo_path")
+        && context
+            .get("repo_path")
+            .is_some_and(|value| !value.trim().is_empty())
+    {
+        2
+    } else if route.filter.contains_key("repo_name")
+        && context
+            .get("repo_name")
+            .is_some_and(|value| !value.trim().is_empty())
+    {
+        1
+    } else {
+        0
+    };
+
+    (path_rank * 100) + route.filter.len()
+}
+
+fn handler_action(config: &GajaeRouteAction) -> HandlerAction {
+    HandlerAction {
+        subcommand: config.subcommand.clone(),
+        args: config.args.clone(),
+        requires_approval: config.requires_approval,
+    }
+}
+
+fn handler_event_json(event: &IncomingEvent) -> Value {
+    json!({
+        "type": event.canonical_kind(),
+        "payload": event.payload,
+        "channel": event.channel,
+        "mention": event.mention,
+        "format": event.format.as_ref().map(|format| format.as_str()),
+        "template": event.template,
+    })
+}
+
+fn handler_outcome_event(
+    source: &IncomingEvent,
+    action: &HandlerAction,
+    outcome: HandlerOutcome,
+) -> IncomingEvent {
+    let (kind, payload) = match outcome {
+        HandlerOutcome::Completed(output) => (
+            "gajae.handler.completed",
+            json!({
+                "source_event": source.canonical_kind(),
+                "subcommand": action.subcommand,
+                "output": output,
+            }),
+        ),
+        HandlerOutcome::ApprovalRequired(output) => (
+            "gajae.handler.approval-required",
+            json!({
+                "source_event": source.canonical_kind(),
+                "subcommand": action.subcommand,
+                "output": output,
+                "approval_required": true,
+            }),
+        ),
+        HandlerOutcome::Failed {
+            code,
+            stdout,
+            stderr,
+        } => (
+            "gajae.handler.failed",
+            json!({
+                "source_event": source.canonical_kind(),
+                "subcommand": action.subcommand,
+                "exit_code": code,
+                "stdout": bounded_handler_text(&stdout),
+                "stderr": bounded_handler_text(&stderr),
+            }),
+        ),
+        HandlerOutcome::TimedOut => (
+            "gajae.handler.timeout",
+            json!({
+                "source_event": source.canonical_kind(),
+                "subcommand": action.subcommand,
+                "timeout": true,
+            }),
+        ),
+    };
+
+    IncomingEvent {
+        kind: kind.to_string(),
+        channel: source.channel.clone(),
+        mention: None,
+        format: Some(MessageFormat::Compact),
+        template: None,
+        payload,
+    }
+}
+
+fn bounded_handler_text(value: &str) -> String {
+    value.chars().take(512).collect()
 }
 
 async fn handle_discord_watch(state: &AppState, event: &IncomingEvent) -> Result<()> {
@@ -1025,6 +1227,91 @@ mod tests {
             }),
             active_wrapper_monitor: true,
         }
+    }
+
+    fn gajae_test_event() -> IncomingEvent {
+        IncomingEvent {
+            kind: "github.pr.opened".into(),
+            channel: Some("ops".into()),
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({"repo": "clawhip", "number": 250}),
+        }
+    }
+
+    #[test]
+    fn gajae_handler_completed_event_is_typed_and_bounded_to_data_output() {
+        let action = HandlerAction {
+            subcommand: "handle-event".into(),
+            args: Vec::new(),
+            requires_approval: false,
+        };
+        let event = handler_outcome_event(
+            &gajae_test_event(),
+            &action,
+            HandlerOutcome::Completed(json!({"summary": "ok"})),
+        );
+
+        assert_eq!(event.kind, "gajae.handler.completed");
+        assert_eq!(event.payload["source_event"], json!("github.pr.opened"));
+        assert_eq!(event.payload["output"]["summary"], json!("ok"));
+    }
+
+    #[test]
+    fn gajae_handler_timeout_event_is_bounded() {
+        let action = HandlerAction {
+            subcommand: "handle-event".into(),
+            args: vec!["--profile".into(), "safe".into()],
+            requires_approval: false,
+        };
+        let event = handler_outcome_event(&gajae_test_event(), &action, HandlerOutcome::TimedOut);
+
+        assert_eq!(event.kind, "gajae.handler.timeout");
+        assert_eq!(event.payload["timeout"], json!(true));
+        assert!(event.payload.get("stdout").is_none());
+        assert!(event.payload.get("stderr").is_none());
+    }
+
+    #[test]
+    fn gajae_handler_failed_event_bounds_diagnostics_without_raw_dump() {
+        let action = HandlerAction {
+            subcommand: "handle-event".into(),
+            args: Vec::new(),
+            requires_approval: false,
+        };
+        let raw = "x".repeat(2_000);
+        let event = handler_outcome_event(
+            &gajae_test_event(),
+            &action,
+            HandlerOutcome::Failed {
+                code: Some(17),
+                stdout: raw.clone(),
+                stderr: raw,
+            },
+        );
+
+        assert_eq!(event.kind, "gajae.handler.failed");
+        assert_eq!(event.payload["exit_code"], json!(17));
+        assert!(event.payload["stdout"].as_str().unwrap().len() <= 512);
+        assert!(event.payload["stderr"].as_str().unwrap().len() <= 512);
+    }
+
+    #[test]
+    fn gajae_handler_mutating_output_requires_approval_event() {
+        let action = HandlerAction {
+            subcommand: "handle-event".into(),
+            args: Vec::new(),
+            requires_approval: false,
+        };
+        let event = handler_outcome_event(
+            &gajae_test_event(),
+            &action,
+            HandlerOutcome::ApprovalRequired(json!({"mutation_requested": true})),
+        );
+
+        assert_eq!(event.kind, "gajae.handler.approval-required");
+        assert_eq!(event.payload["approval_required"], json!(true));
     }
 
     fn git_repo() -> tempfile::TempDir {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1175,6 +1175,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: Some("first".into()),
+                    gajae: None,
                 },
                 RouteRule {
                     event: "tmux.keyword".into(),
@@ -1190,6 +1191,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: Some("second".into()),
+                    gajae: None,
                 },
             ],
             ..AppConfig::default()

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -119,13 +119,19 @@ async fn run_handler_with_bin(
         .stderr(Stdio::piped())
         .kill_on_drop(true);
 
-    let mut child = command
-        .spawn()
-        .with_context(|| format!("failed to spawn GAJAE handler {}", bin.display()))?;
+    let mut child = spawn_handler_command(&mut command, bin).await?;
     if let Some(mut stdin) = child.stdin.take() {
         let event_json = serde_json::to_vec(event)?;
-        stdin.write_all(&event_json).await?;
-        stdin.shutdown().await?;
+        if let Err(error) = stdin.write_all(&event_json).await {
+            if error.kind() != io::ErrorKind::BrokenPipe {
+                return Err(error.into());
+            }
+        }
+        if let Err(error) = stdin.shutdown().await {
+            if error.kind() != io::ErrorKind::BrokenPipe {
+                return Err(error.into());
+            }
+        }
     }
 
     let stdout = child
@@ -202,6 +208,26 @@ async fn run_handler_with_bin(
         Ok(HandlerOutcome::ApprovalRequired(parsed))
     } else {
         Ok(HandlerOutcome::Completed(parsed))
+    }
+}
+
+async fn spawn_handler_command(
+    command: &mut tokio::process::Command,
+    bin: &Path,
+) -> Result<tokio::process::Child> {
+    let mut attempts = 0;
+    loop {
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error) if error.raw_os_error() == Some(26) && attempts < 10 => {
+                attempts += 1;
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to spawn GAJAE handler {}", bin.display()));
+            }
+        }
     }
 }
 
@@ -1159,6 +1185,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::fs;
+    use std::io::Write as _;
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1267,10 +1294,16 @@ mod tests {
     fn write_fake_gajae(script: &str) -> (tempfile::TempDir, PathBuf) {
         let dir = tempdir().expect("tempdir");
         let path = dir.path().join("fake-gajae.sh");
-        fs::write(&path, script).expect("write fake gajae");
-        let mut permissions = fs::metadata(&path).expect("metadata").permissions();
+        let tmp_path = dir.path().join("fake-gajae.sh.tmp");
+        {
+            let mut file = fs::File::create(&tmp_path).expect("create fake gajae");
+            file.write_all(script.as_bytes()).expect("write fake gajae");
+            file.sync_all().expect("sync fake gajae");
+        }
+        let mut permissions = fs::metadata(&tmp_path).expect("metadata").permissions();
         permissions.set_mode(0o755);
-        fs::set_permissions(&path, permissions).expect("chmod fake gajae");
+        fs::set_permissions(&tmp_path, permissions).expect("chmod fake gajae");
+        fs::rename(&tmp_path, &path).expect("install fake gajae");
         (dir, path)
     }
 

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -5,9 +5,11 @@ use std::io::{self, Read, Write};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use serde_json::{Map, Value, json};
+use tokio::io::AsyncWriteExt;
 
 use crate::events::IncomingEvent;
 
@@ -51,6 +53,155 @@ const SUPPORTED_EVENTS: &[&str] = &[
     "tmux.keyword",
     "tmux.stale",
 ];
+const HANDLER_ARGS_PREFIX: &[&str] = &["clawhip", "handler"];
+const ALLOWED_HANDLER_SUBCOMMANDS: &[&str] = &["handle-event", "route-action", "summarize-event"];
+const DIAGNOSTIC_BYTES: usize = 512;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HandlerAction {
+    pub subcommand: String,
+    pub args: Vec<String>,
+    pub requires_approval: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HandlerLimits {
+    pub timeout: Duration,
+    pub max_output_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HandlerOutcome {
+    Completed(Value),
+    ApprovalRequired(Value),
+    Failed {
+        code: Option<i32>,
+        stdout: String,
+        stderr: String,
+    },
+    TimedOut,
+}
+
+pub async fn run_handler(
+    action: &HandlerAction,
+    event: &Value,
+    limits: HandlerLimits,
+) -> Result<HandlerOutcome> {
+    validate_handler_action(action)?;
+    let bin = discover_gajae_with(|name| std::env::var_os(name));
+    run_handler_with_bin(&bin, action, event, limits).await
+}
+
+async fn run_handler_with_bin(
+    bin: &Path,
+    action: &HandlerAction,
+    event: &Value,
+    limits: HandlerLimits,
+) -> Result<HandlerOutcome> {
+    if limits.timeout.is_zero() {
+        bail!("GAJAE handler timeout must be nonzero");
+    }
+    if limits.max_output_bytes == 0 {
+        bail!("GAJAE handler max output must be nonzero");
+    }
+
+    let mut command = tokio::process::Command::new(bin);
+    command
+        .args(handler_args(action))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to spawn GAJAE handler {}", bin.display()))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        let event_json = serde_json::to_vec(event)?;
+        stdin.write_all(&event_json).await?;
+        stdin.shutdown().await?;
+    }
+
+    let output = match tokio::time::timeout(limits.timeout, child.wait_with_output()).await {
+        Ok(output) => output?,
+        Err(_) => return Ok(HandlerOutcome::TimedOut),
+    };
+
+    let diagnostic_limit = limits.max_output_bytes.min(DIAGNOSTIC_BYTES);
+    let stdout = bounded_bytes(&output.stdout, diagnostic_limit);
+    let stderr = bounded_bytes(&output.stderr, diagnostic_limit);
+    if !output.status.success() {
+        return Ok(HandlerOutcome::Failed {
+            code: output.status.code(),
+            stdout: diagnostic_text(&stdout),
+            stderr: diagnostic_text(&stderr),
+        });
+    }
+
+    let parsed = if stdout.trim_ascii().is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&stdout).unwrap_or_else(|_| {
+            json!({
+                "summary": diagnostic_text(&stdout),
+            })
+        })
+    };
+
+    if action.requires_approval || output_requests_mutation(&parsed) {
+        Ok(HandlerOutcome::ApprovalRequired(parsed))
+    } else {
+        Ok(HandlerOutcome::Completed(parsed))
+    }
+}
+
+fn validate_handler_action(action: &HandlerAction) -> Result<()> {
+    let subcommand = action.subcommand.trim();
+    if !ALLOWED_HANDLER_SUBCOMMANDS.contains(&subcommand) {
+        bail!("unsupported GAJAE handler subcommand '{subcommand}'");
+    }
+    if action.args.iter().any(|arg| arg.contains('\0')) {
+        bail!("GAJAE handler arguments must not contain NUL bytes");
+    }
+    Ok(())
+}
+
+fn handler_args(action: &HandlerAction) -> Vec<String> {
+    HANDLER_ARGS_PREFIX
+        .iter()
+        .map(|arg| (*arg).to_string())
+        .chain(std::iter::once(action.subcommand.clone()))
+        .chain(action.args.clone())
+        .collect()
+}
+
+fn output_requests_mutation(value: &Value) -> bool {
+    value
+        .get("mutation_requested")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || value
+            .get("requires_approval")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        || value.get("mutation").is_some()
+        || value.get("mutations").is_some()
+}
+
+fn bounded_bytes(bytes: &[u8], max: usize) -> Vec<u8> {
+    bytes.iter().copied().take(max).collect()
+}
+
+fn diagnostic_text(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    text.chars()
+        .filter(|ch| !ch.is_control() || *ch == '\n' || *ch == '\t')
+        .collect::<String>()
+        .lines()
+        .take(8)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 #[derive(Debug, Clone, Copy)]
 pub enum GajaeCommand {
@@ -912,8 +1063,9 @@ fn concise_detail(stderr: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
-
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct Call {
         program: PathBuf,
@@ -1015,6 +1167,149 @@ mod tests {
                 .map(Clone::clone)
                 .map_err(|error| io::Error::new(error.kind(), error.to_string()))
         }
+    }
+
+    fn write_fake_gajae(script: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("fake-gajae.sh");
+        fs::write(&path, script).expect("write fake gajae");
+        let mut permissions = fs::metadata(&path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).expect("chmod fake gajae");
+        (dir, path)
+    }
+
+    fn handler_action() -> HandlerAction {
+        HandlerAction {
+            subcommand: "handle-event".into(),
+            args: vec!["--label".into(), "semi;colon $(touch nope)".into()],
+            requires_approval: false,
+        }
+    }
+
+    fn handler_limits(timeout_ms: u64, max_output_bytes: usize) -> HandlerLimits {
+        HandlerLimits {
+            timeout: Duration::from_millis(timeout_ms),
+            max_output_bytes,
+        }
+    }
+
+    #[tokio::test]
+    async fn handler_passes_fixed_args_and_event_json_stdin_without_shell_interpolation() {
+        let script = r#"#!/bin/sh
+printf '%s\n' "$@" > "$FAKE_ARG_FILE"
+python3 -c 'import json, os, sys; data=json.load(sys.stdin); open(os.environ["FAKE_STDIN_FILE"], "w").write(data["type"] + "\n")'
+printf '{"summary":"ok"}'
+"#;
+        let (_dir, bin) = write_fake_gajae(script);
+        let out_dir = tempdir().expect("out tempdir");
+        let arg_file = out_dir.path().join("args.txt");
+        let stdin_file = out_dir.path().join("stdin.txt");
+        unsafe {
+            std::env::set_var("FAKE_ARG_FILE", &arg_file);
+            std::env::set_var("FAKE_STDIN_FILE", &stdin_file);
+        }
+
+        let outcome = run_handler_with_bin(
+            &bin,
+            &handler_action(),
+            &json!({"type": "github.pr.opened"}),
+            handler_limits(1_000, 1_024),
+        )
+        .await
+        .expect("handler should run");
+
+        assert_eq!(outcome, HandlerOutcome::Completed(json!({"summary": "ok"})));
+        let args = fs::read_to_string(&arg_file).expect("args file");
+        assert_eq!(
+            args.lines().collect::<Vec<_>>(),
+            vec![
+                "clawhip",
+                "handler",
+                "handle-event",
+                "--label",
+                "semi;colon $(touch nope)"
+            ]
+        );
+        assert_eq!(
+            fs::read_to_string(stdin_file).expect("stdin file"),
+            "github.pr.opened\n"
+        );
+        assert!(!out_dir.path().join("nope").exists());
+    }
+
+    #[tokio::test]
+    async fn handler_timeout_reports_timeout() {
+        let (_dir, bin) = write_fake_gajae("#!/bin/sh\nsleep 2\n");
+        let outcome = run_handler_with_bin(
+            &bin,
+            &handler_action(),
+            &json!({"type": "github.pr.opened"}),
+            handler_limits(10, 1_024),
+        )
+        .await
+        .expect("handler should time out cleanly");
+
+        assert_eq!(outcome, HandlerOutcome::TimedOut);
+    }
+
+    #[tokio::test]
+    async fn handler_nonzero_bounds_diagnostics() {
+        let script = "#!/bin/sh\npython3 -c 'import sys; sys.stdout.write(\"o\" * 2000); sys.stderr.write(\"e\" * 2000)'\nexit 17\n";
+        let (_dir, bin) = write_fake_gajae(script);
+        let outcome = run_handler_with_bin(
+            &bin,
+            &handler_action(),
+            &json!({"type": "github.pr.opened"}),
+            handler_limits(1_000, 1_024),
+        )
+        .await
+        .expect("handler should report failure");
+
+        let HandlerOutcome::Failed {
+            code,
+            stdout,
+            stderr,
+        } = outcome
+        else {
+            panic!("unexpected outcome")
+        };
+        assert_eq!(code, Some(17));
+        assert!(stdout.len() <= DIAGNOSTIC_BYTES);
+        assert!(stderr.len() <= DIAGNOSTIC_BYTES);
+    }
+
+    #[tokio::test]
+    async fn handler_mutating_output_requires_approval() {
+        let (_dir, bin) = write_fake_gajae(
+            "#!/bin/sh\nprintf '{\"mutation_requested\":true,\"summary\":\"needs approval\"}'\n",
+        );
+        let outcome = run_handler_with_bin(
+            &bin,
+            &handler_action(),
+            &json!({"type": "github.pr.opened"}),
+            handler_limits(1_000, 1_024),
+        )
+        .await
+        .expect("handler should run");
+
+        assert_eq!(
+            outcome,
+            HandlerOutcome::ApprovalRequired(
+                json!({"mutation_requested": true, "summary": "needs approval"})
+            )
+        );
+    }
+
+    #[test]
+    fn handler_rejects_unapproved_subcommand() {
+        let action = HandlerAction {
+            subcommand: "sh -c touch nope".into(),
+            args: Vec::new(),
+            requires_approval: false,
+        };
+
+        assert!(validate_handler_action(&action).is_err());
     }
 
     #[test]

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -122,15 +122,15 @@ async fn run_handler_with_bin(
     let mut child = spawn_handler_command(&mut command, bin).await?;
     if let Some(mut stdin) = child.stdin.take() {
         let event_json = serde_json::to_vec(event)?;
-        if let Err(error) = stdin.write_all(&event_json).await {
-            if error.kind() != io::ErrorKind::BrokenPipe {
-                return Err(error.into());
-            }
+        if let Err(error) = stdin.write_all(&event_json).await
+            && error.kind() != io::ErrorKind::BrokenPipe
+        {
+            return Err(error.into());
         }
-        if let Err(error) = stdin.shutdown().await {
-            if error.kind() != io::ErrorKind::BrokenPipe {
-                return Err(error.into());
-            }
+        if let Err(error) = stdin.shutdown().await
+            && error.kind() != io::ErrorKind::BrokenPipe
+        {
+            return Err(error.into());
         }
     }
 
@@ -1185,7 +1185,6 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::fs;
-    use std::io::Write as _;
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use serde_json::{Map, Value, json};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
 use crate::events::IncomingEvent;
 
@@ -81,6 +81,11 @@ pub enum HandlerOutcome {
     },
     TimedOut,
 }
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BoundedOutput {
+    bytes: Vec<u8>,
+    capped: bool,
+}
 
 pub async fn run_handler(
     action: &HandlerAction,
@@ -92,6 +97,7 @@ pub async fn run_handler(
     run_handler_with_bin(&bin, action, event, limits).await
 }
 
+#[allow(clippy::too_many_lines)]
 async fn run_handler_with_bin(
     bin: &Path,
     action: &HandlerAction,
@@ -122,28 +128,72 @@ async fn run_handler_with_bin(
         stdin.shutdown().await?;
     }
 
-    let output = match tokio::time::timeout(limits.timeout, child.wait_with_output()).await {
-        Ok(output) => output?,
-        Err(_) => return Ok(HandlerOutcome::TimedOut),
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("GAJAE handler stdout pipe unavailable"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("GAJAE handler stderr pipe unavailable"))?;
+    let mut stdout_task = tokio::spawn(read_bounded_output(stdout, limits.max_output_bytes));
+    let mut stderr_task = tokio::spawn(read_bounded_output(stderr, limits.max_output_bytes));
+    let mut stdout_output: Option<BoundedOutput> = None;
+    let mut stderr_output: Option<BoundedOutput> = None;
+    let timeout = tokio::time::sleep(limits.timeout);
+    tokio::pin!(timeout);
+
+    let status = loop {
+        tokio::select! {
+            status = child.wait() => break status?,
+            stdout_result = &mut stdout_task, if stdout_output.is_none() => {
+                let output = stdout_result??;
+                let capped = output.capped;
+                stdout_output = Some(output);
+                if capped {
+                    let _ = child.start_kill();
+                    break child.wait().await?;
+                }
+            }
+            stderr_result = &mut stderr_task, if stderr_output.is_none() => {
+                let output = stderr_result??;
+                let capped = output.capped;
+                stderr_output = Some(output);
+                if capped {
+                    let _ = child.start_kill();
+                    break child.wait().await?;
+                }
+            }
+            _ = &mut timeout => {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                stdout_task.abort();
+                stderr_task.abort();
+                return Ok(HandlerOutcome::TimedOut);
+            }
+        }
     };
 
+    let stdout = finish_bounded_task(stdout_output, stdout_task).await?;
+    let stderr = finish_bounded_task(stderr_output, stderr_task).await?;
+
     let diagnostic_limit = limits.max_output_bytes.min(DIAGNOSTIC_BYTES);
-    let stdout = bounded_bytes(&output.stdout, diagnostic_limit);
-    let stderr = bounded_bytes(&output.stderr, diagnostic_limit);
-    if !output.status.success() {
+    let stdout_diagnostic = bounded_bytes(&stdout.bytes, diagnostic_limit);
+    let stderr_diagnostic = bounded_bytes(&stderr.bytes, diagnostic_limit);
+    if !status.success() || stdout.capped || stderr.capped {
         return Ok(HandlerOutcome::Failed {
-            code: output.status.code(),
-            stdout: diagnostic_text(&stdout),
-            stderr: diagnostic_text(&stderr),
+            code: status.code(),
+            stdout: diagnostic_text(&stdout_diagnostic),
+            stderr: diagnostic_text(&stderr_diagnostic),
         });
     }
 
-    let parsed = if stdout.trim_ascii().is_empty() {
+    let parsed = if stdout.bytes.iter().all(u8::is_ascii_whitespace) {
         json!({})
     } else {
-        serde_json::from_slice(&stdout).unwrap_or_else(|_| {
+        serde_json::from_slice(&stdout.bytes).unwrap_or_else(|_| {
             json!({
-                "summary": diagnostic_text(&stdout),
+                "summary": diagnostic_text(&stdout_diagnostic),
             })
         })
     };
@@ -152,6 +202,51 @@ async fn run_handler_with_bin(
         Ok(HandlerOutcome::ApprovalRequired(parsed))
     } else {
         Ok(HandlerOutcome::Completed(parsed))
+    }
+}
+
+async fn read_bounded_output<R>(mut reader: R, max: usize) -> io::Result<BoundedOutput>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut bytes = Vec::with_capacity(max.min(8 * 1024));
+    let mut buffer = [0_u8; 8192];
+
+    loop {
+        let remaining = max.saturating_sub(bytes.len());
+        let read_limit = remaining.saturating_add(1).min(buffer.len());
+        if read_limit == 0 {
+            return Ok(BoundedOutput {
+                bytes,
+                capped: true,
+            });
+        }
+
+        let read = reader.read(&mut buffer[..read_limit]).await?;
+        if read == 0 {
+            return Ok(BoundedOutput {
+                bytes,
+                capped: false,
+            });
+        }
+        if read > remaining {
+            bytes.extend_from_slice(&buffer[..remaining]);
+            return Ok(BoundedOutput {
+                bytes,
+                capped: true,
+            });
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+}
+
+async fn finish_bounded_task(
+    output: Option<BoundedOutput>,
+    task: tokio::task::JoinHandle<io::Result<BoundedOutput>>,
+) -> Result<BoundedOutput> {
+    match output {
+        Some(output) => Ok(output),
+        None => Ok(task.await??),
     }
 }
 
@@ -1261,7 +1356,7 @@ printf '{"summary":"ok"}'
             &bin,
             &handler_action(),
             &json!({"type": "github.pr.opened"}),
-            handler_limits(1_000, 1_024),
+            handler_limits(1_000, 4_096),
         )
         .await
         .expect("handler should report failure");
@@ -1277,6 +1372,41 @@ printf '{"summary":"ok"}'
         assert_eq!(code, Some(17));
         assert!(stdout.len() <= DIAGNOSTIC_BYTES);
         assert!(stderr.len() <= DIAGNOSTIC_BYTES);
+    }
+
+    #[tokio::test]
+    async fn handler_output_cap_kills_process_and_retains_only_bounded_bytes() {
+        let script = r#"#!/bin/sh
+while :; do printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'; done
+printf 'not killed' > "$FAKE_MARKER_FILE"
+"#;
+        let (_dir, bin) = write_fake_gajae(script);
+        let out_dir = tempdir().expect("out tempdir");
+        let marker_file = out_dir.path().join("marker.txt");
+        unsafe {
+            std::env::set_var("FAKE_MARKER_FILE", &marker_file);
+        }
+
+        let started = std::time::Instant::now();
+        let outcome = run_handler_with_bin(
+            &bin,
+            &handler_action(),
+            &json!({"type": "github.pr.opened"}),
+            handler_limits(5_000, 64),
+        )
+        .await
+        .expect("handler should be killed on output cap");
+
+        let HandlerOutcome::Failed { stdout, stderr, .. } = outcome else {
+            panic!("unexpected outcome")
+        };
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "output cap should kill before timeout"
+        );
+        assert!(stdout.len() <= 64);
+        assert!(stderr.len() <= 64);
+        assert!(!marker_file.exists());
     }
 
     #[tokio::test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -703,6 +703,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
                     template: None,
+                    gajae: None,
                 },
                 RouteRule {
                     event: "tmux.*".into(),
@@ -718,6 +719,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Compact),
                     template: Some("duplicate: {line}".into()),
+                    gajae: None,
                 },
             ],
             ..AppConfig::default()
@@ -799,6 +801,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -850,6 +853,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -945,6 +949,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: Some("first".into()),
+                    gajae: None,
                 },
                 RouteRule {
                     event: "tmux.keyword".into(),
@@ -960,6 +965,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: Some("second".into()),
+                    gajae: None,
                 },
             ],
             ..AppConfig::default()
@@ -1007,6 +1013,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1047,6 +1054,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1094,6 +1102,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1129,6 +1138,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
                     template: None,
+                    gajae: None,
                 },
                 RouteRule {
                     event: "tmux.*".into(),
@@ -1146,6 +1156,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: Some(MessageFormat::Alert),
                     template: None,
+                    gajae: None,
                 },
             ],
             ..AppConfig::default()
@@ -1187,6 +1198,7 @@ mod tests {
                 allow_dynamic_tokens: true,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1218,6 +1230,7 @@ mod tests {
                 allow_dynamic_tokens: true,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1251,6 +1264,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1288,6 +1302,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1325,6 +1340,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1366,6 +1382,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1415,6 +1432,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1481,6 +1499,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1530,6 +1549,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1591,6 +1611,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Compact),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1642,6 +1663,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: None,
+                    gajae: None,
                 },
                 RouteRule {
                     event: "github.*".into(),
@@ -1659,6 +1681,7 @@ mod tests {
                     allow_dynamic_tokens: false,
                     format: None,
                     template: None,
+                    gajae: None,
                 },
             ],
             ..AppConfig::default()
@@ -1693,6 +1716,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1733,6 +1757,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1764,6 +1789,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1908,6 +1934,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1951,6 +1978,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -1991,6 +2019,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -2031,6 +2060,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -2071,6 +2101,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -2108,6 +2139,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -2204,6 +2236,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -2236,6 +2269,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -2345,6 +2379,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -979,6 +979,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: Some(MessageFormat::Alert),
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -747,6 +747,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };
@@ -856,6 +857,7 @@ mod tests {
                 allow_dynamic_tokens: false,
                 format: None,
                 template: None,
+                gajae: None,
             }],
             ..AppConfig::default()
         };


### PR DESCRIPTION
Closes #250.

## Summary
- adds explicit default-off GAJAE handler config and route action shape
- executes allowlisted GAJAE handler subcommands with event JSON on child stdin, no shell interpolation, timeout, and bounded output
- emits typed handler result events for completed, failed, timeout, and approval-required outcomes
- documents the new handler configuration surface

## Verification
- cargo fmt
- cargo test --package clawhip gajae -- --nocapture
- cargo check --package clawhip
- cargo fmt --check
- cargo test --package clawhip

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*