### PR TITLE
Persist tmux watch routing registry

### DIFF
--- a/docs/live-verification.md
+++ b/docs/live-verification.md
@@ -105,6 +105,15 @@ Operational flow:
 6. Inspect `clawhip tmux list` to confirm exactly which watch registrations exist.
 7. If alert text disagrees with pane reality, treat it as monitor noise and debug registration overlap / stale math before assuming session failure.
 
+Restart persistence smoke:
+
+1. Start the daemon and register a runtime watch with `clawhip tmux watch <session> --keyword <word>` or the wrapper path.
+2. Confirm `clawhip tmux list` shows the session and `tmux-watch-registry.json` exists beside the cron state file.
+3. Restart the daemon without killing the tmux session.
+4. Confirm `clawhip tmux list` still shows the watch and `/health` includes `tmux.registry_state.status` as `loaded` with a nonzero durable runtime count.
+5. Emit the watched keyword in the tmux pane and confirm routed Discord delivery.
+6. Kill the tmux session or send a terminal session event, then confirm the watch disappears and the registry file no longer rehydrates it after another restart.
+
 ## Helper script
 
 A helper script is included:

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -34,7 +34,9 @@ use crate::router::Router;
 use crate::sink::{DiscordSink, LocalFileSink, Sink, SlackSink};
 use crate::source::{
     GitHubSource, GitSource, RegisteredTmuxSession, SharedTmuxRegistry, Source, TmuxSource,
-    WorkspaceSource, list_active_tmux_registrations,
+    WorkspaceSource, default_registry_state_path, inspect_tmux_registry_state,
+    list_active_tmux_registrations, load_tmux_registry_state, register_runtime_tmux_registration,
+    remove_tmux_registrations, tmux_registry_diagnostics,
 };
 use crate::telemetry;
 use crate::update::{self, SharedPendingUpdate};
