### PR TITLE
Add GAJAE approval hold events

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,8 @@ pub struct GajaeConfig {
     pub handler_timeout_ms: u64,
     #[serde(default = "default_gajae_handler_max_output_bytes")]
     pub handler_max_output_bytes: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hold_target_channel: Option<String>,
 }
 
 impl Default for GajaeConfig {
@@ -53,6 +55,7 @@ impl Default for GajaeConfig {
             handlers_enabled: false,
             handler_timeout_ms: default_gajae_handler_timeout_ms(),
             handler_max_output_bytes: default_gajae_handler_max_output_bytes(),
+            hold_target_channel: None,
         }
     }
 }
@@ -62,6 +65,7 @@ impl GajaeConfig {
         !self.handlers_enabled
             && self.handler_timeout_ms == default_gajae_handler_timeout_ms()
             && self.handler_max_output_bytes == default_gajae_handler_max_output_bytes()
+            && self.hold_target_channel.is_none()
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -959,6 +959,28 @@ async fn list_tmux(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
+fn gajae_hold_target(config: &AppConfig, repo: &str) -> Option<String> {
+    config
+        .routes
+        .iter()
+        .filter(|route| {
+            matches!(
+                route.event.as_str(),
+                "gajae.release.hold" | "gajae.merge.hold" | "gajae.*"
+            )
+        })
+        .find(|route| {
+            route.filter.is_empty()
+                || route
+                    .filter
+                    .get("repo")
+                    .or_else(|| route.filter.get("repo_name"))
+                    .is_some_and(|expected| crate::router::glob_match(expected, repo))
+        })
+        .and_then(|route| route.channel.clone().or_else(|| route.thread.clone()))
+        .or_else(|| config.gajae.hold_target_channel.clone())
+}
+
 async fn post_github(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -1022,6 +1044,21 @@ async fn post_github(
                 .pointer("/sender/login")
                 .and_then(Value::as_str)
                 .map(ToString::to_string);
+            if let Some(target) = gajae_hold_target(&state.config, &repo) {
+                return enqueue_accepted_event(
+                    &state,
+                    IncomingEvent::gajae_release_hold(
+                        repo,
+                        target,
+                        action.to_string(),
+                        tag,
+                        format!("publish or retag release {action}"),
+                        "release and retag boundaries require owner/maintainer approval; autonomous execution cannot create, edit, publish, or retag releases".to_string(),
+                        actor,
+                    ),
+                )
+                .await;
+            }
 
             Some(normalize_event(IncomingEvent::github_release(
                 action,
@@ -1055,6 +1092,47 @@ async fn post_github(
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string();
+            let merged = payload
+                .pointer("/pull_request/merged")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let base_ref = payload
+                .pointer("/pull_request/base/ref")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let merge_sha = payload
+                .pointer("/pull_request/merge_commit_sha")
+                .and_then(Value::as_str)
+                .or_else(|| {
+                    payload
+                        .pointer("/pull_request/head/sha")
+                        .and_then(Value::as_str)
+                })
+                .unwrap_or_default()
+                .to_string();
+            let actor = payload
+                .pointer("/sender/login")
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+            if action == "closed"
+                && merged
+                && matches!(base_ref, "main" | "master")
+                && let Some(target) = gajae_hold_target(&state.config, &repo)
+            {
+                return enqueue_accepted_event(
+                    &state,
+                    IncomingEvent::gajae_merge_hold(
+                        repo,
+                        target,
+                        "merge-to-main".to_string(),
+                        merge_sha,
+                        format!("merge pull request #{number} into {base_ref}"),
+                        "main branch merge boundaries require owner/maintainer approval; autonomous execution cannot merge directly to main".to_string(),
+                        actor,
+                    ),
+                )
+                .await;
+            }
             match action {
                 "opened" => Some(normalize_event(IncomingEvent::github_pr_status_changed(
                     repo,
@@ -1207,6 +1285,46 @@ mod tests {
             },
             rx,
         )
+    }
+
+    fn app_state_with_config(config: AppConfig) -> (AppState, mpsc::Receiver<IncomingEvent>) {
+        let (tx, rx) = mpsc::channel(8);
+        (
+            AppState {
+                config: Arc::new(config),
+                port: 25294,
+                tx,
+                tmux_registry: Arc::new(RwLock::new(HashMap::new())),
+                pending_update: update::new_shared_pending_update(),
+                native_observability: new_shared_native_hook_observability(),
+                cron_state_path: PathBuf::from("cron-state.json"),
+                discord_watch_lock: Arc::new(Mutex::new(())),
+            },
+            rx,
+        )
+    }
+
+    fn hold_config() -> AppConfig {
+        AppConfig {
+            gajae: crate::config::GajaeConfig {
+                hold_target_channel: Some("owner-maintainer".into()),
+                ..crate::config::GajaeConfig::default()
+            },
+            defaults: crate::config::DefaultsConfig {
+                channel: Some("general-zero-backlog".into()),
+                ..crate::config::DefaultsConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "gajae.*".into(),
+                filter: std::collections::BTreeMap::from([(
+                    "repo".into(),
+                    "Yeachan-Heo/clawhip".into(),
+                )]),
+                channel: Some("owner-maintainer".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        }
     }
 
     fn tmux_registration(session: &str) -> RegisteredTmuxSession {
@@ -1364,6 +1482,116 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let response_json: Value = serde_json::from_slice(&body).unwrap();
         (response_json, rx)
+    }
+
+    #[tokio::test]
+    async fn github_release_retag_routes_to_gajae_hold_without_release_event() {
+        let (state, mut rx) = app_state_with_config(hold_config());
+        let mut headers = HeaderMap::new();
+        headers.insert("x-github-event", "release".parse().unwrap());
+        let payload = json!({
+            "action": "edited",
+            "repository": {"full_name": "Yeachan-Heo/clawhip"},
+            "release": {
+                "tag_name": "v0.6.9",
+                "name": "clawhip 0.6.9",
+                "prerelease": false,
+                "html_url": "https://github.com/Yeachan-Heo/clawhip/releases/tag/v0.6.9"
+            },
+            "sender": {"login": "maintainer"}
+        });
+
+        let response = post_github(State(state), headers, Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let queued = rx.recv().await.expect("queued hold");
+
+        assert_eq!(queued.kind, "gajae.release.hold");
+        assert_eq!(queued.channel.as_deref(), Some("owner-maintainer"));
+        assert_ne!(queued.channel.as_deref(), Some("general-zero-backlog"));
+        assert_eq!(queued.payload["repo"], json!("Yeachan-Heo/clawhip"));
+        assert_eq!(queued.payload["target"], json!("owner-maintainer"));
+        assert_eq!(queued.payload["action"], json!("edited"));
+        assert_eq!(queued.payload["version"], json!("v0.6.9"));
+        assert_eq!(
+            queued.payload["dedupe_key"],
+            json!("Yeachan-Heo/clawhip:owner-maintainer:edited:v0.6.9")
+        );
+        assert_eq!(queued.payload["autonomous_execution_allowed"], json!(false));
+        assert_eq!(queued.payload["held_action_executed"], json!(false));
+        assert!(
+            queued.payload["disallowed_action"]
+                .as_str()
+                .unwrap()
+                .contains("release")
+        );
+        assert!(
+            queued.payload["why_autonomous_disallowed"]
+                .as_str()
+                .unwrap()
+                .contains("approval")
+        );
+        assert!(queued.payload.get("raw").is_none());
+    }
+
+    #[tokio::test]
+    async fn github_main_merge_routes_to_gajae_hold_without_merge_event() {
+        let (state, mut rx) = app_state_with_config(hold_config());
+        let mut headers = HeaderMap::new();
+        headers.insert("x-github-event", "pull_request".parse().unwrap());
+        let payload = json!({
+            "action": "closed",
+            "repository": {"full_name": "Yeachan-Heo/clawhip"},
+            "number": 252,
+            "pull_request": {
+                "number": 252,
+                "title": "approval hold events",
+                "html_url": "https://github.com/Yeachan-Heo/clawhip/pull/252",
+                "merged": true,
+                "merge_commit_sha": "0123456789abcdef0123456789abcdef01234567",
+                "base": {"ref": "main"},
+                "head": {"sha": "abcdef0123456789abcdef0123456789abcdef01"}
+            },
+            "sender": {"login": "maintainer"}
+        });
+
+        let response = post_github(State(state), headers, Json(payload))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let queued = rx.recv().await.expect("queued hold");
+
+        assert_eq!(queued.kind, "gajae.merge.hold");
+        assert_eq!(queued.channel.as_deref(), Some("owner-maintainer"));
+        assert_eq!(queued.payload["repo"], json!("Yeachan-Heo/clawhip"));
+        assert_eq!(queued.payload["target"], json!("owner-maintainer"));
+        assert_eq!(queued.payload["action"], json!("merge-to-main"));
+        assert_eq!(
+            queued.payload["sha"],
+            json!("0123456789abcdef0123456789abcdef01234567")
+        );
+        assert_eq!(
+            queued.payload["dedupe_key"],
+            json!(
+                "Yeachan-Heo/clawhip:owner-maintainer:merge-to-main:0123456789abcdef0123456789abcdef01234567"
+            )
+        );
+        assert_eq!(queued.payload["autonomous_execution_allowed"], json!(false));
+        assert_eq!(queued.payload["held_action_executed"], json!(false));
+        assert!(
+            queued.payload["disallowed_action"]
+                .as_str()
+                .unwrap()
+                .contains("merge pull request #252 into main")
+        );
+        assert!(
+            queued.payload["why_autonomous_disallowed"]
+                .as_str()
+                .unwrap()
+                .contains("approval")
+        );
+        assert!(queued.payload.get("raw").is_none());
     }
 
     fn insert_timestamp_at_path(payload: &mut Value, path: &[&str], value: String) {

--- a/src/event/compat.rs
+++ b/src/event/compat.rs
@@ -65,6 +65,12 @@ fn body_for(kind: &str, payload: &Value) -> Result<EventBody> {
         "github.release-edited" => Ok(EventBody::GitHubReleaseEdited(github_release_event(
             payload,
         )?)),
+        "gajae.release.hold" | "gajae.merge.hold" => Ok(EventBody::Custom(CustomEvent {
+            kind: kind.to_string(),
+            message: optional_string_field(payload, "disallowed_action")
+                .unwrap_or_else(|| kind.to_string()),
+            payload: Some(payload.clone()),
+        })),
         "discord.message-create" => Ok(EventBody::DiscordMessageCreate(serde_json::from_value(
             payload.clone(),
         )?)),
@@ -410,7 +416,10 @@ fn priority_for(kind: &str, payload: &Value) -> EventPriority {
         | "session.stopped"
         | "tmux.stale"
         | "workspace.session.blocked" => EventPriority::High,
-        "github.release-published" | "github.release-prereleased" => EventPriority::High,
+        "github.release-published"
+        | "github.release-prereleased"
+        | "gajae.release.hold"
+        | "gajae.merge.hold" => EventPriority::High,
         "github.pr-status-changed"
             if optional_string_field(payload, "new_status")
                 .map(|status| status == "merged" || status == "closed")
@@ -852,5 +861,34 @@ mod tests {
         let envelope = from_incoming_event(&event).unwrap();
         assert_eq!(envelope.metadata.priority, EventPriority::Normal);
         assert!(matches!(envelope.body, EventBody::GitHubReleaseEdited(_)));
+    }
+
+    #[test]
+    fn maps_gajae_hold_event_as_high_priority_custom_event() {
+        let event = IncomingEvent::gajae_release_hold(
+            "Yeachan-Heo/clawhip".into(),
+            "owner-maintainer".into(),
+            "edited".into(),
+            "v0.6.9".into(),
+            "publish or retag release edited".into(),
+            "release boundaries require approval".into(),
+            Some("maintainer".into()),
+        );
+
+        let envelope = from_incoming_event(&event).unwrap();
+        assert_eq!(envelope.source, "gajae");
+        assert_eq!(
+            envelope.metadata.channel_hint.as_deref(),
+            Some("owner-maintainer")
+        );
+        assert_eq!(envelope.metadata.priority, EventPriority::High);
+        match envelope.body {
+            EventBody::Custom(body) => {
+                assert_eq!(body.kind, "gajae.release.hold");
+                assert_eq!(body.message, "publish or retag release edited");
+                assert_eq!(body.payload.unwrap()["held_action_executed"], json!(false));
+            }
+            other => panic!("expected Custom, got {other:?}"),
+        }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -520,6 +520,102 @@ impl IncomingEvent {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn gajae_release_hold(
+        repo: String,
+        target: String,
+        action: String,
+        version: String,
+        disallowed_action: String,
+        why_autonomous_disallowed: String,
+        actor: Option<String>,
+    ) -> Self {
+        Self::gajae_hold(
+            "gajae.release.hold",
+            repo,
+            target,
+            action,
+            "release".to_string(),
+            Some(version),
+            None,
+            disallowed_action,
+            why_autonomous_disallowed,
+            actor,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn gajae_merge_hold(
+        repo: String,
+        target: String,
+        action: String,
+        sha: String,
+        disallowed_action: String,
+        why_autonomous_disallowed: String,
+        actor: Option<String>,
+    ) -> Self {
+        Self::gajae_hold(
+            "gajae.merge.hold",
+            repo,
+            target,
+            action,
+            "main-merge".to_string(),
+            None,
+            Some(sha),
+            disallowed_action,
+            why_autonomous_disallowed,
+            actor,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn gajae_hold(
+        kind: &str,
+        repo: String,
+        target: String,
+        action: String,
+        boundary: String,
+        version: Option<String>,
+        sha: Option<String>,
+        disallowed_action: String,
+        why_autonomous_disallowed: String,
+        actor: Option<String>,
+    ) -> Self {
+        let relevant_ref = version.as_deref().or(sha.as_deref()).unwrap_or_default();
+        let dedupe_key = gajae_hold_dedupe_key(&repo, &target, &action, relevant_ref);
+        let mut payload = Map::new();
+        payload.insert("repo".to_string(), json!(repo));
+        payload.insert("target".to_string(), json!(target.clone()));
+        payload.insert("action".to_string(), json!(action));
+        payload.insert("boundary".to_string(), json!(boundary));
+        payload.insert("disallowed_action".to_string(), json!(disallowed_action));
+        payload.insert(
+            "why_autonomous_disallowed".to_string(),
+            json!(why_autonomous_disallowed),
+        );
+        payload.insert("autonomous_execution_allowed".to_string(), json!(false));
+        payload.insert("held_action_executed".to_string(), json!(false));
+        payload.insert("dedupe_key".to_string(), json!(dedupe_key));
+        if let Some(version) = version {
+            payload.insert("version".to_string(), json!(version));
+        }
+        if let Some(sha) = sha {
+            payload.insert("sha".to_string(), json!(sha));
+        }
+        if let Some(actor) = actor {
+            payload.insert("actor".to_string(), json!(actor));
+        }
+
+        Self {
+            kind: kind.to_string(),
+            channel: Some(target),
+            mention: None,
+            format: Some(MessageFormat::Compact),
+            template: None,
+            payload: Value::Object(payload),
+        }
+    }
+
     #[allow(dead_code)]
     pub fn discord_message_create(message: DiscordMessageCreateEvent) -> Self {
         Self {
@@ -1076,6 +1172,16 @@ fn normalize_native_metadata(payload: &mut Value, raw_kind: &str, canonical_kind
     insert_string_if_missing(object, "event_timestamp", event_timestamp);
     insert_string_if_missing(object, "route_key", route_key);
     insert_string_if_missing(object, "source", source);
+}
+
+fn gajae_hold_dedupe_key(repo: &str, target: &str, action: &str, relevant_ref: &str) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        repo.trim(),
+        target.trim(),
+        action.trim(),
+        relevant_ref.trim()
+    )
 }
 
 fn now_rfc3339() -> String {

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -233,6 +233,24 @@ impl Renderer for DefaultRenderer {
                 MessageFormat::Raw,
             ) => serde_json::to_string_pretty(payload)?,
 
+            ("gajae.release.hold" | "gajae.merge.hold", MessageFormat::Compact) => {
+                render_gajae_hold(payload, event.canonical_kind())?
+            }
+            ("gajae.release.hold" | "gajae.merge.hold", MessageFormat::Alert) => {
+                format!("🚨 {}", render_gajae_hold(payload, event.canonical_kind())?)
+            }
+            ("gajae.release.hold" | "gajae.merge.hold", MessageFormat::Inline) => {
+                let repo = string_field(payload, "repo")?;
+                let action = string_field(payload, "action")?;
+                let relevant = optional_string_field(payload, "version")
+                    .or_else(|| optional_string_field(payload, "sha"))
+                    .unwrap_or_default();
+                format!("[gajae hold] {repo} {action} {relevant}")
+            }
+            ("gajae.release.hold" | "gajae.merge.hold", MessageFormat::Raw) => {
+                serde_json::to_string_pretty(payload)?
+            }
+
             (
                 "github.release-published" | "github.release-prereleased" | "github.release-edited",
                 MessageFormat::Compact,
@@ -654,6 +672,30 @@ fn render_github_release(payload: &Value, kind: &str) -> Result<String> {
     Ok(parts.join(" · "))
 }
 
+fn render_gajae_hold(payload: &Value, kind: &str) -> Result<String> {
+    let repo = string_field(payload, "repo")?;
+    let action = string_field(payload, "action")?;
+    let disallowed_action = string_field(payload, "disallowed_action")?;
+    let why = string_field(payload, "why_autonomous_disallowed")?;
+    let boundary = match kind {
+        "gajae.release.hold" => "release boundary hold",
+        "gajae.merge.hold" => "main-merge boundary hold",
+        _ => "GAJAE boundary hold",
+    };
+    let relevant = optional_string_field(payload, "version")
+        .or_else(|| optional_string_field(payload, "sha"))
+        .unwrap_or_default();
+    let relevant_part = if relevant.is_empty() {
+        String::new()
+    } else {
+        format!(" · {relevant}")
+    };
+
+    Ok(format!(
+        "{boundary} · {repo} · {action}{relevant_part} · blocked action: {disallowed_action} · autonomous execution disallowed: {why}"
+    ))
+}
+
 fn short_sha(sha: &str) -> String {
     sha.chars().take(7).collect()
 }
@@ -1018,5 +1060,27 @@ mod tests {
             .unwrap();
         assert!(rendered.starts_with("🚨"));
         assert!(rendered.contains("release published"));
+    }
+
+    #[test]
+    fn renders_gajae_hold_with_blocked_action_and_reason() {
+        let event = IncomingEvent::gajae_merge_hold(
+            "Yeachan-Heo/clawhip".into(),
+            "owner-maintainer".into(),
+            "merge-to-main".into(),
+            "0123456789abcdef".into(),
+            "merge pull request #252 into main".into(),
+            "main branch merge boundaries require owner/maintainer approval".into(),
+            Some("maintainer".into()),
+        );
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Compact)
+            .unwrap();
+
+        assert!(rendered.contains("main-merge boundary hold"));
+        assert!(rendered.contains("blocked action: merge pull request #252 into main"));
+        assert!(rendered.contains("autonomous execution disallowed"));
+        assert!(rendered.contains("owner/maintainer approval"));
     }
 }


### PR DESCRIPTION
Closes #252

## Summary
- route release/retag and main-merge GitHub webhooks into durable GAJAE hold events when an owner/maintainer target is configured
- add hold payloads with repo/target/action/version-or-sha dedupe keys, blocked-action text, and autonomous execution denial fields
- render and normalize hold events as high-priority custom events

## Verification
- cargo fmt
- cargo test --package clawhip
- cargo clippy --package clawhip --all-targets -- -D warnings