### PR TITLE
Add lightweight zero-backlog follow-up checkpoint receipt (#269)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -502,6 +502,11 @@ pub enum GajaeCommands {
         #[command(subcommand)]
         command: GajaeMutationPlanCommands,
     },
+    /// Produce a lightweight public-safe zero-backlog follow-up checkpoint receipt.
+    Checkpoint {
+        #[command(subcommand)]
+        command: GajaeCheckpointCommands,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -622,6 +627,37 @@ pub struct GajaeMutationPlanArgs {
     /// Existing idempotency key. Repeat to mark matching plans as duplicates.
     #[arg(long = "existing-key", action = ArgAction::Append)]
     pub existing_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GajaeCheckpointCommands {
+    /// Build a compact zero-backlog follow-up checkpoint with a deterministic stop decision.
+    ZeroBacklog(GajaeZeroBacklogCheckpointArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct GajaeZeroBacklogCheckpointArgs {
+    /// GitHub repository in owner/name form.
+    #[arg(long)]
+    pub repo: String,
+    /// Observed count of open issues.
+    #[arg(long, default_value_t = 0)]
+    pub open_issues: u64,
+    /// Observed count of open PRs.
+    #[arg(long, default_value_t = 0)]
+    pub open_prs: u64,
+    /// Observed count of sessions still needing action.
+    #[arg(long, default_value_t = 0)]
+    pub action_needed_sessions: u64,
+    /// Public-safe observation source label, e.g. github-api.
+    #[arg(long, default_value = "github-api")]
+    pub source: String,
+    /// Mark an approval hold as present, which forces follow-up emission.
+    #[arg(long, default_value_t = false)]
+    pub approval_hold: bool,
+    /// Mark a release hold as present, which forces follow-up emission.
+    #[arg(long, default_value_t = false)]
+    pub release_hold: bool,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -1558,6 +1594,35 @@ mod tests {
         let CronCommands::Run { id } = command;
 
         assert_eq!(id, "dev-followup");
+    }
+
+    #[test]
+    fn parses_gajae_zero_backlog_checkpoint_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "gajae",
+            "checkpoint",
+            "zero-backlog",
+            "--repo",
+            "Yeachan-Heo/clawhip",
+            "--open-prs",
+            "0",
+            "--source",
+            "github-api",
+        ]);
+
+        let Some(Commands::Gajae {
+            command: GajaeCommands::Checkpoint { command },
+        }) = cli.command
+        else {
+            panic!("expected gajae checkpoint command");
+        };
+        let GajaeCheckpointCommands::ZeroBacklog(args) = command;
+        assert_eq!(args.repo, "Yeachan-Heo/clawhip");
+        assert_eq!(args.open_issues, 0);
+        assert_eq!(args.open_prs, 0);
+        assert_eq!(args.source, "github-api");
+        assert!(!args.approval_hold);
     }
 
     #[test]

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -347,6 +347,10 @@ fn public_suppression_state(value: &Value) -> BTreeMap<String, Value> {
     insert_public_value(&mut state, value, "session_stale_events");
     insert_public_value(&mut state, value, "approval_hold");
     insert_public_value(&mut state, value, "release_hold");
+    insert_public_value(&mut state, value, "action_needed_sessions");
+    insert_public_value(&mut state, value, "action_required");
+    insert_public_value(&mut state, value, "observation_source");
+    insert_public_value(&mut state, value, "stop_decision");
     insert_public_value(&mut state, value, "new_event_id");
     state
 }
@@ -375,6 +379,12 @@ fn bounded_public_token(value: &str) -> String {
 }
 
 fn is_validated_zero_backlog_receipt(value: &Value) -> bool {
+    is_full_zero_backlog_receipt(value) || is_lightweight_zero_backlog_checkpoint(value)
+}
+
+/// Full zero-backlog receipt: requires green dev CI and explicit session/hold
+/// evidence in addition to a clear backlog. Used for richer transitions.
+fn is_full_zero_backlog_receipt(value: &Value) -> bool {
     validated_zero_backlog_family(value)
         && receipt_status_validated(value)
         && numeric_field(value, "open_issues") == Some(0)
@@ -385,6 +395,24 @@ fn is_validated_zero_backlog_receipt(value: &Value) -> bool {
         && numeric_field(value, "session_stale_events").unwrap_or(0) == 0
         && !bool_field(value, "approval_hold")
         && !bool_field(value, "release_hold")
+}
+
+/// Lightweight zero-backlog follow-up checkpoint: a compact receipt for routine
+/// ticks. It carries observed counts and a deterministic stop decision but
+/// intentionally omits the full CI/session evidence. Suppression only applies
+/// when the checkpoint itself decided to suppress the follow-up.
+fn is_lightweight_zero_backlog_checkpoint(value: &Value) -> bool {
+    value.get("family").and_then(Value::as_str)
+        == Some(crate::gajae::ZERO_BACKLOG_FOLLOWUP_CHECKPOINT_FAMILY)
+        && receipt_status_validated(value)
+        && numeric_field(value, "open_issues") == Some(0)
+        && numeric_field(value, "open_prs") == Some(0)
+        && numeric_field(value, "action_needed_sessions").unwrap_or(0) == 0
+        && !bool_field(value, "approval_hold")
+        && !bool_field(value, "release_hold")
+        && !bool_field(value, "action_required")
+        && value.get("stop_decision").and_then(Value::as_str) == Some("suppress-followup")
+        && bool_field(value, "stop_decision_deterministic")
 }
 
 fn validated_zero_backlog_family(value: &Value) -> bool {
@@ -1151,6 +1179,74 @@ mod tests {
         assert!(schedule.matches(dt(2026, Month::April, 10, 17, 45, 0)));
         assert!(!schedule.matches(dt(2026, Month::April, 10, 17, 10, 0)));
         assert!(!schedule.matches(dt(2026, Month::April, 11, 9, 0, 0)));
+    }
+
+    fn write_lightweight_checkpoint(path: &Path, open_prs: u64) -> std::io::Result<()> {
+        let checkpoint = crate::gajae::zero_backlog_followup_checkpoint(
+            crate::gajae::ZeroBacklogCheckpointRequest {
+                repo: "Yeachan-Heo/clawhip".into(),
+                open_issues: 0,
+                open_prs,
+                action_needed_sessions: 0,
+                observation_source: "github-api".into(),
+                approval_hold: false,
+                release_hold: false,
+            },
+        )
+        .expect("build checkpoint");
+        fs::write(path, serde_json::to_string(&checkpoint).expect("serialize"))
+    }
+
+    #[tokio::test]
+    async fn lightweight_checkpoint_suppresses_repeated_followups_until_ttl() {
+        let dir = tempdir().expect("tempdir");
+        let state_path = dir.path().join("cron-state.json");
+        let repo_state = dir.path().join("repo.json");
+        write_lightweight_checkpoint(&repo_state, 0).expect("write checkpoint");
+
+        let config = sample_config_with_state("*/10 * * * *", Some(repo_state));
+        let mut scheduler =
+            CronScheduler::new_with_state_path(&config, state_path).expect("scheduler");
+        let emitter = RecordingEmitter::default();
+
+        scheduler
+            .emit_due(&emitter, dt(2026, Month::April, 2, 8, 20, 3))
+            .await
+            .expect("first tick");
+        scheduler
+            .emit_due(&emitter, dt(2026, Month::April, 2, 8, 30, 5))
+            .await
+            .expect("second tick suppressed");
+
+        let events = emitter.events.lock().expect("events lock");
+        assert_eq!(events.len(), 1, "routine follow-up should be silent");
+        assert_eq!(events[0].payload["repo_state_zero_backlog"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn lightweight_checkpoint_with_open_backlog_does_not_suppress() {
+        let dir = tempdir().expect("tempdir");
+        let state_path = dir.path().join("cron-state.json");
+        let repo_state = dir.path().join("repo.json");
+        write_lightweight_checkpoint(&repo_state, 1).expect("write checkpoint");
+
+        let config = sample_config_with_state("*/10 * * * *", Some(repo_state));
+        let mut scheduler =
+            CronScheduler::new_with_state_path(&config, state_path).expect("scheduler");
+        let emitter = RecordingEmitter::default();
+
+        scheduler
+            .emit_due(&emitter, dt(2026, Month::April, 2, 8, 20, 3))
+            .await
+            .expect("first tick");
+        scheduler
+            .emit_due(&emitter, dt(2026, Month::April, 2, 8, 30, 5))
+            .await
+            .expect("second tick");
+
+        let events = emitter.events.lock().expect("events lock");
+        assert_eq!(events.len(), 2, "nonzero backlog must keep emitting");
+        assert_eq!(events[0].payload["repo_state_zero_backlog"], json!(false));
     }
 
     fn sample_config(schedule: &str) -> AppConfig {

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -23,6 +23,13 @@ const DEFAULT_ROUTES_PATH: &str = ".clawhip/gajae.routes.yml";
 const DEFAULT_RUNTIME_DIR: &str = ".gajae/runtime";
 const PROFILE_FILE_NAME: &str = "clawhip-profile.yml";
 const MAX_PROFILE_BYTES: usize = 256 * 1024;
+/// Family name for the lightweight zero-backlog follow-up checkpoint receipt.
+///
+/// This is a compact public-safe alternative to the full follow-up receipt
+/// families. It is used for routine zero-backlog ticks that find no open
+/// PRs/issues and no action-needed work, and intentionally omits the heavier
+/// CI/session evidence carried by full receipts.
+pub const ZERO_BACKLOG_FOLLOWUP_CHECKPOINT_FAMILY: &str = "zero-backlog-followup-checkpoint";
 const REQUIRED_RECEIPT_FAMILIES: &[&str] = &[
     "runtime-followup-receipt",
     "mutation-plan",
@@ -1614,6 +1621,84 @@ pub struct BoundedBodyDigest {
     pub capped: bool,
 }
 
+/// Inputs for a lightweight zero-backlog follow-up checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZeroBacklogCheckpointRequest {
+    pub repo: String,
+    pub open_issues: u64,
+    pub open_prs: u64,
+    pub action_needed_sessions: u64,
+    pub observation_source: String,
+    pub approval_hold: bool,
+    pub release_hold: bool,
+}
+
+/// Compact, public-safe checkpoint receipt for routine zero-backlog ticks.
+///
+/// It carries only the bounded fields needed to audit a deterministic stop
+/// decision (repository, observed counts, observation source, and public-safety
+/// flags) and never embeds raw logs, tokens, or private payloads. Full receipt
+/// families remain the path for richer transitions, exceptions, or nonzero
+/// backlog.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ZeroBacklogCheckpoint {
+    pub family: &'static str,
+    pub schema: &'static str,
+    pub mode: &'static str,
+    pub status: &'static str,
+    pub repo: String,
+    pub open_issues: u64,
+    pub open_prs: u64,
+    pub action_needed_sessions: u64,
+    pub observation_source: String,
+    pub stop_decision: &'static str,
+    pub stop_decision_deterministic: bool,
+    pub approval_hold: bool,
+    pub release_hold: bool,
+    pub action_required: bool,
+    pub public_safe: bool,
+}
+
+/// Build a lightweight zero-backlog follow-up checkpoint from observed counts.
+///
+/// The stop decision is fully deterministic: a clear backlog (zero open
+/// issues/PRs, no action-needed sessions, and no holds) suppresses the routine
+/// follow-up; anything else emits it. The receipt only ever contains bounded
+/// public identifiers and numeric counts.
+pub fn zero_backlog_followup_checkpoint(
+    request: ZeroBacklogCheckpointRequest,
+) -> Result<ZeroBacklogCheckpoint> {
+    let repo = public_identifier(&request.repo, "repo")?;
+    let observation_source = public_identifier(&request.observation_source, "observation-source")?;
+    let clear = request.open_issues == 0
+        && request.open_prs == 0
+        && request.action_needed_sessions == 0
+        && !request.approval_hold
+        && !request.release_hold;
+    let stop_decision = if clear {
+        "suppress-followup"
+    } else {
+        "emit-followup"
+    };
+    Ok(ZeroBacklogCheckpoint {
+        family: ZERO_BACKLOG_FOLLOWUP_CHECKPOINT_FAMILY,
+        schema: "gajae.zero-backlog-followup-checkpoint.v1",
+        mode: "lightweight",
+        status: "validated",
+        repo,
+        open_issues: request.open_issues,
+        open_prs: request.open_prs,
+        action_needed_sessions: request.action_needed_sessions,
+        observation_source,
+        stop_decision,
+        stop_decision_deterministic: true,
+        approval_hold: request.approval_hold,
+        release_hold: request.release_hold,
+        action_required: !clear,
+        public_safe: true,
+    })
+}
+
 pub fn read_receipt_stdin(reader: &mut impl Read) -> Result<Vec<u8>> {
     let mut input = Vec::new();
     reader
@@ -1904,6 +1989,7 @@ fn event_kind_for_family(family: &str) -> &'static str {
         "review-verdict-evidence" => "gajae.review.verdict",
         "merge-hold-decision" => "gajae.merge.hold",
         "zero-backlog-checkpoint" => "gajae.backlog.zero",
+        "zero-backlog-followup-checkpoint" => "gajae.backlog.zero",
         family if family.contains("release-hold") => "gajae.release.hold",
         _ => "gajae.receipt.validated",
     }
@@ -2025,6 +2111,84 @@ mod mutation_plan_tests {
         assert!(plan.blocked);
         assert_eq!(plan.block_reason, Some("authority-required"));
         assert!(!plan.execution.executed);
+    }
+
+    #[test]
+    fn zero_backlog_checkpoint_clear_backlog_suppresses_followup() {
+        let checkpoint = zero_backlog_followup_checkpoint(ZeroBacklogCheckpointRequest {
+            repo: "Yeachan-Heo/clawhip".into(),
+            open_issues: 0,
+            open_prs: 0,
+            action_needed_sessions: 0,
+            observation_source: "github-api".into(),
+            approval_hold: false,
+            release_hold: false,
+        })
+        .expect("checkpoint should build");
+
+        assert_eq!(checkpoint.family, "zero-backlog-followup-checkpoint");
+        assert_eq!(checkpoint.mode, "lightweight");
+        assert_eq!(checkpoint.status, "validated");
+        assert_eq!(checkpoint.stop_decision, "suppress-followup");
+        assert!(checkpoint.stop_decision_deterministic);
+        assert!(!checkpoint.action_required);
+        assert!(checkpoint.public_safe);
+
+        let serialized = serde_json::to_string(&checkpoint).expect("serialize");
+        assert!(serialized.contains("\"open_issues\":0"));
+        assert!(serialized.contains("github-api"));
+        assert_eq!(
+            event_kind_for_family(checkpoint.family),
+            "gajae.backlog.zero"
+        );
+    }
+
+    #[test]
+    fn zero_backlog_checkpoint_nonzero_backlog_emits_followup() {
+        let checkpoint = zero_backlog_followup_checkpoint(ZeroBacklogCheckpointRequest {
+            repo: "Yeachan-Heo/clawhip".into(),
+            open_issues: 0,
+            open_prs: 2,
+            action_needed_sessions: 0,
+            observation_source: "github-api".into(),
+            approval_hold: false,
+            release_hold: false,
+        })
+        .expect("checkpoint should build");
+
+        assert_eq!(checkpoint.stop_decision, "emit-followup");
+        assert!(checkpoint.action_required);
+    }
+
+    #[test]
+    fn zero_backlog_checkpoint_holds_force_followup_emission() {
+        let checkpoint = zero_backlog_followup_checkpoint(ZeroBacklogCheckpointRequest {
+            repo: "Yeachan-Heo/clawhip".into(),
+            open_issues: 0,
+            open_prs: 0,
+            action_needed_sessions: 0,
+            observation_source: "github-api".into(),
+            approval_hold: true,
+            release_hold: false,
+        })
+        .expect("checkpoint should build");
+
+        assert_eq!(checkpoint.stop_decision, "emit-followup");
+        assert!(checkpoint.action_required);
+    }
+
+    #[test]
+    fn zero_backlog_checkpoint_rejects_unsafe_source() {
+        let result = zero_backlog_followup_checkpoint(ZeroBacklogCheckpointRequest {
+            repo: "Yeachan-Heo/clawhip".into(),
+            open_issues: 0,
+            open_prs: 0,
+            action_needed_sessions: 0,
+            observation_source: "secret-token-source".into(),
+            approval_hold: false,
+            release_hold: false,
+        });
+        assert!(result.is_err());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,11 @@ use clap::Parser;
 use tokio::runtime::Builder;
 
 use crate::cli::{
-    AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs, GajaeCommands,
-    GajaeMutationPlanCommands, GajaeProfileCommands, GajaeReceiptCommands, GitCommands,
-    GithubCommands, HooksCommands, MemoryCommands, NativeCommands, PluginCommands, ReleaseCommands,
-    SetupArgs, TmuxCommands, UpdateCommands, VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
+    AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs,
+    GajaeCheckpointCommands, GajaeCommands, GajaeMutationPlanCommands, GajaeProfileCommands,
+    GajaeReceiptCommands, GitCommands, GithubCommands, HooksCommands, MemoryCommands,
+    NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, TmuxCommands, UpdateCommands,
+    VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
 };
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, SetupEdits};
@@ -440,6 +441,23 @@ async fn real_main(cli: Cli) -> Result<()> {
                         existing_keys: args.existing_keys,
                     })?;
                     println!("{}", serde_json::to_string(&plan)?);
+                    Ok(())
+                }
+            },
+            GajaeCommands::Checkpoint { command } => match command {
+                GajaeCheckpointCommands::ZeroBacklog(args) => {
+                    let checkpoint = gajae::zero_backlog_followup_checkpoint(
+                        gajae::ZeroBacklogCheckpointRequest {
+                            repo: args.repo,
+                            open_issues: args.open_issues,
+                            open_prs: args.open_prs,
+                            action_needed_sessions: args.action_needed_sessions,
+                            observation_source: args.source,
+                            approval_hold: args.approval_hold,
+                            release_hold: args.release_hold,
+                        },
+                    )?;
+                    println!("{}", serde_json::to_string(&checkpoint)?);
                     Ok(())
                 }
             },


### PR DESCRIPTION
Closes #269.

## Problem
A full backlog-zero receipt is heavy for simple zero-backlog follow-up checks. Routine zero-backlog ticks should be auditable without feeling like a full operational incident artifact.

## Change
- Add `clawhip gajae checkpoint zero-backlog`, a producer for a compact public-safe receipt family `zero-backlog-followup-checkpoint`. It carries repository, observed counts (open issues/PRs, action-needed sessions), observation source, a deterministic stop decision (`suppress-followup` / `emit-followup`), and public-safety flags. It deliberately omits the heavier CI/session evidence carried by full receipts.
- The deterministic stop decision suppresses the follow-up only when the backlog is clear (zero open issues/PRs, no action-needed sessions, no holds); any nonzero backlog or hold forces emission.
- Teach the cron zero-backlog suppression path to validate this lightweight family directly via `is_lightweight_zero_backlog_checkpoint`, without requiring green-CI/session evidence, while leaving the existing full-receipt path (`is_full_zero_backlog_receipt`) unchanged for richer transitions, exceptions, or nonzero backlog.
- Observation source and stop decision are folded into the public-safe suppression fingerprint so any delta breaks suppression.

## Public-safety
All emitted fields are bounded public identifiers/counts; repo and source go through `public_identifier` (rejects whitespace/control and token/secret/password substrings). No raw logs, tokens, or private payloads are embedded.

## Acceptance criteria
- [x] Compact receipt family/mode for zero-backlog follow-up checks
- [x] Includes repository, observed counts, observation source, deterministic stop decision, public-safety flags
- [x] Full receipts remain available for richer transitions / nonzero backlog
- [x] Lightweight path validates cleanly through clawhip cron dogfood (producer output round-trips into the suppression evaluator in tests)

## Tests
- gajae producer: clear backlog suppresses, nonzero backlog emits, holds force emission, unsafe source rejected
- CLI parsing for the new subcommand
- cron: lightweight checkpoint suppresses repeated follow-ups until TTL; open backlog keeps emitting

Note: 4 pre-existing unit tests fail locally on macOS only, due to `/private/var` vs `/var` temp-path symlink canonicalization and a timing-based handler test; they are unrelated to this change and fail identically on the clean base.