### PR TITLE
feat(config): warn when env Discord token shadows config token (#274)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -836,6 +836,30 @@ impl AppConfig {
         }
     }
 
+    /// Returns the name of the environment variable whose Discord token shadows
+    /// a token that is also present in the config file. Returns `None` when env
+    /// does not win or when no config token is set, so a `Some(_)` value always
+    /// means env precedence is silently overriding a configured token.
+    ///
+    /// Only the precedence source is exposed — never the token value itself.
+    pub fn discord_token_env_shadow(&self) -> Option<&'static str> {
+        self.discord_token_env_shadow_with(|name| env::var(name).ok())
+    }
+
+    fn discord_token_env_shadow_with<F>(&self, mut get_env: F) -> Option<&'static str>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        let env_var = DISCORD_TOKEN_ENV_VARS
+            .iter()
+            .copied()
+            .find(|name| normalize_secret(get_env(name)).is_some())?;
+        let config_token_present = normalize_secret(self.providers.discord.bot_token.clone())
+            .is_some()
+            || normalize_secret(self.discord.bot_token.clone()).is_some();
+        config_token_present.then_some(env_var)
+    }
+
     pub fn webhook_route_count(&self) -> usize {
         self.routes
             .iter()
@@ -1602,6 +1626,55 @@ mod tests {
             config.effective_token_with(|_| None).as_deref(),
             Some("config-token")
         );
+    }
+
+    #[test]
+    fn discord_token_env_shadow_detected_when_env_overrides_config() {
+        let mut config = AppConfig::default();
+        config.providers.discord.bot_token = Some("config-token".into());
+
+        assert_eq!(
+            config.discord_token_env_shadow_with(|name| {
+                (name == "CLAWHIP_DISCORD_BOT_TOKEN").then(|| "env-token".to_string())
+            }),
+            Some("CLAWHIP_DISCORD_BOT_TOKEN")
+        );
+        assert_eq!(
+            config.discord_token_env_shadow_with(|name| {
+                (name == "DISCORD_TOKEN").then(|| "env-token".to_string())
+            }),
+            Some("DISCORD_TOKEN")
+        );
+    }
+
+    #[test]
+    fn discord_token_env_shadow_uses_legacy_config_token() {
+        let mut config = AppConfig::default();
+        config.discord.bot_token = Some("legacy-config-token".into());
+
+        assert_eq!(
+            config.discord_token_env_shadow_with(|name| {
+                (name == "DISCORD_TOKEN").then(|| "env-token".to_string())
+            }),
+            Some("DISCORD_TOKEN")
+        );
+    }
+
+    #[test]
+    fn discord_token_env_shadow_none_without_conflict() {
+        let mut config = AppConfig::default();
+
+        // No config token: env wins but nothing is shadowed.
+        assert_eq!(
+            config.discord_token_env_shadow_with(|name| {
+                (name == "DISCORD_TOKEN").then(|| "env-token".to_string())
+            }),
+            None
+        );
+
+        // Config token present but no env token: config wins, no shadow.
+        config.providers.discord.bot_token = Some("config-token".into());
+        assert_eq!(config.discord_token_env_shadow_with(|_| None), None);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -82,6 +82,14 @@ pub async fn run(
         telemetry::reason::DAEMON_STARTUP,
         json!({"version": VERSION, "token_source": token_source}),
     ));
+    if let Some(env_var) = config.discord_token_env_shadow() {
+        let warning = discord_token_shadow_warning(env_var);
+        eprintln!("warning: {warning}");
+        telemetry::emit(daemon_record(
+            telemetry::reason::DISCORD_TOKEN_ENV_SHADOW,
+            json!({"env_var": env_var, "token_source": token_source, "warning": warning}),
+        ));
+    }
 
     let mut sinks: HashMap<String, Box<dyn Sink>> = HashMap::new();
     sinks.insert(
@@ -234,6 +242,12 @@ fn daemon_record(reason_code: &str, details: Value) -> serde_json::Map<String, V
     record
 }
 
+fn discord_token_shadow_warning(env_var: &str) -> String {
+    format!(
+        "Discord token from environment variable {env_var} is overriding the token configured in the config file (token_source: env). Unset {env_var} to use the configured token, or remove the config token to silence this notice."
+    )
+}
+
 fn source_lifecycle_record(
     reason_code: &str,
     source_name: &str,
@@ -289,6 +303,7 @@ fn health_payload(
         "ok": true,
         "version": VERSION,
         "token_source": config.discord_token_source(),
+        "token_precedence_warning": config.discord_token_env_shadow().map(discord_token_shadow_warning),
         "webhook_routes_configured": config.has_webhook_routes(),
         "port": port,
         "daemon_base_url": config.daemon.base_url,
@@ -1728,6 +1743,18 @@ mod tests {
         assert_eq!(payload["configured_workspace_monitors"], Value::from(1));
         assert_eq!(payload["registered_tmux_sessions"], Value::from(3));
         assert!(payload["native_hooks"]["totals"]["received"].is_number());
+        assert_eq!(payload["token_precedence_warning"], Value::Null);
+    }
+
+    #[test]
+    fn discord_token_shadow_warning_names_env_var_without_leaking_value() {
+        let warning = discord_token_shadow_warning("CLAWHIP_DISCORD_BOT_TOKEN");
+
+        assert!(warning.contains("CLAWHIP_DISCORD_BOT_TOKEN"));
+        assert!(warning.contains("token_source: env"));
+        // The diagnostic must describe precedence only, never the secret value.
+        assert!(!warning.to_lowercase().contains("config-token"));
+        assert!(!warning.to_lowercase().contains("env-token"));
     }
 
     #[tokio::test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -25,6 +25,7 @@ pub mod event_name {
 
 pub mod reason {
     pub const DAEMON_STARTUP: &str = "daemon_startup";
+    pub const DISCORD_TOKEN_ENV_SHADOW: &str = "discord_token_env_shadow";
     pub const DAEMON_LISTENING: &str = "daemon_listening";
     pub const SOURCE_START: &str = "source_start";
     pub const SOURCE_STOPPED: &str = "source_stopped";


### PR DESCRIPTION
Closes #274.

## Problem
When a systemd user unit (or any environment) still exports `CLAWHIP_DISCORD_BOT_TOKEN`/`DISCORD_TOKEN`, env precedence silently overrides a newly configured config-file token. Startup and `clawhip status` only reported `token_source: env`, so the ignored config token was discovered only after a Discord 401 smoke failure.

## Change
Keep env-over-config compatibility (env still wins), but make the override explicit and non-secret:

- `AppConfig::discord_token_env_shadow` detects when an env token shadows a present config token and returns only the offending env var name — never a token value.
- Daemon startup emits a `warning:` log line and a `discord_token_env_shadow` telemetry record.
- `health_payload` gains `token_precedence_warning` (null unless shadowed), surfaced by `clawhip status`.

## Safety
- No raw token values are ever printed or stored; only source/precedence and the env var name.
- Behavior is backward compatible: env still wins unless the operator unsets it.

## Tests
- `discord_token_env_shadow_detected_when_env_overrides_config`
- `discord_token_env_shadow_uses_legacy_config_token`
- `discord_token_env_shadow_none_without_conflict`
- `discord_token_shadow_warning_names_env_var_without_leaking_value`
- `health_payload_includes_version_and_token_source` extended to assert the warning field is null when no shadow.

`cargo build`, `cargo clippy`, and the full `cargo test` suite (623 tests) pass.