### PR TITLE
Fix route monitor onboarding idempotency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +234,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "tempfile",
  "time",
  "tokio",
@@ -239,12 +249,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -343,6 +382,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1204,6 +1253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1648,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 tokio = { version = "1.45", features = ["full"] }
 time = { version = "0.3", features = ["formatting", "parsing"] }
 uuid = { version = "1", features = ["v4"] }

--- a/src/binding_verify.rs
+++ b/src/binding_verify.rs
@@ -1202,6 +1202,54 @@ mod tests {
     }
 
     #[test]
+    fn drift_audit_ignores_manual_github_monitor_without_setup_route() {
+        let config = AppConfig {
+            monitors: MonitorConfig {
+                git: GitMonitorConfig {
+                    repos: vec![GitRepoMonitor {
+                        path: "/work/repo".to_string(),
+                        name: Some("repo".to_string()),
+                        github_repo: Some("owner/repo".to_string()),
+                        ..GitRepoMonitor::default()
+                    }],
+                },
+                ..MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let audit = audit_route_monitor_drift(&config);
+
+        assert!(audit.ok);
+        assert!(audit.findings.is_empty());
+    }
+
+    #[test]
+    fn drift_audit_allows_branch_specific_manual_route_override() {
+        let mut manual_filter = BTreeMap::new();
+        manual_filter.insert("repo".to_string(), "clawhip".to_string());
+        manual_filter.insert("branch".to_string(), "main".to_string());
+        let config = config_with_routes(vec![
+            setup_route("clawhip", "123", Some("dev")),
+            RouteRule {
+                event: "git.push".to_string(),
+                filter: manual_filter,
+                channel: Some("456".to_string()),
+                ..RouteRule::default()
+            },
+        ]);
+
+        let audit = audit_route_monitor_drift(&config);
+
+        assert!(
+            !audit
+                .findings
+                .iter()
+                .any(|finding| finding.code == "manual_route_conflict")
+        );
+    }
+
+    #[test]
     fn drift_audit_redacts_checkout_label_and_json_shape() {
         let tempdir = tempfile::tempdir().unwrap();
         let checkout = tempdir.path().join("secret-checkout");

--- a/src/binding_verify.rs
+++ b/src/binding_verify.rs
@@ -251,19 +251,16 @@ pub fn audit_route_monitor_drift(config: &AppConfig) -> BindingDriftAudit {
 
     for route in &routes {
         if route.indices.len() > 1 {
-            findings.push(finding(
-                "error",
-                "duplicate_setup_route",
-                &route.repo,
-                route.indices.clone(),
-                Vec::new(),
-                route.channel.clone(),
-                None,
-                route.channel_name.clone(),
-                None,
-                None,
-                format!("repo '{}' has multiple setup-owned routes", route.repo),
-            ));
+            findings.push(finding(FindingParams {
+                severity: "error",
+                code: "duplicate_setup_route",
+                repo: &route.repo,
+                route_indices: route.indices.clone(),
+                route_channel_id: route.channel.clone(),
+                route_channel_name: route.channel_name.clone(),
+                message: format!("repo '{}' has multiple setup-owned routes", route.repo),
+                ..FindingParams::default()
+            }));
         }
 
         let matching: Vec<&SetupMonitor> = monitors
@@ -271,154 +268,148 @@ pub fn audit_route_monitor_drift(config: &AppConfig) -> BindingDriftAudit {
             .filter(|monitor| monitor.repo.as_deref() == Some(route.repo.as_str()))
             .collect();
         if matching.is_empty() {
-            findings.push(finding(
-                "error",
-                "missing_git_monitor",
-                &route.repo,
-                route.indices.clone(),
-                Vec::new(),
-                route.channel.clone(),
-                None,
-                route.channel_name.clone(),
-                None,
-                None,
-                format!(
+            findings.push(finding(FindingParams {
+                severity: "error",
+                code: "missing_git_monitor",
+                repo: &route.repo,
+                route_indices: route.indices.clone(),
+                route_channel_id: route.channel.clone(),
+                route_channel_name: route.channel_name.clone(),
+                message: format!(
                     "repo '{}' has a setup-owned route but no setup-owned git monitor",
                     route.repo
                 ),
-            ));
+                ..FindingParams::default()
+            }));
         }
 
         for monitor in matching {
             if route.channel.as_deref() != monitor.channel.as_deref() {
-                findings.push(finding(
-                    "error",
-                    "channel_mismatch",
-                    &route.repo,
-                    route.indices.clone(),
-                    vec![monitor.index],
-                    route.channel.clone(),
-                    monitor.channel.clone(),
-                    route.channel_name.clone(),
-                    monitor.channel_name.clone(),
-                    Some(checkout_label(&monitor.path)),
-                    format!(
+                findings.push(finding(FindingParams {
+                    severity: "error",
+                    code: "channel_mismatch",
+                    repo: &route.repo,
+                    route_indices: route.indices.clone(),
+                    monitor_indices: vec![monitor.index],
+                    route_channel_id: route.channel.clone(),
+                    monitor_channel_id: monitor.channel.clone(),
+                    route_channel_name: route.channel_name.clone(),
+                    monitor_channel_name: monitor.channel_name.clone(),
+                    checkout_label: Some(checkout_label(&monitor.path)),
+                    message: format!(
                         "repo '{}' route and git monitor target different channels",
                         route.repo
                     ),
-                ));
+                }));
             }
             if route.channel_name != monitor.channel_name {
-                findings.push(finding(
-                    "error",
-                    "channel_name_mismatch",
-                    &route.repo,
-                    route.indices.clone(),
-                    vec![monitor.index],
-                    route.channel.clone(),
-                    monitor.channel.clone(),
-                    route.channel_name.clone(),
-                    monitor.channel_name.clone(),
-                    Some(checkout_label(&monitor.path)),
-                    format!(
+                findings.push(finding(FindingParams {
+                    severity: "error",
+                    code: "channel_name_mismatch",
+                    repo: &route.repo,
+                    route_indices: route.indices.clone(),
+                    monitor_indices: vec![monitor.index],
+                    route_channel_id: route.channel.clone(),
+                    monitor_channel_id: monitor.channel.clone(),
+                    route_channel_name: route.channel_name.clone(),
+                    monitor_channel_name: monitor.channel_name.clone(),
+                    checkout_label: Some(checkout_label(&monitor.path)),
+                    message: format!(
                         "repo '{}' route and git monitor have different channel_name hints",
                         route.repo
                     ),
-                ));
+                }));
             }
             if !Path::new(&monitor.path).exists() {
-                findings.push(finding(
-                    "error",
-                    "checkout_missing",
-                    &route.repo,
-                    route.indices.clone(),
-                    vec![monitor.index],
-                    route.channel.clone(),
-                    monitor.channel.clone(),
-                    route.channel_name.clone(),
-                    monitor.channel_name.clone(),
-                    Some(checkout_label(&monitor.path)),
-                    format!("repo '{}' git monitor checkout is missing", route.repo),
-                ));
+                findings.push(finding(FindingParams {
+                    severity: "error",
+                    code: "checkout_missing",
+                    repo: &route.repo,
+                    route_indices: route.indices.clone(),
+                    monitor_indices: vec![monitor.index],
+                    route_channel_id: route.channel.clone(),
+                    monitor_channel_id: monitor.channel.clone(),
+                    route_channel_name: route.channel_name.clone(),
+                    monitor_channel_name: monitor.channel_name.clone(),
+                    checkout_label: Some(checkout_label(&monitor.path)),
+                    message: format!("repo '{}' git monitor checkout is missing", route.repo),
+                }));
             } else if !looks_like_git_worktree(&monitor.path) {
-                findings.push(finding(
-                    "error",
-                    "checkout_not_git_worktree",
-                    &route.repo,
-                    route.indices.clone(),
-                    vec![monitor.index],
-                    route.channel.clone(),
-                    monitor.channel.clone(),
-                    route.channel_name.clone(),
-                    monitor.channel_name.clone(),
-                    Some(checkout_label(&monitor.path)),
-                    format!(
+                findings.push(finding(FindingParams {
+                    severity: "error",
+                    code: "checkout_not_git_worktree",
+                    repo: &route.repo,
+                    route_indices: route.indices.clone(),
+                    monitor_indices: vec![monitor.index],
+                    route_channel_id: route.channel.clone(),
+                    monitor_channel_id: monitor.channel.clone(),
+                    route_channel_name: route.channel_name.clone(),
+                    monitor_channel_name: monitor.channel_name.clone(),
+                    checkout_label: Some(checkout_label(&monitor.path)),
+                    message: format!(
                         "repo '{}' git monitor checkout is not a git worktree",
                         route.repo
                     ),
-                ));
+                }));
             }
         }
 
         for monitor in monitors.iter().filter(|monitor| monitor.repo.is_none()) {
             if route.channel.is_some() && route.channel == monitor.channel {
-                findings.push(finding(
-                    "error",
-                    "manual_monitor_conflict",
-                    &route.repo,
-                    route.indices.clone(),
-                    vec![monitor.index],
-                    route.channel.clone(),
-                    monitor.channel.clone(),
-                    route.channel_name.clone(),
-                    monitor.channel_name.clone(),
-                    Some(checkout_label(&monitor.path)),
-                    format!(
+                findings.push(finding(FindingParams {
+                    severity: "error",
+                    code: "manual_monitor_conflict",
+                    repo: &route.repo,
+                    route_indices: route.indices.clone(),
+                    monitor_indices: vec![monitor.index],
+                    route_channel_id: route.channel.clone(),
+                    monitor_channel_id: monitor.channel.clone(),
+                    route_channel_name: route.channel_name.clone(),
+                    monitor_channel_name: monitor.channel_name.clone(),
+                    checkout_label: Some(checkout_label(&monitor.path)),
+                    message: format!(
                         "repo '{}' route shares a channel with a manual channel-only git monitor",
                         route.repo
                     ),
-                ));
+                }));
             }
         }
     }
 
     for monitor in &monitors {
         if monitor.indices_len > 1 {
-            findings.push(finding(
-                "error",
-                "duplicate_setup_monitor",
-                monitor.repo.as_deref().unwrap_or("<manual>"),
-                Vec::new(),
-                vec![monitor.index],
-                None,
-                monitor.channel.clone(),
-                None,
-                monitor.channel_name.clone(),
-                Some(checkout_label(&monitor.path)),
-                "multiple setup-owned git monitors share the same repo identity".to_string(),
-            ));
+            findings.push(finding(FindingParams {
+                severity: "error",
+                code: "duplicate_setup_monitor",
+                repo: monitor.repo.as_deref().unwrap_or("<manual>"),
+                monitor_indices: vec![monitor.index],
+                monitor_channel_id: monitor.channel.clone(),
+                monitor_channel_name: monitor.channel_name.clone(),
+                checkout_label: Some(checkout_label(&monitor.path)),
+                message: "multiple setup-owned git monitors share the same repo identity"
+                    .to_string(),
+                ..FindingParams::default()
+            }));
         }
     }
 
     for monitor in monitors.iter().filter(|monitor| monitor.repo.is_some()) {
         let repo = monitor.repo.as_ref().unwrap();
         if !routes.iter().any(|route| route.repo == *repo) {
-            findings.push(finding(
-                "error",
-                "repo_identity_mismatch",
+            findings.push(finding(FindingParams {
+                severity: "error",
+                code: "repo_identity_mismatch",
                 repo,
-                Vec::new(),
-                vec![monitor.index],
-                None,
-                monitor.channel.clone(),
-                None,
-                monitor.channel_name.clone(),
-                Some(checkout_label(&monitor.path)),
-                format!(
+                monitor_indices: vec![monitor.index],
+                monitor_channel_id: monitor.channel.clone(),
+                monitor_channel_name: monitor.channel_name.clone(),
+                checkout_label: Some(checkout_label(&monitor.path)),
+                message: format!(
                     "git monitor repo '{}' has no matching setup-owned route",
                     repo
                 ),
-            ));
+                ..FindingParams::default()
+            }));
         }
     }
 
@@ -426,23 +417,20 @@ pub fn audit_route_monitor_drift(config: &AppConfig) -> BindingDriftAudit {
         if !is_setup_repo_route(route)
             && route.effective_sink() == "discord"
             && route.channel.is_some()
-            && route.filter.get("repo").is_some()
+            && route.filter.contains_key("repo")
         {
             let repo = route.filter.get("repo").cloned().unwrap_or_default();
             if routes.iter().any(|setup| setup.repo == repo) {
-                findings.push(finding(
-                    "error",
-                    "manual_route_conflict",
-                    &repo,
-                    vec![index],
-                    Vec::new(),
-                    route.channel.clone(),
-                    None,
-                    route.channel_name.clone(),
-                    None,
-                    None,
-                    format!("repo '{}' has a manual wildcard Discord route", repo),
-                ));
+                findings.push(finding(FindingParams {
+                    severity: "error",
+                    code: "manual_route_conflict",
+                    repo: &repo,
+                    route_indices: vec![index],
+                    route_channel_id: route.channel.clone(),
+                    route_channel_name: route.channel_name.clone(),
+                    message: format!("repo '{}' has a manual wildcard Discord route", repo),
+                    ..FindingParams::default()
+                }));
             }
         }
     }
@@ -597,10 +585,11 @@ fn stable_hash32(value: &str) -> u32 {
     hash
 }
 
-fn finding(
-    severity: &str,
-    code: &str,
-    repo: &str,
+#[derive(Default)]
+struct FindingParams<'a> {
+    severity: &'a str,
+    code: &'a str,
+    repo: &'a str,
     route_indices: Vec<usize>,
     monitor_indices: Vec<usize>,
     route_channel_id: Option<String>,
@@ -609,19 +598,21 @@ fn finding(
     monitor_channel_name: Option<String>,
     checkout_label: Option<String>,
     message: String,
-) -> BindingDriftFinding {
+}
+
+fn finding(params: FindingParams<'_>) -> BindingDriftFinding {
     BindingDriftFinding {
-        severity: severity.to_string(),
-        code: code.to_string(),
-        repo: repo.to_string(),
-        route_indices,
-        monitor_indices,
-        route_channel_id,
-        monitor_channel_id,
-        route_channel_name,
-        monitor_channel_name,
-        checkout_label,
-        message,
+        severity: params.severity.to_string(),
+        code: params.code.to_string(),
+        repo: params.repo.to_string(),
+        route_indices: params.route_indices,
+        monitor_indices: params.monitor_indices,
+        route_channel_id: params.route_channel_id,
+        monitor_channel_id: params.monitor_channel_id,
+        route_channel_name: params.route_channel_name,
+        monitor_channel_name: params.monitor_channel_name,
+        checkout_label: params.checkout_label,
+        message: params.message,
     }
 }
 

--- a/src/binding_verify.rs
+++ b/src/binding_verify.rs
@@ -540,6 +540,9 @@ fn is_setup_repo_route(route: &crate::config::RouteRule) -> bool {
 }
 
 fn setup_monitor_repo_identity(monitor: &crate::config::GitRepoMonitor) -> Option<String> {
+    if !monitor.setup_owned {
+        return None;
+    }
     if monitor
         .channel
         .as_deref()
@@ -1085,6 +1088,36 @@ mod tests {
         assert_eq!(config.routes[0].channel_name.as_deref(), Some("new-name"));
     }
 
+    #[test]
+    fn apply_owner_qualified_binding_does_not_steal_different_github_repo_by_basename() {
+        let mut config = AppConfig::default();
+        config.monitors.git.repos.push(GitRepoMonitor {
+            path: "/work/owner1-repo".into(),
+            name: Some("repo".into()),
+            github_repo: Some("owner1/repo".into()),
+            channel: Some("old".into()),
+            channel_name: Some("old-dev".into()),
+            setup_owned: true,
+            ..GitRepoMonitor::default()
+        });
+
+        config
+            .apply_repo_channel_binding("owner2/repo", "new", Some("new-dev"), "/work/owner2-repo")
+            .unwrap();
+
+        assert_eq!(config.monitors.git.repos.len(), 2);
+        let old = &config.monitors.git.repos[0];
+        assert_eq!(old.path, "/work/owner1-repo");
+        assert_eq!(old.github_repo.as_deref(), Some("owner1/repo"));
+        assert_eq!(old.channel.as_deref(), Some("old"));
+        let new = &config.monitors.git.repos[1];
+        assert_eq!(new.path, "/work/owner2-repo");
+        assert_eq!(new.name.as_deref(), Some("repo"));
+        assert_eq!(new.github_repo.as_deref(), Some("owner2/repo"));
+        assert_eq!(new.channel.as_deref(), Some("new"));
+        assert!(new.setup_owned);
+    }
+
     fn setup_route(repo: &str, channel: &str, channel_name: Option<&str>) -> RouteRule {
         let mut filter = BTreeMap::new();
         filter.insert("repo".to_string(), repo.to_string());
@@ -1108,6 +1141,7 @@ mod tests {
             name: name.map(ToOwned::to_owned),
             channel: channel.map(ToOwned::to_owned),
             channel_name: channel_name.map(ToOwned::to_owned),
+            setup_owned: true,
             ..GitRepoMonitor::default()
         }
     }
@@ -1222,6 +1256,32 @@ mod tests {
 
         assert!(audit.ok);
         assert!(audit.findings.is_empty());
+    }
+
+    #[test]
+    fn drift_audit_ignores_manual_github_monitor_with_route_like_metadata() {
+        let config = config_with_route_and_monitors(
+            setup_route("owner/repo", "456", Some("ops")),
+            vec![GitRepoMonitor {
+                path: "/manual/repo".to_string(),
+                name: Some("repo".to_string()),
+                github_repo: Some("owner/repo".to_string()),
+                channel: Some("123".to_string()),
+                channel_name: Some("dev".to_string()),
+                ..GitRepoMonitor::default()
+            }],
+        );
+
+        let audit = audit_route_monitor_drift(&config);
+
+        assert!(
+            !audit
+                .findings
+                .iter()
+                .any(|finding| finding.code == "repo_identity_mismatch"
+                    || finding.monitor_indices == vec![0]),
+            "manual monitor must not be audited as setup-owned: {audit:?}"
+        );
     }
 
     #[test]

--- a/src/binding_verify.rs
+++ b/src/binding_verify.rs
@@ -4,7 +4,9 @@
 //! Discord API to confirm each channel exists and (optionally) that the live
 //! name matches the operator's `channel_name` hint.
 
+use std::collections::BTreeMap;
 use std::fmt;
+use std::path::Path;
 
 use serde::Serialize;
 
@@ -218,6 +220,411 @@ impl BindingAudit {
     }
 }
 
+/// Aggregate route↔git-monitor drift result for setup-owned repo bindings.
+#[derive(Debug, Clone, Serialize)]
+pub struct BindingDriftAudit {
+    pub ok: bool,
+    pub findings: Vec<BindingDriftFinding>,
+}
+
+/// A public-safe route↔git-monitor drift finding.
+#[derive(Debug, Clone, Serialize)]
+pub struct BindingDriftFinding {
+    pub severity: String,
+    pub code: String,
+    pub repo: String,
+    pub route_indices: Vec<usize>,
+    pub monitor_indices: Vec<usize>,
+    pub route_channel_id: Option<String>,
+    pub monitor_channel_id: Option<String>,
+    pub route_channel_name: Option<String>,
+    pub monitor_channel_name: Option<String>,
+    pub checkout_label: Option<String>,
+    pub message: String,
+}
+
+/// Audit setup-owned repo routes and git monitors for local config drift.
+pub fn audit_route_monitor_drift(config: &AppConfig) -> BindingDriftAudit {
+    let mut findings = Vec::new();
+    let routes = setup_repo_routes(config);
+    let monitors = setup_git_monitors(config);
+
+    for route in &routes {
+        if route.indices.len() > 1 {
+            findings.push(finding(
+                "error",
+                "duplicate_setup_route",
+                &route.repo,
+                route.indices.clone(),
+                Vec::new(),
+                route.channel.clone(),
+                None,
+                route.channel_name.clone(),
+                None,
+                None,
+                format!("repo '{}' has multiple setup-owned routes", route.repo),
+            ));
+        }
+
+        let matching: Vec<&SetupMonitor> = monitors
+            .iter()
+            .filter(|monitor| monitor.repo.as_deref() == Some(route.repo.as_str()))
+            .collect();
+        if matching.is_empty() {
+            findings.push(finding(
+                "error",
+                "missing_git_monitor",
+                &route.repo,
+                route.indices.clone(),
+                Vec::new(),
+                route.channel.clone(),
+                None,
+                route.channel_name.clone(),
+                None,
+                None,
+                format!(
+                    "repo '{}' has a setup-owned route but no setup-owned git monitor",
+                    route.repo
+                ),
+            ));
+        }
+
+        for monitor in matching {
+            if route.channel.as_deref() != monitor.channel.as_deref() {
+                findings.push(finding(
+                    "error",
+                    "channel_mismatch",
+                    &route.repo,
+                    route.indices.clone(),
+                    vec![monitor.index],
+                    route.channel.clone(),
+                    monitor.channel.clone(),
+                    route.channel_name.clone(),
+                    monitor.channel_name.clone(),
+                    Some(checkout_label(&monitor.path)),
+                    format!(
+                        "repo '{}' route and git monitor target different channels",
+                        route.repo
+                    ),
+                ));
+            }
+            if route.channel_name != monitor.channel_name {
+                findings.push(finding(
+                    "error",
+                    "channel_name_mismatch",
+                    &route.repo,
+                    route.indices.clone(),
+                    vec![monitor.index],
+                    route.channel.clone(),
+                    monitor.channel.clone(),
+                    route.channel_name.clone(),
+                    monitor.channel_name.clone(),
+                    Some(checkout_label(&monitor.path)),
+                    format!(
+                        "repo '{}' route and git monitor have different channel_name hints",
+                        route.repo
+                    ),
+                ));
+            }
+            if !Path::new(&monitor.path).exists() {
+                findings.push(finding(
+                    "error",
+                    "checkout_missing",
+                    &route.repo,
+                    route.indices.clone(),
+                    vec![monitor.index],
+                    route.channel.clone(),
+                    monitor.channel.clone(),
+                    route.channel_name.clone(),
+                    monitor.channel_name.clone(),
+                    Some(checkout_label(&monitor.path)),
+                    format!("repo '{}' git monitor checkout is missing", route.repo),
+                ));
+            } else if !looks_like_git_worktree(&monitor.path) {
+                findings.push(finding(
+                    "error",
+                    "checkout_not_git_worktree",
+                    &route.repo,
+                    route.indices.clone(),
+                    vec![monitor.index],
+                    route.channel.clone(),
+                    monitor.channel.clone(),
+                    route.channel_name.clone(),
+                    monitor.channel_name.clone(),
+                    Some(checkout_label(&monitor.path)),
+                    format!(
+                        "repo '{}' git monitor checkout is not a git worktree",
+                        route.repo
+                    ),
+                ));
+            }
+        }
+
+        for monitor in monitors.iter().filter(|monitor| monitor.repo.is_none()) {
+            if route.channel.is_some() && route.channel == monitor.channel {
+                findings.push(finding(
+                    "error",
+                    "manual_monitor_conflict",
+                    &route.repo,
+                    route.indices.clone(),
+                    vec![monitor.index],
+                    route.channel.clone(),
+                    monitor.channel.clone(),
+                    route.channel_name.clone(),
+                    monitor.channel_name.clone(),
+                    Some(checkout_label(&monitor.path)),
+                    format!(
+                        "repo '{}' route shares a channel with a manual channel-only git monitor",
+                        route.repo
+                    ),
+                ));
+            }
+        }
+    }
+
+    for monitor in &monitors {
+        if monitor.indices_len > 1 {
+            findings.push(finding(
+                "error",
+                "duplicate_setup_monitor",
+                monitor.repo.as_deref().unwrap_or("<manual>"),
+                Vec::new(),
+                vec![monitor.index],
+                None,
+                monitor.channel.clone(),
+                None,
+                monitor.channel_name.clone(),
+                Some(checkout_label(&monitor.path)),
+                "multiple setup-owned git monitors share the same repo identity".to_string(),
+            ));
+        }
+    }
+
+    for monitor in monitors.iter().filter(|monitor| monitor.repo.is_some()) {
+        let repo = monitor.repo.as_ref().unwrap();
+        if !routes.iter().any(|route| route.repo == *repo) {
+            findings.push(finding(
+                "error",
+                "repo_identity_mismatch",
+                repo,
+                Vec::new(),
+                vec![monitor.index],
+                None,
+                monitor.channel.clone(),
+                None,
+                monitor.channel_name.clone(),
+                Some(checkout_label(&monitor.path)),
+                format!(
+                    "git monitor repo '{}' has no matching setup-owned route",
+                    repo
+                ),
+            ));
+        }
+    }
+
+    for (index, route) in config.routes.iter().enumerate() {
+        if !is_setup_repo_route(route)
+            && route.effective_sink() == "discord"
+            && route.channel.is_some()
+            && route.filter.get("repo").is_some()
+        {
+            let repo = route.filter.get("repo").cloned().unwrap_or_default();
+            if routes.iter().any(|setup| setup.repo == repo) {
+                findings.push(finding(
+                    "error",
+                    "manual_route_conflict",
+                    &repo,
+                    vec![index],
+                    Vec::new(),
+                    route.channel.clone(),
+                    None,
+                    route.channel_name.clone(),
+                    None,
+                    None,
+                    format!("repo '{}' has a manual wildcard Discord route", repo),
+                ));
+            }
+        }
+    }
+
+    BindingDriftAudit {
+        ok: findings.is_empty(),
+        findings,
+    }
+}
+
+#[derive(Debug)]
+struct SetupRoute {
+    repo: String,
+    indices: Vec<usize>,
+    channel: Option<String>,
+    channel_name: Option<String>,
+}
+
+#[derive(Debug)]
+struct SetupMonitor {
+    repo: Option<String>,
+    index: usize,
+    indices_len: usize,
+    path: String,
+    channel: Option<String>,
+    channel_name: Option<String>,
+}
+
+fn setup_repo_routes(config: &AppConfig) -> Vec<SetupRoute> {
+    let mut by_repo: BTreeMap<String, SetupRoute> = BTreeMap::new();
+    for (index, route) in config.routes.iter().enumerate() {
+        if is_setup_repo_route(route) {
+            let repo = route.filter.get("repo").cloned().unwrap_or_default();
+            by_repo
+                .entry(repo.clone())
+                .and_modify(|entry| entry.indices.push(index))
+                .or_insert_with(|| SetupRoute {
+                    repo,
+                    indices: vec![index],
+                    channel: route.channel.clone(),
+                    channel_name: route.channel_name.clone(),
+                });
+        }
+    }
+    by_repo.into_values().collect()
+}
+
+fn setup_git_monitors(config: &AppConfig) -> Vec<SetupMonitor> {
+    let mut identity_counts: BTreeMap<String, usize> = BTreeMap::new();
+    for monitor in &config.monitors.git.repos {
+        if let Some(repo) = monitor_repo_identity(monitor) {
+            *identity_counts.entry(repo).or_default() += 1;
+        }
+    }
+
+    config
+        .monitors
+        .git
+        .repos
+        .iter()
+        .enumerate()
+        .map(|(index, monitor)| {
+            let repo = monitor_repo_identity(monitor);
+            let indices_len = repo
+                .as_ref()
+                .and_then(|repo| identity_counts.get(repo))
+                .copied()
+                .unwrap_or(1);
+            SetupMonitor {
+                repo,
+                index,
+                indices_len,
+                path: monitor.path.clone(),
+                channel: monitor.channel.clone(),
+                channel_name: monitor.channel_name.clone(),
+            }
+        })
+        .collect()
+}
+
+fn is_setup_repo_route(route: &crate::config::RouteRule) -> bool {
+    route.event == "*"
+        && route.sink.trim() == "discord"
+        && route.effective_sink() == "discord"
+        && route.filter.len() == 1
+        && route
+            .filter
+            .get("repo")
+            .map(|repo| !repo.trim().is_empty())
+            .unwrap_or(false)
+        && route
+            .channel
+            .as_deref()
+            .map(|channel| !channel.trim().is_empty())
+            .unwrap_or(false)
+        && route.thread.is_none()
+        && route.webhook.is_none()
+        && route.slack_webhook.is_none()
+        && route.local_path.is_none()
+        && route.mention.is_none()
+        && route.template.is_none()
+        && route.gajae.is_none()
+        && !route.allow_dynamic_tokens
+        && route.format.is_none()
+}
+
+fn monitor_repo_identity(monitor: &crate::config::GitRepoMonitor) -> Option<String> {
+    monitor
+        .github_repo
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            monitor
+                .name
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
+}
+
+fn looks_like_git_worktree(path: &str) -> bool {
+    let path = Path::new(path);
+    path.join(".git").exists()
+        || path
+            .parent()
+            .map(|parent| parent.join(".git").exists())
+            .unwrap_or(false)
+}
+
+fn checkout_label(path: &str) -> String {
+    let path = Path::new(path);
+    let basename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("checkout");
+    format!(
+        "{}#{:08x}",
+        basename,
+        stable_hash32(path.to_string_lossy().as_ref())
+    )
+}
+
+fn stable_hash32(value: &str) -> u32 {
+    let mut hash: u32 = 0x811c9dc5;
+    for byte in value.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x01000193);
+    }
+    hash
+}
+
+fn finding(
+    severity: &str,
+    code: &str,
+    repo: &str,
+    route_indices: Vec<usize>,
+    monitor_indices: Vec<usize>,
+    route_channel_id: Option<String>,
+    monitor_channel_id: Option<String>,
+    route_channel_name: Option<String>,
+    monitor_channel_name: Option<String>,
+    checkout_label: Option<String>,
+    message: String,
+) -> BindingDriftFinding {
+    BindingDriftFinding {
+        severity: severity.to_string(),
+        code: code.to_string(),
+        repo: repo.to_string(),
+        route_indices,
+        monitor_indices,
+        route_channel_id,
+        monitor_channel_id,
+        route_channel_name,
+        monitor_channel_name,
+        checkout_label,
+        message,
+    }
+}
+
 /// Resolve a lookup result into a verdict given the expected-name hint.
 fn resolve_verdict(lookup: ChannelLookup, expected: &Option<String>) -> VerdictKind {
     match lookup {
@@ -325,6 +732,35 @@ impl fmt::Display for BindingAudit {
             )?;
         }
 
+        Ok(())
+    }
+}
+
+impl fmt::Display for BindingDriftAudit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Route/monitor drift:")?;
+        if self.findings.is_empty() {
+            writeln!(f, "[  ok] no route/monitor drift found")?;
+            return Ok(());
+        }
+        for finding in &self.findings {
+            let route = finding
+                .route_indices
+                .first()
+                .map(|index| (index + 1).to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let monitor = finding
+                .monitor_indices
+                .first()
+                .map(|index| (index + 1).to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let checkout = finding.checkout_label.as_deref().unwrap_or("-");
+            writeln!(
+                f,
+                "[FAIL] {} repo={} route={} monitor={} checkout={} {}",
+                finding.code, finding.repo, route, monitor, checkout, finding.message
+            )?;
+        }
         Ok(())
     }
 }
@@ -612,10 +1048,10 @@ mod tests {
     }
 
     #[test]
-    fn apply_repo_binding_creates_route() {
+    fn apply_repo_channel_binding_creates_route_and_monitor() {
         let mut config = AppConfig::default();
         config
-            .apply_repo_binding("clawhip", "123456", Some("clawhip-dev"))
+            .apply_repo_channel_binding("clawhip", "123456", Some("clawhip-dev"), "/work/clawhip")
             .unwrap();
         assert_eq!(config.routes.len(), 1);
         assert_eq!(config.routes[0].channel.as_deref(), Some("123456"));
@@ -627,16 +1063,151 @@ mod tests {
     }
 
     #[test]
-    fn apply_repo_binding_updates_existing() {
+    fn apply_repo_channel_binding_updates_existing() {
         let mut config = AppConfig::default();
         config
-            .apply_repo_binding("clawhip", "111", Some("old-name"))
+            .apply_repo_channel_binding("clawhip", "111", Some("old-name"), "/work/clawhip")
             .unwrap();
         config
-            .apply_repo_binding("clawhip", "222", Some("new-name"))
+            .apply_repo_channel_binding("clawhip", "222", Some("new-name"), "/work/clawhip")
             .unwrap();
         assert_eq!(config.routes.len(), 1);
         assert_eq!(config.routes[0].channel.as_deref(), Some("222"));
         assert_eq!(config.routes[0].channel_name.as_deref(), Some("new-name"));
+    }
+
+    fn setup_route(repo: &str, channel: &str, channel_name: Option<&str>) -> RouteRule {
+        let mut filter = BTreeMap::new();
+        filter.insert("repo".to_string(), repo.to_string());
+        RouteRule {
+            event: "*".to_string(),
+            filter,
+            channel: Some(channel.to_string()),
+            channel_name: channel_name.map(ToOwned::to_owned),
+            ..RouteRule::default()
+        }
+    }
+
+    fn git_monitor(
+        path: &str,
+        name: Option<&str>,
+        channel: Option<&str>,
+        channel_name: Option<&str>,
+    ) -> GitRepoMonitor {
+        GitRepoMonitor {
+            path: path.to_string(),
+            name: name.map(ToOwned::to_owned),
+            channel: channel.map(ToOwned::to_owned),
+            channel_name: channel_name.map(ToOwned::to_owned),
+            ..GitRepoMonitor::default()
+        }
+    }
+
+    fn config_with_route_and_monitors(route: RouteRule, repos: Vec<GitRepoMonitor>) -> AppConfig {
+        AppConfig {
+            routes: vec![route],
+            monitors: MonitorConfig {
+                git: GitMonitorConfig { repos },
+                ..MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        }
+    }
+
+    #[test]
+    fn drift_audit_detects_missing_monitor() {
+        let config = config_with_routes(vec![setup_route("clawhip", "123", Some("dev"))]);
+
+        let audit = audit_route_monitor_drift(&config);
+
+        assert!(!audit.ok);
+        assert_eq!(audit.findings[0].code, "missing_git_monitor");
+        assert_eq!(audit.findings[0].repo, "clawhip");
+        assert_eq!(audit.findings[0].route_channel_id.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn drift_audit_detects_channel_mismatch() {
+        let tempdir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tempdir.path().join(".git")).unwrap();
+        let config = config_with_route_and_monitors(
+            setup_route("clawhip", "123", Some("dev")),
+            vec![git_monitor(
+                tempdir.path().to_str().unwrap(),
+                Some("clawhip"),
+                Some("456"),
+                Some("dev"),
+            )],
+        );
+
+        let audit = audit_route_monitor_drift(&config);
+
+        assert!(
+            audit
+                .findings
+                .iter()
+                .any(|finding| finding.code == "channel_mismatch")
+        );
+    }
+
+    #[test]
+    fn drift_audit_detects_manual_channel_only_monitor_conflict() {
+        let tempdir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tempdir.path().join(".git")).unwrap();
+        let config = config_with_route_and_monitors(
+            setup_route("clawhip", "123", Some("dev")),
+            vec![git_monitor(
+                tempdir.path().to_str().unwrap(),
+                None,
+                Some("123"),
+                Some("dev"),
+            )],
+        );
+
+        let audit = audit_route_monitor_drift(&config);
+
+        assert!(
+            audit
+                .findings
+                .iter()
+                .any(|finding| finding.code == "manual_monitor_conflict")
+        );
+    }
+
+    #[test]
+    fn drift_audit_redacts_checkout_label_and_json_shape() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let checkout = tempdir.path().join("secret-checkout");
+        std::fs::create_dir(&checkout).unwrap();
+        let raw_path = checkout.to_str().unwrap();
+        let config = config_with_route_and_monitors(
+            setup_route("clawhip", "123", Some("dev")),
+            vec![git_monitor(
+                raw_path,
+                Some("clawhip"),
+                Some("123"),
+                Some("dev"),
+            )],
+        );
+
+        let audit = audit_route_monitor_drift(&config);
+        let finding = audit
+            .findings
+            .iter()
+            .find(|finding| finding.code == "checkout_not_git_worktree")
+            .unwrap();
+        let label = finding.checkout_label.as_ref().unwrap();
+        let json = serde_json::to_string(&audit).unwrap();
+        let text = audit.to_string();
+
+        assert!(label.starts_with("secret-checkout#"));
+        assert_eq!(label.len(), "secret-checkout#".len() + 8);
+        assert!(json.contains("\"ok\":"));
+        assert!(json.contains("\"findings\":"));
+        assert!(json.contains("\"checkout_label\":"));
+        assert!(!json.contains(raw_path));
+        assert!(!text.contains(raw_path));
+        assert!(text.contains("Route/monitor drift:"));
+        assert!(text.contains("[FAIL]"));
     }
 }

--- a/src/binding_verify.rs
+++ b/src/binding_verify.rs
@@ -415,8 +415,10 @@ pub fn audit_route_monitor_drift(config: &AppConfig) -> BindingDriftAudit {
 
     for (index, route) in config.routes.iter().enumerate() {
         if !is_setup_repo_route(route)
+            && route.event == "*"
             && route.effective_sink() == "discord"
             && route.channel.is_some()
+            && route.filter.len() == 1
             && route.filter.contains_key("repo")
         {
             let repo = route.filter.get("repo").cloned().unwrap_or_default();
@@ -481,7 +483,7 @@ fn setup_repo_routes(config: &AppConfig) -> Vec<SetupRoute> {
 fn setup_git_monitors(config: &AppConfig) -> Vec<SetupMonitor> {
     let mut identity_counts: BTreeMap<String, usize> = BTreeMap::new();
     for monitor in &config.monitors.git.repos {
-        if let Some(repo) = monitor_repo_identity(monitor) {
+        if let Some(repo) = setup_monitor_repo_identity(monitor) {
             *identity_counts.entry(repo).or_default() += 1;
         }
     }
@@ -493,7 +495,7 @@ fn setup_git_monitors(config: &AppConfig) -> Vec<SetupMonitor> {
         .iter()
         .enumerate()
         .map(|(index, monitor)| {
-            let repo = monitor_repo_identity(monitor);
+            let repo = setup_monitor_repo_identity(monitor);
             let indices_len = repo
                 .as_ref()
                 .and_then(|repo| identity_counts.get(repo))
@@ -535,6 +537,22 @@ fn is_setup_repo_route(route: &crate::config::RouteRule) -> bool {
         && route.gajae.is_none()
         && !route.allow_dynamic_tokens
         && route.format.is_none()
+}
+
+fn setup_monitor_repo_identity(monitor: &crate::config::GitRepoMonitor) -> Option<String> {
+    if monitor
+        .channel
+        .as_deref()
+        .is_none_or(|value| value.trim().is_empty())
+        || monitor
+            .channel_name
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+    {
+        return None;
+    }
+
+    monitor_repo_identity(monitor)
 }
 
 fn monitor_repo_identity(monitor: &crate::config::GitRepoMonitor) -> Option<String> {
@@ -1115,6 +1133,24 @@ mod tests {
         assert_eq!(audit.findings[0].code, "missing_git_monitor");
         assert_eq!(audit.findings[0].repo, "clawhip");
         assert_eq!(audit.findings[0].route_channel_id.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn drift_audit_ignores_manual_git_monitor_without_route_binding() {
+        let config = AppConfig {
+            monitors: MonitorConfig {
+                git: GitMonitorConfig {
+                    repos: vec![git_monitor("/tmp", Some("manual"), None, None)],
+                },
+                ..MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let audit = audit_route_monitor_drift(&config);
+
+        assert!(audit.ok);
+        assert!(audit.findings.is_empty());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -237,6 +237,10 @@ pub struct SetupArgs {
     /// resolved (missing, forbidden, or no bot token). Repeatable.
     #[arg(long = "bind", value_name = "REPO=CHANNEL_ID")]
     pub bind: Vec<String>,
+    /// Bind a repo to a checkout path for setup-owned git monitoring. Format: `repo=path`.
+    /// Repeatable. Every repo named here must also be present in `--bind`.
+    #[arg(long = "bind-checkout", value_name = "REPO=PATH")]
+    pub bind_checkout: Vec<String>,
     /// When combined with `--bind`, refuse unless the live channel name
     /// matches the expected name. Format: `repo=expected_name`. Repeatable.
     #[arg(long = "expect-name", value_name = "REPO=NAME")]
@@ -1210,6 +1214,24 @@ mod tests {
         assert_eq!(args.bind[1], "oh-my-codex=1480171106324189335");
         assert_eq!(args.expect_name.len(), 1);
         assert_eq!(args.expect_name[0], "clawhip=clawhip-dev");
+        assert!(args.bind_checkout.is_empty());
+    }
+
+    #[test]
+    fn parses_setup_bind_checkout_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "setup",
+            "--bind",
+            "clawhip=1480171113253175356",
+            "--bind-checkout",
+            "clawhip=/work/clawhip",
+        ]);
+        let Commands::Setup(args) = cli.command.expect("setup command") else {
+            panic!("expected Setup");
+        };
+        assert_eq!(args.bind, vec!["clawhip=1480171113253175356"]);
+        assert_eq!(args.bind_checkout, vec!["clawhip=/work/clawhip"]);
     }
 
     #[test]
@@ -1340,6 +1362,7 @@ mod tests {
         assert!(help.contains("Advanced routes and monitors still require manual config editing"));
         assert!(help.contains("--default-format <DEFAULT_FORMAT>"));
         assert!(help.contains("--daemon-base-url <DAEMON_BASE_URL>"));
+        assert!(help.contains("--bind-checkout <REPO=PATH>"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -345,6 +345,11 @@ pub struct GitRepoMonitor {
     /// Human-readable channel name hint for binding verification.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub channel_name: Option<String>,
+    /// Marks git monitors created and owned by `clawhip setup --bind`.
+    /// Manual monitors default to false so binding drift audits do not infer
+    /// ownership from repo/channel metadata alone.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub setup_owned: bool,
     pub mention: Option<String>,
     pub format: Option<MessageFormat>,
 }
@@ -362,6 +367,7 @@ impl Default for GitRepoMonitor {
             emit_pr_status: false,
             channel: None,
             channel_name: None,
+            setup_owned: false,
             mention: None,
             format: None,
         }
@@ -1353,10 +1359,7 @@ impl AppConfig {
             return Err(format!("manual_route_conflict for repo '{repo}'").into());
         }
 
-        let setup_route_pair = route_matches.first().and_then(|index| {
-            let route = &self.routes[*index];
-            Some((route.channel.as_deref()?, route.channel_name.as_deref()?))
-        });
+        let requested_owner_repo = github_repo.as_deref();
         if self.monitors.git.repos.iter().any(|monitor| {
             monitor.channel.as_deref() == Some(channel_id.as_str())
                 && monitor.github_repo.is_none()
@@ -1372,12 +1375,21 @@ impl AppConfig {
             .iter()
             .enumerate()
             .filter(|(_, monitor)| {
-                monitor.path.trim() == checkout_path
-                    || monitor.name.as_deref() == Some(monitor_name.as_str())
-                    || (github_repo.is_some() && monitor.github_repo.as_ref() == github_repo.as_ref())
+                let path_matches = monitor.path.trim() == checkout_path;
+                let github_repo_matches = requested_owner_repo
+                    .is_some_and(|repo| monitor.github_repo.as_deref() == Some(repo));
+                let name_matches = monitor.name.as_deref() == Some(monitor_name.as_str())
+                    && requested_owner_repo.is_none_or(|repo| {
+                        monitor
+                            .github_repo
+                            .as_deref()
+                            .is_none_or(|existing| existing.trim().is_empty() || existing == repo)
+                    });
+
+                path_matches || github_repo_matches || name_matches
             })
             .map(|(index, monitor)| {
-                if is_setup_owned_git_monitor(monitor, channel_name.as_deref(), setup_route_pair) {
+                if is_setup_owned_git_monitor(monitor) {
                     Ok(index)
                 } else if monitor.channel.as_deref() == Some(channel_id.as_str())
                     && monitor.github_repo.is_none()
@@ -1437,6 +1449,7 @@ impl AppConfig {
                 monitor.github_repo = github_repo;
                 monitor.channel = Some(channel_id);
                 monitor.channel_name = channel_name;
+                monitor.setup_owned = true;
             }
             [] => self.monitors.git.repos.push(GitRepoMonitor {
                 path: checkout_path,
@@ -1444,6 +1457,7 @@ impl AppConfig {
                 github_repo,
                 channel: Some(channel_id),
                 channel_name,
+                setup_owned: true,
                 ..GitRepoMonitor::default()
             }),
             _ => unreachable!(),
@@ -1706,40 +1720,17 @@ fn is_repo_binding_route(route: &RouteRule, repo: &str) -> bool {
         && route.format.is_none()
 }
 
-fn normalized_channel_name(value: &str) -> String {
-    value.trim().trim_start_matches('#').to_ascii_lowercase()
-}
-
-fn names_match(left: &str, right: &str) -> bool {
-    normalized_channel_name(left) == normalized_channel_name(right)
-}
-
 fn is_owner_repo(repo: &str) -> bool {
     let mut parts = repo.split('/');
     matches!((parts.next(), parts.next(), parts.next()), (Some(owner), Some(name), None) if !owner.is_empty() && !name.is_empty())
 }
 
-fn is_setup_owned_git_monitor(
-    monitor: &GitRepoMonitor,
-    channel_name: Option<&str>,
-    setup_route_pair: Option<(&str, &str)>,
-) -> bool {
-    if let (Some(monitor_name), Some(channel_name)) =
-        (monitor.channel_name.as_deref(), channel_name)
-        && names_match(monitor_name, channel_name)
-    {
-        return true;
-    }
+fn is_setup_owned_git_monitor(monitor: &GitRepoMonitor) -> bool {
+    monitor.setup_owned
+}
 
-    if let (Some((route_channel, route_name)), Some(monitor_channel), Some(monitor_name)) = (
-        setup_route_pair,
-        monitor.channel.as_deref(),
-        monitor.channel_name.as_deref(),
-    ) {
-        return monitor_channel == route_channel && names_match(monitor_name, route_name);
-    }
-
-    false
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 fn sha256_first8(bytes: &[u8]) -> String {
@@ -2880,6 +2871,7 @@ name = "general"
                         emit_pr_status: true,
                         channel: Some("old".into()),
                         channel_name: Some("#DEV".into()),
+                        setup_owned: true,
                         mention: Some("<@1>".into()),
                         format: Some(MessageFormat::Raw),
                     }],

--- a/src/config.rs
+++ b/src/config.rs
@@ -1657,10 +1657,9 @@ fn is_setup_owned_git_monitor(
 ) -> bool {
     if let (Some(monitor_name), Some(channel_name)) =
         (monitor.channel_name.as_deref(), channel_name)
+        && names_match(monitor_name, channel_name)
     {
-        if names_match(monitor_name, channel_name) {
-            return true;
-        }
+        return true;
     }
 
     if let (Some((route_channel, route_name)), Some(monitor_channel), Some(monitor_name)) = (

--- a/src/config.rs
+++ b/src/config.rs
@@ -1244,6 +1244,75 @@ impl AppConfig {
         }
     }
 
+    pub fn apply_repo_channel_route_binding(
+        &mut self,
+        repo: &str,
+        channel_id: &str,
+        channel_name: Option<&str>,
+    ) -> Result<()> {
+        let repo = normalize_text(Some(repo.to_string()))
+            .ok_or_else(|| "repo binding requires a non-empty repo name".to_string())?;
+        let channel_id = normalize_text(Some(channel_id.to_string()))
+            .ok_or_else(|| "repo binding requires a non-empty channel id".to_string())?;
+        let channel_name = channel_name.and_then(|value| normalize_text(Some(value.to_string())));
+
+        let route_matches = self
+            .routes
+            .iter()
+            .enumerate()
+            .filter(|(_, route)| is_repo_binding_route(route, &repo))
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if route_matches.len() > 1 {
+            return Err(format!(
+                "multiple setup-owned routes found for repo '{repo}'; clean up duplicates before updating binding"
+            )
+            .into());
+        }
+        if self.routes.iter().any(|route| {
+            !is_repo_binding_route(route, &repo)
+                && route.event == "*"
+                && route.effective_sink() == "discord"
+                && route.filter.len() == 1
+                && route.filter.get("repo").is_some_and(|value| value == &repo)
+        }) {
+            return Err(format!("manual_route_conflict for repo '{repo}'").into());
+        }
+
+        match route_matches.as_slice() {
+            [index] => {
+                let route = &mut self.routes[*index];
+                route.channel = Some(channel_id);
+                route.thread = None;
+                route.channel_name = channel_name;
+                route.webhook = None;
+            }
+            [] => {
+                let mut filter = BTreeMap::new();
+                filter.insert("repo".to_string(), repo);
+                self.routes.push(RouteRule {
+                    event: "*".to_string(),
+                    filter,
+                    sink: default_sink_name(),
+                    channel: Some(channel_id),
+                    thread: None,
+                    channel_name,
+                    webhook: None,
+                    slack_webhook: None,
+                    local_path: None,
+                    mention: None,
+                    allow_dynamic_tokens: false,
+                    format: None,
+                    template: None,
+                    gajae: None,
+                });
+            }
+            _ => unreachable!(),
+        }
+
+        Ok(())
+    }
+
     pub fn apply_repo_channel_binding(
         &mut self,
         repo: &str,
@@ -2718,6 +2787,46 @@ name = "general"
         assert!(toml.contains("[discord_watch]"));
         assert!(toml.contains("pending_mentions_threshold = 7"));
         assert!(toml.contains("doctrine_template = \"Sweep <#{channel_id}>\""));
+    }
+
+    #[test]
+    fn repo_channel_route_binding_keeps_legacy_bind_route_only() {
+        let mut config = AppConfig::default();
+
+        config
+            .apply_repo_channel_route_binding("owner/repo", "123", Some("dev"))
+            .unwrap();
+        config
+            .apply_repo_channel_route_binding("owner/repo", "123", Some("dev"))
+            .unwrap();
+
+        assert_eq!(config.routes.len(), 1);
+        assert_eq!(config.routes[0].channel.as_deref(), Some("123"));
+        assert_eq!(config.routes[0].channel_name.as_deref(), Some("dev"));
+        assert!(config.monitors.git.repos.is_empty());
+    }
+
+    #[test]
+    fn repo_channel_binding_allows_branch_specific_manual_route() {
+        let mut filter = BTreeMap::new();
+        filter.insert("repo".to_string(), "owner/repo".to_string());
+        filter.insert("branch".to_string(), "main".to_string());
+        let mut config = AppConfig {
+            routes: vec![RouteRule {
+                event: "git.push".into(),
+                filter,
+                channel: Some("manual".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        config
+            .apply_repo_channel_route_binding("owner/repo", "123", Some("dev"))
+            .unwrap();
+
+        assert_eq!(config.routes.len(), 2);
+        assert!(config.monitors.git.repos.is_empty());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
@@ -6,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use time::{Duration as TimeDuration, OffsetDateTime, PrimitiveDateTime, format_description};
 
 use crate::Result;
 use crate::events::MessageFormat;
@@ -797,11 +799,53 @@ impl AppConfig {
         Ok(toml::to_string_pretty(self)?)
     }
 
-    pub fn save(&self, path: &Path) -> Result<()> {
+    pub fn save_with_backup(&self, path: &Path) -> Result<()> {
+        let serialized = self.to_pretty_toml()?;
+        let new_bytes = serialized.as_bytes();
+        let old_bytes = if path.exists() {
+            Some(fs::read(path)?)
+        } else {
+            None
+        };
+
+        if old_bytes.as_deref() == Some(new_bytes) {
+            return Ok(());
+        }
+
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(path, self.to_pretty_toml()?)?;
+
+        let backup_context = if let Some(old_bytes) = old_bytes.as_deref() {
+            let parent = path.parent().unwrap_or_else(|| Path::new("."));
+            let backups_dir = parent.join(".clawhip-config-backups");
+            fs::create_dir_all(&backups_dir)?;
+            let filename = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| "config path must have a UTF-8 filename".to_string())?;
+            let timestamp = utc_backup_timestamp(OffsetDateTime::now_utc())?;
+            let backup_path = backups_dir.join(format!(
+                "{filename}.{timestamp}.{}.bak",
+                sha256_first8(old_bytes)
+            ));
+            fs::write(&backup_path, old_bytes)?;
+            Some((backups_dir, filename.to_string()))
+        } else {
+            None
+        };
+
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let filename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| "config path must have a UTF-8 filename".to_string())?;
+        let temp_path = parent.join(format!(".{filename}.tmp.{}", std::process::id()));
+        fs::write(&temp_path, new_bytes)?;
+        fs::rename(temp_path, path)?;
+        if let Some((backups_dir, filename)) = backup_context {
+            cleanup_config_backups(&backups_dir, &filename, OffsetDateTime::now_utc())?;
+        }
         Ok(())
     }
 
@@ -1200,56 +1244,109 @@ impl AppConfig {
         }
     }
 
-    /// Scaffold or update a repo→channel route with a binding-verify hint.
-    ///
-    /// Creates a `[[routes]]` entry shaped as:
-    ///
-    /// ```toml
-    /// [[routes]]
-    /// event = "*"
-    /// filter = { repo = "<repo>" }
-    /// sink = "discord"
-    /// channel = "<channel_id>"
-    /// channel_name = "<live_name>"  # hint, used by verify-bindings
-    /// ```
-    ///
-    /// If an existing route matches the exact `(event="*", filter={repo=...},
-    /// sink="discord")` shape, its channel and channel_name are updated in place
-    /// instead of appending a duplicate.
-    pub fn apply_repo_binding(
+    pub fn apply_repo_channel_binding(
         &mut self,
         repo: &str,
         channel_id: &str,
         channel_name: Option<&str>,
+        checkout_path: &str,
     ) -> Result<()> {
         let repo = normalize_text(Some(repo.to_string()))
             .ok_or_else(|| "repo binding requires a non-empty repo name".to_string())?;
         let channel_id = normalize_text(Some(channel_id.to_string()))
             .ok_or_else(|| "repo binding requires a non-empty channel id".to_string())?;
         let channel_name = channel_name.and_then(|value| normalize_text(Some(value.to_string())));
+        let checkout_path = normalize_text(Some(checkout_path.to_string()))
+            .ok_or_else(|| "repo binding requires a non-empty checkout path".to_string())?;
+        let monitor_name = repo.rsplit('/').next().unwrap_or(&repo).to_string();
+        let github_repo = is_owner_repo(&repo).then_some(repo.clone());
 
-        let existing = self
+        let route_matches = self
             .routes
-            .iter_mut()
-            .find(|route| is_repo_binding_route(route, &repo));
+            .iter()
+            .enumerate()
+            .filter(|(_, route)| is_repo_binding_route(route, &repo))
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if route_matches.len() > 1 {
+            return Err(format!(
+                "multiple setup-owned routes found for repo '{repo}'; clean up duplicates before updating binding"
+            )
+            .into());
+        }
+        if self.routes.iter().any(|route| {
+            !is_repo_binding_route(route, &repo)
+                && route.event == "*"
+                && route.effective_sink() == "discord"
+                && route.filter.len() == 1
+                && route.filter.get("repo").is_some_and(|value| value == &repo)
+        }) {
+            return Err(format!("manual_route_conflict for repo '{repo}'").into());
+        }
 
-        match existing {
-            Some(route) => {
-                route.channel = Some(channel_id);
+        let setup_route_pair = route_matches.first().and_then(|index| {
+            let route = &self.routes[*index];
+            Some((route.channel.as_deref()?, route.channel_name.as_deref()?))
+        });
+        if self.monitors.git.repos.iter().any(|monitor| {
+            monitor.channel.as_deref() == Some(channel_id.as_str())
+                && monitor.github_repo.is_none()
+                && monitor.name.as_deref() != Some(monitor_name.as_str())
+        }) {
+            return Err("manual_monitor_conflict".into());
+        }
+
+        let monitor_matches = self
+            .monitors
+            .git
+            .repos
+            .iter()
+            .enumerate()
+            .filter(|(_, monitor)| {
+                monitor.path.trim() == checkout_path
+                    || monitor.name.as_deref() == Some(monitor_name.as_str())
+                    || (github_repo.is_some() && monitor.github_repo.as_ref() == github_repo.as_ref())
+            })
+            .map(|(index, monitor)| {
+                if is_setup_owned_git_monitor(monitor, channel_name.as_deref(), setup_route_pair) {
+                    Ok(index)
+                } else if monitor.channel.as_deref() == Some(channel_id.as_str())
+                    && monitor.github_repo.is_none()
+                {
+                    Err("manual_monitor_conflict".to_string())
+                } else {
+                    Err(format!(
+                        "git monitor conflict for repo '{repo}'; existing monitor is not setup-owned"
+                    ))
+                }
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|message| -> Box<dyn std::error::Error + Send + Sync> { message.into() })?;
+        if monitor_matches.len() > 1 {
+            return Err(format!(
+                "multiple setup-owned git monitors found for repo '{repo}'; clean up duplicates before updating binding"
+            )
+            .into());
+        }
+
+        match route_matches.as_slice() {
+            [index] => {
+                let route = &mut self.routes[*index];
+                route.channel = Some(channel_id.clone());
                 route.thread = None;
-                route.channel_name = channel_name;
+                route.channel_name = channel_name.clone();
                 route.webhook = None;
             }
-            None => {
+            [] => {
                 let mut filter = BTreeMap::new();
-                filter.insert("repo".to_string(), repo);
+                filter.insert("repo".to_string(), repo.clone());
                 self.routes.push(RouteRule {
                     event: "*".to_string(),
                     filter,
                     sink: default_sink_name(),
-                    channel: Some(channel_id),
+                    channel: Some(channel_id.clone()),
                     thread: None,
-                    channel_name,
+                    channel_name: channel_name.clone(),
                     webhook: None,
                     slack_webhook: None,
                     local_path: None,
@@ -1260,7 +1357,29 @@ impl AppConfig {
                     gajae: None,
                 });
             }
+            _ => unreachable!(),
         }
+
+        match monitor_matches.as_slice() {
+            [index] => {
+                let monitor = &mut self.monitors.git.repos[*index];
+                monitor.path = checkout_path;
+                monitor.name = Some(monitor_name);
+                monitor.github_repo = github_repo;
+                monitor.channel = Some(channel_id);
+                monitor.channel_name = channel_name;
+            }
+            [] => self.monitors.git.repos.push(GitRepoMonitor {
+                path: checkout_path,
+                name: Some(monitor_name),
+                github_repo,
+                channel: Some(channel_id),
+                channel_name,
+                ..GitRepoMonitor::default()
+            }),
+            _ => unreachable!(),
+        }
+
         Ok(())
     }
 
@@ -1327,7 +1446,7 @@ impl AppConfig {
                     self.scaffold_webhook_quickstart(webhook)?;
                 }
                 "6" => {
-                    self.save(path)?;
+                    self.save_with_backup(path)?;
                     println!("Saved {}", path.display());
                     break;
                 }
@@ -1500,13 +1619,108 @@ impl AppConfig {
 fn is_repo_binding_route(route: &RouteRule, repo: &str) -> bool {
     route.event == "*"
         && route.sink.trim() == "discord"
-        && route.slack_webhook.is_none()
+        && route.effective_sink() == "discord"
         && route.filter.len() == 1
+        && route.filter.get("repo").is_some_and(|value| value == repo)
         && route
-            .filter
-            .get("repo")
-            .map(|value| value == repo)
-            .unwrap_or(false)
+            .channel
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty())
+        && route.thread.is_none()
+        && route.webhook.is_none()
+        && route.slack_webhook.is_none()
+        && route.local_path.is_none()
+        && route.mention.is_none()
+        && route.template.is_none()
+        && route.gajae.is_none()
+        && !route.allow_dynamic_tokens
+        && route.format.is_none()
+}
+
+fn normalized_channel_name(value: &str) -> String {
+    value.trim().trim_start_matches('#').to_ascii_lowercase()
+}
+
+fn names_match(left: &str, right: &str) -> bool {
+    normalized_channel_name(left) == normalized_channel_name(right)
+}
+
+fn is_owner_repo(repo: &str) -> bool {
+    let mut parts = repo.split('/');
+    matches!((parts.next(), parts.next(), parts.next()), (Some(owner), Some(name), None) if !owner.is_empty() && !name.is_empty())
+}
+
+fn is_setup_owned_git_monitor(
+    monitor: &GitRepoMonitor,
+    channel_name: Option<&str>,
+    setup_route_pair: Option<(&str, &str)>,
+) -> bool {
+    if let (Some(monitor_name), Some(channel_name)) =
+        (monitor.channel_name.as_deref(), channel_name)
+    {
+        if names_match(monitor_name, channel_name) {
+            return true;
+        }
+    }
+
+    if let (Some((route_channel, route_name)), Some(monitor_channel), Some(monitor_name)) = (
+        setup_route_pair,
+        monitor.channel.as_deref(),
+        monitor.channel_name.as_deref(),
+    ) {
+        return monitor_channel == route_channel && names_match(monitor_name, route_name);
+    }
+
+    false
+}
+
+fn sha256_first8(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    format!("{digest:x}")[..8].to_string()
+}
+
+fn utc_backup_timestamp(now: OffsetDateTime) -> Result<String> {
+    let format = format_description::parse("[year][month][day]T[hour][minute][second]Z")?;
+    Ok(now.format(&format)?)
+}
+
+fn cleanup_config_backups(backups_dir: &Path, filename: &str, now: OffsetDateTime) -> Result<()> {
+    let prefix = format!("{filename}.");
+    let cutoff = now - TimeDuration::days(30);
+    let format = format_description::parse("[year][month][day]T[hour][minute][second]Z")?;
+    let mut backups = Vec::new();
+
+    for entry in fs::read_dir(backups_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with(&prefix) || !name.ends_with(".bak") {
+            continue;
+        }
+        let rest = &name[prefix.len()..name.len() - 4];
+        let Some((timestamp, hash)) = rest.split_once('.') else {
+            continue;
+        };
+        if hash.len() != 8 || !hash.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            continue;
+        }
+        let Ok(created_at) =
+            PrimitiveDateTime::parse(timestamp, &format).map(|value| value.assume_utc())
+        else {
+            continue;
+        };
+        backups.push((created_at, entry.path()));
+    }
+
+    backups.sort_by_key(|(created_at, _)| *created_at);
+    let keep_from = backups.len().saturating_sub(10);
+    for (index, (created_at, path)) in backups.into_iter().enumerate() {
+        if index < keep_from && created_at < cutoff {
+            fs::remove_file(path)?;
+        }
+    }
+
+    Ok(())
 }
 
 fn is_canonical_quickstart_route(route: &RouteRule) -> bool {
@@ -2505,5 +2719,164 @@ name = "general"
         assert!(toml.contains("[discord_watch]"));
         assert!(toml.contains("pending_mentions_threshold = 7"));
         assert!(toml.contains("doctrine_template = \"Sweep <#{channel_id}>\""));
+    }
+
+    #[test]
+    fn repo_channel_binding_create_is_idempotent_and_adds_monitor() {
+        let mut config = AppConfig::default();
+
+        config
+            .apply_repo_channel_binding("owner/repo", "123", Some("#dev"), "/work/repo")
+            .unwrap();
+        config
+            .apply_repo_channel_binding("owner/repo", "123", Some("dev"), "/work/repo")
+            .unwrap();
+
+        assert_eq!(config.routes.len(), 1);
+        assert_eq!(
+            config.routes[0].filter.get("repo").map(String::as_str),
+            Some("owner/repo")
+        );
+        assert_eq!(config.routes[0].channel.as_deref(), Some("123"));
+        assert_eq!(config.routes[0].channel_name.as_deref(), Some("dev"));
+        assert_eq!(config.monitors.git.repos.len(), 1);
+        let monitor = &config.monitors.git.repos[0];
+        assert_eq!(monitor.path, "/work/repo");
+        assert_eq!(monitor.name.as_deref(), Some("repo"));
+        assert_eq!(monitor.github_repo.as_deref(), Some("owner/repo"));
+        assert_eq!(monitor.channel.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn repo_channel_binding_updates_setup_owned_monitor_and_preserves_options() {
+        let mut filter = BTreeMap::new();
+        filter.insert("repo".to_string(), "owner/repo".to_string());
+        let mut config = AppConfig {
+            routes: vec![RouteRule {
+                event: "*".into(),
+                filter,
+                channel: Some("old".into()),
+                channel_name: Some("dev".into()),
+                ..RouteRule::default()
+            }],
+            monitors: MonitorConfig {
+                git: GitMonitorConfig {
+                    repos: vec![GitRepoMonitor {
+                        path: "/old/repo".into(),
+                        name: Some("repo".into()),
+                        remote: "upstream".into(),
+                        github_repo: Some("owner/repo".into()),
+                        emit_commits: false,
+                        emit_branch_changes: false,
+                        emit_issue_opened: false,
+                        emit_pr_status: true,
+                        channel: Some("old".into()),
+                        channel_name: Some("#DEV".into()),
+                        mention: Some("<@1>".into()),
+                        format: Some(MessageFormat::Raw),
+                    }],
+                },
+                ..MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        };
+
+        config
+            .apply_repo_channel_binding("owner/repo", "new", Some("dev"), "/new/repo")
+            .unwrap();
+
+        assert_eq!(config.routes[0].channel.as_deref(), Some("new"));
+        let monitor = &config.monitors.git.repos[0];
+        assert_eq!(monitor.path, "/new/repo");
+        assert_eq!(monitor.remote, "upstream");
+        assert!(!monitor.emit_commits);
+        assert!(!monitor.emit_branch_changes);
+        assert!(!monitor.emit_issue_opened);
+        assert!(monitor.emit_pr_status);
+        assert_eq!(monitor.mention.as_deref(), Some("<@1>"));
+        assert_eq!(monitor.format, Some(MessageFormat::Raw));
+        assert_eq!(monitor.channel.as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn repo_channel_binding_manual_monitor_conflict_does_not_mutate() {
+        let mut config = AppConfig {
+            monitors: MonitorConfig {
+                git: GitMonitorConfig {
+                    repos: vec![GitRepoMonitor {
+                        path: "/manual".into(),
+                        name: Some("manual".into()),
+                        channel: Some("123".into()),
+                        channel_name: None,
+                        ..GitRepoMonitor::default()
+                    }],
+                },
+                ..MonitorConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let before = config.to_pretty_toml().unwrap();
+
+        let error = config
+            .apply_repo_channel_binding("owner/repo", "123", Some("dev"), "/work/repo")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("manual_monitor_conflict"));
+        assert_eq!(config.to_pretty_toml().unwrap(), before);
+    }
+
+    #[test]
+    fn save_with_backup_skips_new_and_identical_then_backs_up_changed_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut config = AppConfig::default();
+
+        config.save_with_backup(&path).unwrap();
+        assert!(!dir.path().join(".clawhip-config-backups").exists());
+        config.save_with_backup(&path).unwrap();
+        assert!(!dir.path().join(".clawhip-config-backups").exists());
+
+        config.defaults.channel = Some("alerts".into());
+        config.save_with_backup(&path).unwrap();
+
+        let backups = fs::read_dir(dir.path().join(".clawhip-config-backups"))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(backups.len(), 1);
+        let backup = fs::read_to_string(backups[0].path()).unwrap();
+        assert!(!backup.contains("alerts"));
+    }
+
+    #[test]
+    fn backup_retention_removes_old_backups_but_keeps_newest_ten() {
+        let dir = tempfile::tempdir().unwrap();
+        let backups_dir = dir.path().join(".clawhip-config-backups");
+        fs::create_dir(&backups_dir).unwrap();
+        let now = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+
+        for index in 0..12 {
+            let created_at = now - TimeDuration::days(45 - index);
+            let name = format!(
+                "config.toml.{}.0000000{:x}.bak",
+                utc_backup_timestamp(created_at).unwrap(),
+                index
+            );
+            fs::write(backups_dir.join(name), "old").unwrap();
+        }
+        let recent_name = format!(
+            "config.toml.{}.abcdef12.bak",
+            utc_backup_timestamp(now - TimeDuration::days(5)).unwrap()
+        );
+        fs::write(backups_dir.join(recent_name), "recent").unwrap();
+
+        cleanup_config_backups(&backups_dir, "config.toml", now).unwrap();
+
+        let remaining = fs::read_dir(&backups_dir)
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(remaining.len(), 10);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -576,22 +576,19 @@ fn resolve_bind_checkout_path(
     explicit: &std::collections::HashMap<String, String>,
     bind_count: usize,
     config: &AppConfig,
-) -> Result<String> {
+) -> Result<Option<String>> {
     if let Some(path) = explicit.get(repo) {
-        return Ok(path.clone());
+        return Ok(Some(path.clone()));
     }
     if let Some(path) = existing_setup_monitor_checkout_path(config, repo)? {
-        return Ok(path);
+        return Ok(Some(path));
     }
     if bind_count == 1
         && let Some(path) = infer_cwd_checkout_path(repo)?
     {
-        return Ok(path);
+        return Ok(Some(path));
     }
-    Err(format!(
-        "bind {repo}: checkout path could not be resolved; pass --bind-checkout {repo}=PATH"
-    )
-    .into())
+    Ok(None)
 }
 
 fn existing_setup_monitor_checkout_path(config: &AppConfig, repo: &str) -> Result<Option<String>> {
@@ -706,15 +703,10 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
     }
 
     // Process --bind entries: resolve each channel against Discord and write a
-    // repo binding route plus setup-owned git monitor metadata.
+    // route binding. Git monitor onboarding is conditional: it is added or
+    // updated only when a checkout is explicit, already known, or safely inferred.
+    let mut monitored_bind_repos = std::collections::HashSet::new();
     if !binds.is_empty() {
-        let checkout_paths = binds
-            .iter()
-            .map(|(repo, _)| {
-                resolve_bind_checkout_path(repo, &checkout_map, binds.len(), &editable)
-                    .map(|path| (repo.clone(), path))
-            })
-            .collect::<Result<std::collections::HashMap<_, _>>>()?;
         let client = DiscordClient::from_config(Arc::new(editable.clone()))?;
 
         for (repo, channel_id) in &binds {
@@ -733,16 +725,24 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
                         }
                     }
 
-                    let checkout_path = checkout_paths.get(repo).ok_or_else(|| {
-                        format!("bind {repo}: internal checkout path resolution failed")
-                    })?;
+                    let checkout_path =
+                        resolve_bind_checkout_path(repo, &checkout_map, binds.len(), &editable)?;
                     println!("bind: {repo} -> {channel_id} (#{live_name})");
-                    editable.apply_repo_channel_binding(
-                        repo,
-                        channel_id,
-                        name.as_deref(),
-                        checkout_path,
-                    )?;
+                    if let Some(checkout_path) = checkout_path.as_deref() {
+                        editable.apply_repo_channel_binding(
+                            repo,
+                            channel_id,
+                            name.as_deref(),
+                            checkout_path,
+                        )?;
+                        monitored_bind_repos.insert(repo.as_str());
+                    } else {
+                        editable.apply_repo_channel_route_binding(
+                            repo,
+                            channel_id,
+                            name.as_deref(),
+                        )?;
+                    }
                 }
                 binding_verify::ChannelLookup::NotFound => {
                     return Err(
@@ -773,11 +773,8 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
     editable.validate()?;
 
     let drift_audit = binding_verify::audit_route_monitor_drift(&editable);
-    if !binds.is_empty() {
-        let bind_repos = binds
-            .iter()
-            .map(|(repo, _)| repo.as_str())
-            .collect::<std::collections::HashSet<_>>();
+    if !monitored_bind_repos.is_empty() {
+        let bind_repos = monitored_bind_repos;
         let affected_errors = drift_audit
             .findings
             .iter()
@@ -807,6 +804,16 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
     Ok(())
 }
 
+fn verify_bindings_json(
+    audit: &binding_verify::BindingAudit,
+    drift_audit: &binding_verify::BindingDriftAudit,
+) -> serde_json::Value {
+    serde_json::json!({
+        "verdicts": &audit.verdicts,
+        "drift_audit": drift_audit,
+    })
+}
+
 async fn run_verify_bindings(config: Arc<AppConfig>, args: VerifyBindingsArgs) -> Result<()> {
     let client = DiscordClient::from_config(config.clone())?;
     let audit = binding_verify::verify(&client, &config).await;
@@ -815,10 +822,7 @@ async fn run_verify_bindings(config: Arc<AppConfig>, args: VerifyBindingsArgs) -
     if args.json {
         println!(
             "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "channel_audit": audit,
-                "drift_audit": drift_audit,
-            }))?
+            serde_json::to_string_pretty(&verify_bindings_json(&audit, &drift_audit))?
         );
     } else {
         print!("{audit}");
@@ -921,8 +925,9 @@ fn format_tmux_list(registrations: &[crate::source::RegisteredTmuxSession]) -> S
 mod tests {
     use super::{
         format_tmux_list, parse_bind_checkout_overrides, parse_bind_overrides,
-        parse_expect_name_overrides, validate_bind_checkout_repos,
+        parse_expect_name_overrides, validate_bind_checkout_repos, verify_bindings_json,
     };
+    use crate::binding_verify::{BindingAudit, BindingDriftAudit};
     use crate::events::RoutingMetadata;
     use crate::source::tmux::{ParentProcessInfo, RegisteredTmuxSession, RegistrationSource};
 
@@ -1072,6 +1077,21 @@ mod tests {
         let checkout_map = parse_bind_checkout_overrides(&["clawhip=/work/clawhip".to_string()])
             .expect("valid checkout");
         validate_bind_checkout_repos(&checkout_map, &binds).expect("matching repo is valid");
+    }
+
+    #[test]
+    fn verify_bindings_json_preserves_top_level_verdicts() {
+        let audit = BindingAudit { verdicts: vec![] };
+        let drift = BindingDriftAudit {
+            ok: true,
+            findings: vec![],
+        };
+
+        let json = verify_bindings_json(&audit, &drift);
+
+        assert!(json.get("verdicts").is_some());
+        assert!(json.get("drift_audit").is_some());
+        assert!(json.get("channel_audit").is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -598,13 +598,9 @@ fn existing_setup_monitor_checkout_path(config: &AppConfig, repo: &str) -> Resul
         .repos
         .iter()
         .filter(|monitor| {
-            let identity_matches = monitor.github_repo.as_deref() == Some(repo)
-                || (monitor.github_repo.is_none() && monitor.name.as_deref() == Some(repo));
-            identity_matches
-                && monitor
-                    .channel_name
-                    .as_deref()
-                    .is_some_and(|name| !name.trim().is_empty())
+            monitor.setup_owned
+                && (monitor.github_repo.as_deref() == Some(repo)
+                    || (monitor.github_repo.is_none() && monitor.name.as_deref() == Some(repo)))
         })
         .collect::<Vec<_>>();
     match matches.as_slice() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,10 +583,10 @@ fn resolve_bind_checkout_path(
     if let Some(path) = existing_setup_monitor_checkout_path(config, repo)? {
         return Ok(path);
     }
-    if bind_count == 1 {
-        if let Some(path) = infer_cwd_checkout_path(repo)? {
-            return Ok(path);
-        }
+    if bind_count == 1
+        && let Some(path) = infer_cwd_checkout_path(repo)?
+    {
+        return Ok(path);
     }
     Err(format!(
         "bind {repo}: checkout path could not be resolved; pass --bind-checkout {repo}=PATH"

--- a/src/main.rs
+++ b/src/main.rs
@@ -509,6 +509,176 @@ fn parse_expect_name_overrides(
     Ok(map)
 }
 
+fn parse_bind_overrides(entries: &[String]) -> Result<Vec<(String, String)>> {
+    let mut repos = std::collections::HashSet::new();
+    let mut binds = Vec::new();
+    for entry in entries {
+        let (repo, channel_id) = entry
+            .split_once('=')
+            .ok_or_else(|| format!("--bind must be REPO=CHANNEL_ID, got '{entry}'"))?;
+        let repo = repo.trim();
+        let channel_id = channel_id.trim();
+        if repo.is_empty() {
+            return Err(format!("--bind '{entry}' has an empty repo name").into());
+        }
+        if channel_id.is_empty() {
+            return Err(format!("--bind '{entry}' has an empty channel id").into());
+        }
+        if !repos.insert(repo.to_string()) {
+            return Err(format!("--bind has duplicate entries for repo '{repo}'").into());
+        }
+        binds.push((repo.to_string(), channel_id.to_string()));
+    }
+    Ok(binds)
+}
+
+fn parse_bind_checkout_overrides(
+    entries: &[String],
+) -> Result<std::collections::HashMap<String, String>> {
+    let mut map = std::collections::HashMap::new();
+    for entry in entries {
+        let (repo, path) = entry
+            .split_once('=')
+            .ok_or_else(|| format!("--bind-checkout must be REPO=PATH, got '{entry}'"))?;
+        let repo = repo.trim();
+        let path = path.trim();
+        if repo.is_empty() {
+            return Err(format!("--bind-checkout '{entry}' has an empty repo name").into());
+        }
+        if path.is_empty() {
+            return Err(format!("--bind-checkout '{entry}' has an empty checkout path").into());
+        }
+        if map.insert(repo.to_string(), path.to_string()).is_some() {
+            return Err(format!("--bind-checkout has duplicate entries for repo '{repo}'").into());
+        }
+    }
+    Ok(map)
+}
+
+fn validate_bind_checkout_repos(
+    checkout_map: &std::collections::HashMap<String, String>,
+    binds: &[(String, String)],
+) -> Result<()> {
+    let bind_repos: std::collections::HashSet<&str> =
+        binds.iter().map(|(repo, _)| repo.as_str()).collect();
+    for repo in checkout_map.keys() {
+        if !bind_repos.contains(repo.as_str()) {
+            return Err(
+                format!("--bind-checkout repo '{repo}' must also be present in --bind").into(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn resolve_bind_checkout_path(
+    repo: &str,
+    explicit: &std::collections::HashMap<String, String>,
+    bind_count: usize,
+    config: &AppConfig,
+) -> Result<String> {
+    if let Some(path) = explicit.get(repo) {
+        return Ok(path.clone());
+    }
+    if let Some(path) = existing_setup_monitor_checkout_path(config, repo)? {
+        return Ok(path);
+    }
+    if bind_count == 1 {
+        if let Some(path) = infer_cwd_checkout_path(repo)? {
+            return Ok(path);
+        }
+    }
+    Err(format!(
+        "bind {repo}: checkout path could not be resolved; pass --bind-checkout {repo}=PATH"
+    )
+    .into())
+}
+
+fn existing_setup_monitor_checkout_path(config: &AppConfig, repo: &str) -> Result<Option<String>> {
+    let matches = config
+        .monitors
+        .git
+        .repos
+        .iter()
+        .filter(|monitor| {
+            let identity_matches = monitor.github_repo.as_deref() == Some(repo)
+                || (monitor.github_repo.is_none() && monitor.name.as_deref() == Some(repo));
+            identity_matches
+                && monitor
+                    .channel_name
+                    .as_deref()
+                    .is_some_and(|name| !name.trim().is_empty())
+        })
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [monitor] => Ok(Some(monitor.path.clone())),
+        _ => Err(format!(
+            "bind {repo}: multiple setup-owned git monitors already exist; pass --bind-checkout {repo}=PATH after cleanup"
+        )
+        .into()),
+    }
+}
+
+fn infer_cwd_checkout_path(repo: &str) -> Result<Option<String>> {
+    let cwd = std::env::current_dir()?;
+    let inside = std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(&cwd)
+        .output();
+    let Ok(inside) = inside else {
+        return Ok(None);
+    };
+    if !inside.status.success() || String::from_utf8_lossy(&inside.stdout).trim() != "true" {
+        return Ok(None);
+    }
+
+    let top_level = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(&cwd)
+        .output()?;
+    if !top_level.status.success() {
+        return Ok(None);
+    }
+
+    let remote = std::process::Command::new("git")
+        .args(["config", "--get", "remote.origin.url"])
+        .current_dir(&cwd)
+        .output()?;
+    if !remote.status.success() {
+        return Ok(None);
+    }
+    let remote = String::from_utf8_lossy(&remote.stdout);
+    if remote_repo_identity(remote.trim()).as_deref() != Some(repo) {
+        return Ok(None);
+    }
+
+    Ok(Some(
+        String::from_utf8_lossy(&top_level.stdout)
+            .trim()
+            .to_string(),
+    ))
+}
+
+fn remote_repo_identity(remote: &str) -> Option<String> {
+    let mut value = remote.trim().trim_end_matches('/').trim_end_matches(".git");
+    if let Some((_, path)) = value.rsplit_once(':') {
+        if !path.contains('/') && value.contains("://") {
+            return None;
+        }
+        value = path;
+    } else if let Some((_, path)) = value.split_once("://") {
+        value = path.split_once('/').map(|(_, rest)| rest)?;
+    }
+    let mut parts = value.rsplit('/');
+    let repo = parts.next()?.trim();
+    let owner = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
 async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()> {
     let mut editable = AppConfig::load_or_default(config_path)?;
 
@@ -520,8 +690,13 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
         daemon_base_url: args.daemon_base_url,
     };
 
+    let binds = parse_bind_overrides(&args.bind)?;
+    let checkout_map = parse_bind_checkout_overrides(&args.bind_checkout)?;
+    validate_bind_checkout_repos(&checkout_map, &binds)?;
+    let expect_map = parse_expect_name_overrides(&args.expect_name)?;
+
     // Must have at least one meaningful action.
-    if standard_edits.is_empty() && args.bind.is_empty() && !args.verify_bindings {
+    if standard_edits.is_empty() && binds.is_empty() && !args.verify_bindings {
         return Err("setup requires at least one non-empty setup flag".into());
     }
 
@@ -531,22 +706,18 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
     }
 
     // Process --bind entries: resolve each channel against Discord and write a
-    // repo binding route with a channel_name hint.
-    if !args.bind.is_empty() {
+    // repo binding route plus setup-owned git monitor metadata.
+    if !binds.is_empty() {
+        let checkout_paths = binds
+            .iter()
+            .map(|(repo, _)| {
+                resolve_bind_checkout_path(repo, &checkout_map, binds.len(), &editable)
+                    .map(|path| (repo.clone(), path))
+            })
+            .collect::<Result<std::collections::HashMap<_, _>>>()?;
         let client = DiscordClient::from_config(Arc::new(editable.clone()))?;
 
-        // Collect expected-name overrides (repo -> name). Hard-fails on
-        // malformed input so a typo like `--expect-name clawhip` cannot
-        // silently bypass the name-match guard.
-        let expect_map = parse_expect_name_overrides(&args.expect_name)?;
-
-        for entry in &args.bind {
-            let (repo, channel_id) = entry
-                .split_once('=')
-                .ok_or_else(|| format!("--bind must be REPO=CHANNEL_ID, got '{entry}'"))?;
-            let repo = repo.trim();
-            let channel_id = channel_id.trim();
-
+        for (repo, channel_id) in &binds {
             let lookup = client.lookup_channel(channel_id).await;
             match &lookup {
                 binding_verify::ChannelLookup::Found { name, .. } => {
@@ -562,8 +733,16 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
                         }
                     }
 
+                    let checkout_path = checkout_paths.get(repo).ok_or_else(|| {
+                        format!("bind {repo}: internal checkout path resolution failed")
+                    })?;
                     println!("bind: {repo} -> {channel_id} (#{live_name})");
-                    editable.apply_repo_binding(repo, channel_id, name.as_deref())?;
+                    editable.apply_repo_channel_binding(
+                        repo,
+                        channel_id,
+                        name.as_deref(),
+                        checkout_path,
+                    )?;
                 }
                 binding_verify::ChannelLookup::NotFound => {
                     return Err(
@@ -593,17 +772,37 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
 
     editable.validate()?;
 
+    let drift_audit = binding_verify::audit_route_monitor_drift(&editable);
+    if !binds.is_empty() {
+        let bind_repos = binds
+            .iter()
+            .map(|(repo, _)| repo.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        let affected_errors = drift_audit
+            .findings
+            .iter()
+            .filter(|finding| {
+                finding.severity == "error" && bind_repos.contains(finding.repo.as_str())
+            })
+            .collect::<Vec<_>>();
+        if !affected_errors.is_empty() {
+            eprint!("{drift_audit}");
+            return Err("setup aborted: route/monitor drift check failed for bound repo(s)".into());
+        }
+    }
+
     // Optional full binding audit before saving.
     if args.verify_bindings {
         let client = DiscordClient::from_config(Arc::new(editable.clone()))?;
         let audit = binding_verify::verify(&client, &editable).await;
         print!("{audit}");
-        if !audit.all_ok() {
+        print!("{drift_audit}");
+        if !audit.all_ok() || !drift_audit.ok {
             return Err("setup aborted: binding verification failed (see above)".into());
         }
     }
 
-    editable.save(config_path)?;
+    editable.save_with_backup(config_path)?;
     println!("Saved {}", config_path.display());
     Ok(())
 }
@@ -611,14 +810,22 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
 async fn run_verify_bindings(config: Arc<AppConfig>, args: VerifyBindingsArgs) -> Result<()> {
     let client = DiscordClient::from_config(config.clone())?;
     let audit = binding_verify::verify(&client, &config).await;
+    let drift_audit = binding_verify::audit_route_monitor_drift(&config);
 
     if args.json {
-        println!("{}", serde_json::to_string_pretty(&audit)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "channel_audit": audit,
+                "drift_audit": drift_audit,
+            }))?
+        );
     } else {
         print!("{audit}");
+        print!("{drift_audit}");
     }
 
-    if !audit.all_ok() {
+    if !audit.all_ok() || !drift_audit.ok {
         std::process::exit(1);
     }
     Ok(())
@@ -712,7 +919,10 @@ fn format_tmux_list(registrations: &[crate::source::RegisteredTmuxSession]) -> S
 
 #[cfg(test)]
 mod tests {
-    use super::{format_tmux_list, parse_expect_name_overrides};
+    use super::{
+        format_tmux_list, parse_bind_checkout_overrides, parse_bind_overrides,
+        parse_expect_name_overrides, validate_bind_checkout_repos,
+    };
     use crate::events::RoutingMetadata;
     use crate::source::tmux::{ParentProcessInfo, RegisteredTmuxSession, RegistrationSource};
 
@@ -797,6 +1007,71 @@ mod tests {
     fn parse_expect_name_overrides_accepts_empty_input() {
         let map = parse_expect_name_overrides(&[]).expect("empty input is fine");
         assert!(map.is_empty());
+    }
+
+    #[test]
+    fn parse_bind_checkout_overrides_accepts_well_formed_entries() {
+        let entries = vec![
+            "clawhip=/work/clawhip".to_string(),
+            "oh-my-codex=../omx".to_string(),
+        ];
+        let map = parse_bind_checkout_overrides(&entries).expect("valid entries");
+        assert_eq!(
+            map.get("clawhip").map(String::as_str),
+            Some("/work/clawhip")
+        );
+        assert_eq!(map.get("oh-my-codex").map(String::as_str), Some("../omx"));
+    }
+
+    #[test]
+    fn parse_bind_checkout_overrides_rejects_duplicate_repo() {
+        let entries = vec![
+            "clawhip=/work/clawhip".to_string(),
+            "clawhip=/tmp/clawhip".to_string(),
+        ];
+        let error = parse_bind_checkout_overrides(&entries).expect_err("duplicate repo must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate entries for repo 'clawhip'")
+        );
+    }
+
+    #[test]
+    fn parse_bind_checkout_overrides_rejects_malformed_or_empty_parts() {
+        let missing_equals = parse_bind_checkout_overrides(&["clawhip".to_string()])
+            .expect_err("missing equals must fail");
+        assert!(missing_equals.to_string().contains("REPO=PATH"));
+
+        let empty_repo = parse_bind_checkout_overrides(&["=/work/clawhip".to_string()])
+            .expect_err("empty repo must fail");
+        assert!(empty_repo.to_string().contains("empty repo name"));
+
+        let empty_path = parse_bind_checkout_overrides(&["clawhip=   ".to_string()])
+            .expect_err("empty path must fail");
+        assert!(empty_path.to_string().contains("empty checkout path"));
+    }
+
+    #[test]
+    fn bind_checkout_repos_must_also_be_bound() {
+        let binds = parse_bind_overrides(&["clawhip=123".to_string()]).expect("valid bind");
+        let checkout_map = parse_bind_checkout_overrides(&["oh-my-codex=/work/omx".to_string()])
+            .expect("valid checkout");
+        let error = validate_bind_checkout_repos(&checkout_map, &binds)
+            .expect_err("unmatched checkout repo must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("repo 'oh-my-codex' must also be present in --bind")
+        );
+    }
+
+    #[test]
+    fn bind_checkout_repos_accept_matching_bind() {
+        let binds = parse_bind_overrides(&["clawhip=123".to_string()]).expect("valid bind");
+        let checkout_map = parse_bind_checkout_overrides(&["clawhip=/work/clawhip".to_string()])
+            .expect("valid checkout");
+        validate_bind_checkout_repos(&checkout_map, &binds).expect("matching repo is valid");
     }
 
     #[test]

--- a/tests/setup_bind_legacy_route_only.rs
+++ b/tests/setup_bind_legacy_route_only.rs
@@ -1,0 +1,78 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::Command;
+use std::sync::mpsc;
+use std::thread;
+
+use tempfile::TempDir;
+
+fn clawhip_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clawhip")
+}
+
+fn spawn_discord_channel_mock() -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock Discord API");
+    let addr = listener.local_addr().expect("mock addr");
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept lookup");
+        let mut request = [0_u8; 2048];
+        let read = stream.read(&mut request).expect("read lookup");
+        tx.send(String::from_utf8_lossy(&request[..read]).into_owned())
+            .expect("send request");
+        let body = r#"{"name":"dev"}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .expect("write response");
+    });
+
+    (format!("http://{addr}"), rx)
+}
+
+#[test]
+fn legacy_setup_bind_without_checkout_writes_route_only() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = temp.path().join("clawhip.toml");
+    fs::write(
+        &config_path,
+        r#"
+[providers.discord]
+bot_token = "test-token"
+"#,
+    )
+    .expect("write config");
+    let (api_base, request_rx) = spawn_discord_channel_mock();
+
+    let output = Command::new(clawhip_bin())
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("CLAWHIP_DISCORD_API_BASE", api_base)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("setup")
+        .arg("--bind")
+        .arg("owner/repo=123")
+        .output()
+        .expect("run clawhip setup");
+
+    assert!(
+        output.status.success(),
+        "setup failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = request_rx.recv().expect("mock saw lookup");
+    assert!(request.starts_with("GET /channels/123 "));
+
+    let saved = fs::read_to_string(&config_path).expect("read saved config");
+    assert!(saved.contains("repo = \"owner/repo\""));
+    assert!(saved.contains("channel = \"123\""));
+    assert!(saved.contains("channel_name = \"dev\""));
+    assert!(!saved.contains("[[monitors.git.repos]]"));
+}


### PR DESCRIPTION
## Summary
- Add `setup --bind-checkout REPO=PATH` and converge setup-owned repo/channel routes with git monitors idempotently.
- Reject manual route/monitor conflicts, duplicate setup-owned entries, and channel-only monitor adoption before saving.
- Add route/monitor drift diagnostics to `config verify-bindings` text/JSON output and backup retention for config writes.

## Verification
- `cargo fmt`
- `cargo test`
- `cargo build`
- `target/debug/clawhip setup --help`
- `target/debug/clawhip config verify-bindings --config /tmp/clawhip-empty-verify-282.toml --json`

Fixes #282

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