@@ -101,6 +103,8 @@ pub async fn run(
     let renderer: Box<dyn Renderer> = Box::new(DefaultRenderer);
     let router = Router::new(config.clone());
     let tmux_registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+    let tmux_registry_state_path = default_registry_state_path(&cron_state_path);
+    load_tmux_registry_state(&tmux_registry_state_path, &tmux_registry).await;
     let (tx, rx) = mpsc::channel(EVENT_QUEUE_CAPACITY);
     let native_observability = new_shared_native_hook_observability();
 
@@ -124,7 +128,11 @@ pub async fn run(
     spawn_source(GitSource::new(config.clone()), tx.clone());
     spawn_source(GitHubSource::new(config.clone()), tx.clone());
     spawn_source(
-        TmuxSource::new(config.clone(), tmux_registry.clone()),
+        TmuxSource::new(
+            config.clone(),
+            tmux_registry.clone(),
+            tmux_registry_state_path.clone(),
+        ),
         tx.clone(),
     );
     spawn_source(WorkspaceSource::new(config.clone()), tx.clone());
@@ -285,11 +293,15 @@ fn event_record(
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let registered = state.tmux_registry.read().await.len();
     let native_hooks = snapshot_shared(&state.native_observability);
+    let registry_state =
+        inspect_tmux_registry_state(&default_registry_state_path(&state.cron_state_path)).await;
+    let tmux = tmux_registry_diagnostics(&state.tmux_registry, registry_state).await;
     Json(health_payload(
         state.config.as_ref(),
         state.port,
         registered,
         native_hooks,
+        json!(tmux),
     ))
 }
 
@@ -298,6 +310,7 @@ fn health_payload(
     port: u16,
     registered_tmux_sessions: usize,
     native_hooks: Value,
+    tmux: Value,
 ) -> Value {
     json!({
         "ok": true,
@@ -312,6 +325,7 @@ fn health_payload(
         "configured_workspace_monitors": config.monitors.workspace.len(),
         "configured_cron_jobs": config.cron.jobs.len(),
         "registered_tmux_sessions": registered_tmux_sessions,
+        "tmux": tmux,
         "native_hooks": native_hooks,
     })
 }
@@ -908,10 +922,17 @@ async fn expire_terminal_tmux_registration(state: &AppState, event: &IncomingEve
         return;
     }
 
-    let mut registry = state.tmux_registry.write().await;
-    for session in candidates {
-        if registry.remove(&session).is_some() {
-            telemetry::emit(tmux_terminal_expiry_record(&session));
+    let registry_state_path = default_registry_state_path(&state.cron_state_path);
+    match remove_tmux_registrations(&state.tmux_registry, &registry_state_path, &candidates).await {
+        Ok(removed) => {
+            if removed > 0 {
+                for session in candidates {
+                    telemetry::emit(tmux_terminal_expiry_record(&session));
+                }
+            }
+        }
+        Err(error) => {
+            eprintln!("clawhip tmux registry expiry save failed: {error}");
         }
     }
 }
@@ -951,20 +972,36 @@ async fn register_tmux(
     State(state): State<AppState>,
     Json(registration): Json<RegisteredTmuxSession>,
 ) -> impl IntoResponse {
-    state
-        .tmux_registry
-        .write()
-        .await
-        .insert(registration.session.clone(), registration.clone());
-    (
-        StatusCode::ACCEPTED,
-        Json(json!({"ok": true, "session": registration.session})),
+    let session = registration.session.clone();
+    let registry_state_path = default_registry_state_path(&state.cron_state_path);
+    match register_runtime_tmux_registration(
+        &state.tmux_registry,
+        &registry_state_path,
+        registration,
     )
-        .into_response()
+    .await
+    {
+        Ok(_) => (
+            StatusCode::ACCEPTED,
+            Json(json!({"ok": true, "session": session})),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"ok": false, "error": error.to_string()})),
+        )
+            .into_response(),
+    }
 }
 
 async fn list_tmux(State(state): State<AppState>) -> impl IntoResponse {
-    match list_active_tmux_registrations(state.config.as_ref(), &state.tmux_registry).await {
+    match list_active_tmux_registrations(
+        state.config.as_ref(),
+        &state.tmux_registry,
+        &default_registry_state_path(&state.cron_state_path),
+    )
+    .await
+    {
         Ok(registrations) => (StatusCode::OK, Json(json!(registrations))).into_response(),
         Err(error) => (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -1636,6 +1673,7 @@ mod tests {
             .write()
             .await
             .insert("still-active".into(), tmux_registration("still-active"));
+        let dir = tempdir().expect("tempdir");
         let state = AppState {
             config: Arc::new(AppConfig::default()),
             port: 25294,
@@ -1643,7 +1681,7 @@ mod tests {
             tmux_registry: registry.clone(),
             pending_update: update::new_shared_pending_update(),
             native_observability: new_shared_native_hook_observability(),
-            cron_state_path: PathBuf::from("cron-state.json"),
+            cron_state_path: dir.path().join("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
         };
 
@@ -1732,6 +1770,7 @@ mod tests {
             25294,
             3,
             snapshot_shared(&new_shared_native_hook_observability()),
+            json!({}),
         );
 
         assert_eq!(payload["ok"], Value::Bool(true));
@@ -2603,7 +2642,7 @@ mod tests {
                     pid: 4242,
                     name: Some("codex".into()),
                 }),
-                active_wrapper_monitor: true,
+                active_wrapper_monitor: false,
             },
         );
         let state = AppState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,12 @@ async fn real_main(cli: Cli) -> Result<()> {
             TmuxCommands::List => {
                 let client = DaemonClient::from_config(config.as_ref());
                 let registrations = client.list_tmux().await?;
-                render_tmux_list(&registrations);
+                let health = if registrations.is_empty() {
+                    client.health().await.ok()
+                } else {
+                    None
+                };
+                render_tmux_list(&registrations, health.as_ref());
                 Ok(())
             }
         },
@@ -667,13 +672,25 @@ fn run_explain(config: &AppConfig, args: ExplainArgs) -> Result<()> {
     Ok(())
 }
 
-fn render_tmux_list(registrations: &[crate::source::RegisteredTmuxSession]) {
-    print!("{}", format_tmux_list(registrations));
+fn render_tmux_list(
+    registrations: &[crate::source::RegisteredTmuxSession],
+    health: Option<&serde_json::Value>,
+) {
+    print!("{}", format_tmux_list_with_health(registrations, health));
 }
 
+#[cfg(test)]
 fn format_tmux_list(registrations: &[crate::source::RegisteredTmuxSession]) -> String {
+    format_tmux_list_with_health(registrations, None)
+}
+
+fn format_tmux_list_with_health(
+    registrations: &[crate::source::RegisteredTmuxSession],
+    health: Option<&serde_json::Value>,
+) -> String {
     if registrations.is_empty() {
-        return "No active tmux watches found\n".to_string();
+        let detail = tmux_empty_list_detail(health);
+        return format!("No active tmux watches found{detail}\n");
     }
 
     let mut output =
@@ -708,6 +725,42 @@ fn format_tmux_list(registrations: &[crate::source::RegisteredTmuxSession]) -> S
     }
 
     output
+}
+
+fn tmux_empty_list_detail(health: Option<&serde_json::Value>) -> String {
+    let Some(tmux) = health.and_then(|health| health.get("tmux")) else {
+        return String::new();
+    };
+    let registry_state = tmux.get("registry_state");
+    if registry_state
+        .and_then(|state| state.get("status"))
+        .and_then(serde_json::Value::as_str)
+        == Some("ignored-invalid")
+    {
+        let path = registry_state
+            .and_then(|state| state.get("path"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("tmux-watch-registry.json");
+        return format!("; ignored invalid registry state at {path}");
+    }
+    if let Some(error) = tmux
+        .get("live_probe")
+        .and_then(|probe| probe.get("error"))
+        .and_then(serde_json::Value::as_str)
+    {
+        return format!("; live tmux probe failed: {error}");
+    }
+    let live_count = tmux
+        .get("live_probe")
+        .and_then(|probe| probe.get("count"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    if live_count > 0 {
+        return format!(
+            "; {live_count} live tmux session(s) exist but no clawhip watch routes are registered"
+        );
+    }
+    String::new()
 }
 
 #[cfg(test)]

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -11,7 +11,9 @@ pub mod workspace;
 pub use git::GitSource;
 pub use github::GitHubSource;
 pub use tmux::{
-    RegisteredTmuxSession, SharedTmuxRegistry, TmuxSource, list_active_tmux_registrations,
+    RegisteredTmuxSession, SharedTmuxRegistry, TmuxSource, default_registry_state_path,
+    inspect_tmux_registry_state, list_active_tmux_registrations, load_tmux_registry_state,
+    register_runtime_tmux_registration, remove_tmux_registrations, tmux_registry_diagnostics,
 };
 pub use workspace::WorkspaceSource;
 

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -469,10 +469,11 @@ pub async fn register_runtime_tmux_registration(
 ) -> Result<usize> {
     registration.registration_source =
         normalize_runtime_registration_source(registration.registration_source);
-    let mut next = registry.read().await.clone();
+    let mut write = registry.write().await;
+    let mut next = write.clone();
     next.insert(registration.session.clone(), registration);
     let durable_count = save_durable_tmux_registry(path, &next).await?;
-    *registry.write().await = next;
+    *write = next;
     Ok(durable_count)
 }
 
@@ -481,7 +482,8 @@ pub async fn remove_tmux_registrations(
     path: &Path,
     sessions: &[String],
 ) -> Result<usize> {
-    let mut next = registry.read().await.clone();
+    let mut write = registry.write().await;
+    let mut next = write.clone();
     let mut removed = 0;
     for session in sessions {
         if next.remove(session).is_some() {
@@ -490,7 +492,7 @@ pub async fn remove_tmux_registrations(
     }
     if removed > 0 {
         save_durable_tmux_registry(path, &next).await?;
-        *registry.write().await = next;
+        *write = next;
     }
     Ok(removed)
 }
@@ -1657,6 +1659,36 @@ PR created #7",
             RegistrationSource::CliWatch
         );
         assert!(!loaded.contains_key("config"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_runtime_registrations_preserve_all_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tmux-watch-registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut first = registration(vec!["panic"]);
+        first.session = "runtime-a".into();
+        first.registration_source = RegistrationSource::CliWatch;
+        let mut second = registration(vec!["warn"]);
+        second.session = "runtime-b".into();
+        second.registration_source = RegistrationSource::CliNew;
+
+        let first_register = register_runtime_tmux_registration(&registry, &path, first);
+        let second_register = register_runtime_tmux_registration(&registry, &path, second);
+        let (first_count, second_count) = tokio::join!(first_register, second_register);
+        first_count.unwrap();
+        second_count.unwrap();
+
+        let snapshot = registry.read().await;
+        assert!(snapshot.contains_key("runtime-a"));
+        assert!(snapshot.contains_key("runtime-b"));
+        drop(snapshot);
+
+        let loaded: BTreeMap<String, RegisteredTmuxSession> =
+            serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
+        assert!(loaded.contains_key("runtime-a"));
+        assert!(loaded.contains_key("runtime-b"));
     }
 
     #[tokio::test]

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -22,6 +23,40 @@ use crate::source::Source;
 use crate::telemetry;
 
 pub type SharedTmuxRegistry = Arc<RwLock<HashMap<String, RegisteredTmuxSession>>>;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TmuxRegistryDiagnostics {
+    pub registered_count: usize,
+    pub durable_runtime_count: usize,
+    pub config_projected_count: usize,
+    pub live_probe: TmuxLiveProbeDiagnostics,
+    pub registry_state: TmuxRegistryStateDiagnostics,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TmuxLiveProbeDiagnostics {
+    pub ok: bool,
+    pub count: usize,
+    pub sample: Vec<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TmuxRegistryStateDiagnostics {
+    pub path: PathBuf,
+    pub status: TmuxRegistryStateStatus,
+    pub loaded: usize,
+    pub ignored: usize,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TmuxRegistryStateStatus {
+    Missing,
+    Loaded,
+    IgnoredInvalid,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -93,11 +128,20 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
 pub struct TmuxSource {
     config: Arc<AppConfig>,
     registry: SharedTmuxRegistry,
+    registry_state_path: PathBuf,
 }
 
 impl TmuxSource {
-    pub fn new(config: Arc<AppConfig>, registry: SharedTmuxRegistry) -> Self {
-        Self { config, registry }
+    pub fn new(
+        config: Arc<AppConfig>,
+        registry: SharedTmuxRegistry,
+        registry_state_path: PathBuf,
+    ) -> Self {
+        Self {
+            config,
+            registry,
+            registry_state_path,
+        }
     }
 }
 
@@ -120,7 +164,14 @@ impl Source for TmuxSource {
                 .await;
                 continue;
             }
-            poll_tmux(self.config.as_ref(), &self.registry, &tx, &mut state).await?;
+            poll_tmux(
+                self.config.as_ref(),
+                &self.registry,
+                &self.registry_state_path,
+                &tx,
+                &mut state,
+            )
+            .await?;
             sleep(Duration::from_secs(
                 self.config.monitors.poll_interval_secs.max(1),
             ))
@@ -281,13 +332,225 @@ pub async fn monitor_registered_session(
     Ok(())
 }
 
+pub fn default_registry_state_path(cron_state_path: &Path) -> PathBuf {
+    cron_state_path.with_file_name("tmux-watch-registry.json")
+}
+
+pub fn normalize_runtime_registration_source(source: RegistrationSource) -> RegistrationSource {
+    match source {
+        RegistrationSource::ConfigMonitor => RegistrationSource::CliWatch,
+        RegistrationSource::CliWatch | RegistrationSource::CliNew => source,
+    }
+}
+
+fn durable_runtime_entries(
+    registry: &HashMap<String, RegisteredTmuxSession>,
+) -> BTreeMap<String, RegisteredTmuxSession> {
+    registry
+        .iter()
+        .filter(|(_, registration)| {
+            registration.registration_source != RegistrationSource::ConfigMonitor
+        })
+        .map(|(session, registration)| (session.clone(), registration.clone()))
+        .collect()
+}
+
+async fn save_durable_tmux_registry(
+    path: &Path,
+    registry: &HashMap<String, RegisteredTmuxSession>,
+) -> Result<usize> {
+    let durable = durable_runtime_entries(registry);
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let content = serde_json::to_vec_pretty(&durable)?;
+    let tmp_path = path.with_extension("json.tmp");
+    tokio::fs::write(&tmp_path, content).await?;
+    tokio::fs::rename(&tmp_path, path).await?;
+    Ok(durable.len())
+}
+
+pub async fn load_tmux_registry_state(
+    path: &Path,
+    registry: &SharedTmuxRegistry,
+) -> TmuxRegistryStateDiagnostics {
+    match tokio::fs::read(path).await {
+        Ok(content) => {
+            match serde_json::from_slice::<BTreeMap<String, RegisteredTmuxSession>>(&content) {
+                Ok(loaded) => {
+                    let mut write = registry.write().await;
+                    for (session, mut registration) in loaded {
+                        registration.registration_source =
+                            normalize_runtime_registration_source(registration.registration_source);
+                        write.insert(session, registration);
+                    }
+                    TmuxRegistryStateDiagnostics {
+                        path: path.to_path_buf(),
+                        status: TmuxRegistryStateStatus::Loaded,
+                        loaded: durable_runtime_entries(&write).len(),
+                        ignored: 0,
+                        last_error: None,
+                    }
+                }
+                Err(error) => TmuxRegistryStateDiagnostics {
+                    path: path.to_path_buf(),
+                    status: TmuxRegistryStateStatus::IgnoredInvalid,
+                    loaded: 0,
+                    ignored: 1,
+                    last_error: Some(error.to_string()),
+                },
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            TmuxRegistryStateDiagnostics {
+                path: path.to_path_buf(),
+                status: TmuxRegistryStateStatus::Missing,
+                loaded: 0,
+                ignored: 0,
+                last_error: None,
+            }
+        }
+        Err(error) => TmuxRegistryStateDiagnostics {
+            path: path.to_path_buf(),
+            status: TmuxRegistryStateStatus::IgnoredInvalid,
+            loaded: 0,
+            ignored: 1,
+            last_error: Some(error.to_string()),
+        },
+    }
+}
+
+pub async fn inspect_tmux_registry_state(path: &Path) -> TmuxRegistryStateDiagnostics {
+    match tokio::fs::read(path).await {
+        Ok(content) => {
+            match serde_json::from_slice::<BTreeMap<String, RegisteredTmuxSession>>(&content) {
+                Ok(loaded) => TmuxRegistryStateDiagnostics {
+                    path: path.to_path_buf(),
+                    status: TmuxRegistryStateStatus::Loaded,
+                    loaded: loaded.len(),
+                    ignored: 0,
+                    last_error: None,
+                },
+                Err(error) => TmuxRegistryStateDiagnostics {
+                    path: path.to_path_buf(),
+                    status: TmuxRegistryStateStatus::IgnoredInvalid,
+                    loaded: 0,
+                    ignored: 1,
+                    last_error: Some(error.to_string()),
+                },
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            TmuxRegistryStateDiagnostics {
+                path: path.to_path_buf(),
+                status: TmuxRegistryStateStatus::Missing,
+                loaded: 0,
+                ignored: 0,
+                last_error: None,
+            }
+        }
+        Err(error) => TmuxRegistryStateDiagnostics {
+            path: path.to_path_buf(),
+            status: TmuxRegistryStateStatus::IgnoredInvalid,
+            loaded: 0,
+            ignored: 1,
+            last_error: Some(error.to_string()),
+        },
+    }
+}
+
+pub async fn register_runtime_tmux_registration(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    mut registration: RegisteredTmuxSession,
+) -> Result<usize> {
+    registration.registration_source =
+        normalize_runtime_registration_source(registration.registration_source);
+    let mut next = registry.read().await.clone();
+    next.insert(registration.session.clone(), registration);
+    let durable_count = save_durable_tmux_registry(path, &next).await?;
+    *registry.write().await = next;
+    Ok(durable_count)
+}
+
+pub async fn remove_tmux_registrations(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    sessions: &[String],
+) -> Result<usize> {
+    let mut next = registry.read().await.clone();
+    let mut removed = 0;
+    for session in sessions {
+        if next.remove(session).is_some() {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        save_durable_tmux_registry(path, &next).await?;
+        *registry.write().await = next;
+    }
+    Ok(removed)
+}
+
+pub async fn tmux_registry_diagnostics(
+    registry: &SharedTmuxRegistry,
+    registry_state: TmuxRegistryStateDiagnostics,
+) -> TmuxRegistryDiagnostics {
+    let snapshot = registry.read().await;
+    let registered_count = snapshot.len();
+    let durable_runtime_count = durable_runtime_entries(&snapshot).len();
+    let config_projected_count = registered_count.saturating_sub(durable_runtime_count);
+    drop(snapshot);
+
+    let live_probe = match list_tmux_sessions().await {
+        Ok(sessions) => {
+            let mut sample = sessions.iter().take(5).cloned().collect::<Vec<_>>();
+            sample.sort();
+            TmuxLiveProbeDiagnostics {
+                ok: true,
+                count: sessions.len(),
+                sample,
+                error: None,
+            }
+        }
+        Err(error) => TmuxLiveProbeDiagnostics {
+            ok: false,
+            count: 0,
+            sample: Vec::new(),
+            error: Some(error.to_string()),
+        },
+    };
+
+    TmuxRegistryDiagnostics {
+        registered_count,
+        durable_runtime_count,
+        config_projected_count,
+        live_probe,
+        registry_state,
+    }
+}
+
 pub async fn list_active_tmux_registrations(
     config: &AppConfig,
     registry: &SharedTmuxRegistry,
+    registry_state_path: &Path,
 ) -> Result<Vec<RegisteredTmuxSession>> {
     match list_tmux_sessions().await {
         Ok(available_sessions) => {
             sync_active_config_registrations(config, registry, &available_sessions).await;
+            let stale_sessions = registry
+                .read()
+                .await
+                .iter()
+                .filter(|(session, registration)| {
+                    registration.active_wrapper_monitor && !available_sessions.contains(*session)
+                })
+                .map(|(session, _)| session.clone())
+                .collect::<Vec<_>>();
+            remove_tmux_registrations(registry, registry_state_path, &stale_sessions).await?;
         }
         Err(error) => {
             telemetry::emit(source_record(
@@ -307,6 +570,7 @@ pub async fn list_active_tmux_registrations(
 async fn poll_tmux(
     config: &AppConfig,
     registry: &SharedTmuxRegistry,
+    registry_state_path: &Path,
     tx: &mpsc::Sender<IncomingEvent>,
     state: &mut TmuxMonitorState,
 ) -> Result<()> {
@@ -344,11 +608,6 @@ async fn poll_tmux(
     let mut sessions_to_unregister = Vec::new();
 
     for (session_name, registration) in &sessions {
-        if registration.active_wrapper_monitor {
-            state.pending_keyword_hits.remove(session_name);
-            continue;
-        }
-
         let now = Instant::now();
 
         match session_exists(session_name).await {
@@ -378,6 +637,11 @@ async fn poll_tmux(
                 continue;
             }
             Ok(true) => {}
+        }
+
+        if registration.active_wrapper_monitor {
+            state.pending_keyword_hits.remove(session_name);
+            continue;
         }
 
         flush_session_pending_keyword_hits(
@@ -493,10 +757,7 @@ async fn poll_tmux(
     state.panes.retain(|key, _| active_panes.contains(key));
 
     if !sessions_to_unregister.is_empty() {
-        let mut write = registry.write().await;
-        for session in sessions_to_unregister {
-            write.remove(&session);
-        }
+        remove_tmux_registrations(registry, registry_state_path, &sessions_to_unregister).await?;
     }
 
     state
@@ -1359,6 +1620,78 @@ PR created #7",
         ));
         assert!(registration.parent_process.is_none());
         assert!(!registration.registered_at.is_empty());
+    }
+
+    #[test]
+    fn default_registry_state_path_sits_beside_cron_state() {
+        let path = default_registry_state_path(Path::new("/tmp/clawhip/cron-state.json"));
+        assert_eq!(path, PathBuf::from("/tmp/clawhip/tmux-watch-registry.json"));
+    }
+
+    #[tokio::test]
+    async fn runtime_registry_persistence_filters_config_entries_and_normalizes_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tmux-watch-registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut runtime = registration(vec!["panic"]);
+        runtime.session = "runtime".into();
+        runtime.registration_source = RegistrationSource::ConfigMonitor;
+        register_runtime_tmux_registration(&registry, &path, runtime)
+            .await
+            .unwrap();
+
+        let mut config = registration(vec!["warn"]);
+        config.session = "config".into();
+        config.registration_source = RegistrationSource::ConfigMonitor;
+        registry.write().await.insert("config".into(), config);
+
+        let snapshot = registry.read().await.clone();
+        save_durable_tmux_registry(&path, &snapshot).await.unwrap();
+        let loaded: BTreeMap<String, RegisteredTmuxSession> =
+            serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(
+            loaded["runtime"].registration_source,
+            RegistrationSource::CliWatch
+        );
+        assert!(!loaded.contains_key("config"));
+    }
+
+    #[tokio::test]
+    async fn failed_register_save_leaves_registry_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join("missing-parent")
+            .join("tmux-watch-registry.json");
+        tokio::fs::write(dir.path().join("missing-parent"), b"not a directory")
+            .await
+            .unwrap();
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let mut runtime = registration(vec!["panic"]);
+        runtime.session = "runtime".into();
+        runtime.registration_source = RegistrationSource::CliWatch;
+
+        let result = register_runtime_tmux_registration(&registry, &path, runtime).await;
+
+        assert!(result.is_err());
+        assert!(registry.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_registry_state_is_ignored_fail_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tmux-watch-registry.json");
+        tokio::fs::write(&path, b"not json").await.unwrap();
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+
+        let diagnostics = load_tmux_registry_state(&path, &registry).await;
+
+        assert_eq!(diagnostics.status, TmuxRegistryStateStatus::IgnoredInvalid);
+        assert_eq!(diagnostics.ignored, 1);
+        assert!(registry.read().await.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Persist runtime/API tmux watch registrations to `tmux-watch-registry.json` beside cron state and reload them on daemon startup.
- Keep config-projected monitors out of durable state, normalize ambiguous API registration source to `cli-watch`, and persist durable removals.
- Add tmux health diagnostics, CLI empty-list hints, and restart persistence smoke coverage.

Fixes #281

## Verification
- `cargo fmt`
- `cargo test tmux`
- `cargo check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*