### PR TITLE
Add GAJAE doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,9 +912,11 @@ clawhip gajae status    # check local GAJAE CLI bridge availability
 clawhip gajae status
 clawhip gajae profile install
 clawhip gajae preflight
+clawhip gajae doctor --repo owner/repo
+clawhip gajae profile verify
 ```
 
-`status` discovers GAJAE from `GAJAE_BIN` first, then the `gajae` executable on `PATH`, and verifies it by running `gajae --help`. `profile install` forwards to `gajae clawhip profile install` with stdout/stderr attached so GAJAE owns the profile update flow. `preflight` is the public-safe readiness check: it verifies GAJAE discovery, required receipt validators, the installed clawhip profile, public-safe output mode, and disabled raw-payload export, then prints a concise JSON summary safe to paste into issues or PRs. Preflight does not mutate cron/config, does not contact GitHub, and does not require GAJAE for baseline clawhip routing.
+`status` discovers GAJAE from `GAJAE_BIN` first, then the `gajae` executable on `PATH`, and verifies it by running `gajae --help`. `profile install` forwards to `gajae clawhip profile install` with stdout/stderr attached so GAJAE owns the profile update flow. `preflight` is the #257 public-safe readiness check: it verifies GAJAE discovery, required receipt validators, the installed clawhip profile, public-safe output mode, and disabled raw-payload export, then prints a concise JSON summary safe to paste into issues or PRs. Preflight does not mutate cron/config, does not contact GitHub, and does not require GAJAE for baseline clawhip routing. `doctor` extends those bounded diagnostics with schema capability, handler-command drift, and optional dry-run onboard-plan checks. `profile verify` checks the installed profile and handler commands without executing routes. Doctor and verify never run `gajae clawhip profile install` and never mutate live profiles.
 
 GAJAE route handlers are daemon-side and default off. Enable them explicitly and attach a bounded handler to an approved route:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -485,6 +485,8 @@ pub enum GajaeCommands {
     Status,
     /// Verify GAJAE-native receipts, profile install, and public-safe output readiness.
     Preflight,
+    /// Diagnose GAJAE CLI/profile conformance without mutating local profiles.
+    Doctor(GajaeDoctorArgs),
     /// Manage gajae-installed clawhip profiles.
     Profile {
         #[command(subcommand)]
@@ -501,6 +503,8 @@ pub enum GajaeCommands {
 pub enum GajaeProfileCommands {
     /// Install the clawhip profile through gajae.
     Install,
+    /// Verify the installed GAJAE clawhip profile and handler commands without executing routes.
+    Verify(GajaeProfileVerifyArgs),
     /// Inspect the installed GAJAE clawhip route profile without executing routes.
     Inspect(GajaeProfileFileArgs),
     /// Explain which GAJAE route would match an event without executing it.
@@ -540,6 +544,23 @@ pub struct GajaeProfileApplyArgs {
     /// Placeholder approval gate for future live apply support; does not enable execution yet.
     #[arg(long, default_value_t = false)]
     pub approve: bool,
+}
+
+#[derive(Debug, Clone, Default, Args)]
+pub struct GajaeDoctorArgs {
+    /// Optional owner/repo used to check whether GAJAE can produce a dry-run clawhip onboard plan.
+    #[arg(long)]
+    pub repo: Option<String>,
+    /// Read this profile/routes file instead of auto-discovering the installed GAJAE profile.
+    #[arg(long)]
+    pub file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Default, Args)]
+pub struct GajaeProfileVerifyArgs {
+    /// Read this profile/routes file instead of auto-discovering the installed GAJAE profile.
+    #[arg(long)]
+    pub file: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -522,17 +522,15 @@ fn load_profile_from_cwd(explicit_file: Option<&Path>, cwd: &Path) -> Result<Gaj
 }
 
 fn read_bounded_profile(path: &Path, description: &str) -> Result<String> {
-    let file = fs::File::open(path)
-        .with_context(|| format!("failed to read {description} {}", path.display()))?;
+    let file = fs::File::open(path).with_context(|| format!("failed to read {description}"))?;
     let mut bytes = Vec::new();
     file.take((MAX_PROFILE_BYTES + 1) as u64)
         .read_to_end(&mut bytes)
-        .with_context(|| format!("failed to read {description} {}", path.display()))?;
+        .with_context(|| format!("failed to read {description}"))?;
     if bytes.len() > MAX_PROFILE_BYTES {
         bail!("{description} exceeds maximum size of {MAX_PROFILE_BYTES} bytes");
     }
-    String::from_utf8(bytes)
-        .with_context(|| format!("{description} {} is not valid UTF-8", path.display()))
+    String::from_utf8(bytes).with_context(|| format!("{description} is not valid UTF-8"))
 }
 
 fn resolve_routes_file(routes_file: &Path, source: &Path, cwd: &Path) -> Result<PathBuf> {
@@ -1074,10 +1072,9 @@ fn check_gajae_help(
             true
         }
         Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
             checks.push(PreflightCheck::fail(
                 "gajae_help",
-                format!("gajae --help failed{}", concise_detail(&stderr)),
+                public_child_failure_detail("gajae --help", &output),
             ));
             false
         }
@@ -1184,9 +1181,9 @@ fn check_profile_and_handlers(
                 ));
             }
         }
-        Err(error) => checks.push(PreflightCheck::fail(
+        Err(_) => checks.push(PreflightCheck::fail(
             "profile",
-            format!("run `clawhip gajae profile install`: {error}"),
+            "profile could not be loaded or parsed; run `clawhip gajae profile install` or pass a readable --file profile",
         )),
     }
 }
@@ -1751,6 +1748,17 @@ fn bounded_public_string(raw: &str) -> String {
         out.push(safe);
     }
     out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn public_child_failure_detail(command: &str, output: &CommandOutput) -> String {
+    let reason = if !output.stderr.is_empty() {
+        "stderr produced"
+    } else if !output.stdout.is_empty() {
+        "unexpected stdout produced"
+    } else {
+        "no diagnostic output"
+    };
+    format!("{command} failed ({reason}); update GAJAE or check the configured GAJAE binary")
 }
 
 fn concise_detail(stderr: &str) -> String {

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -355,6 +355,17 @@ pub struct ProfileApplyOptions {
     pub approve: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct DoctorOptions {
+    pub repo: Option<String>,
+    pub file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ProfileVerifyOptions {
+    pub file: Option<PathBuf>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct GajaeRouteProfile {
     source: PathBuf,
@@ -1000,6 +1011,367 @@ fn run_status_with(
             bail!("gajae unavailable: set {GAJAE_ENV} or install `{GAJAE_PATH_NAME}` on PATH")
         }
         Err(error) => Err(error).with_context(|| format!("failed to run {} --help", bin.display())),
+    }
+}
+
+pub fn run_doctor(options: DoctorOptions) -> Result<()> {
+    let mut runner = StdCommandRunner;
+    run_doctor_with(&mut runner, |name| std::env::var_os(name), options)
+}
+
+fn run_doctor_with(
+    runner: &mut impl CommandRunner,
+    env_var: impl Fn(&str) -> Option<OsString>,
+    options: DoctorOptions,
+) -> Result<()> {
+    let bin = discover_gajae_with(env_var);
+    let mut checks = Vec::new();
+    if !check_gajae_help(runner, &bin, &mut checks) {
+        return finish_conformance("doctor", checks);
+    }
+    check_schema_capabilities(runner, &bin, &mut checks);
+    check_receipt_validators(runner, &bin, &mut checks);
+    check_profile_and_handlers(runner, &bin, options.file.as_deref(), &mut checks);
+    if let Some(repo) = options.repo.as_deref() {
+        check_onboard_plan(runner, &bin, repo, &mut checks);
+    } else {
+        checks.push(PreflightCheck::pass(
+            "onboard_plan",
+            "skipped; pass --repo owner/repo to verify dry-run plan support",
+        ));
+    }
+    finish_conformance("doctor", checks)
+}
+
+pub fn run_profile_verify(options: ProfileVerifyOptions) -> Result<()> {
+    let mut runner = StdCommandRunner;
+    run_profile_verify_with(&mut runner, |name| std::env::var_os(name), options)
+}
+
+fn run_profile_verify_with(
+    runner: &mut impl CommandRunner,
+    env_var: impl Fn(&str) -> Option<OsString>,
+    options: ProfileVerifyOptions,
+) -> Result<()> {
+    let bin = discover_gajae_with(env_var);
+    let mut checks = Vec::new();
+    if !check_gajae_help(runner, &bin, &mut checks) {
+        return finish_conformance("profile_verify", checks);
+    }
+    check_receipt_validators(runner, &bin, &mut checks);
+    check_profile_and_handlers(runner, &bin, options.file.as_deref(), &mut checks);
+    finish_conformance("profile_verify", checks)
+}
+
+fn check_gajae_help(
+    runner: &mut impl CommandRunner,
+    bin: &Path,
+    checks: &mut Vec<PreflightCheck>,
+) -> bool {
+    match runner.output(bin, &["--help"]) {
+        Ok(output) if output.success => {
+            checks.push(PreflightCheck::pass("gajae_help", "gajae --help succeeded"));
+            true
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            checks.push(PreflightCheck::fail(
+                "gajae_help",
+                format!("gajae --help failed{}", concise_detail(&stderr)),
+            ));
+            false
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            checks.push(PreflightCheck::fail(
+                "gajae_help",
+                format!("set {GAJAE_ENV} or install `{GAJAE_PATH_NAME}` on PATH"),
+            ));
+            false
+        }
+        Err(error) => {
+            checks.push(PreflightCheck::fail(
+                "gajae_help",
+                format!("failed to run gajae --help: {error}"),
+            ));
+            false
+        }
+    }
+}
+
+fn check_schema_capabilities(
+    runner: &mut impl CommandRunner,
+    bin: &Path,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    let args = ["schema", "list", "--capabilities"];
+    match runner.output_with_stdin(bin, &args, None) {
+        Ok(output) if output.success => {
+            let missing = missing_receipt_families(&output.stdout);
+            if missing.is_empty() {
+                checks.push(PreflightCheck::pass(
+                    "schema_capabilities",
+                    "required receipt families advertised",
+                ));
+            } else {
+                checks.push(PreflightCheck::fail(
+                    "schema_capabilities",
+                    format!("missing receipt families: {}", missing.join(", ")),
+                ));
+            }
+        }
+        Ok(_) => checks.push(PreflightCheck::fail(
+            "schema_capabilities",
+            "`gajae schema list --capabilities` failed",
+        )),
+        Err(error) => checks.push(PreflightCheck::fail(
+            "schema_capabilities",
+            format!("`gajae schema list --capabilities` unavailable: {error}"),
+        )),
+    }
+}
+
+fn check_receipt_validators(
+    runner: &mut impl CommandRunner,
+    bin: &Path,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    for family in REQUIRED_RECEIPT_FAMILIES {
+        let args = [*family, "validate", "--help"];
+        match runner.output_with_stdin(bin, &args, None) {
+            Ok(output) if output.success => checks.push(PreflightCheck::pass(
+                "receipt_validator",
+                format!("{family} validate available"),
+            )),
+            Ok(_) => checks.push(PreflightCheck::fail(
+                "receipt_validator",
+                format!("{family} validate missing; update GAJAE or profile family mapping"),
+            )),
+            Err(error) => checks.push(PreflightCheck::fail(
+                "receipt_validator",
+                format!("{family} validate unavailable: {error}"),
+            )),
+        }
+    }
+}
+
+fn check_profile_and_handlers(
+    runner: &mut impl CommandRunner,
+    bin: &Path,
+    explicit_file: Option<&Path>,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    match load_profile(explicit_file) {
+        Ok(profile) => {
+            checks.push(PreflightCheck::pass(
+                "profile",
+                format!("loaded {} routes", profile.routes.len()),
+            ));
+            let validation = validate_profile(&profile);
+            if validation.is_clean() {
+                checks.push(PreflightCheck::pass(
+                    "profile_routes",
+                    format!("{} supported routes", profile.routes.len()),
+                ));
+                check_handler_commands(runner, bin, &profile, checks);
+                check_profile_safety(&profile, checks);
+            } else {
+                checks.push(PreflightCheck::fail(
+                    "profile_routes",
+                    format!(
+                        "{}; rerun `clawhip gajae profile install` for current handler names",
+                        profile_validation_summary(&validation)
+                    ),
+                ));
+            }
+        }
+        Err(error) => checks.push(PreflightCheck::fail(
+            "profile",
+            format!("run `clawhip gajae profile install`: {error}"),
+        )),
+    }
+}
+
+fn check_handler_commands(
+    runner: &mut impl CommandRunner,
+    bin: &Path,
+    profile: &GajaeRouteProfile,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    let mut commands = profile
+        .routes
+        .iter()
+        .filter_map(|(event, command)| handler_probe_args(command, event))
+        .collect::<Vec<_>>();
+    commands.sort();
+    commands.dedup();
+    if commands.is_empty() {
+        checks.push(PreflightCheck::fail(
+            "handler_command",
+            "no supported GAJAE handler commands found in profile",
+        ));
+        return;
+    }
+    for args in commands {
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        match runner.output_with_stdin(bin, &arg_refs, None) {
+            Ok(output) if output.success => checks.push(PreflightCheck::pass(
+                "handler_command",
+                format!("{} available", handler_probe_summary(&args)),
+            )),
+            Ok(_) => checks.push(PreflightCheck::fail(
+                "handler_command",
+                format!(
+                    "{} missing or renamed; rerun `clawhip gajae profile install` with current GAJAE",
+                    handler_probe_summary(&args)
+                ),
+            )),
+            Err(error) => checks.push(PreflightCheck::fail(
+                "handler_command",
+                format!("{} unavailable: {error}", handler_probe_summary(&args)),
+            )),
+        }
+    }
+}
+
+fn check_profile_safety(profile: &GajaeRouteProfile, checks: &mut Vec<PreflightCheck>) {
+    if profile.public_safe_output == Some(true) {
+        checks.push(PreflightCheck::pass(
+            "public_safe_output",
+            "public-safe output mode enabled",
+        ));
+    } else {
+        checks.push(PreflightCheck::fail(
+            "public_safe_output",
+            "run `clawhip gajae profile install` to enable public-safe output mode",
+        ));
+    }
+    if profile.raw_payload_export == Some(false) {
+        checks.push(PreflightCheck::pass(
+            "raw_payload_export",
+            "raw payload export disabled",
+        ));
+    } else {
+        checks.push(PreflightCheck::fail(
+            "raw_payload_export",
+            "run `clawhip gajae profile install` with no raw-payload export required",
+        ));
+    }
+}
+
+fn check_onboard_plan(
+    runner: &mut impl CommandRunner,
+    bin: &Path,
+    repo: &str,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    if !valid_repo_label(repo) {
+        checks.push(PreflightCheck::fail(
+            "onboard_plan",
+            "repo must be public owner/repo syntax",
+        ));
+        return;
+    }
+    let args = [
+        "operator",
+        "onboard",
+        "plan",
+        "--repo",
+        repo,
+        "--router",
+        "clawhip",
+        "--dry-run",
+    ];
+    match runner.output_with_stdin(bin, &args, None) {
+        Ok(output) if output.success => checks.push(PreflightCheck::pass(
+            "onboard_plan",
+            "dry-run clawhip onboard plan available",
+        )),
+        Ok(_) => checks.push(PreflightCheck::fail(
+            "onboard_plan",
+            "dry-run clawhip onboard plan unavailable; update GAJAE operator onboard support",
+        )),
+        Err(error) => checks.push(PreflightCheck::fail(
+            "onboard_plan",
+            format!("dry-run clawhip onboard plan unavailable: {error}"),
+        )),
+    }
+}
+
+fn missing_receipt_families(stdout: &[u8]) -> Vec<&'static str> {
+    let text = String::from_utf8_lossy(stdout);
+    REQUIRED_RECEIPT_FAMILIES
+        .iter()
+        .copied()
+        .filter(|family| !text.contains(family))
+        .collect()
+}
+
+fn handler_probe_args(command: &str, event: &str) -> Option<Vec<String>> {
+    if command == format!("gajae handle {event}") {
+        Some(vec!["handle".into(), event.into(), "--help".into()])
+    } else if command == format!("gajae runtime handle --router clawhip --event {event}") {
+        Some(vec![
+            "runtime".into(),
+            "handle".into(),
+            "--router".into(),
+            "clawhip".into(),
+            "--event".into(),
+            event.into(),
+            "--help".into(),
+        ])
+    } else {
+        None
+    }
+}
+
+fn handler_probe_summary(args: &[String]) -> String {
+    if args.first().map(String::as_str) == Some("runtime") {
+        "runtime handle --router clawhip".to_string()
+    } else {
+        "handle <event>".to_string()
+    }
+}
+
+fn valid_repo_label(repo: &str) -> bool {
+    let Some((owner, name)) = repo.split_once('/') else {
+        return false;
+    };
+    !owner.is_empty()
+        && !name.is_empty()
+        && !name.contains('/')
+        && owner.bytes().all(is_repo_label_byte)
+        && name.bytes().all(is_repo_label_byte)
+}
+
+fn is_repo_label_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+}
+
+fn finish_conformance(kind: &'static str, checks: Vec<PreflightCheck>) -> Result<()> {
+    let conformant = checks.iter().all(|check| check.status == "pass");
+    let failures = checks
+        .iter()
+        .filter(|check| check.status == "fail")
+        .map(|check| json!({"check": check.name, "detail": check.detail}))
+        .collect::<Vec<_>>();
+    let checks_json = checks
+        .iter()
+        .map(|check| json!({"check": check.name, "status": check.status, "detail": check.detail}))
+        .collect::<Vec<_>>();
+    println!(
+        "{}",
+        serde_json::to_string(&json!({
+            "kind": kind,
+            "conformant": conformant,
+            "checks": checks_json,
+            "failures": failures,
+            "next_step": if conformant { Value::Null } else { json!("fix failed checks; reinstall the clawhip GAJAE profile with `clawhip gajae profile install` when handler names drift") },
+        }))?
+    );
+    if conformant {
+        Ok(())
+    } else {
+        bail!("GAJAE conformance diagnostics failed")
     }
 }
 pub fn run_preflight() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,6 +357,10 @@ async fn real_main(cli: Cli) -> Result<()> {
         Commands::Gajae { command } => match command {
             GajaeCommands::Status => Ok(gajae::run(gajae::GajaeCommand::Status)?),
             GajaeCommands::Preflight => Ok(gajae::run_preflight()?),
+            GajaeCommands::Doctor(args) => Ok(gajae::run_doctor(gajae::DoctorOptions {
+                repo: args.repo,
+                file: args.file,
+            })?),
             GajaeCommands::Profile { command } => match command {
                 GajaeProfileCommands::Install => {
                     let status = gajae::run_profile_install()?;
@@ -369,6 +373,11 @@ async fn real_main(cli: Cli) -> Result<()> {
                         );
                         std::process::exit(status.code.unwrap_or(1));
                     }
+                }
+                GajaeProfileCommands::Verify(args) => {
+                    Ok(gajae::run_profile_verify(gajae::ProfileVerifyOptions {
+                        file: args.file,
+                    })?)
                 }
                 GajaeProfileCommands::Inspect(args) => {
                     Ok(gajae::run_profile_inspect(gajae::ProfileInspectOptions {

--- a/tests/gajae_profile_install_stdin.rs
+++ b/tests/gajae_profile_install_stdin.rs
@@ -220,6 +220,96 @@ fn gajae_profile_verify_reports_missing_gajae_public_safely() {
 }
 
 #[test]
+fn gajae_doctor_redacts_failed_help_stderr_from_json_detail() {
+    let temp = TempDir::new().expect("tempdir");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "--help" ]]; then
+  printf '/home/operator/private token secret-token-123\n' >&2
+  exit 64
+fi
+exit 64
+"#,
+    );
+
+    let output = Command::new(clawhip_bin())
+        .args(["gajae", "doctor"])
+        .env("GAJAE_BIN", &stub)
+        .output()
+        .expect("run doctor");
+
+    assert!(!output.status.success());
+    let summary: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json summary");
+    assert_eq!(summary["kind"], "doctor");
+    assert_eq!(summary["conformant"], false);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("gajae --help failed"), "stdout={stdout}");
+    assert!(
+        stdout.contains("check the configured GAJAE binary"),
+        "stdout={stdout}"
+    );
+    assert!(!stdout.contains("/home/operator"), "stdout={stdout}");
+    assert!(!stdout.contains("secret-token"), "stdout={stdout}");
+    assert!(!stdout.contains("private token"), "stdout={stdout}");
+    assert!(
+        !stdout.contains("token secret-token-123"),
+        "stdout={stdout}"
+    );
+    assert!(stdout.len() < 1_200, "stdout too long: {}", stdout.len());
+}
+
+#[test]
+fn gajae_profile_verify_redacts_missing_private_file_path() {
+    let temp = TempDir::new().expect("tempdir");
+    let private_profile = temp.path().join("home/operator/secret/profile.yml");
+    let explicit_path = private_profile.to_string_lossy().into_owned();
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "--help" ]]; then
+  exit 0
+fi
+if [[ "${2:-}" == "validate" && "${3:-}" == "--help" ]]; then
+  exit 0
+fi
+exit 64
+"#,
+    );
+
+    let output = Command::new(clawhip_bin())
+        .args(["gajae", "profile", "verify", "--file", &explicit_path])
+        .env("GAJAE_BIN", &stub)
+        .output()
+        .expect("run verify");
+
+    assert!(!output.status.success());
+    let summary: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json summary");
+    assert_eq!(summary["kind"], "profile_verify");
+    assert_eq!(summary["conformant"], false);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("profile could not be loaded or parsed"),
+        "stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("clawhip gajae profile install"),
+        "stdout={stdout}"
+    );
+    assert!(!stdout.contains("/home/operator"), "stdout={stdout}");
+    assert!(
+        !stdout.contains("home/operator/secret/profile.yml"),
+        "stdout={stdout}"
+    );
+    assert!(!stdout.contains(&explicit_path), "stdout={stdout}");
+    assert!(!stdout.contains("secret-token"), "stdout={stdout}");
+    assert!(!stdout.contains("profile.yml"), "stdout={stdout}");
+    assert!(stdout.len() < 2_000, "stdout too long: {}", stdout.len());
+}
+
+#[test]
 fn gajae_profile_verify_reports_renamed_handler_without_installing() {
     let temp = TempDir::new().expect("tempdir");
     let profile = temp.path().join("profile.yml");

--- a/tests/gajae_profile_install_stdin.rs
+++ b/tests/gajae_profile_install_stdin.rs
@@ -110,6 +110,235 @@ exit 64
 }
 
 #[test]
+fn gajae_doctor_succeeds_with_fake_gajae_without_mutating_profile() {
+    let temp = TempDir::new().expect("tempdir");
+    let profile = temp.path().join("profile.yml");
+    fs::write(
+        &profile,
+        r#"
+profile: gajae
+safety:
+  publicSafeOutput: true
+  rawPayloadExport: false
+routes:
+  github.issue-opened:
+    command: gajae handle github.issue-opened
+  session.started:
+    command: gajae runtime handle --router clawhip --event session.started
+"#,
+    )
+    .expect("write profile");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GAJAE_ARG_LOG"
+if IFS= read -r inherited_input; then
+  printf 'unexpected stdin: %s\n' "$inherited_input" >&2
+  exit 66
+fi
+if [[ "$1" == "--help" ]]; then
+  exit 0
+fi
+if [[ "$1" == "schema" && "${2:-}" == "list" && "${3:-}" == "--capabilities" ]]; then
+  printf 'runtime-followup-receipt mutation-plan review-verdict-evidence merge-hold-decision\n'
+  exit 0
+fi
+if [[ "${2:-}" == "validate" && "${3:-}" == "--help" ]]; then
+  exit 0
+fi
+if [[ "$1" == "handle" && "${3:-}" == "--help" ]]; then
+  exit 0
+fi
+if [[ "$1" == "runtime" && "${2:-}" == "handle" && "${3:-}" == "--router" && "${4:-}" == "clawhip" && "${5:-}" == "--event" && "${7:-}" == "--help" ]]; then
+  exit 0
+fi
+if [[ "$1" == "operator" && "${2:-}" == "onboard" && "${3:-}" == "plan" && "${4:-}" == "--repo" && "${6:-}" == "--router" && "${7:-}" == "clawhip" && "${8:-}" == "--dry-run" ]]; then
+  exit 0
+fi
+exit 64
+"#,
+    );
+
+    let output = Command::new(clawhip_bin())
+        .args([
+            "gajae",
+            "doctor",
+            "--file",
+            profile.to_str().expect("profile path"),
+            "--repo",
+            "owner/repo",
+        ])
+        .env("GAJAE_BIN", &stub)
+        .env("GAJAE_ARG_LOG", temp.path().join("gajae.args"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn doctor")
+        .wait_with_output()
+        .expect("wait doctor");
+
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let summary: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json summary");
+    assert_eq!(summary["kind"], "doctor");
+    assert_eq!(summary["conformant"], true);
+    let args = fs::read_to_string(temp.path().join("gajae.args")).expect("arg log");
+    assert!(args.contains("--help\n"));
+    assert!(args.contains("schema list --capabilities\n"));
+    assert!(args.contains("operator onboard plan --repo owner/repo --router clawhip --dry-run\n"));
+    assert!(
+        !args.contains("profile install"),
+        "doctor must not mutate profile: {args}"
+    );
+}
+
+#[test]
+fn gajae_profile_verify_reports_missing_gajae_public_safely() {
+    let temp = TempDir::new().expect("tempdir");
+    let missing = temp.path().join("missing-gajae");
+
+    let output = Command::new(clawhip_bin())
+        .args(["gajae", "profile", "verify"])
+        .env("GAJAE_BIN", &missing)
+        .output()
+        .expect("run verify");
+
+    assert!(!output.status.success());
+    let summary: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json summary");
+    assert_eq!(summary["kind"], "profile_verify");
+    assert_eq!(summary["conformant"], false);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("gajae_help"), "stdout={stdout}");
+    assert!(!stdout.contains("secret"), "stdout={stdout}");
+    assert!(stdout.len() < 1_000, "stdout too long: {}", stdout.len());
+}
+
+#[test]
+fn gajae_profile_verify_reports_renamed_handler_without_installing() {
+    let temp = TempDir::new().expect("tempdir");
+    let profile = temp.path().join("profile.yml");
+    fs::write(
+        &profile,
+        r#"
+profile: gajae
+safety:
+  publicSafeOutput: true
+  rawPayloadExport: false
+routes:
+  github.issue-opened:
+    command: gajae handle github.issue-opened
+"#,
+    )
+    .expect("write profile");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GAJAE_ARG_LOG"
+if [[ "$1" == "--help" ]]; then
+  exit 0
+fi
+if [[ "${2:-}" == "validate" && "${3:-}" == "--help" ]]; then
+  exit 0
+fi
+if [[ "$1" == "handle" ]]; then
+  printf '/home/operator/secret/profile command renamed and no longer exists %0500d\n' 1 >&2
+  exit 64
+fi
+exit 64
+"#,
+    );
+
+    let output = Command::new(clawhip_bin())
+        .args([
+            "gajae",
+            "profile",
+            "verify",
+            "--file",
+            profile.to_str().expect("profile path"),
+        ])
+        .env("GAJAE_BIN", &stub)
+        .env("GAJAE_ARG_LOG", temp.path().join("gajae.args"))
+        .output()
+        .expect("run verify");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("missing or renamed"), "stdout={stdout}");
+    assert!(!stdout.contains("/home/operator/secret"), "stdout={stdout}");
+    assert!(stdout.len() < 2_000, "stdout too long: {}", stdout.len());
+    let args = fs::read_to_string(temp.path().join("gajae.args")).expect("arg log");
+    assert!(args.contains("handle github.issue-opened --help\n"));
+    assert!(
+        !args.contains("profile install"),
+        "verify must not mutate profile: {args}"
+    );
+}
+
+#[test]
+fn gajae_profile_verify_reports_mismatched_profile_without_raw_command_leak() {
+    let temp = TempDir::new().expect("tempdir");
+    let profile = temp.path().join("profile.yml");
+    fs::write(
+        &profile,
+        r#"
+profile: gajae
+safety:
+  publicSafeOutput: true
+  rawPayloadExport: false
+routes:
+  github.issue-opened:
+    command: gajae renamed-handler github.issue-opened --token secret-token-123
+"#,
+    )
+    .expect("write profile");
+    let stub = gajae_stub(
+        &temp,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GAJAE_ARG_LOG"
+if [[ "$1" == "--help" ]]; then
+  exit 0
+fi
+if [[ "${2:-}" == "validate" && "${3:-}" == "--help" ]]; then
+  exit 0
+fi
+exit 64
+"#,
+    );
+
+    let output = Command::new(clawhip_bin())
+        .args([
+            "gajae",
+            "profile",
+            "verify",
+            "--file",
+            profile.to_str().expect("profile path"),
+        ])
+        .env("GAJAE_BIN", &stub)
+        .env("GAJAE_ARG_LOG", temp.path().join("gajae.args"))
+        .output()
+        .expect("run verify");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("unsupported commands"), "stdout={stdout}");
+    assert!(!stdout.contains("secret-token-123"), "stdout={stdout}");
+    assert!(!stdout.contains("renamed-handler"), "stdout={stdout}");
+    let args = fs::read_to_string(temp.path().join("gajae.args")).expect("arg log");
+    assert!(
+        !args.contains("profile install"),
+        "verify must not mutate profile: {args}"
+    );
+}
+
+#[test]
 fn gajae_profile_install_does_not_forward_parent_stdin() {
     let temp = TempDir::new().expect("tempdir");
     let stub = gajae_stub(


### PR DESCRIPTION
Closes #253.\n\n## Summary\n- add `clawhip gajae doctor` for bounded GAJAE CLI/profile diagnostics with optional dry-run onboard plan check\n- add `clawhip gajae profile verify` for non-mutating profile and handler command drift checks\n- cover success, missing GAJAE, mismatched profile, renamed handler, and no live profile mutation with fake GAJAE tests\n- preserve #257 preflight behavior/docs and document the new safe diagnostics\n\n## Verification\n- `cargo fmt`\n- `cargo test --package clawhip --test gajae_profile_install_stdin`\n- `cargo test --package clawhip`\n- `cargo clippy --package clawhip --all-targets -- -D warnings`