### PR TITLE
cron: coalesce repeated zero-backlog follow-ups via branch head/check digest (#276)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -554,7 +554,8 @@ pub struct CronJob {
     /// PRs, green dev CI, no action-needed sessions, and no holds suppress
     /// repeated notifications only while the same public-safe key remains within
     /// `zero_backlog_suppression_ttl_secs`. New public events, non-zero backlog,
-    /// CI failures, stale sessions, holds, missing files, or malformed JSON fail
+    /// CI failures, branch head or check-summary changes, stale sessions, holds,
+    /// missing files, or malformed JSON fail
     /// open and emit normally.
     ///
     /// GitHub API/rate-limit failures are detected separately from an empty

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -381,6 +381,16 @@ fn public_suppression_state(value: &Value) -> BTreeMap<String, Value> {
     insert_public_value(&mut state, value, "open_prs");
     insert_public_value(&mut state, value, "latest_dev_ci");
     insert_public_value(&mut state, value, "dev_ci");
+    // Branch head / check-summary digests so a real `dev` head change (a new
+    // commit landing with otherwise-identical counts and CI label) alters the
+    // fingerprint and re-emits, instead of being coalesced as an unchanged tick.
+    // Values pass through `bounded_public_token`, so only public-safe identifiers
+    // (e.g. a commit SHA) are retained.
+    insert_public_value(&mut state, value, "dev_head");
+    insert_public_value(&mut state, value, "branch_head");
+    insert_public_value(&mut state, value, "head_sha");
+    insert_public_value(&mut state, value, "dev_check_summary");
+    insert_public_value(&mut state, value, "check_summary");
     insert_public_value(&mut state, value, "active_sessions_needing_action");
     insert_public_value(&mut state, value, "sessions_needing_action");
     insert_public_value(&mut state, value, "session_stale_events");
@@ -1193,6 +1203,95 @@ mod tests {
         let events = emitter.events.lock().expect("events lock");
         assert_eq!(events.len(), 2);
         assert_eq!(events[1].payload["repo_state_zero_backlog"], json!(false));
+    }
+
+    #[tokio::test]
+    async fn branch_head_change_breaks_zero_backlog_suppression_immediately() {
+        let dir = tempdir().expect("tempdir");
+        let state_path = dir.path().join("cron-state.json");
+        let repo_state = dir.path().join("repo.json");
+        fs::write(
+            &repo_state,
+            r#"{"family":"runtime-followup-receipt","status":"validated","open_issues":0,"open_prs":0,"latest_dev_ci":"green","active_sessions_needing_action":0,"dev_head":"aaaaaaaaaaaa"}"#,
+        )
+        .expect("write head-a receipt");
+
+        let config = sample_config_with_state("*/10 * * * *", Some(repo_state.clone()));
+        let mut scheduler =
+            CronScheduler::new_with_state_path(&config, state_path).expect("scheduler");
+        let emitter = RecordingEmitter::default();
+
+        scheduler
+            .emit_due(&emitter, dt(2026, Month::April, 2, 8, 20, 0))
+            .await
+            .expect("tick 1");
+        scheduler
+            .emit_due(&emitter, dt(2026, Month::April, 2, 8, 30, 0))
+            .await
+            .expect("tick 2 suppressed");
+
+        // Identical zero-backlog counts and CI label, but a new dev commit landed:
+        // the head digest changed, so this is a real transition and must re-emit.
+        fs::write(
+            &repo_state,
+            r#"{"family":"runtime-followup-receipt","status":"validated","open_issues":0,"open_prs":0,"latest_dev_ci":"green","active_sessions_needing_action":0,"dev_head":"bbbbbbbbbbbb"}"#,
+        )
+        .expect("write head-b receipt");
+        scheduler
+            .emit_due(&emitter, dt(2026, Month::April, 2, 8, 40, 0))
+            .await
+            .expect("branch head change re-emits");
+
+        let events = emitter.events.lock().expect("events lock");
+        assert_eq!(
+            events.len(),
+            2,
+            "first tick + head-change tick emit; the identical middle tick coalesces"
+        );
+        assert_eq!(
+            events[1].payload["repo_state_zero_backlog"],
+            json!(true),
+            "a new dev head is still a valid zero-backlog state, just a fresh transition"
+        );
+        assert_ne!(
+            events[0].payload["repo_state_fingerprint"],
+            events[1].payload["repo_state_fingerprint"],
+            "a branch head change must alter the public-safe key and re-emit"
+        );
+    }
+
+    #[test]
+    fn branch_head_digest_is_part_of_fingerprint_and_public_safe() {
+        let dir = tempdir().expect("tempdir");
+        let head_a = dir.path().join("head-a.json");
+        let head_b = dir.path().join("head-b.json");
+        fs::write(
+            &head_a,
+            r#"{"family":"runtime-followup-receipt","status":"validated","open_issues":0,"open_prs":0,"latest_dev_ci":"green","active_sessions_needing_action":0,"dev_head":"abc123def456","raw_log":"secret-token must not leak"}"#,
+        )
+        .expect("write head-a");
+        fs::write(
+            &head_b,
+            r#"{"family":"runtime-followup-receipt","status":"validated","open_issues":0,"open_prs":0,"latest_dev_ci":"green","active_sessions_needing_action":0,"dev_head":"999fedcba000","raw_log":"secret-token must not leak"}"#,
+        )
+        .expect("write head-b");
+
+        let eval_a = evaluate_state_file(&head_a).expect("eval a");
+        let eval_b = evaluate_state_file(&head_b).expect("eval b");
+        assert!(
+            eval_a.zero_backlog && eval_b.zero_backlog,
+            "both receipts remain valid zero-backlog states"
+        );
+        assert_ne!(
+            eval_a.fingerprint, eval_b.fingerprint,
+            "a branch head change must alter the fingerprint"
+        );
+        assert_ne!(eval_a.suppression_key, eval_b.suppression_key);
+        assert!(
+            !eval_a.fingerprint.contains("secret-token"),
+            "the fingerprint must never leak private receipt content"
+        );
+        assert_eq!(eval_a.fingerprint.len(), 16);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #276.

`clawhip` already coalesces repeated zero-backlog follow-up cron emissions: a cron job's `state_file` GAJAE receipt is reduced to a deterministic public-safe fingerprint, and `should_suppress` withholds an emission while the same fingerprint stays within the suppression TTL. The fingerprint covered backlog counts, CI label, holds, and session markers — but **omitted any branch head / check-summary digest**, which issue #276 explicitly lists as part of the state key (point 1) and as a trigger that must re-emit (point 4).

As a result, a follow-up reporting the same counts and the same CI label but a **new `dev` commit** (head SHA changed) produced an identical fingerprint and was wrongly suppressed — hiding a real state change.

## Change

- `src/cron.rs` — `public_suppression_state` now folds public-safe branch-head / check-summary digest fields (`dev_head`, `branch_head`, `head_sha`, `dev_check_summary`, `check_summary`) into the fingerprint. They flow through the existing `bounded_public_token` sanitizer, so only public-safe identifiers (e.g. a commit SHA) are retained — no tokens, raw logs, or private payloads.
- `src/config.rs` — documents that branch head / check-summary changes re-emit normally.

This only ever **widens** the fingerprint, so the change can cause more emissions on real transitions, never wrongly suppress. The suppression *authority* (`is_validated_zero_backlog_receipt`) is unchanged, and receipts without these fields behave exactly as before (fail-open preserved).

## Behavior matrix (acceptance #276)

- First zero-backlog tick → emits + records lease ✅
- Identical repeated zero-backlog tick → coalesced (silent, with public-safe stderr receipt) ✅
- Branch head change / nonzero backlog / CI change / hold / stale session / lease expiry → re-emits ✅
- Auditability preserved via the existing `suppression_notice` log path ✅
- Configurable + safe-by-default via `zero_backlog_suppression_ttl_secs` (`0` disables) ✅

## Tests

- `branch_head_change_breaks_zero_backlog_suppression_immediately` — first emit, identical middle tick coalesced, head-only change (still zero-backlog) re-emits.
- `branch_head_digest_is_part_of_fingerprint_and_public_safe` — a head delta changes the fingerprint and never leaks private receipt content.

`cargo test --bin clawhip cron::` → 27 passed. `cargo clippy --bin clawhip` → clean.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
