### PR TITLE
ci: move workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   check:
     name: Check
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -35,7 +35,7 @@ jobs:
           fi
 
           if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the runner."
             exit 1
           fi
 
@@ -44,7 +44,7 @@ jobs:
           elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             apt_get=(sudo apt-get)
           else
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the runner or configure passwordless sudo."
             exit 1
           fi
 
@@ -62,7 +62,7 @@ jobs:
   test:
     name: Test
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -84,7 +84,7 @@ jobs:
           fi
 
           if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the runner."
             exit 1
           fi
 
@@ -93,7 +93,7 @@ jobs:
           elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             apt_get=(sudo apt-get)
           else
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the runner or configure passwordless sudo."
             exit 1
           fi
 
@@ -111,7 +111,7 @@ jobs:
   clippy:
     name: Clippy
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -135,7 +135,7 @@ jobs:
           fi
 
           if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the runner."
             exit 1
           fi
 
@@ -144,7 +144,7 @@ jobs:
           elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             apt_get=(sudo apt-get)
           else
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the runner or configure passwordless sudo."
             exit 1
           fi
 
@@ -162,7 +162,7 @@ jobs:
   fmt:
     name: Format
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -185,7 +185,7 @@ jobs:
           fi
 
           if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the runner."
             exit 1
           fi
 
@@ -194,7 +194,7 @@ jobs:
           elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             apt_get=(sudo apt-get)
           else
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the runner or configure passwordless sudo."
             exit 1
           fi
 
@@ -213,7 +213,7 @@ jobs:
     name: Build
     needs: [check, test, clippy, fmt]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -235,7 +235,7 @@ jobs:
           fi
 
           if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the runner."
             exit 1
           fi
 
@@ -244,7 +244,7 @@ jobs:
           elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             apt_get=(sudo apt-get)
           else
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the runner or configure passwordless sudo."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Fail fast if tag/Cargo.toml/Cargo.lock/CHANGELOG are out of sync.
   preflight:
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request }}
     steps:
       - uses: actions/checkout@v6
@@ -72,7 +72,7 @@ jobs:
           fi
 
           if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the runner."
             exit 1
           fi
 
@@ -81,7 +81,7 @@ jobs:
           elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             apt_get=(sudo apt-get)
           else
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the runner or configure passwordless sudo."
             exit 1
           fi
 
@@ -104,7 +104,7 @@ jobs:
     needs:
       - preflight
     if: ${{ always() && (needs.preflight.result == 'success' || needs.preflight.result == 'skipped') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -135,7 +135,7 @@ jobs:
           fi
 
           if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the self-hosted runner."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get is unavailable. Install build-essential and xz-utils on the runner."
             exit 1
           fi
 
@@ -144,7 +144,7 @@ jobs:
           elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             apt_get=(sudo apt-get)
           else
-            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the self-hosted runner or configure passwordless sudo."
+            echo "::error::Missing required native build tools (${missing[*]}) and apt-get cannot run with root privileges. Install build-essential and xz-utils on the runner or configure passwordless sudo."
             exit 1
           fi
 
@@ -262,7 +262,7 @@ jobs:
       - plan
       - build-local-artifacts
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -314,7 +314,7 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -392,7 +392,7 @@ jobs:
       - plan
       - host
     if: ${{ always() && needs.host.result == 'success' && needs.plan.outputs.publishing == 'true' }}
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
@@ -416,7 +416,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
## Summary
- Move workflows off self-hosted runner labels and onto GitHub-hosted `ubuntu-latest`.
- Remove the PR-vs-internal split that routed trusted events to `gajae-layofflabs-2` / self-hosted labels.
- Update self-hosted prerequisite wording where touched so CI logs no longer point maintainers back to broken private runners.

## Context
Owner requested retiring the broken self-hosted runner path and moving required CI to GitHub Actions hosted runners across the managed repos.

## Verification
- Grepped changed workflow files for blocking `runs-on` self-hosted/custom runner labels after migration.
- YAML-only CI routing change; full GitHub Actions verification will run on this PR.