### PR TITLE
feat: add durable thread-native lane verification

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,6 +85,16 @@ pub enum Commands {
         #[command(subcommand)]
         command: AgentCommands,
     },
+    /// Inspect and update retained Discord-thread lane evidence through the local daemon.
+    #[command(
+        about = "Inspect, verify, and update retained Discord-thread lane evidence",
+        long_about = "Inspect, verify, and update retained Discord-thread lane evidence. Lane commands resolve targets only from daemon-owned retained records and never accept raw Discord thread IDs."
+    )]
+    Lane {
+        #[command(subcommand)]
+        command: LaneCommands,
+    },
+
     /// Send tmux-related events to the local daemon or launch/register tmux sessions.
     Tmux {
         #[command(subcommand)]
@@ -699,6 +709,79 @@ pub enum UpdateCommands {
     /// Show the current pending-update status from the daemon.
     Status,
 }
+#[derive(Debug, Clone, Subcommand)]
+pub enum LaneCommands {
+    /// List retained lane snapshots with daemon-owned evidence and local best-effort tmux/marker observation.
+    #[command(
+        about = "List retained lane status",
+        long_about = "List retained lane status by combining daemon-owned lane evidence with local best-effort tmux liveness and R2 marker observation. Routine output redacts Discord targets."
+    )]
+    Status {
+        /// Limit status to one retained lane session.
+        #[arg(long)]
+        session: Option<String>,
+        /// Emit explicit JSON nulls for absent lane fields.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Probe a stored thread target without changing workflow or sending a message.
+    #[command(
+        name = "verify-thread",
+        about = "Verify stored Discord thread evidence",
+        long_about = "Verify the stored Discord thread target for a retained session. A stored kickoff receipt is fetched exactly; otherwise at most one message is observed. Empty history remains unverified."
+    )]
+    VerifyThread {
+        /// Retained lane session whose stored thread target will be probed.
+        #[arg(long)]
+        session: String,
+        /// Emit explicit JSON nulls for absent verification fields.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Deliver a bounded lifecycle update to a stored thread target.
+    #[command(
+        about = "Send a lifecycle update to a stored Discord thread",
+        long_about = "Send a lifecycle update only to the stored target for a retained session. An explicit workflow change is persisted before delivery; failed delivery does not revert it."
+    )]
+    Update {
+        /// Retained lane session whose stored thread target receives the update.
+        #[arg(long)]
+        session: String,
+        /// Lifecycle message to deliver; limited to 2,000 Unicode scalar values.
+        #[arg(long)]
+        message: String,
+        /// Audit and delivery label for the lifecycle message.
+        #[arg(long, value_enum)]
+        kind: LaneUpdateKind,
+        /// Optional durable workflow transition to persist before delivery.
+        #[arg(long, value_enum)]
+        workflow: Option<LaneWorkflowArg>,
+        /// Emit explicit JSON nulls for absent receipt and verification fields.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LaneUpdateKind {
+    Kickoff,
+    Progress,
+    Blocked,
+    PrOpen,
+    Handoff,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LaneWorkflowArg {
+    Active,
+    NeedsReview,
+    NeedsQa,
+    PrOpen,
+    AwaitingCi,
+    AwaitingHuman,
+    Retired,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum TmuxCommands {
     Keyword {
@@ -779,6 +862,16 @@ pub struct TmuxNewArgs {
     pub retry_enter_delay_ms: u64,
     #[arg(long)]
     pub shell: Option<String>,
+    /// Optional stored Discord thread target for the lane-aware launch path.
+    #[arg(long)]
+    pub thread: Option<String>,
+    /// Initial Discord message; requires --thread and is limited to 2,000 Unicode scalar values.
+    #[arg(long, requires = "thread")]
+    pub kickoff: Option<String>,
+    /// Emit lane launch evidence as JSON without changing legacy non-lane output.
+    #[arg(long)]
+    pub json: bool,
+
     #[arg(last = true, allow_hyphen_values = true)]
     pub command: Vec<String>,
 }
@@ -1947,6 +2040,119 @@ mod tests {
         assert_eq!(args.project.as_deref(), Some("clawhip"));
         assert!(args.write);
         assert!(args.force);
+    }
+    #[test]
+    fn parses_lane_update_with_optional_workflow() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "lane",
+            "update",
+            "--session",
+            "issue-285",
+            "--message",
+            "handoff ready",
+            "--kind",
+            "handoff",
+            "--workflow",
+            "awaiting-human",
+            "--json",
+        ]);
+
+        let Commands::Lane {
+            command:
+                LaneCommands::Update {
+                    session,
+                    message,
+                    kind,
+                    workflow,
+                    json,
+                },
+        } = cli.command.expect("lane command")
+        else {
+            panic!("expected lane update command");
+        };
+        assert_eq!(session, "issue-285");
+        assert_eq!(message, "handoff ready");
+        assert_eq!(kind, LaneUpdateKind::Handoff);
+        assert_eq!(workflow, Some(LaneWorkflowArg::AwaitingHuman));
+        assert!(json);
+    }
+
+    #[test]
+    fn lane_commands_require_their_contractual_arguments() {
+        assert!(Cli::try_parse_from(["clawhip", "lane", "verify-thread"]).is_err());
+        assert!(
+            Cli::try_parse_from(["clawhip", "lane", "update", "--session", "issue-285"]).is_err()
+        );
+    }
+
+    #[test]
+    fn lane_help_describes_all_subcommands() {
+        let mut root = Cli::command();
+        let lane = root.find_subcommand_mut("lane").expect("lane command");
+        let lane_help = lane.render_long_help().to_string();
+        assert!(lane_help.contains("status"));
+        assert!(lane_help.contains("verify-thread"));
+        assert!(lane_help.contains("update"));
+
+        let status = lane
+            .find_subcommand_mut("status")
+            .expect("lane status command");
+        let status_help = status.render_long_help().to_string();
+        assert!(status_help.contains("daemon-owned lane evidence"));
+        assert!(status_help.contains("local best-effort tmux liveness"));
+        assert!(status_help.contains("R2 marker observation"));
+    }
+    #[test]
+    fn parses_lane_aware_tmux_new_flags_without_changing_legacy_defaults() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "tmux",
+            "new",
+            "--session",
+            "issue-285",
+            "--thread",
+            "123",
+            "--kickoff",
+            "Starting work",
+            "--json",
+        ]);
+        let Commands::Tmux {
+            command: TmuxCommands::New(args),
+        } = cli.command.expect("tmux command")
+        else {
+            panic!("expected tmux new command");
+        };
+        assert_eq!(args.thread.as_deref(), Some("123"));
+        assert_eq!(args.kickoff.as_deref(), Some("Starting work"));
+        assert!(args.json);
+
+        let legacy = Cli::parse_from(["clawhip", "tmux", "new", "--session", "legacy"]);
+        let Commands::Tmux {
+            command: TmuxCommands::New(args),
+        } = legacy.command.expect("legacy tmux command")
+        else {
+            panic!("expected tmux new command");
+        };
+        assert_eq!(args.thread, None);
+        assert_eq!(args.kickoff, None);
+        assert!(!args.json);
+    }
+
+    #[test]
+    fn tmux_new_kickoff_requires_thread() {
+        assert!(
+            Cli::try_parse_from([
+                "clawhip",
+                "tmux",
+                "new",
+                "--session",
+                "issue-285",
+                "--kickoff",
+                "Starting work",
+            ])
+            .is_err()
+        );
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,10 @@ use crate::Result;
 use crate::config::AppConfig;
 use crate::events::IncomingEvent;
 use crate::source::tmux::RegisteredTmuxSession;
+use crate::source::tmux::{
+    LaneDeliveryMutation, LaneDetail, LaneEvidenceMutation, LaneRegistrationInput,
+    LaneRetirementMutation, LaneSnapshot, LaneVerificationMutation,
+};
 
 #[derive(Clone)]
 pub struct DaemonClient {
@@ -16,7 +20,10 @@ pub struct DaemonClient {
 impl DaemonClient {
     pub fn from_config(config: &AppConfig) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            http: reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .expect("reqwest client construction"),
             base_url: config.daemon_base_url().trim_end_matches('/').to_string(),
         }
     }
@@ -110,5 +117,214 @@ impl DaemonClient {
             let body = response.text().await.unwrap_or_default();
             Err(format!("daemon request failed with {status}: {body}").into())
         }
+    }
+
+    pub async fn list_lanes(&self) -> Result<Vec<LaneSnapshot>> {
+        self.private_get_json("/api/lane").await
+    }
+
+    pub async fn claim_lane(
+        &self,
+        session: &str,
+        generation_id: &str,
+        executor_id: &str,
+        expected_revision: u64,
+    ) -> Result<LaneSnapshot> {
+        self.private_post_typed("/api/lane/claim", &serde_json::json!({"session": session, "generation_id": generation_id, "executor_id": executor_id, "expected_revision": expected_revision})).await
+    }
+
+    pub async fn update_lane_evidence(&self, input: &LaneEvidenceMutation) -> Result<LaneSnapshot> {
+        self.private_post_typed("/api/lane/evidence", input).await
+    }
+
+    pub async fn update_lane_workflow(
+        &self,
+        input: &crate::source::tmux::LaneWorkflowMutation,
+    ) -> Result<LaneSnapshot> {
+        self.private_post_typed("/api/lane/workflow", input).await
+    }
+
+    async fn private_get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
+        self.ensure_loopback_daemon()?;
+        self.get_json(path).await
+    }
+    async fn private_post_typed<T: serde::de::DeserializeOwned, P: Serialize>(
+        &self,
+        path: &str,
+        payload: &P,
+    ) -> Result<T> {
+        self.ensure_loopback_daemon()?;
+        self.post_typed(path, payload).await
+    }
+    fn ensure_loopback_daemon(&self) -> Result<()> {
+        let url = reqwest::Url::parse(&self.base_url)?;
+        let host = url
+            .host_str()
+            .ok_or("private daemon URL lacks host")?
+            .trim_matches(['[', ']']);
+        let allowed = host.eq_ignore_ascii_case("localhost")
+            || host
+                .parse::<std::net::IpAddr>()
+                .ok()
+                .is_some_and(|ip| match ip {
+                    std::net::IpAddr::V4(ip) => ip.is_loopback(),
+                    std::net::IpAddr::V6(ip) => {
+                        ip.is_loopback() || ip.to_ipv4().is_some_and(|mapped| mapped.is_loopback())
+                    }
+                });
+        if allowed {
+            Ok(())
+        } else {
+            Err("private lane requests require a loopback daemon URL".into())
+        }
+    }
+
+    async fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let response = self
+            .http
+            .get(format!("{}{}", self.base_url, path))
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(response.json().await?)
+        } else {
+            Err(format!("daemon lane request failed with {}", response.status()).into())
+        }
+    }
+    async fn lane_error_response(
+        response: reqwest::Response,
+    ) -> Box<dyn std::error::Error + Send + Sync> {
+        let status = response.status();
+        let payload = response.json::<Value>().await.unwrap_or(Value::Null);
+        let message = if payload.get("error_code").and_then(Value::as_str) == Some("runtime-active")
+        {
+            "lane runtime remains active; quiesce it before retirement".to_owned()
+        } else {
+            format!("daemon lane request failed with {status}")
+        };
+        Box::new(std::io::Error::other(message))
+    }
+
+    async fn post_typed<T: serde::de::DeserializeOwned, P: Serialize>(
+        &self,
+        path: &str,
+        payload: &P,
+    ) -> Result<T> {
+        let response = self
+            .http
+            .post(format!("{}{}", self.base_url, path))
+            .json(payload)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(response.json().await?)
+        } else {
+            Err(Self::lane_error_response(response).await)
+        }
+    }
+
+    pub async fn lane_detail(&self, session: &str) -> Result<LaneDetail> {
+        self.ensure_loopback_daemon()?;
+        let mut url = reqwest::Url::parse(&self.base_url)?;
+        url.path_segments_mut()
+            .map_err(|_| "private daemon URL cannot accept path segments")?
+            .extend(["api", "lane", "detail", session]);
+        let response = self.http.get(url).send().await?;
+        if response.status().is_success() {
+            Ok(response.json().await?)
+        } else {
+            Err(format!("daemon lane request failed with {}", response.status()).into())
+        }
+    }
+    pub async fn register_lane(&self, input: &LaneRegistrationInput) -> Result<LaneDetail> {
+        self.private_post_typed("/api/lane/register", input).await
+    }
+    pub async fn record_lane_verification(
+        &self,
+        input: &LaneVerificationMutation,
+    ) -> Result<LaneSnapshot> {
+        self.private_post_typed("/api/lane/verification", input)
+            .await
+    }
+    pub async fn record_lane_delivery(&self, input: &LaneDeliveryMutation) -> Result<LaneSnapshot> {
+        self.private_post_typed("/api/lane/delivery", input).await
+    }
+    pub async fn retire_lane(&self, input: &LaneRetirementMutation) -> Result<LaneSnapshot> {
+        self.private_post_typed("/api/lane/retire", input).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tokio::io::AsyncWriteExt;
+    use tokio::time::{Duration, timeout};
+
+    #[test]
+    fn private_lane_client_rejects_non_loopback_urls() {
+        let remote = DaemonClient {
+            http: reqwest::Client::new(),
+            base_url: "http://example.com".into(),
+        };
+        let ipv4 = DaemonClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:8080".into(),
+        };
+        let ipv6 = DaemonClient {
+            http: reqwest::Client::new(),
+            base_url: "http://[::1]:8080".into(),
+        };
+        assert!(remote.ensure_loopback_daemon().is_err());
+        assert!(ipv4.ensure_loopback_daemon().is_ok());
+        assert!(ipv6.ensure_loopback_daemon().is_ok());
+    }
+
+    #[test]
+    fn lane_detail_path_segments_escape_unsafe_session_text() {
+        let mut url = reqwest::Url::parse("http://127.0.0.1:8080").unwrap();
+        url.path_segments_mut()
+            .unwrap()
+            .extend(["api", "lane", "detail", "a/b?c#d"]);
+        assert_eq!(url.path(), "/api/lane/detail/a%2Fb%3Fc%23d");
+    }
+
+    #[tokio::test]
+    async fn private_lane_requests_do_not_follow_redirects() {
+        let target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_address = target.local_addr().unwrap();
+        let target_hits = Arc::new(AtomicUsize::new(0));
+        let target_counter = target_hits.clone();
+        let target_task = tokio::spawn(async move {
+            if timeout(Duration::from_millis(150), target.accept())
+                .await
+                .is_ok()
+            {
+                target_counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        let redirector = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let redirector_address = redirector.local_addr().unwrap();
+        let redirect_task = tokio::spawn(async move {
+            let (mut stream, _) = redirector.accept().await.unwrap();
+            let response = format!(
+                "HTTP/1.1 307 Temporary Redirect\r\nLocation: http://{target_address}/private\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        let client = DaemonClient {
+            http: reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .unwrap(),
+            base_url: format!("http://{redirector_address}"),
+        };
+        assert!(client.lane_detail("safe-session").await.is_err());
+        redirect_task.await.unwrap();
+        target_task.await.unwrap();
+        assert_eq!(target_hits.load(Ordering::SeqCst), 0);
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::State;
+use axum::extract::{ConnectInfo, FromRequestParts, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
@@ -32,6 +32,13 @@ use crate::native_observability::{
 use crate::render::{DefaultRenderer, Renderer};
 use crate::router::Router;
 use crate::sink::{DiscordSink, LocalFileSink, Sink, SlackSink};
+use crate::source::tmux::{
+    BoundedCategory, BoundedReason, LaneDeliveryMutation, LaneEvidenceMutation, LaneLaunchState,
+    LaneRegistrationInput, LaneRetirementMutation, LaneVerificationMutation, LaneVisibility,
+    LaneWorkflow, LaneWorkflowMutation, claim_lane, lane_detail_for_session, list_lane_snapshots,
+    record_lane_delivery, record_lane_verification, register_lane_registration,
+    retire_lane_if_absent, update_lane_evidence, update_lane_workflow,
+};
 use crate::source::{
     GitHubSource, GitSource, RegisteredTmuxSession, SharedTmuxRegistry, Source, TmuxSource,
     WorkspaceSource, default_registry_state_path, inspect_tmux_registry_state,
@@ -164,7 +171,19 @@ pub async fn run(
         .route("/github", post(post_github))
         .route("/api/update/status", get(update_status))
         .route("/api/update/approve", post(approve_update))
-        .route("/api/update/dismiss", post(dismiss_update));
+        .route("/api/update/dismiss", post(dismiss_update))
+        .route("/api/lane", get(list_lanes))
+        .route("/api/lane/claim", post(claim_lane_handler))
+        .route("/api/lane/evidence", post(update_lane_evidence_handler))
+        .route("/api/lane/workflow", post(update_lane_workflow_handler))
+        .route("/api/lane/detail/{session}", get(lane_detail_handler))
+        .route("/api/lane/register", post(register_lane_handler))
+        .route(
+            "/api/lane/verification",
+            post(record_lane_verification_handler),
+        )
+        .route("/api/lane/delivery", post(record_lane_delivery_handler))
+        .route("/api/lane/retire", post(retire_lane_handler));
     let port = port_override.unwrap_or(config.daemon.port);
 
     let app = app.with_state(AppState {
@@ -188,7 +207,11 @@ pub async fn run(
         telemetry::reason::DAEMON_LISTENING,
         json!({"version": VERSION, "addr": local_addr.to_string(), "token_source": token_source}),
     ));
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
     Ok(())
 }
 
@@ -1011,6 +1034,299 @@ async fn list_tmux(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
+#[derive(serde::Deserialize)]
+struct LaneClaimDto {
+    session: String,
+    generation_id: String,
+    executor_id: String,
+    expected_revision: u64,
+}
+#[derive(serde::Deserialize)]
+struct LaneEvidenceDto {
+    session: String,
+    generation_id: String,
+    launch_operation_id: String,
+    expected_revision: u64,
+    launch_state: LaneLaunchState,
+    #[serde(default)]
+    failure_category: Option<String>,
+    executor_id: String,
+    worker_effect_kind: crate::source::tmux::WorkerEffectKind,
+}
+#[derive(serde::Deserialize)]
+struct LaneWorkflowDto {
+    session: String,
+    expected_revision: u64,
+    workflow: LaneWorkflow,
+    #[serde(default)]
+    quiesced: bool,
+    generation_id: String,
+}
+
+struct LoopbackLanePeer;
+impl<S: Send + Sync> FromRequestParts<S> for LoopbackLanePeer {
+    type Rejection = (StatusCode, Json<Value>);
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        let peer = parts
+            .extensions
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|peer| peer.0);
+        if peer.is_some_and(|peer| {
+            peer.ip().is_loopback() || peer.ip().to_string().starts_with("::ffff:127.")
+        }) {
+            Ok(Self)
+        } else {
+            Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({"ok": false, "error": "lane endpoints require a loopback peer"})),
+            ))
+        }
+    }
+}
+fn lane_error(error: impl std::fmt::Display) -> (StatusCode, Json<Value>) {
+    let message = error.to_string();
+    if message == "lane runtime remains active" {
+        return (
+            StatusCode::CONFLICT,
+            Json(
+                json!({"ok": false, "error_code": "runtime-active", "error": "lane runtime remains active; quiesce it before retirement"}),
+            ),
+        );
+    }
+    let status = if message.contains("not found") {
+        StatusCode::NOT_FOUND
+    } else if message.contains("conflict")
+        || message.contains("revision")
+        || message.contains("transition")
+        || message.contains("retained")
+        || message.contains("active")
+    {
+        StatusCode::CONFLICT
+    } else {
+        StatusCode::BAD_REQUEST
+    };
+    (
+        status,
+        Json(json!({"ok": false, "error": "lane request rejected"})),
+    )
+}
+
+async fn list_lanes(_peer: LoopbackLanePeer, State(state): State<AppState>) -> impl IntoResponse {
+    Json(list_lane_snapshots(&state.tmux_registry, None).await).into_response()
+}
+async fn claim_lane_handler(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    Json(request): Json<LaneClaimDto>,
+) -> impl IntoResponse {
+    let path = default_registry_state_path(&state.cron_state_path);
+    match claim_lane(
+        &state.tmux_registry,
+        &path,
+        &request.session,
+        &request.generation_id,
+        &request.executor_id,
+        request.expected_revision,
+    )
+    .await
+    {
+        Ok(snapshot) => Json(snapshot).into_response(),
+        Err(error) => lane_error(error).into_response(),
+    }
+}
+async fn update_lane_evidence_handler(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    Json(request): Json<LaneEvidenceDto>,
+) -> impl IntoResponse {
+    let path = default_registry_state_path(&state.cron_state_path);
+    match update_lane_evidence(
+        &state.tmux_registry,
+        &path,
+        LaneEvidenceMutation {
+            session: request.session,
+            expected_revision: request.expected_revision,
+            generation_id: request.generation_id,
+            launch_operation_id: request.launch_operation_id,
+            launch_state: request.launch_state,
+            executor_id: request.executor_id,
+            worker_effect_kind: request.worker_effect_kind,
+            failure_category: request.failure_category.map(BoundedCategory::new),
+        },
+    )
+    .await
+    {
+        Ok(snapshot) => Json(snapshot).into_response(),
+        Err(error) => lane_error(error).into_response(),
+    }
+}
+async fn update_lane_workflow_handler(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    Json(request): Json<LaneWorkflowDto>,
+) -> impl IntoResponse {
+    let path = default_registry_state_path(&state.cron_state_path);
+    match update_lane_workflow(
+        &state.tmux_registry,
+        &path,
+        LaneWorkflowMutation {
+            session: request.session,
+            generation_id: request.generation_id,
+            expected_revision: request.expected_revision,
+            workflow: request.workflow,
+            quiesced: request.quiesced,
+        },
+    )
+    .await
+    {
+        Ok(snapshot) => Json(snapshot).into_response(),
+        Err(error) => lane_error(error).into_response(),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct LaneVerificationDto {
+    session: String,
+    expected_revision: u64,
+    checked_at: String,
+    outcome: String,
+    #[serde(default)]
+    reason: Option<String>,
+    visibility: LaneVisibility,
+    generation_id: String,
+}
+#[derive(serde::Deserialize)]
+struct LaneDeliveryDto {
+    session: String,
+    expected_revision: u64,
+    #[serde(default)]
+    workflow: Option<LaneWorkflow>,
+    #[serde(default)]
+    message_id: Option<String>,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    delivered_at: Option<String>,
+    visibility: LaneVisibility,
+    #[serde(default)]
+    error_category: Option<String>,
+    #[serde(default)]
+    disposition: Option<String>,
+    generation_id: String,
+    #[serde(default)]
+    initial_kickoff: bool,
+    #[serde(default)]
+    kickoff_operation_id: Option<String>,
+}
+#[derive(serde::Deserialize)]
+struct LaneRetireDto {
+    session: String,
+    generation_id: String,
+    expected_revision: u64,
+}
+async fn lane_detail_handler(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    axum::extract::Path(session): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    match lane_detail_for_session(&state.tmux_registry, &session).await {
+        Ok(detail) => Json(detail).into_response(),
+        Err(error) => lane_error(error).into_response(),
+    }
+}
+async fn register_lane_handler(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    Json(input): Json<LaneRegistrationInput>,
+) -> impl IntoResponse {
+    match register_lane_registration(
+        &state.tmux_registry,
+        &default_registry_state_path(&state.cron_state_path),
+        input,
+    )
+    .await
+    {
+        Ok(detail) => Json(detail).into_response(),
+        Err(error) => lane_error(error).into_response(),
+    }
+}
+async fn record_lane_verification_handler(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    Json(request): Json<LaneVerificationDto>,
+) -> impl IntoResponse {
+    match record_lane_verification(
+        &state.tmux_registry,
+        &default_registry_state_path(&state.cron_state_path),
+        LaneVerificationMutation {
+            session: request.session,
+            expected_revision: request.expected_revision,
+            checked_at: request.checked_at,
+            outcome: request.outcome,
+            reason: request.reason.map(BoundedReason::new),
+            visibility: request.visibility,
+            generation_id: request.generation_id,
+        },
+    )
+    .await
+    {
+        Ok(snapshot) => Json(snapshot).into_response(),
+        Err(error) => lane_error(error).into_response(),
+    }
+}
+async fn record_lane_delivery_handler(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    Json(request): Json<LaneDeliveryDto>,
+) -> impl IntoResponse {
+    match record_lane_delivery(
+        &state.tmux_registry,
+        &default_registry_state_path(&state.cron_state_path),
+        LaneDeliveryMutation {
+            session: request.session,
+            expected_revision: request.expected_revision,
+            workflow: request.workflow,
+            message_id: request.message_id,
+            kind: request.kind,
+            delivered_at: request.delivered_at,
+            visibility: request.visibility,
+            error_category: request.error_category.map(BoundedCategory::new),
+            disposition: request.disposition,
+            generation_id: request.generation_id,
+            initial_kickoff: request.initial_kickoff,
+            kickoff_operation_id: request.kickoff_operation_id,
+        },
+    )
+    .await
+    {
+        Ok(snapshot) => Json(snapshot).into_response(),
+        Err(error) => lane_error(error).into_response(),
+    }
+}
+async fn retire_lane_handler(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    Json(request): Json<LaneRetireDto>,
+) -> impl IntoResponse {
+    match retire_lane_if_absent(
+        &state.tmux_registry,
+        &default_registry_state_path(&state.cron_state_path),
+        LaneRetirementMutation {
+            session: request.session,
+            generation_id: request.generation_id,
+            expected_revision: request.expected_revision,
+        },
+    )
+    .await
+    {
+        Ok(snapshot) => Json(snapshot).into_response(),
+        Err(error) => lane_error(error).into_response(),
+    }
+}
+
 fn gajae_hold_target(config: &AppConfig, repo: &str) -> Option<String> {
     config
         .routes
@@ -1339,6 +1655,54 @@ mod tests {
         )
     }
 
+    #[tokio::test]
+    async fn loopback_lane_peer_accepts_loopbacks_and_rejects_remote_or_missing_peer() {
+        for address in ["127.0.0.1:1", "[::1]:1", "[::ffff:127.0.0.1]:1"] {
+            let mut parts = axum::http::Request::new(()).into_parts().0;
+            parts
+                .extensions
+                .insert(ConnectInfo(address.parse::<SocketAddr>().unwrap()));
+            assert!(
+                LoopbackLanePeer::from_request_parts(&mut parts, &())
+                    .await
+                    .is_ok()
+            );
+        }
+        let mut remote = axum::http::Request::new(()).into_parts().0;
+        remote
+            .extensions
+            .insert(ConnectInfo("192.0.2.1:1".parse::<SocketAddr>().unwrap()));
+        assert!(
+            LoopbackLanePeer::from_request_parts(&mut remote, &())
+                .await
+                .is_err()
+        );
+        let mut missing = axum::http::Request::new(()).into_parts().0;
+        assert!(
+            LoopbackLanePeer::from_request_parts(&mut missing, &())
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn bare_lane_registration_payload_matches_client_wire_schema() {
+        let input = LaneRegistrationInput {
+            registration: tmux_registration("lane"),
+            generation_id: "g".into(),
+            kickoff_operation_id: "k".into(),
+            launch_operation_id: "l".into(),
+            executor_id: "e".into(),
+            worker_effect_kind: crate::source::tmux::WorkerEffectKind::CommandSubmission,
+            thread_id: None,
+            expect_absent_or_retired: true,
+        };
+        let parsed: LaneRegistrationInput =
+            serde_json::from_value(serde_json::to_value(&input).unwrap()).unwrap();
+        assert_eq!(parsed.generation_id, "g");
+        assert_eq!(parsed.registration.session, "lane");
+    }
+
     fn app_state_with_config(config: AppConfig) -> (AppState, mpsc::Receiver<IncomingEvent>) {
         let (tx, rx) = mpsc::channel(8);
         (
@@ -1396,6 +1760,7 @@ mod tests {
                 name: Some("codex".into()),
             }),
             active_wrapper_monitor: true,
+            lane: None,
         }
     }
 
@@ -2643,6 +3008,7 @@ mod tests {
                     name: Some("codex".into()),
                 }),
                 active_wrapper_monitor: false,
+                lane: None,
             },
         );
         let state = AppState {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,11 +1,14 @@
+use std::fmt;
+
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use reqwest::StatusCode;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use reqwest::{StatusCode, Url};
 use serde::Deserialize;
 use serde_json::json;
+use time::OffsetDateTime;
 
 use crate::Result;
 use crate::binding_verify::ChannelLookup;
@@ -51,9 +54,114 @@ struct DiscordRateLimitBody {
 }
 
 #[derive(Debug, Deserialize)]
+struct DiscordErrorBody {
+    code: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
 struct DiscordChannelBody {
     #[serde(default)]
     name: Option<String>,
+}
+
+const LANE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const DISCORD_MAX_CONTENT_SCALARS: usize = 2_000;
+
+/// Source of the timestamp on a lane delivery receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordLaneTimestampSource {
+    Discord,
+    Local,
+}
+
+/// Durable evidence returned after Discord accepts a lane message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordLaneReceipt {
+    pub message_id: String,
+    pub timestamp: OffsetDateTime,
+    pub timestamp_source: DiscordLaneTimestampSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordLaneErrorCategory {
+    ContentTooLong,
+    BadRequest,
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    RateLimited,
+    ArchivedOrNotWritable,
+    Timeout,
+    Transport,
+    MalformedSuccess,
+    EmptyMessageId,
+    MissingMessageId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordLaneRetry {
+    Never,
+    After(Duration),
+    Bounded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordLaneDisposition {
+    DefinitiveFailure,
+    AmbiguousAcceptance,
+}
+
+/// A sanitized delivery error. It never contains a Discord response body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordLaneError {
+    pub category: DiscordLaneErrorCategory,
+    pub status: Option<u16>,
+    pub retry: DiscordLaneRetry,
+    pub disposition: DiscordLaneDisposition,
+}
+
+impl fmt::Display for DiscordLaneError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Discord lane delivery {:?}", self.category)
+    }
+}
+
+impl std::error::Error for DiscordLaneError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscordThreadReachability {
+    Reachable,
+    Unreachable(DiscordLaneErrorCategory),
+    Unknown(DiscordLaneErrorCategory),
+}
+
+/// A content-free message observation for a read probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscordThreadMessageProbe {
+    pub message_id: String,
+    pub timestamp: Option<OffsetDateTime>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscordThreadMessageFetch {
+    Found(DiscordThreadMessageProbe),
+    NotFound,
+    Unavailable(DiscordLaneErrorCategory),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscordThreadMessageList {
+    Empty,
+    One(DiscordThreadMessageProbe),
+    Unavailable(DiscordLaneErrorCategory),
+}
+
+#[derive(Debug, Deserialize)]
+struct DiscordMessageBody {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    timestamp: Option<String>,
 }
 
 impl DiscordClient {
@@ -213,6 +321,208 @@ impl DiscordClient {
         let error = format!("Discord delivery exhausted retries for {safe_target}");
         self.record_dlq(target, message, MAX_ATTEMPTS, error.clone());
         Err(error.into())
+    }
+
+    /// Sends exactly one POST to a Discord thread and returns content-free acceptance evidence.
+    /// This lane-only path has isolated circuit/rate-limit state, never retries a dispatched POST,
+    /// and never writes the generic DLQ.
+    pub async fn send_thread_with_receipt(
+        &self,
+        thread_id: &str,
+        content: &str,
+    ) -> std::result::Result<DiscordLaneReceipt, DiscordLaneError> {
+        if !is_discord_snowflake(thread_id) {
+            return Err(lane_error(
+                DiscordLaneErrorCategory::BadRequest,
+                None,
+                DiscordLaneRetry::Never,
+                DiscordLaneDisposition::DefinitiveFailure,
+            ));
+        }
+        if content.chars().count() > DISCORD_MAX_CONTENT_SCALARS {
+            return Err(lane_error(
+                DiscordLaneErrorCategory::ContentTooLong,
+                None,
+                DiscordLaneRetry::Never,
+                DiscordLaneDisposition::DefinitiveFailure,
+            ));
+        }
+        let Some(client) = self.bot_client.as_ref() else {
+            return Err(lane_error(
+                DiscordLaneErrorCategory::Unauthorized,
+                None,
+                DiscordLaneRetry::Never,
+                DiscordLaneDisposition::DefinitiveFailure,
+            ));
+        };
+        let key = format!("discord:lane-thread:{thread_id}");
+        let (allowed, _) = self.allow_request(&key);
+        if !allowed {
+            return Err(lane_error(
+                DiscordLaneErrorCategory::Transport,
+                None,
+                DiscordLaneRetry::Bounded,
+                DiscordLaneDisposition::DefinitiveFailure,
+            ));
+        }
+
+        let delay = self.rate_limit_delay(&key);
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        let Some(url) = discord_lane_url(&self.api_base, &["channels", thread_id, "messages"])
+        else {
+            return Err(lane_error(
+                DiscordLaneErrorCategory::Transport,
+                None,
+                DiscordLaneRetry::Never,
+                DiscordLaneDisposition::DefinitiveFailure,
+            ));
+        };
+        let response = match client
+            .post(url)
+            .timeout(LANE_REQUEST_TIMEOUT)
+            .json(&json!({ "content": content }))
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                self.record_failure(&key);
+                return Err(lane_error(
+                    request_error_category(&error),
+                    None,
+                    DiscordLaneRetry::Bounded,
+                    DiscordLaneDisposition::AmbiguousAcceptance,
+                ));
+            }
+        };
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            let error = lane_http_error_from_body(status, &body);
+            self.record_failure(&key);
+            return Err(error);
+        }
+        match response.json::<DiscordMessageBody>().await {
+            Ok(body) => match receipt_from_message_body(body) {
+                Ok(receipt) => {
+                    self.record_success(&key);
+                    Ok(receipt)
+                }
+                Err(mut error) => {
+                    self.record_failure(&key);
+                    error.status = Some(status.as_u16());
+                    Err(error)
+                }
+            },
+            Err(_) => {
+                self.record_failure(&key);
+                Err(lane_error(
+                    DiscordLaneErrorCategory::MalformedSuccess,
+                    Some(status.as_u16()),
+                    DiscordLaneRetry::Bounded,
+                    DiscordLaneDisposition::AmbiguousAcceptance,
+                ))
+            }
+        }
+    }
+
+    /// Checks thread reachability without changing delivery circuit, limiter, telemetry, or DLQ state.
+    pub async fn probe_thread_reachability(&self, thread_id: &str) -> DiscordThreadReachability {
+        if !is_discord_snowflake(thread_id) {
+            return DiscordThreadReachability::Unknown(DiscordLaneErrorCategory::BadRequest);
+        }
+        let Some(client) = self.bot_client.as_ref() else {
+            return DiscordThreadReachability::Unreachable(DiscordLaneErrorCategory::Unauthorized);
+        };
+        let Some(url) = discord_lane_url(&self.api_base, &["channels", thread_id]) else {
+            return DiscordThreadReachability::Unknown(DiscordLaneErrorCategory::Transport);
+        };
+        match client.get(url).timeout(LANE_REQUEST_TIMEOUT).send().await {
+            Ok(response) if response.status().is_success() => DiscordThreadReachability::Reachable,
+            Ok(response) => match lane_http_error(response.status(), None).category {
+                DiscordLaneErrorCategory::Unauthorized
+                | DiscordLaneErrorCategory::Forbidden
+                | DiscordLaneErrorCategory::NotFound => DiscordThreadReachability::Unreachable(
+                    lane_http_error(response.status(), None).category,
+                ),
+                category => DiscordThreadReachability::Unknown(category),
+            },
+            Err(error) => DiscordThreadReachability::Unknown(request_error_category(&error)),
+        }
+    }
+
+    /// Fetches one exact message and exposes only its ID and optional timestamp.
+    pub async fn fetch_thread_message(
+        &self,
+        thread_id: &str,
+        message_id: &str,
+    ) -> DiscordThreadMessageFetch {
+        if !is_discord_snowflake(thread_id) || !is_discord_snowflake(message_id) {
+            return DiscordThreadMessageFetch::Unavailable(DiscordLaneErrorCategory::BadRequest);
+        }
+        let Some(client) = self.bot_client.as_ref() else {
+            return DiscordThreadMessageFetch::Unavailable(DiscordLaneErrorCategory::Unauthorized);
+        };
+        let Some(url) = discord_lane_url(
+            &self.api_base,
+            &["channels", thread_id, "messages", message_id],
+        ) else {
+            return DiscordThreadMessageFetch::Unavailable(DiscordLaneErrorCategory::Transport);
+        };
+        match client.get(url).timeout(LANE_REQUEST_TIMEOUT).send().await {
+            Ok(response) if response.status().is_success() => response
+                .json::<DiscordMessageBody>()
+                .await
+                .ok()
+                .and_then(probe_from_message_body)
+                .map(DiscordThreadMessageFetch::Found)
+                .unwrap_or(DiscordThreadMessageFetch::Unavailable(
+                    DiscordLaneErrorCategory::MalformedSuccess,
+                )),
+            Ok(response) if response.status() == StatusCode::NOT_FOUND => {
+                DiscordThreadMessageFetch::NotFound
+            }
+            Ok(response) => DiscordThreadMessageFetch::Unavailable(
+                lane_http_error(response.status(), None).category,
+            ),
+            Err(error) => DiscordThreadMessageFetch::Unavailable(request_error_category(&error)),
+        }
+    }
+
+    /// Lists at most one thread message and never exposes message body or channel metadata.
+    pub async fn list_thread_messages(&self, thread_id: &str) -> DiscordThreadMessageList {
+        if !is_discord_snowflake(thread_id) {
+            return DiscordThreadMessageList::Unavailable(DiscordLaneErrorCategory::BadRequest);
+        }
+        let Some(client) = self.bot_client.as_ref() else {
+            return DiscordThreadMessageList::Unavailable(DiscordLaneErrorCategory::Unauthorized);
+        };
+        let Some(mut url) = discord_lane_url(&self.api_base, &["channels", thread_id, "messages"])
+        else {
+            return DiscordThreadMessageList::Unavailable(DiscordLaneErrorCategory::Transport);
+        };
+        url.query_pairs_mut().append_pair("limit", "1");
+        match client.get(url).timeout(LANE_REQUEST_TIMEOUT).send().await {
+            Ok(response) if response.status().is_success() => response
+                .json::<Vec<DiscordMessageBody>>()
+                .await
+                .ok()
+                .and_then(|mut messages| match messages.len() {
+                    0 => Some(DiscordThreadMessageList::Empty),
+                    1 => probe_from_message_body(messages.remove(0))
+                        .map(DiscordThreadMessageList::One),
+                    _ => None,
+                })
+                .unwrap_or(DiscordThreadMessageList::Unavailable(
+                    DiscordLaneErrorCategory::MalformedSuccess,
+                )),
+            Ok(response) => DiscordThreadMessageList::Unavailable(
+                lane_http_error(response.status(), None).category,
+            ),
+            Err(error) => DiscordThreadMessageList::Unavailable(request_error_category(&error)),
+        }
     }
 
     /// Look up a Discord channel by ID using the bot API.
@@ -506,6 +816,140 @@ impl DiscordClient {
             .entries()
             .to_vec()
     }
+}
+
+fn lane_error(
+    category: DiscordLaneErrorCategory,
+    status: Option<u16>,
+    retry: DiscordLaneRetry,
+    disposition: DiscordLaneDisposition,
+) -> DiscordLaneError {
+    DiscordLaneError {
+        category,
+        status,
+        retry,
+        disposition,
+    }
+}
+
+fn lane_http_error(status: StatusCode, retry_after: Option<Duration>) -> DiscordLaneError {
+    let category = match status {
+        StatusCode::BAD_REQUEST => DiscordLaneErrorCategory::BadRequest,
+        StatusCode::UNAUTHORIZED => DiscordLaneErrorCategory::Unauthorized,
+        StatusCode::FORBIDDEN => DiscordLaneErrorCategory::Forbidden,
+        StatusCode::NOT_FOUND => DiscordLaneErrorCategory::NotFound,
+        StatusCode::TOO_MANY_REQUESTS => DiscordLaneErrorCategory::RateLimited,
+        _ => DiscordLaneErrorCategory::Transport,
+    };
+    let retry = match status {
+        StatusCode::TOO_MANY_REQUESTS => {
+            retry_after.map_or(DiscordLaneRetry::Bounded, DiscordLaneRetry::After)
+        }
+        status if status.is_server_error() => DiscordLaneRetry::Bounded,
+        _ => DiscordLaneRetry::Never,
+    };
+    lane_error(
+        category,
+        Some(status.as_u16()),
+        retry,
+        DiscordLaneDisposition::DefinitiveFailure,
+    )
+}
+
+fn lane_http_error_from_body(status: StatusCode, body: &str) -> DiscordLaneError {
+    let mut error = lane_http_error(status, parse_retry_after(status, body));
+    if matches!(status, StatusCode::BAD_REQUEST | StatusCode::FORBIDDEN)
+        && serde_json::from_str::<DiscordErrorBody>(body)
+            .ok()
+            .and_then(|parsed| parsed.code)
+            == Some(50_083)
+    {
+        error.category = DiscordLaneErrorCategory::ArchivedOrNotWritable;
+    }
+    error
+}
+
+fn request_error_category(error: &reqwest::Error) -> DiscordLaneErrorCategory {
+    if error.is_timeout() {
+        DiscordLaneErrorCategory::Timeout
+    } else {
+        DiscordLaneErrorCategory::Transport
+    }
+}
+
+fn is_discord_snowflake(value: &str) -> bool {
+    (1..=20).contains(&value.len()) && value.as_bytes().iter().all(u8::is_ascii_digit)
+}
+
+fn discord_lane_url(api_base: &str, segments: &[&str]) -> Option<Url> {
+    let mut url = Url::parse(api_base).ok()?;
+    {
+        let mut path = url.path_segments_mut().ok()?;
+        path.pop_if_empty();
+        for segment in segments {
+            path.push(segment);
+        }
+    }
+    Some(url)
+}
+
+fn parse_discord_timestamp(value: &str) -> Option<OffsetDateTime> {
+    OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).ok()
+}
+
+fn receipt_from_message_body(
+    body: DiscordMessageBody,
+) -> std::result::Result<DiscordLaneReceipt, DiscordLaneError> {
+    let Some(message_id) = body.id else {
+        return Err(lane_error(
+            DiscordLaneErrorCategory::MissingMessageId,
+            None,
+            DiscordLaneRetry::Never,
+            DiscordLaneDisposition::AmbiguousAcceptance,
+        ));
+    };
+    if message_id.trim().is_empty() {
+        return Err(lane_error(
+            DiscordLaneErrorCategory::EmptyMessageId,
+            None,
+            DiscordLaneRetry::Never,
+            DiscordLaneDisposition::AmbiguousAcceptance,
+        ));
+    }
+    if !is_discord_snowflake(&message_id) {
+        return Err(lane_error(
+            DiscordLaneErrorCategory::MalformedSuccess,
+            None,
+            DiscordLaneRetry::Never,
+            DiscordLaneDisposition::AmbiguousAcceptance,
+        ));
+    }
+    let (timestamp, timestamp_source) = match body.timestamp.as_deref() {
+        Some(value) => parse_discord_timestamp(value)
+            .map(|timestamp| (timestamp, DiscordLaneTimestampSource::Discord))
+            .ok_or_else(|| {
+                lane_error(
+                    DiscordLaneErrorCategory::MalformedSuccess,
+                    None,
+                    DiscordLaneRetry::Never,
+                    DiscordLaneDisposition::AmbiguousAcceptance,
+                )
+            })?,
+        None => (OffsetDateTime::now_utc(), DiscordLaneTimestampSource::Local),
+    };
+    Ok(DiscordLaneReceipt {
+        message_id,
+        timestamp,
+        timestamp_source,
+    })
+}
+
+fn probe_from_message_body(body: DiscordMessageBody) -> Option<DiscordThreadMessageProbe> {
+    let message_id = body.id?;
+    is_discord_snowflake(&message_id).then(|| DiscordThreadMessageProbe {
+        message_id,
+        timestamp: body.timestamp.as_deref().and_then(parse_discord_timestamp),
+    })
 }
 
 fn parse_retry_after(status: StatusCode, body: &str) -> Option<Duration> {
@@ -966,5 +1410,338 @@ mod tests {
         assert_eq!(dlq[0].correlation_id.as_deref(), Some("corr-214"));
         assert_eq!(dlq[0].content_bytes, Some(4));
         assert!(dlq[0].payload_bytes.is_some());
+    }
+
+    #[test]
+    fn lane_receipt_requires_nonempty_id_and_tracks_timestamp_source() {
+        let receipt = receipt_from_message_body(DiscordMessageBody {
+            id: Some("12345678901234567890".into()),
+            timestamp: None,
+        })
+        .unwrap();
+        assert_eq!(receipt.message_id, "12345678901234567890");
+        assert_eq!(receipt.timestamp_source, DiscordLaneTimestampSource::Local);
+
+        let missing = receipt_from_message_body(DiscordMessageBody {
+            id: None,
+            timestamp: None,
+        })
+        .unwrap_err();
+        assert_eq!(missing.category, DiscordLaneErrorCategory::MissingMessageId);
+        assert_eq!(
+            missing.disposition,
+            DiscordLaneDisposition::AmbiguousAcceptance
+        );
+
+        let empty = receipt_from_message_body(DiscordMessageBody {
+            id: Some(" ".into()),
+            timestamp: None,
+        })
+        .unwrap_err();
+        assert_eq!(empty.category, DiscordLaneErrorCategory::EmptyMessageId);
+        let invalid = receipt_from_message_body(DiscordMessageBody {
+            id: Some("message-1".into()),
+            timestamp: None,
+        })
+        .unwrap_err();
+        assert_eq!(invalid.category, DiscordLaneErrorCategory::MalformedSuccess);
+        assert_eq!(
+            invalid.disposition,
+            DiscordLaneDisposition::AmbiguousAcceptance
+        );
+    }
+
+    #[test]
+    fn lane_http_errors_are_typed_and_retry_is_bounded() {
+        let rate_limited =
+            lane_http_error(StatusCode::TOO_MANY_REQUESTS, Some(Duration::from_secs(1)));
+        assert_eq!(rate_limited.category, DiscordLaneErrorCategory::RateLimited);
+        assert_eq!(
+            rate_limited.retry,
+            DiscordLaneRetry::After(Duration::from_secs(1))
+        );
+        assert_eq!(
+            rate_limited.disposition,
+            DiscordLaneDisposition::DefinitiveFailure
+        );
+        assert_eq!(
+            lane_http_error(StatusCode::BAD_REQUEST, None).category,
+            DiscordLaneErrorCategory::BadRequest
+        );
+        assert_eq!(
+            lane_http_error_from_body(StatusCode::BAD_REQUEST, r#"{"code":50083}"#).category,
+            DiscordLaneErrorCategory::ArchivedOrNotWritable
+        );
+        assert_eq!(
+            lane_http_error(StatusCode::INTERNAL_SERVER_ERROR, None).retry,
+            DiscordLaneRetry::Bounded
+        );
+    }
+
+    #[test]
+    fn lane_circuits_are_isolated_per_thread_key() {
+        let client = DiscordClient::from_config(Arc::new(AppConfig::default())).unwrap();
+        for _ in 0..CIRCUIT_FAILURE_THRESHOLD {
+            client.record_failure("discord:lane-thread:thread-a");
+        }
+        assert!(!client.allow_request("discord:lane-thread:thread-a").0);
+        assert!(client.allow_request("discord:lane-thread:thread-b").0);
+    }
+
+    #[test]
+    fn lane_content_limit_uses_unicode_scalars() {
+        assert_eq!("🦀".chars().count(), 1);
+        assert!(
+            "🦀".repeat(DISCORD_MAX_CONTENT_SCALARS).chars().count() <= DISCORD_MAX_CONTENT_SCALARS
+        );
+        assert!(
+            "🦀".repeat(DISCORD_MAX_CONTENT_SCALARS + 1).chars().count()
+                > DISCORD_MAX_CONTENT_SCALARS
+        );
+    }
+
+    #[test]
+    fn lane_errors_never_include_response_sentinel() {
+        let sentinel = "private-thread-body-sentinel";
+        let error = lane_error(
+            DiscordLaneErrorCategory::Forbidden,
+            Some(403),
+            DiscordLaneRetry::Never,
+            DiscordLaneDisposition::DefinitiveFailure,
+        );
+        assert!(!error.to_string().contains(sentinel));
+        assert!(!format!("{error:?}").contains(sentinel));
+    }
+
+    #[tokio::test]
+    async fn lane_read_probes_are_content_free_and_do_not_touch_delivery_state() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once(
+            listener,
+            "HTTP/1.1 200 OK",
+            r#"[{"id":"12345678901234567890","timestamp":"2026-07-10T00:00:00Z","content":"private-thread-body-sentinel"}]"#,
+        ));
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", format!("http://{addr}")).unwrap();
+        let result = client.list_thread_messages("12345678901234567890").await;
+        server.await.unwrap();
+        assert!(
+            matches!(result, DiscordThreadMessageList::One(DiscordThreadMessageProbe { ref message_id, .. }) if message_id == "12345678901234567890")
+        );
+        assert!(client.dlq_entries().is_empty());
+    }
+
+    #[tokio::test]
+    async fn lane_exact_fetch_distinguishes_found_and_missing() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once(
+            listener,
+            "HTTP/1.1 404 Not Found",
+            r#"{"message":"private-thread-body-sentinel"}"#,
+        ));
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", format!("http://{addr}")).unwrap();
+        assert!(matches!(
+            client
+                .fetch_thread_message("12345678901234567890", "12345678901234567890")
+                .await,
+            DiscordThreadMessageFetch::NotFound
+        ));
+        server.await.unwrap();
+        assert!(client.dlq_entries().is_empty());
+    }
+
+    async fn serve_once_and_assert_no_second(
+        listener: tokio::net::TcpListener,
+        status_line: &'static str,
+        body: &'static str,
+    ) {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buffer = vec![0_u8; 4096];
+        let _ = stream.read(&mut buffer).await.unwrap();
+        let response = format!(
+            "{status_line}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "lane delivery retried a dispatched POST"
+        );
+    }
+
+    #[tokio::test]
+    async fn lane_post_429_is_single_attempt_and_definitive() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once_and_assert_no_second(
+            listener,
+            "HTTP/1.1 429 Too Many Requests",
+            r#"{"retry_after":0.01,"message":"private-thread-body-sentinel"}"#,
+        ));
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", format!("http://{addr}")).unwrap();
+        let error = client
+            .send_thread_with_receipt("12345678901234567890", "message")
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        assert_eq!(error.category, DiscordLaneErrorCategory::RateLimited);
+        assert_eq!(error.disposition, DiscordLaneDisposition::DefinitiveFailure);
+        assert!(matches!(error.retry, DiscordLaneRetry::After(_)));
+        assert!(client.dlq_entries().is_empty());
+    }
+
+    #[tokio::test]
+    async fn lane_post_5xx_is_single_attempt_and_definitive() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once_and_assert_no_second(
+            listener,
+            "HTTP/1.1 500 Internal Server Error",
+            r#"{"message":"private-thread-body-sentinel"}"#,
+        ));
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", format!("http://{addr}")).unwrap();
+        let error = client
+            .send_thread_with_receipt("12345678901234567890", "message")
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        assert_eq!(error.status, Some(500));
+        assert_eq!(error.retry, DiscordLaneRetry::Bounded);
+        assert_eq!(error.disposition, DiscordLaneDisposition::DefinitiveFailure);
+    }
+
+    #[tokio::test]
+    async fn lane_malformed_success_is_single_attempt_and_ambiguous() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once_and_assert_no_second(
+            listener,
+            "HTTP/1.1 200 OK",
+            r#"{"id":"","content":"private-thread-body-sentinel"}"#,
+        ));
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", format!("http://{addr}")).unwrap();
+        let error = client
+            .send_thread_with_receipt("12345678901234567890", "message")
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        assert_eq!(error.category, DiscordLaneErrorCategory::EmptyMessageId);
+        assert_eq!(
+            error.disposition,
+            DiscordLaneDisposition::AmbiguousAcceptance
+        );
+        assert_eq!(error.status, Some(200));
+    }
+
+    #[tokio::test]
+    async fn lane_transport_failure_is_ambiguous_and_never_enters_dlq() {
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", "http://127.0.0.1:1".into())
+                .unwrap();
+        let error = client
+            .send_thread_with_receipt("12345678901234567890", "message")
+            .await
+            .unwrap_err();
+        assert_eq!(error.category, DiscordLaneErrorCategory::Transport);
+        assert_eq!(
+            error.disposition,
+            DiscordLaneDisposition::AmbiguousAcceptance
+        );
+        assert_eq!(error.retry, DiscordLaneRetry::Bounded);
+        assert!(client.dlq_entries().is_empty());
+    }
+
+    #[tokio::test]
+    async fn lane_timeout_is_single_attempt_and_ambiguous() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = vec![0_u8; 4096];
+            let _ = stream.read(&mut buffer).await.unwrap();
+            tokio::time::sleep(LANE_REQUEST_TIMEOUT + Duration::from_millis(50)).await;
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err(),
+                "lane delivery retried a timed-out POST"
+            );
+        });
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", format!("http://{addr}")).unwrap();
+        let error = client
+            .send_thread_with_receipt("12345678901234567890", "message")
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        assert_eq!(error.category, DiscordLaneErrorCategory::Timeout);
+        assert_eq!(
+            error.disposition,
+            DiscordLaneDisposition::AmbiguousAcceptance
+        );
+        assert_eq!(error.retry, DiscordLaneRetry::Bounded);
+        assert!(client.dlq_entries().is_empty());
+    }
+
+    #[tokio::test]
+    async fn lane_rejects_unsafe_snowflakes_without_http_requests() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err()
+            );
+        });
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", format!("http://{addr}")).unwrap();
+        for invalid in ["/", "?", "#", "../1", "123456789012345678901", "１２３"] {
+            let error = client
+                .send_thread_with_receipt(invalid, "message")
+                .await
+                .unwrap_err();
+            assert_eq!(error.category, DiscordLaneErrorCategory::BadRequest);
+            assert_eq!(error.disposition, DiscordLaneDisposition::DefinitiveFailure);
+            assert!(matches!(
+                client
+                    .fetch_thread_message("12345678901234567890", invalid)
+                    .await,
+                DiscordThreadMessageFetch::Unavailable(DiscordLaneErrorCategory::BadRequest)
+            ));
+        }
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn lane_numeric_snowflakes_preserve_endpoint_path() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once_capture(
+            listener,
+            "HTTP/1.1 200 OK",
+            r#"{"id":"12345678901234567890"}"#,
+        ));
+        let client =
+            DiscordClient::for_tests_with_api_base("test-token", format!("http://{addr}")).unwrap();
+        client
+            .send_thread_with_receipt("12345678901234567890", "message")
+            .await
+            .unwrap();
+        assert!(
+            server
+                .await
+                .unwrap()
+                .starts_with("POST /channels/12345678901234567890/messages ")
+        );
     }
 }

--- a/src/lane.rs
+++ b/src/lane.rs
@@ -1,0 +1,825 @@
+use std::sync::Arc;
+
+use serde_json::json;
+use time::format_description::well_known::Rfc3339;
+
+use crate::Result;
+use crate::cli::{LaneUpdateKind, LaneWorkflowArg};
+use crate::client::DaemonClient;
+use crate::config::AppConfig;
+use crate::discord::{
+    DiscordClient, DiscordLaneDisposition, DiscordThreadMessageFetch, DiscordThreadMessageList,
+    DiscordThreadReachability,
+};
+use crate::source::tmux::{
+    BoundedCategory, LaneDeliveryMutation, LaneDetail, LaneLaunchState, LaneRetirementMutation,
+    LaneSnapshot, LaneVerificationMutation, LaneVisibility, LaneWorkflow, LaneWorkflowMutation,
+    current_timestamp_rfc3339, session_exists,
+};
+use crate::tmux_wrapper::{LaneInspectionResult, inspect_lane_r2};
+
+const RETIREMENT_GUIDANCE: &str = "lane runtime remains active; quiesce it before retirement";
+
+pub async fn status(
+    config: Arc<AppConfig>,
+    session: Option<String>,
+    json_output: bool,
+) -> Result<()> {
+    let client = DaemonClient::from_config(config.as_ref());
+    let snapshots = client.list_lanes().await?;
+    let mut details = Vec::new();
+    for snapshot in snapshots {
+        if session
+            .as_deref()
+            .is_some_and(|requested| requested != snapshot.session)
+        {
+            continue;
+        }
+        let detail = client.lane_detail(&snapshot.session).await?;
+        let current = status_snapshot(&detail);
+
+        if session.is_none() && current.workflow == LaneWorkflow::Retired {
+            continue;
+        }
+        let runtime_live = session_exists(&current.session).await.ok();
+        let inspection = if current.durable_launch_state == LaneLaunchState::IdentityVerified {
+            Some(inspect_lane_r2(&current.session, current).await)
+        } else {
+            None
+        };
+        details.push((detail, runtime_live, inspection));
+    }
+    if let Some(requested) = session
+        && details.is_empty()
+    {
+        return Err(format!("lane session not found: {requested}").into());
+    }
+    render_status(&details, json_output)
+}
+
+fn status_snapshot(detail: &LaneDetail) -> &LaneSnapshot {
+    &detail.snapshot
+}
+
+pub async fn verify_thread(
+    config: Arc<AppConfig>,
+    session: String,
+    json_output: bool,
+) -> Result<()> {
+    let client = DaemonClient::from_config(config.as_ref());
+    let detail = client.lane_detail(&session).await?;
+    let Some(thread_id) = detail.thread_id.as_deref() else {
+        return verification_result(
+            &client,
+            &detail,
+            "unverified",
+            Some("thread-target-missing"),
+            LaneVisibility::Unverified,
+            json_output,
+            true,
+        )
+        .await;
+    };
+    let discord = DiscordClient::from_config(config)?;
+    match discord.probe_thread_reachability(thread_id).await {
+        DiscordThreadReachability::Reachable => {}
+        DiscordThreadReachability::Unreachable(category) => {
+            return verification_result(
+                &client,
+                &detail,
+                "unreachable",
+                Some(discord_category(category)),
+                LaneVisibility::Unreachable,
+                json_output,
+                true,
+            )
+            .await;
+        }
+        DiscordThreadReachability::Unknown(category) => {
+            return verification_result(
+                &client,
+                &detail,
+                "unverified",
+                Some(discord_category(category)),
+                LaneVisibility::Unverified,
+                json_output,
+                true,
+            )
+            .await;
+        }
+    }
+
+    if let Some(kickoff_id) = detail.kickoff_message_id.as_deref() {
+        match discord.fetch_thread_message(thread_id, kickoff_id).await {
+            DiscordThreadMessageFetch::Found(_) => {
+                verification_result(
+                    &client,
+                    &detail,
+                    "kickoff-visible",
+                    None,
+                    LaneVisibility::Visible,
+                    json_output,
+                    false,
+                )
+                .await
+            }
+            DiscordThreadMessageFetch::NotFound => {
+                verification_result(
+                    &client,
+                    &detail,
+                    "kickoff-missing",
+                    Some("kickoff-missing"),
+                    LaneVisibility::Unreachable,
+                    json_output,
+                    true,
+                )
+                .await
+            }
+            DiscordThreadMessageFetch::Unavailable(category) => {
+                verification_result(
+                    &client,
+                    &detail,
+                    "unverified",
+                    Some(discord_category(category)),
+                    LaneVisibility::Unverified,
+                    json_output,
+                    true,
+                )
+                .await
+            }
+        }
+    } else {
+        match discord.list_thread_messages(thread_id).await {
+            DiscordThreadMessageList::One(_) => {
+                verification_result(
+                    &client,
+                    &detail,
+                    "message-observed-unverified",
+                    Some("kickoff-receipt-missing"),
+                    LaneVisibility::Unverified,
+                    json_output,
+                    true,
+                )
+                .await
+            }
+            DiscordThreadMessageList::Empty => {
+                verification_result(
+                    &client,
+                    &detail,
+                    "unverified",
+                    Some("no-message-observed"),
+                    LaneVisibility::Unverified,
+                    json_output,
+                    true,
+                )
+                .await
+            }
+            DiscordThreadMessageList::Unavailable(category) => {
+                verification_result(
+                    &client,
+                    &detail,
+                    "unverified",
+                    Some(discord_category(category)),
+                    LaneVisibility::Unverified,
+                    json_output,
+                    true,
+                )
+                .await
+            }
+        }
+    }
+}
+
+pub async fn update(
+    config: Arc<AppConfig>,
+    session: String,
+    message: String,
+    kind: LaneUpdateKind,
+    workflow: Option<LaneWorkflowArg>,
+    json_output: bool,
+) -> Result<()> {
+    if message.chars().count() > 2_000 {
+        return Err("payload-too-large".into());
+    }
+    let client = DaemonClient::from_config(config.as_ref());
+    let mut detail = client.lane_detail(&session).await?;
+    let thread_id = detail
+        .thread_id
+        .clone()
+        .ok_or("stored-thread-target-missing")?;
+
+    let delivery_workflow = delivery_workflow(workflow);
+
+    if let Some(workflow) = workflow {
+        if workflow == LaneWorkflowArg::Retired {
+            let retirement = LaneRetirementMutation {
+                session: session.clone(),
+                generation_id: detail.snapshot.generation_id.clone(),
+                expected_revision: detail.snapshot.revision,
+            };
+            let snapshot = client
+                .retire_lane(&retirement)
+                .await
+                .map_err(retirement_error)?;
+
+            detail = client.lane_detail(&session).await?;
+            debug_assert_eq!(snapshot.revision, detail.snapshot.revision);
+        } else {
+            let workflow_mutation = LaneWorkflowMutation {
+                session: session.clone(),
+                generation_id: detail.snapshot.generation_id.clone(),
+                expected_revision: detail.snapshot.revision,
+                workflow: workflow.into(),
+                quiesced: false,
+            };
+            let snapshot = client.update_lane_workflow(&workflow_mutation).await?;
+            detail = client.lane_detail(&session).await?;
+            debug_assert_eq!(snapshot.revision, detail.snapshot.revision);
+        }
+    }
+
+    let discord = DiscordClient::from_config(config)?;
+    match discord.send_thread_with_receipt(&thread_id, &message).await {
+        Ok(receipt) => {
+            let delivered_at = receipt.timestamp.format(&Rfc3339)?;
+            let input = LaneDeliveryMutation {
+                session: session.clone(),
+                expected_revision: detail.snapshot.revision,
+                workflow: delivery_workflow,
+
+                message_id: Some(receipt.message_id.clone()),
+                kind: Some(kind.as_str().into()),
+                delivered_at: Some(delivered_at.clone()),
+                visibility: LaneVisibility::Visible,
+                error_category: None,
+                disposition: Some("accepted".into()),
+                generation_id: detail.snapshot.generation_id.clone(),
+                initial_kickoff: lane_update_initial_kickoff(),
+                kickoff_operation_id: lane_update_kickoff_operation_id(),
+            };
+            let snapshot = client.record_lane_delivery(&input).await?;
+
+            render_update(
+                &snapshot,
+                Some(&receipt.message_id),
+                Some(&delivered_at),
+                None,
+                json_output,
+            );
+            Ok(())
+        }
+        Err(error) => {
+            let category = BoundedCategory::new(discord_category(error.category));
+            let visibility = delivery_failure_visibility(error.disposition);
+            let disposition = delivery_disposition_name(error.disposition);
+            let input = LaneDeliveryMutation {
+                session: session.clone(),
+                expected_revision: detail.snapshot.revision,
+                workflow: delivery_workflow,
+
+                message_id: None,
+                kind: Some(kind.as_str().into()),
+                delivered_at: None,
+                visibility,
+                error_category: Some(category.clone()),
+                disposition: Some(disposition.into()),
+                generation_id: detail.snapshot.generation_id.clone(),
+                initial_kickoff: lane_update_initial_kickoff(),
+                kickoff_operation_id: lane_update_kickoff_operation_id(),
+            };
+            let snapshot = client.record_lane_delivery(&input).await?;
+
+            render_update(&snapshot, None, None, Some(category.as_str()), json_output);
+            Err("lane update delivery failed".into())
+        }
+    }
+}
+
+async fn verification_result(
+    client: &DaemonClient,
+    detail: &LaneDetail,
+    outcome: &str,
+    reason: Option<&str>,
+    visibility: LaneVisibility,
+    json_output: bool,
+    failed: bool,
+) -> Result<()> {
+    let input = LaneVerificationMutation {
+        session: detail.snapshot.session.clone(),
+        expected_revision: detail.snapshot.revision,
+        checked_at: current_timestamp_rfc3339(),
+        outcome: outcome.into(),
+        reason: reason.map(crate::source::tmux::BoundedReason::new),
+        visibility,
+        generation_id: detail.snapshot.generation_id.clone(),
+    };
+    let snapshot = client.record_lane_verification(&input).await?;
+    let value = json!({
+        "session": snapshot.session,
+        "outcome": outcome,
+        "reason": reason,
+        "visibility": visibility_name(visibility),
+        "workflow": workflow_name(snapshot.workflow),
+    });
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!("SESSION\tOUTCOME\tVISIBILITY\tREASON");
+        println!(
+            "{}\t{}\t{}\t{}",
+            snapshot.session,
+            outcome,
+            visibility_name(visibility),
+            reason.unwrap_or("—")
+        );
+    }
+    if failed {
+        Err("thread verification is unverified".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn render_status(
+    details: &[(LaneDetail, Option<bool>, Option<LaneInspectionResult>)],
+    json_output: bool,
+) -> Result<()> {
+    if json_output {
+        let lanes: Vec<_> = details
+            .iter()
+            .map(|(detail, runtime_live, inspection)| {
+                status_json(detail, *runtime_live, inspection.as_ref())
+            })
+            .collect();
+
+        println!("{}", serde_json::to_string_pretty(&lanes)?);
+        return Ok(());
+    }
+    println!("SESSION\tWORKFLOW\tRUNTIME\tSTATUS\tVISIBILITY\tWORKER\tCHECKED-AT\tREASON");
+    for (detail, runtime_live, inspection) in details {
+        let snapshot = &detail.snapshot;
+        let verification = detail.verification.as_ref();
+        let derived_status = inspection
+            .as_ref()
+            .and_then(|value| value.derived_status.as_deref())
+            .or_else(|| launched_runtime_status(snapshot, *runtime_live))
+            .or(snapshot.derived_status.as_deref())
+            .unwrap_or("—");
+        let worker_started = inspection
+            .as_ref()
+            .map(|value| value.worker_started)
+            .unwrap_or(snapshot.worker_started);
+        let observation_reason = inspection
+            .as_ref()
+            .and_then(|value| value.observation_reason.as_deref())
+            .or_else(|| {
+                snapshot
+                    .observation_reason
+                    .as_ref()
+                    .map(|reason| reason.as_str())
+            })
+            .or_else(|| {
+                verification.and_then(|item| item.reason.as_ref().map(|reason| reason.as_str()))
+            })
+            .unwrap_or("—");
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            snapshot.session,
+            workflow_name(snapshot.workflow),
+            runtime_name(*runtime_live),
+            derived_status,
+            snapshot.visibility.map(visibility_name).unwrap_or("—"),
+            worker_name(worker_started),
+            verification
+                .map(|item| item.checked_at.as_str())
+                .unwrap_or("—"),
+            observation_reason,
+        );
+    }
+    Ok(())
+}
+
+fn status_json(
+    detail: &LaneDetail,
+    runtime_live: Option<bool>,
+    inspection: Option<&LaneInspectionResult>,
+) -> serde_json::Value {
+    let snapshot = &detail.snapshot;
+    json!({
+        "session": snapshot.session,
+        "worker_effect_kind": worker_effect_name(snapshot.worker_effect_kind),
+        "durable_launch_state": launch_state_name(snapshot.durable_launch_state),
+        "workflow": workflow_name(snapshot.workflow),
+        "runtime": runtime_name(runtime_live),
+
+        "derived_status": inspection.as_ref().and_then(|value| value.derived_status.as_deref()).or_else(|| launched_runtime_status(snapshot, runtime_live)).or(snapshot.derived_status.as_deref()),
+        "observation_reason": inspection.as_ref().and_then(|value| value.observation_reason.as_deref()).or_else(|| snapshot.observation_reason.as_ref().map(|reason| reason.as_str())),
+        "worker_started": inspection.as_ref().map(|value| value.worker_started).unwrap_or(snapshot.worker_started),
+        "evidence_commit": inspection.as_ref().map(|value| value.evidence_commit).unwrap_or(snapshot.evidence_commit),
+        "repair_needed": inspection.as_ref().map(|value| value.repair_needed).unwrap_or(snapshot.repair_needed),
+        "healthy": inspection.as_ref().map(|value| value.healthy).unwrap_or_else(|| launched_runtime_healthy(snapshot, runtime_live)),
+        "exit_category": inspection.as_ref().and_then(|value| value.exit_category.as_deref()).or_else(|| snapshot.exit_category.as_ref().map(|category| category.as_str())),
+
+        "visibility": snapshot.visibility.map(visibility_name),
+        "checked_at": detail.verification.as_ref().map(|item| item.checked_at.as_str()),
+        "verification_outcome": detail.verification.as_ref().map(|item| item.outcome.as_str()),
+        "verification_reason": detail.verification.as_ref().and_then(|item| item.reason.as_ref().map(|reason| reason.as_str())),
+    })
+}
+
+fn render_update(
+    snapshot: &LaneSnapshot,
+    message_id: Option<&str>,
+    delivered_at: Option<&str>,
+    error: Option<&str>,
+    json_output: bool,
+) {
+    let value = json!({
+        "session": snapshot.session,
+        "workflow": workflow_name(snapshot.workflow),
+        "visibility": snapshot.visibility.map(visibility_name),
+        "message_id": message_id,
+        "delivered_at": delivered_at,
+        "error_category": error,
+    });
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&value).expect("lane update JSON is serializable")
+        );
+    } else {
+        println!("SESSION\tWORKFLOW\tVISIBILITY\tDELIVERY");
+
+        println!(
+            "{}\t{}\t{}\t{}",
+            snapshot.session,
+            workflow_name(snapshot.workflow),
+            snapshot.visibility.map(visibility_name).unwrap_or("—"),
+            error.unwrap_or("accepted")
+        );
+    }
+}
+
+fn delivery_workflow(workflow: Option<LaneWorkflowArg>) -> Option<LaneWorkflow> {
+    match workflow {
+        Some(LaneWorkflowArg::Retired) => Some(LaneWorkflow::Retired),
+        _ => None,
+    }
+}
+
+fn lane_update_initial_kickoff() -> bool {
+    false
+}
+
+fn lane_update_kickoff_operation_id() -> Option<String> {
+    None
+}
+
+fn runtime_name(runtime_live: Option<bool>) -> &'static str {
+    match runtime_live {
+        Some(true) => "live",
+        Some(false) => "tmux-missing",
+        None => "unknown",
+    }
+}
+
+fn launched_runtime_status(
+    snapshot: &LaneSnapshot,
+    runtime_live: Option<bool>,
+) -> Option<&'static str> {
+    if snapshot.durable_launch_state != LaneLaunchState::Launched || runtime_live != Some(false) {
+        return None;
+    }
+    match snapshot.workflow {
+        LaneWorkflow::Active => Some("tmux-missing"),
+        LaneWorkflow::NeedsReview
+        | LaneWorkflow::NeedsQa
+        | LaneWorkflow::PrOpen
+        | LaneWorkflow::AwaitingCi
+        | LaneWorkflow::AwaitingHuman => Some("workflow-handoff"),
+        LaneWorkflow::Retired => None,
+    }
+}
+
+fn launched_runtime_healthy(snapshot: &LaneSnapshot, runtime_live: Option<bool>) -> bool {
+    if snapshot.durable_launch_state != LaneLaunchState::Launched {
+        return snapshot.healthy;
+    }
+    snapshot.workflow == LaneWorkflow::Active
+        && runtime_live == Some(true)
+        && snapshot.visibility == Some(LaneVisibility::Visible)
+}
+
+fn delivery_failure_visibility(disposition: DiscordLaneDisposition) -> LaneVisibility {
+    match disposition {
+        DiscordLaneDisposition::DefinitiveFailure => LaneVisibility::DeliveryFailed,
+        DiscordLaneDisposition::AmbiguousAcceptance => LaneVisibility::Unverified,
+    }
+}
+
+fn delivery_disposition_name(disposition: DiscordLaneDisposition) -> &'static str {
+    match disposition {
+        DiscordLaneDisposition::DefinitiveFailure => "definitive-failure",
+        DiscordLaneDisposition::AmbiguousAcceptance => "ambiguous-acceptance",
+    }
+}
+
+fn worker_name(worker_started: Option<bool>) -> &'static str {
+    match worker_started {
+        Some(true) => "yes",
+        Some(false) => "no",
+        None => "unknown",
+    }
+}
+
+fn workflow_name(workflow: LaneWorkflow) -> &'static str {
+    match workflow {
+        LaneWorkflow::Active => "active",
+        LaneWorkflow::NeedsReview => "needs-review",
+        LaneWorkflow::NeedsQa => "needs-qa",
+        LaneWorkflow::PrOpen => "pr-open",
+        LaneWorkflow::AwaitingCi => "awaiting-ci",
+        LaneWorkflow::AwaitingHuman => "awaiting-human",
+        LaneWorkflow::Retired => "retired",
+    }
+}
+
+fn visibility_name(visibility: LaneVisibility) -> &'static str {
+    match visibility {
+        LaneVisibility::Unverified => "unverified",
+        LaneVisibility::Visible => "visible",
+        LaneVisibility::Unreachable => "unreachable",
+        LaneVisibility::DeliveryFailed => "delivery-failed",
+    }
+}
+
+fn worker_effect_name(kind: crate::source::tmux::WorkerEffectKind) -> &'static str {
+    match kind {
+        crate::source::tmux::WorkerEffectKind::CommandSubmission => "command-submission",
+        crate::source::tmux::WorkerEffectKind::SessionCreation => "session-creation",
+    }
+}
+
+fn launch_state_name(state: crate::source::tmux::LaneLaunchState) -> &'static str {
+    match state {
+        crate::source::tmux::LaneLaunchState::Ready => "ready",
+        crate::source::tmux::LaneLaunchState::Claimed => "claimed",
+        crate::source::tmux::LaneLaunchState::IdentityVerified => "identity-markers-verified",
+        crate::source::tmux::LaneLaunchState::Launched => "launched",
+        crate::source::tmux::LaneLaunchState::NoWorkerEffect => "launch-failed-no-worker-effect",
+
+        crate::source::tmux::LaneLaunchState::CommandSubmitAmbiguous => {
+            "blocked-command-submit-ambiguous"
+        }
+        crate::source::tmux::LaneLaunchState::SessionCreationAmbiguous => {
+            "blocked-session-creation-ambiguous"
+        }
+    }
+}
+
+fn discord_category(category: crate::discord::DiscordLaneErrorCategory) -> &'static str {
+    match category {
+        crate::discord::DiscordLaneErrorCategory::ContentTooLong => "payload-too-large",
+        crate::discord::DiscordLaneErrorCategory::BadRequest => "bad-request",
+        crate::discord::DiscordLaneErrorCategory::Unauthorized => "unauthorized",
+        crate::discord::DiscordLaneErrorCategory::Forbidden => "forbidden",
+        crate::discord::DiscordLaneErrorCategory::NotFound => "not-found",
+        crate::discord::DiscordLaneErrorCategory::RateLimited => "rate-limited",
+        crate::discord::DiscordLaneErrorCategory::ArchivedOrNotWritable => {
+            "archived-or-not-writable"
+        }
+        crate::discord::DiscordLaneErrorCategory::Timeout => "timeout",
+        crate::discord::DiscordLaneErrorCategory::Transport => "transport",
+        crate::discord::DiscordLaneErrorCategory::MalformedSuccess => "malformed-success",
+        crate::discord::DiscordLaneErrorCategory::EmptyMessageId => "empty-message-id",
+        crate::discord::DiscordLaneErrorCategory::MissingMessageId => "missing-message-id",
+    }
+}
+
+impl LaneUpdateKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Kickoff => "kickoff",
+            Self::Progress => "progress",
+            Self::Blocked => "blocked",
+            Self::PrOpen => "pr-open",
+            Self::Handoff => "handoff",
+        }
+    }
+}
+
+impl From<LaneWorkflowArg> for LaneWorkflow {
+    fn from(value: LaneWorkflowArg) -> Self {
+        match value {
+            LaneWorkflowArg::Active => Self::Active,
+            LaneWorkflowArg::NeedsReview => Self::NeedsReview,
+            LaneWorkflowArg::NeedsQa => Self::NeedsQa,
+            LaneWorkflowArg::PrOpen => Self::PrOpen,
+            LaneWorkflowArg::AwaitingCi => Self::AwaitingCi,
+            LaneWorkflowArg::AwaitingHuman => Self::AwaitingHuman,
+            LaneWorkflowArg::Retired => Self::Retired,
+        }
+    }
+}
+
+fn retirement_error(error: crate::DynError) -> crate::DynError {
+    if error.to_string().contains("lane runtime remains active") {
+        RETIREMENT_GUIDANCE.into()
+    } else {
+        error
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_launch_state_names_match_canonical_launch_surface() {
+        assert_eq!(
+            launch_state_name(LaneLaunchState::NoWorkerEffect),
+            "launch-failed-no-worker-effect",
+        );
+        assert_eq!(
+            launch_state_name(LaneLaunchState::SessionCreationAmbiguous),
+            "blocked-session-creation-ambiguous",
+        );
+    }
+    #[test]
+    fn lane_update_kickoff_kind_is_never_an_initial_kickoff() {
+        assert!(!lane_update_initial_kickoff());
+        assert_eq!(lane_update_kickoff_operation_id(), None);
+    }
+
+    #[test]
+    fn status_uses_detail_snapshot_identity_over_list_snapshot() {
+        let mut detail = LaneDetail {
+            snapshot: snapshot_with_status(None),
+            thread_id: None,
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            verification: None,
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+            last_error: None,
+            quiesced: false,
+        };
+        detail.snapshot.generation_id = "current-generation".into();
+        detail.snapshot.revision = 9;
+        let current = status_snapshot(&detail);
+        assert_eq!(current.generation_id, "current-generation");
+        assert_eq!(current.revision, 9);
+    }
+
+    #[test]
+    fn runtime_rendering_preserves_missing_and_unknown_liveness() {
+        assert_eq!(runtime_name(Some(false)), "tmux-missing");
+        assert_eq!(runtime_name(None), "unknown");
+    }
+
+    #[test]
+    fn retirement_runtime_error_includes_manual_quiescence_guidance() {
+        let error = retirement_error("lane runtime remains active".into());
+        assert_eq!(error.to_string(), RETIREMENT_GUIDANCE);
+    }
+
+    #[test]
+    fn update_ambiguity_persists_unverified_visibility_and_canonical_disposition() {
+        assert_eq!(
+            delivery_failure_visibility(DiscordLaneDisposition::DefinitiveFailure),
+            LaneVisibility::DeliveryFailed,
+        );
+        assert_eq!(
+            delivery_failure_visibility(DiscordLaneDisposition::AmbiguousAcceptance),
+            LaneVisibility::Unverified,
+        );
+        assert_eq!(
+            delivery_disposition_name(DiscordLaneDisposition::DefinitiveFailure),
+            "definitive-failure",
+        );
+        assert_eq!(
+            delivery_disposition_name(DiscordLaneDisposition::AmbiguousAcceptance),
+            "ambiguous-acceptance",
+        );
+    }
+
+    #[test]
+    fn retired_update_delivery_repeats_only_the_retired_workflow_exception() {
+        assert_eq!(
+            delivery_workflow(Some(LaneWorkflowArg::Retired)),
+            Some(LaneWorkflow::Retired),
+        );
+        assert_eq!(
+            delivery_workflow(Some(LaneWorkflowArg::AwaitingHuman)),
+            None,
+        );
+        assert_eq!(delivery_workflow(None), None);
+    }
+
+    #[test]
+    fn launched_runtime_overlay_distinguishes_active_missing_from_handoff_and_health() {
+        let mut snapshot = snapshot_with_status(None);
+        assert_eq!(
+            launched_runtime_status(&snapshot, Some(false)),
+            Some("tmux-missing")
+        );
+        assert!(launched_runtime_healthy(&snapshot, Some(true)));
+        assert!(!launched_runtime_healthy(&snapshot, Some(false)));
+
+        snapshot.workflow = LaneWorkflow::NeedsReview;
+        assert_eq!(
+            launched_runtime_status(&snapshot, Some(false)),
+            Some("workflow-handoff")
+        );
+        assert!(!launched_runtime_healthy(&snapshot, Some(true)));
+
+        snapshot.workflow = LaneWorkflow::Active;
+        snapshot.visibility = Some(LaneVisibility::Unverified);
+        assert!(!launched_runtime_healthy(&snapshot, Some(true)));
+        assert_eq!(launched_runtime_status(&snapshot, Some(true)), None);
+    }
+
+    #[test]
+    fn status_json_does_not_include_private_thread_target() {
+        let detail = LaneDetail {
+            snapshot: snapshot_with_status(None),
+            thread_id: Some("private-thread".into()),
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            verification: None,
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+            last_error: None,
+            quiesced: false,
+        };
+        assert!(
+            !status_json(&detail, Some(true), None)
+                .to_string()
+                .contains("private-thread")
+        );
+    }
+
+    #[test]
+    fn r2_overlay_wins_status_rendering_without_private_target() {
+        let mut snapshot = snapshot_with_status(Some("launch-commit-ambiguous"));
+        snapshot.durable_launch_state = LaneLaunchState::IdentityVerified;
+        let detail = LaneDetail {
+            snapshot,
+            thread_id: Some("private-thread".into()),
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            verification: None,
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+            last_error: None,
+            quiesced: false,
+        };
+        let overlay = LaneInspectionResult {
+            derived_status: Some("identity-conflict".into()),
+            observation_reason: Some("identity-mismatch".into()),
+            worker_started: None,
+            evidence_commit: false,
+            repair_needed: true,
+            healthy: false,
+            exit_category: Some("identity-mismatch".into()),
+            runtime: "tmux-missing",
+        };
+        let rendered = status_json(&detail, Some(false), Some(&overlay));
+        assert_eq!(rendered["runtime"], "tmux-missing");
+        assert_eq!(rendered["derived_status"], "identity-conflict");
+        assert_eq!(rendered["observation_reason"], "identity-mismatch");
+        assert_eq!(rendered["worker_started"], serde_json::Value::Null);
+        assert_eq!(rendered["exit_category"], "identity-mismatch");
+        assert!(!rendered.to_string().contains("private-thread"));
+    }
+
+    fn snapshot_with_status(status: Option<&str>) -> LaneSnapshot {
+        LaneSnapshot {
+            session: "lane".into(),
+            generation_id: "g".into(),
+            kickoff_operation_id: "k".into(),
+            launch_operation_id: "l".into(),
+            executor_id: "e".into(),
+            worker_effect_kind: crate::source::tmux::WorkerEffectKind::CommandSubmission,
+            durable_launch_state: crate::source::tmux::LaneLaunchState::Launched,
+            derived_status: status.map(str::to_owned),
+            observation_reason: None,
+            worker_started: Some(true),
+            evidence_commit: true,
+            repair_needed: false,
+            healthy: true,
+            exit_category: None,
+            workflow: LaneWorkflow::Active,
+            visibility: Some(LaneVisibility::Visible),
+            revision: 1,
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod gajae;
 mod gateway_allowlist;
 mod hooks;
 mod keyword_window;
+mod lane;
 mod lifecycle;
 mod memory;
 mod native_hooks;
@@ -29,6 +30,7 @@ mod slack;
 mod source;
 mod telemetry;
 mod tmux_wrapper;
+
 mod update;
 
 use std::sync::Arc;
@@ -39,10 +41,11 @@ use tokio::runtime::Builder;
 use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs,
     GajaeCheckpointCommands, GajaeCommands, GajaeMutationPlanCommands, GajaeProfileCommands,
-    GajaeReceiptCommands, GitCommands, GithubCommands, HooksCommands, MemoryCommands,
+    GajaeReceiptCommands, GitCommands, GithubCommands, HooksCommands, LaneCommands, MemoryCommands,
     NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, TmuxCommands, UpdateCommands,
     VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
 };
+
 use crate::client::DaemonClient;
 use crate::config::{AppConfig, SetupEdits};
 use crate::discord::DiscordClient;
@@ -243,6 +246,19 @@ async fn real_main(cli: Cli) -> Result<()> {
             remove_systemd,
             remove_config,
         } => lifecycle::uninstall(remove_systemd, remove_config),
+        Commands::Lane { command } => match command {
+            LaneCommands::Status { session, json } => lane::status(config, session, json).await,
+            LaneCommands::VerifyThread { session, json } => {
+                lane::verify_thread(config, session, json).await
+            }
+            LaneCommands::Update {
+                session,
+                message,
+                kind,
+                workflow,
+                json,
+            } => lane::update(config, session, message, kind, workflow, json).await,
+        },
         Commands::Tmux { command } => match command {
             TmuxCommands::Keyword {
                 session,
@@ -1161,6 +1177,7 @@ mod tests {
                 name: Some("codex".into()),
             }),
             active_wrapper_monitor: true,
+            lane: None,
         }]);
 
         assert!(output.contains(

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -23,6 +23,7 @@ use crate::source::Source;
 use crate::telemetry;
 
 pub type SharedTmuxRegistry = Arc<RwLock<HashMap<String, RegisteredTmuxSession>>>;
+static REGISTRY_MUTATION_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TmuxRegistryDiagnostics {
@@ -104,6 +105,604 @@ pub struct RegisteredTmuxSession {
     pub parent_process: Option<ParentProcessInfo>,
     #[serde(default)]
     pub active_wrapper_monitor: bool,
+    #[serde(skip)]
+    pub(crate) lane: Option<LaneEvidence>,
+}
+
+/// Private, durable lane evidence. It is deliberately excluded from legacy
+/// registration serialization and `/api/tmux` projections.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaneEvidence {
+    pub lane_version: u8,
+    pub generation_id: String,
+    pub kickoff_operation_id: String,
+    pub launch_operation_id: String,
+    pub executor_id: String,
+    pub worker_effect_kind: WorkerEffectKind,
+    pub launch_state: LaneLaunchState,
+    #[serde(default)]
+    pub workflow: LaneWorkflow,
+    #[serde(default)]
+    pub revision: u64,
+    #[serde(default)]
+    pub quiesced: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kickoff_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kickoff_delivered_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<LaneVisibility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification: Option<LaneVerification>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_failure: Option<BoundedCategory>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_update_message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_update_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_update_delivered_at: Option<String>,
+    #[serde(default)]
+    pub delivery_retry_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery_disposition: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkerEffectKind {
+    CommandSubmission,
+    SessionCreation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LaneLaunchState {
+    Ready,
+    Claimed,
+    IdentityVerified,
+    Launched,
+    NoWorkerEffect,
+    CommandSubmitAmbiguous,
+    SessionCreationAmbiguous,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum LaneWorkflow {
+    #[default]
+    Active,
+    NeedsReview,
+    NeedsQa,
+    PrOpen,
+    AwaitingCi,
+    AwaitingHuman,
+    Retired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LaneVisibility {
+    Unverified,
+    Visible,
+    Unreachable,
+    DeliveryFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaneVerification {
+    pub checked_at: String,
+    pub outcome: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<BoundedReason>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BoundedReason(String);
+impl BoundedReason {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into().chars().take(96).collect())
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct BoundedCategory(String);
+impl BoundedCategory {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into().chars().take(96).collect())
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// On-disk migration wrapper. Old maps deserialize through `deserialize_stored_registry`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredTmuxRegistration {
+    pub registration: RegisteredTmuxSession,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lane: Option<LaneEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneSnapshot {
+    pub session: String,
+    pub generation_id: String,
+    pub kickoff_operation_id: String,
+    pub launch_operation_id: String,
+    pub executor_id: String,
+    pub worker_effect_kind: WorkerEffectKind,
+    pub durable_launch_state: LaneLaunchState,
+    pub derived_status: Option<String>,
+    pub observation_reason: Option<BoundedReason>,
+    pub worker_started: Option<bool>,
+    pub evidence_commit: bool,
+    pub repair_needed: bool,
+    pub healthy: bool,
+    pub exit_category: Option<BoundedCategory>,
+    pub workflow: LaneWorkflow,
+    pub visibility: Option<LaneVisibility>,
+    pub revision: u64,
+    #[serde(default)]
+    pub kickoff_message_id: Option<String>,
+    #[serde(default)]
+    pub kickoff_delivered_at: Option<String>,
+    #[serde(default)]
+    pub latest_update_message_id: Option<String>,
+    #[serde(default)]
+    pub latest_update_kind: Option<String>,
+    #[serde(default)]
+    pub latest_update_delivered_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneDetail {
+    pub snapshot: LaneSnapshot,
+    pub thread_id: Option<String>,
+    pub kickoff_message_id: Option<String>,
+    pub kickoff_delivered_at: Option<String>,
+    pub verification: Option<LaneVerification>,
+    pub latest_update_message_id: Option<String>,
+    pub latest_update_kind: Option<String>,
+    pub latest_update_delivered_at: Option<String>,
+    pub last_error: Option<BoundedCategory>,
+    pub quiesced: bool,
+}
+
+fn lane_detail(session: &str, lane: &LaneEvidence, runtime_live: Option<bool>) -> LaneDetail {
+    LaneDetail {
+        snapshot: lane_snapshot(session, lane, runtime_live),
+        thread_id: lane.thread_id.clone(),
+        kickoff_message_id: lane.kickoff_message_id.clone(),
+        kickoff_delivered_at: lane.kickoff_delivered_at.clone(),
+        verification: lane.verification.clone(),
+        latest_update_message_id: lane.latest_update_message_id.clone(),
+        latest_update_kind: lane.latest_update_kind.clone(),
+        latest_update_delivered_at: lane.latest_update_delivered_at.clone(),
+        last_error: lane.last_failure.clone(),
+        quiesced: lane.quiesced,
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum StoredRegistryValue {
+    Wrapped(Box<StoredTmuxRegistration>),
+    Legacy(Box<RegisteredTmuxSession>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneEvidenceMutation {
+    pub session: String,
+    pub expected_revision: u64,
+    pub generation_id: String,
+    pub launch_operation_id: String,
+    pub launch_state: LaneLaunchState,
+    #[serde(default)]
+    pub failure_category: Option<BoundedCategory>,
+    pub executor_id: String,
+    pub worker_effect_kind: WorkerEffectKind,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneVerificationMutation {
+    pub session: String,
+    pub expected_revision: u64,
+    pub checked_at: String,
+    pub outcome: String,
+    #[serde(default)]
+    pub reason: Option<BoundedReason>,
+    pub visibility: LaneVisibility,
+    pub generation_id: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneDeliveryMutation {
+    pub session: String,
+    pub expected_revision: u64,
+    #[serde(default)]
+    pub workflow: Option<LaneWorkflow>,
+    #[serde(default)]
+    pub message_id: Option<String>,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub delivered_at: Option<String>,
+    pub visibility: LaneVisibility,
+    #[serde(default)]
+    pub error_category: Option<BoundedCategory>,
+    #[serde(default)]
+    pub disposition: Option<String>,
+    pub generation_id: String,
+    #[serde(default)]
+    pub initial_kickoff: bool,
+    #[serde(default)]
+    pub kickoff_operation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneRegistrationInput {
+    pub registration: RegisteredTmuxSession,
+    pub generation_id: String,
+    pub kickoff_operation_id: String,
+    pub launch_operation_id: String,
+    pub executor_id: String,
+    pub worker_effect_kind: WorkerEffectKind,
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    pub expect_absent_or_retired: bool,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneWorkflowMutation {
+    pub session: String,
+    pub generation_id: String,
+    pub expected_revision: u64,
+    pub workflow: LaneWorkflow,
+    #[serde(default)]
+    pub quiesced: bool,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LaneRetirementMutation {
+    pub session: String,
+    pub generation_id: String,
+    pub expected_revision: u64,
+}
+
+fn lane_of(registration: &RegisteredTmuxSession) -> Option<&LaneEvidence> {
+    registration.lane.as_ref()
+}
+
+fn valid_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value.is_ascii()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+fn valid_discord_id(value: &str) -> bool {
+    (1..=20).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+fn valid_session(value: &str) -> bool {
+    (1..=128).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+fn valid_text(value: &str) -> bool {
+    !value.is_empty() && value.len() <= 64 && value.is_ascii()
+}
+fn valid_delivery(input: &LaneDeliveryMutation) -> bool {
+    let error_ok = matches!(
+        (
+            input.disposition.as_deref(),
+            input.error_category.as_ref().map(BoundedCategory::as_str),
+        ),
+        (Some("accepted"), None)
+            | (
+                Some("definitive-failure"),
+                Some(
+                    "payload-too-large"
+                        | "bad-request"
+                        | "unauthorized"
+                        | "forbidden"
+                        | "not-found"
+                        | "rate-limited"
+                        | "archived-or-not-writable"
+                        | "transport",
+                ),
+            )
+            | (
+                Some("ambiguous-acceptance"),
+                Some(
+                    "timeout"
+                        | "transport"
+                        | "malformed-success"
+                        | "empty-message-id"
+                        | "missing-message-id",
+                ),
+            )
+    );
+    let kind_ok = input.kind.as_deref().is_none_or(|value| {
+        matches!(
+            value,
+            "kickoff" | "progress" | "blocked" | "pr-open" | "handoff"
+        )
+    });
+    let disposition_ok = match input.disposition.as_deref() {
+        Some("accepted") => {
+            input.message_id.is_some()
+                && input.delivered_at.is_some()
+                && input.visibility == LaneVisibility::Visible
+                && input.error_category.is_none()
+        }
+        Some("definitive-failure") => {
+            input.message_id.is_none()
+                && input.delivered_at.is_none()
+                && input.visibility == LaneVisibility::DeliveryFailed
+                && input.error_category.is_some()
+        }
+        Some("ambiguous-acceptance") => {
+            input.message_id.is_none()
+                && input.delivered_at.is_none()
+                && input.visibility == LaneVisibility::Unverified
+                && input.error_category.is_some()
+        }
+        _ => false,
+    };
+    input.message_id.as_deref().is_none_or(valid_discord_id)
+        && input.delivered_at.as_deref().is_none_or(valid_text)
+        && kind_ok
+        && error_ok
+        && disposition_ok
+}
+fn valid_verification(input: &LaneVerificationMutation) -> bool {
+    let discord_error = |reason: &str| {
+        matches!(
+            reason,
+            "payload-too-large"
+                | "bad-request"
+                | "unauthorized"
+                | "forbidden"
+                | "not-found"
+                | "rate-limited"
+                | "archived-or-not-writable"
+                | "timeout"
+                | "transport"
+                | "malformed-success"
+                | "empty-message-id"
+                | "missing-message-id"
+        )
+    };
+    let reason = input.reason.as_ref().map(BoundedReason::as_str);
+    let reason_ok = reason.is_none_or(|reason| {
+        discord_error(reason)
+            || matches!(
+                reason,
+                "thread-target-missing"
+                    | "kickoff-missing"
+                    | "kickoff-receipt-missing"
+                    | "no-message-observed"
+                    | "unreachable"
+            )
+    });
+    valid_text(&input.checked_at)
+        && reason_ok
+        && match input.outcome.as_str() {
+            "kickoff-visible" => reason.is_none(),
+            "kickoff-missing" => reason == Some("kickoff-missing"),
+            "message-observed-unverified" => reason == Some("kickoff-receipt-missing"),
+            "unverified" => reason.is_some_and(|reason| {
+                reason == "thread-target-missing"
+                    || reason == "no-message-observed"
+                    || discord_error(reason)
+            }),
+            "unreachable" => {
+                reason.is_some_and(|reason| reason == "unreachable" || discord_error(reason))
+            }
+            _ => false,
+        }
+}
+fn terminal_category_is_valid(
+    kind: WorkerEffectKind,
+    state: LaneLaunchState,
+    category: Option<&BoundedCategory>,
+) -> bool {
+    matches!(
+        (kind, state, category.map(BoundedCategory::as_str)),
+        (
+            _,
+            LaneLaunchState::Ready
+                | LaneLaunchState::Claimed
+                | LaneLaunchState::IdentityVerified
+                | LaneLaunchState::Launched,
+            None,
+        ) | (
+            WorkerEffectKind::CommandSubmission,
+            LaneLaunchState::NoWorkerEffect,
+            Some(
+                "session-create-failed"
+                    | "identity-marker-set-failed"
+                    | "identity-marker-read-failed"
+                    | "identity-marker-mismatch"
+                    | "r1-to-r2-persistence-failed-after-create",
+            ),
+        ) | (
+            WorkerEffectKind::CommandSubmission,
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some(
+                "submission-attempt-error"
+                    | "submitted-marker-set-failed"
+                    | "submitted-marker-read-failed"
+                    | "submitted-marker-missing"
+                    | "submitted-marker-mismatch",
+            ),
+        ) | (
+            WorkerEffectKind::SessionCreation,
+            LaneLaunchState::SessionCreationAmbiguous,
+            Some(
+                "identity-marker-set-failed"
+                    | "identity-marker-read-failed"
+                    | "identity-marker-mismatch"
+                    | "r1-to-r2-persistence-failed-after-create"
+                    | "owner-aborted-before-r2",
+            ),
+        )
+    )
+}
+
+fn lane_snapshot(session: &str, lane: &LaneEvidence, runtime_live: Option<bool>) -> LaneSnapshot {
+    let (
+        derived_status,
+        observation_reason,
+        worker_started,
+        evidence_commit,
+        repair_needed,
+        healthy,
+        exit_category,
+    ) = match lane.launch_state {
+        LaneLaunchState::Launched => {
+            let healthy = lane.workflow == LaneWorkflow::Active
+                && runtime_live == Some(true)
+                && lane.visibility == Some(LaneVisibility::Visible);
+            let status = match (runtime_live, lane.workflow) {
+                (Some(false), LaneWorkflow::Active) => Some("tmux-missing".into()),
+                (
+                    Some(false),
+                    LaneWorkflow::NeedsReview
+                    | LaneWorkflow::NeedsQa
+                    | LaneWorkflow::PrOpen
+                    | LaneWorkflow::AwaitingCi
+                    | LaneWorkflow::AwaitingHuman,
+                ) => Some("workflow-handoff".into()),
+                _ => None,
+            };
+            (status, None, Some(true), true, false, healthy, None)
+        }
+        LaneLaunchState::CommandSubmitAmbiguous => {
+            let category = lane
+                .last_failure
+                .clone()
+                .unwrap_or_else(|| BoundedCategory::new("submission-attempt-error"));
+            (
+                Some("command-submit-ambiguous-blocked".into()),
+                Some(BoundedReason::new(category.as_str())),
+                None,
+                true,
+                false,
+                false,
+                Some(category),
+            )
+        }
+        LaneLaunchState::SessionCreationAmbiguous => {
+            let category = lane
+                .last_failure
+                .clone()
+                .unwrap_or_else(|| BoundedCategory::new("owner-aborted-before-r2"));
+            (
+                Some("session-creation-ambiguous-blocked".into()),
+                Some(BoundedReason::new(category.as_str())),
+                None,
+                true,
+                false,
+                false,
+                Some(category),
+            )
+        }
+        LaneLaunchState::IdentityVerified => {
+            let reason = lane
+                .last_failure
+                .clone()
+                .unwrap_or_else(|| BoundedCategory::new("session-liveness-unavailable"));
+            let status = if reason.as_str() == "identity-mismatch" {
+                "identity-conflict"
+            } else if lane.worker_effect_kind == WorkerEffectKind::CommandSubmission {
+                "launch-commit-ambiguous"
+            } else {
+                "session-creation-effect-uncommitted"
+            };
+            (
+                Some(status.into()),
+                Some(BoundedReason::new(reason.as_str())),
+                None,
+                false,
+                true,
+                false,
+                Some(reason),
+            )
+        }
+        LaneLaunchState::NoWorkerEffect => {
+            let category = lane
+                .last_failure
+                .clone()
+                .unwrap_or_else(|| BoundedCategory::new("launch-failed-no-worker-effect"));
+            (
+                Some("launch-failed-no-worker-effect".into()),
+                Some(BoundedReason::new(category.as_str())),
+                None,
+                true,
+                false,
+                false,
+                Some(category),
+            )
+        }
+        LaneLaunchState::Ready => {
+            if let Some(category) = lane.last_failure.clone() {
+                let status = match lane.delivery_disposition.as_deref() {
+                    Some("ambiguous-acceptance") => "kickoff-ambiguous",
+                    Some("definitive-failure") => "kickoff-failed",
+                    _ => "pending",
+                };
+                (
+                    Some(status.into()),
+                    Some(BoundedReason::new(category.as_str())),
+                    None,
+                    true,
+                    true,
+                    false,
+                    Some(category),
+                )
+            } else {
+                (Some("pending".into()), None, None, false, true, false, None)
+            }
+        }
+        LaneLaunchState::Claimed => {
+            let status = if lane.worker_effect_kind == WorkerEffectKind::CommandSubmission {
+                "command-execution-claim-stranded"
+            } else {
+                "session-creation-effect-uncommitted"
+            };
+            (Some(status.into()), None, None, false, true, false, None)
+        }
+    };
+    LaneSnapshot {
+        session: session.into(),
+        generation_id: lane.generation_id.clone(),
+        kickoff_operation_id: lane.kickoff_operation_id.clone(),
+        launch_operation_id: lane.launch_operation_id.clone(),
+        executor_id: lane.executor_id.clone(),
+        worker_effect_kind: lane.worker_effect_kind,
+        durable_launch_state: lane.launch_state,
+        derived_status,
+        observation_reason,
+        worker_started,
+        evidence_commit,
+        repair_needed,
+        healthy,
+        exit_category,
+        workflow: lane.workflow,
+        visibility: lane.visibility,
+        revision: lane.revision,
+        kickoff_message_id: lane.kickoff_message_id.clone(),
+        kickoff_delivered_at: lane.kickoff_delivered_at.clone(),
+        latest_update_message_id: lane.latest_update_message_id.clone(),
+        latest_update_kind: lane.latest_update_kind.clone(),
+        latest_update_delivered_at: lane.latest_update_delivered_at.clone(),
+    }
 }
 
 impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
@@ -121,6 +720,7 @@ impl From<&TmuxSessionMonitor> for RegisteredTmuxSession {
             registration_source: RegistrationSource::ConfigMonitor,
             parent_process: None,
             active_wrapper_monitor: false,
+            lane: None,
         }
     }
 }
@@ -345,13 +945,21 @@ pub fn normalize_runtime_registration_source(source: RegistrationSource) -> Regi
 
 fn durable_runtime_entries(
     registry: &HashMap<String, RegisteredTmuxSession>,
-) -> BTreeMap<String, RegisteredTmuxSession> {
+) -> BTreeMap<String, StoredTmuxRegistration> {
     registry
         .iter()
         .filter(|(_, registration)| {
             registration.registration_source != RegistrationSource::ConfigMonitor
         })
-        .map(|(session, registration)| (session.clone(), registration.clone()))
+        .map(|(session, registration)| {
+            (
+                session.clone(),
+                StoredTmuxRegistration {
+                    registration: registration.clone(),
+                    lane: registration.lane.clone(),
+                },
+            )
+        })
         .collect()
 }
 
@@ -379,10 +987,18 @@ pub async fn load_tmux_registry_state(
 ) -> TmuxRegistryStateDiagnostics {
     match tokio::fs::read(path).await {
         Ok(content) => {
-            match serde_json::from_slice::<BTreeMap<String, RegisteredTmuxSession>>(&content) {
+            match serde_json::from_slice::<BTreeMap<String, StoredRegistryValue>>(&content) {
                 Ok(loaded) => {
                     let mut write = registry.write().await;
-                    for (session, mut registration) in loaded {
+                    for (session, stored) in loaded {
+                        let mut registration = match stored {
+                            StoredRegistryValue::Wrapped(stored) => {
+                                let mut registration = stored.registration;
+                                registration.lane = stored.lane;
+                                registration
+                            }
+                            StoredRegistryValue::Legacy(registration) => *registration,
+                        };
                         registration.registration_source =
                             normalize_runtime_registration_source(registration.registration_source);
                         write.insert(session, registration);
@@ -426,7 +1042,7 @@ pub async fn load_tmux_registry_state(
 pub async fn inspect_tmux_registry_state(path: &Path) -> TmuxRegistryStateDiagnostics {
     match tokio::fs::read(path).await {
         Ok(content) => {
-            match serde_json::from_slice::<BTreeMap<String, RegisteredTmuxSession>>(&content) {
+            match serde_json::from_slice::<BTreeMap<String, StoredRegistryValue>>(&content) {
                 Ok(loaded) => TmuxRegistryStateDiagnostics {
                     path: path.to_path_buf(),
                     status: TmuxRegistryStateStatus::Loaded,
@@ -469,11 +1085,18 @@ pub async fn register_runtime_tmux_registration(
 ) -> Result<usize> {
     registration.registration_source =
         normalize_runtime_registration_source(registration.registration_source);
-    let mut write = registry.write().await;
-    let mut next = write.clone();
+    let _mutation = REGISTRY_MUTATION_LOCK.lock().await;
+    let mut next = registry.read().await.clone();
+    if next
+        .get(&registration.session)
+        .and_then(lane_of)
+        .is_some_and(|lane| lane.workflow != LaneWorkflow::Retired)
+    {
+        return Err("lane session is retained until explicit quiesced retirement".into());
+    }
     next.insert(registration.session.clone(), registration);
     let durable_count = save_durable_tmux_registry(path, &next).await?;
-    *write = next;
+    *registry.write().await = next;
     Ok(durable_count)
 }
 
@@ -482,19 +1105,538 @@ pub async fn remove_tmux_registrations(
     path: &Path,
     sessions: &[String],
 ) -> Result<usize> {
-    let mut write = registry.write().await;
-    let mut next = write.clone();
+    let _mutation = REGISTRY_MUTATION_LOCK.lock().await;
+    let mut next = registry.read().await.clone();
     let mut removed = 0;
     for session in sessions {
-        if next.remove(session).is_some() {
+        let removable = next.get(session).is_none_or(|registration| {
+            registration
+                .lane
+                .as_ref()
+                .is_none_or(|lane| lane.workflow == LaneWorkflow::Retired)
+        });
+        if removable && next.remove(session).is_some() {
             removed += 1;
         }
     }
     if removed > 0 {
         save_durable_tmux_registry(path, &next).await?;
-        *write = next;
+        *registry.write().await = next;
     }
     Ok(removed)
+}
+
+pub async fn lane_detail_for_session(
+    registry: &SharedTmuxRegistry,
+    session: &str,
+) -> Result<LaneDetail> {
+    let runtime_live = None;
+    let registration = registry
+        .read()
+        .await
+        .get(session)
+        .cloned()
+        .ok_or("lane session not found")?;
+    let lane = registration
+        .lane
+        .as_ref()
+        .ok_or("session has no lane evidence")?;
+    Ok(lane_detail(session, lane, runtime_live))
+}
+pub async fn register_lane_registration(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    input: LaneRegistrationInput,
+) -> Result<LaneDetail> {
+    if !input.expect_absent_or_retired
+        || !valid_session(&input.registration.session)
+        || !valid_id(&input.generation_id)
+        || !valid_id(&input.kickoff_operation_id)
+        || !valid_id(&input.launch_operation_id)
+        || !valid_id(&input.executor_id)
+        || input
+            .thread_id
+            .as_deref()
+            .is_some_and(|value| !valid_discord_id(value))
+    {
+        return Err("invalid lane registration input".into());
+    }
+    let mut registration = input.registration;
+    if registration.lane.is_some() {
+        return Err("lane registration input must not contain evidence".into());
+    }
+    let session = registration.session.clone();
+    registration.registration_source =
+        normalize_runtime_registration_source(registration.registration_source);
+    let _mutation = REGISTRY_MUTATION_LOCK.lock().await;
+    let mut next = registry.read().await.clone();
+    if let Some(existing) = next.get(&session) {
+        if let Some(lane) = existing.lane.as_ref().filter(|lane| {
+            lane.launch_state == LaneLaunchState::Ready
+                && lane.revision == 0
+                && lane.workflow == LaneWorkflow::Active
+                && lane.generation_id == input.generation_id
+                && lane.kickoff_operation_id == input.kickoff_operation_id
+                && lane.launch_operation_id == input.launch_operation_id
+                && lane.executor_id == input.executor_id
+                && lane.worker_effect_kind == input.worker_effect_kind
+                && lane.thread_id == input.thread_id
+        }) {
+            let mut public_existing = existing.clone();
+            public_existing.lane = None;
+            if serde_json::to_value(&public_existing).ok()
+                == serde_json::to_value(&registration).ok()
+            {
+                return Ok(lane_detail(&session, lane, None));
+            }
+        }
+        if existing
+            .lane
+            .as_ref()
+            .is_none_or(|lane| lane.workflow != LaneWorkflow::Retired)
+        {
+            return Err("lane registration conflicts with existing session".into());
+        }
+    }
+    registration.lane = Some(LaneEvidence {
+        lane_version: 1,
+        generation_id: input.generation_id,
+        kickoff_operation_id: input.kickoff_operation_id,
+        launch_operation_id: input.launch_operation_id,
+        executor_id: input.executor_id,
+        worker_effect_kind: input.worker_effect_kind,
+        launch_state: LaneLaunchState::Ready,
+        workflow: LaneWorkflow::Active,
+        revision: 0,
+        quiesced: false,
+        thread_id: input.thread_id,
+        kickoff_message_id: None,
+        kickoff_delivered_at: None,
+        visibility: Some(LaneVisibility::Unverified),
+        verification: None,
+        last_failure: None,
+        latest_update_message_id: None,
+        latest_update_kind: None,
+        latest_update_delivered_at: None,
+        delivery_retry_count: 0,
+        delivery_disposition: None,
+    });
+    next.insert(session.clone(), registration);
+    save_durable_tmux_registry(path, &next).await?;
+    *registry.write().await = next;
+    drop(_mutation);
+    lane_detail_for_session(registry, &session).await
+}
+pub async fn record_lane_verification(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    input: LaneVerificationMutation,
+) -> Result<LaneSnapshot> {
+    {
+        let snapshot = registry.read().await;
+        let lane = snapshot
+            .get(&input.session)
+            .and_then(|registration| registration.lane.as_ref())
+            .ok_or("lane session not found")?;
+        if lane.revision == input.expected_revision.saturating_add(1)
+            && lane.generation_id == input.generation_id
+            && lane.visibility == Some(input.visibility)
+            && lane.verification.as_ref().is_some_and(|value| {
+                value.checked_at == input.checked_at
+                    && value.outcome == input.outcome
+                    && value.reason == input.reason
+            })
+        {
+            return Ok(lane_snapshot(&input.session, lane, None));
+        }
+    }
+    if !valid_verification(&input) || !valid_id(&input.generation_id) {
+        return Err("invalid lane verification input".into());
+    }
+    mutate_lane(
+        registry,
+        path,
+        &input.session,
+        input.expected_revision,
+        |lane| {
+            if lane.generation_id != input.generation_id || lane.workflow == LaneWorkflow::Retired {
+                return Err("lane generation conflict or retired".into());
+            }
+            lane.verification = Some(LaneVerification {
+                checked_at: input.checked_at,
+                outcome: input.outcome,
+                reason: input.reason,
+            });
+            lane.visibility = Some(input.visibility);
+            Ok(())
+        },
+    )
+    .await
+}
+pub async fn record_lane_delivery(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    input: LaneDeliveryMutation,
+) -> Result<LaneSnapshot> {
+    if !valid_delivery(&input)
+        || !valid_id(&input.generation_id)
+        || (input.initial_kickoff
+            && input
+                .kickoff_operation_id
+                .as_deref()
+                .is_none_or(|value| !valid_id(value)))
+    {
+        return Err("invalid lane delivery input".into());
+    }
+    if input.initial_kickoff {
+        let snapshot = registry.read().await;
+        let lane = snapshot
+            .get(&input.session)
+            .and_then(|registration| registration.lane.as_ref())
+            .ok_or("lane session not found")?;
+        if lane.revision == input.expected_revision.saturating_add(1)
+            && lane.generation_id == input.generation_id
+            && lane.launch_state == LaneLaunchState::Ready
+            && input.kind.as_deref() == Some("kickoff")
+            && input.kickoff_operation_id.as_deref() == Some(lane.kickoff_operation_id.as_str())
+            && lane.kickoff_message_id == input.message_id
+            && lane.kickoff_delivered_at == input.delivered_at
+            && lane.last_failure == input.error_category
+            && lane.delivery_disposition == input.disposition
+            && lane.visibility == Some(input.visibility)
+            && input.workflow.is_none()
+        {
+            return Ok(lane_snapshot(&input.session, lane, None));
+        }
+    }
+    if !input.initial_kickoff {
+        let snapshot = registry.read().await;
+        let lane = snapshot
+            .get(&input.session)
+            .and_then(|registration| registration.lane.as_ref())
+            .ok_or("lane session not found")?;
+        if lane.revision == input.expected_revision.saturating_add(1)
+            && lane.generation_id == input.generation_id
+            && lane.latest_update_message_id == input.message_id
+            && lane.latest_update_kind == input.kind
+            && lane.latest_update_delivered_at == input.delivered_at
+            && lane.visibility == Some(input.visibility)
+            && lane.last_failure == input.error_category
+            && lane.delivery_disposition == input.disposition
+            && input
+                .workflow
+                .is_none_or(|workflow| lane.workflow == workflow)
+        {
+            return Ok(lane_snapshot(&input.session, lane, None));
+        }
+    }
+    mutate_lane(
+        registry,
+        path,
+        &input.session,
+        input.expected_revision,
+        |lane| {
+            if lane.generation_id != input.generation_id
+                || (lane.workflow == LaneWorkflow::Retired
+                    && input.workflow != Some(LaneWorkflow::Retired))
+            {
+                return Err("lane generation conflict or retired".into());
+            }
+            if let Some(workflow) = input.workflow {
+                lane.workflow = workflow;
+            }
+            if input.initial_kickoff {
+                if input.kind.as_deref() != Some("kickoff")
+                    || input.kickoff_operation_id.as_deref()
+                        != Some(lane.kickoff_operation_id.as_str())
+                    || lane.launch_state != LaneLaunchState::Ready
+                    || lane.kickoff_message_id.is_some()
+                    || lane.delivery_disposition.is_some()
+                {
+                    return Err("initial kickoff fact conflict".into());
+                }
+                lane.kickoff_message_id = input.message_id;
+                lane.kickoff_delivered_at = input.delivered_at;
+            } else {
+                lane.latest_update_message_id = input.message_id;
+                lane.latest_update_kind = input.kind;
+                lane.latest_update_delivered_at = input.delivered_at;
+            }
+            lane.visibility = Some(input.visibility);
+            lane.last_failure = input.error_category;
+            lane.delivery_disposition = input.disposition;
+            lane.delivery_retry_count = lane.delivery_retry_count.saturating_add(1);
+            Ok(())
+        },
+    )
+    .await
+}
+pub async fn retire_lane_if_absent(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    input: LaneRetirementMutation,
+) -> Result<LaneSnapshot> {
+    if !valid_id(&input.generation_id) {
+        return Err("invalid lane retirement generation".into());
+    }
+    {
+        let snapshot = registry.read().await;
+        let lane = snapshot
+            .get(&input.session)
+            .and_then(|registration| registration.lane.as_ref())
+            .ok_or("lane session not found")?;
+        if lane.revision == input.expected_revision.saturating_add(1)
+            && lane.generation_id == input.generation_id
+            && lane.workflow == LaneWorkflow::Retired
+            && lane.quiesced
+        {
+            return Ok(lane_snapshot(&input.session, lane, None));
+        }
+    }
+    if session_exists(&input.session).await? {
+        return Err("lane runtime remains active".into());
+    }
+    mutate_lane(
+        registry,
+        path,
+        &input.session,
+        input.expected_revision,
+        |lane| {
+            if lane.generation_id != input.generation_id {
+                return Err("lane generation conflict".into());
+            }
+            if lane.workflow == LaneWorkflow::Retired && lane.quiesced {
+                return Ok(());
+            }
+            lane.workflow = LaneWorkflow::Retired;
+            lane.quiesced = true;
+            Ok(())
+        },
+    )
+    .await
+}
+
+pub async fn list_lane_snapshots(
+    registry: &SharedTmuxRegistry,
+    session: Option<&str>,
+) -> Vec<LaneSnapshot> {
+    let runtime = list_tmux_sessions().await.ok();
+    registry
+        .read()
+        .await
+        .iter()
+        .filter(|(name, registration)| {
+            session.is_none_or(|requested| requested == name.as_str())
+                && registration.lane.is_some()
+        })
+        .filter_map(|(name, registration)| {
+            registration.lane.as_ref().map(|lane| {
+                lane_snapshot(
+                    name,
+                    lane,
+                    runtime.as_ref().map(|sessions| sessions.contains(name)),
+                )
+            })
+        })
+        .collect()
+}
+
+pub async fn claim_lane(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    session: &str,
+    generation_id: &str,
+    executor_id: &str,
+    expected_revision: u64,
+) -> Result<LaneSnapshot> {
+    if !valid_id(generation_id) || !valid_id(executor_id) {
+        return Err("invalid lane claim identity".into());
+    }
+    {
+        let snapshot = registry.read().await;
+        let lane = snapshot
+            .get(session)
+            .and_then(|registration| registration.lane.as_ref())
+            .ok_or("lane session not found")?;
+        if lane.workflow == LaneWorkflow::Retired {
+            return Err("lane claim conflicts with retired workflow".into());
+        }
+        if lane.revision == expected_revision.saturating_add(1)
+            && lane.generation_id == generation_id
+            && lane.executor_id == executor_id
+            && lane.launch_state == LaneLaunchState::Claimed
+        {
+            return Ok(lane_snapshot(session, lane, None));
+        }
+    }
+    mutate_lane(registry, path, session, expected_revision, |lane| {
+        if lane.generation_id != generation_id || lane.executor_id != executor_id {
+            return Err("lane claim identity conflict".into());
+        }
+        if lane.workflow == LaneWorkflow::Retired {
+            return Err("lane claim conflicts with retired workflow".into());
+        }
+        if lane.launch_state == LaneLaunchState::Ready {
+            lane.launch_state = LaneLaunchState::Claimed;
+        }
+        if lane.launch_state != LaneLaunchState::Claimed {
+            return Err("lane claim conflicts with durable state".into());
+        }
+        Ok(())
+    })
+    .await
+}
+
+pub async fn update_lane_evidence(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    input: LaneEvidenceMutation,
+) -> Result<LaneSnapshot> {
+    if !valid_id(&input.generation_id)
+        || !valid_id(&input.launch_operation_id)
+        || !valid_id(&input.executor_id)
+    {
+        return Err("invalid lane evidence identity".into());
+    }
+    {
+        let snapshot = registry.read().await;
+        let existing = snapshot
+            .get(&input.session)
+            .and_then(|registration| registration.lane.as_ref())
+            .ok_or("lane session not found")?;
+        if (existing.revision == input.expected_revision
+            || existing.revision == input.expected_revision.saturating_add(1))
+            && existing.generation_id == input.generation_id
+            && existing.launch_operation_id == input.launch_operation_id
+            && existing.executor_id == input.executor_id
+            && existing.worker_effect_kind == input.worker_effect_kind
+            && existing.launch_state == input.launch_state
+            && existing.last_failure == input.failure_category
+        {
+            return Ok(lane_snapshot(&input.session, existing, None));
+        }
+    }
+    mutate_lane(
+        registry,
+        path,
+        &input.session,
+        input.expected_revision,
+        |lane| {
+            if lane.generation_id != input.generation_id
+                || lane.launch_operation_id != input.launch_operation_id
+                || lane.executor_id != input.executor_id
+                || lane.worker_effect_kind != input.worker_effect_kind
+                || lane.workflow == LaneWorkflow::Retired
+            {
+                return Err("lane immutable identity conflict or retired".into());
+            }
+            if !terminal_category_is_valid(
+                lane.worker_effect_kind,
+                input.launch_state,
+                input.failure_category.as_ref(),
+            ) {
+                return Err("invalid terminal category for worker effect kind".into());
+            }
+            let valid = lane.launch_state == input.launch_state
+                || matches!(
+                    (lane.launch_state, input.launch_state),
+                    (LaneLaunchState::Claimed, LaneLaunchState::IdentityVerified)
+                        | (LaneLaunchState::IdentityVerified, LaneLaunchState::Launched)
+                        | (
+                            LaneLaunchState::Claimed,
+                            LaneLaunchState::NoWorkerEffect
+                                | LaneLaunchState::CommandSubmitAmbiguous
+                                | LaneLaunchState::SessionCreationAmbiguous
+                        )
+                        | (
+                            LaneLaunchState::IdentityVerified,
+                            LaneLaunchState::NoWorkerEffect
+                                | LaneLaunchState::CommandSubmitAmbiguous
+                                | LaneLaunchState::SessionCreationAmbiguous
+                        )
+                );
+            if !valid {
+                return Err("invalid lane launch transition".into());
+            }
+            lane.launch_state = input.launch_state;
+            lane.last_failure = input.failure_category;
+            Ok(())
+        },
+    )
+    .await
+}
+
+pub async fn update_lane_workflow(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    input: LaneWorkflowMutation,
+) -> Result<LaneSnapshot> {
+    if !valid_id(&input.generation_id) {
+        return Err("invalid lane workflow generation".into());
+    }
+    {
+        let snapshot = registry.read().await;
+        let lane = snapshot
+            .get(&input.session)
+            .and_then(|registration| registration.lane.as_ref())
+            .ok_or("lane session not found")?;
+        if lane.revision == input.expected_revision.saturating_add(1)
+            && lane.generation_id == input.generation_id
+            && lane.workflow == input.workflow
+            && lane.quiesced == input.quiesced
+        {
+            return Ok(lane_snapshot(&input.session, lane, None));
+        }
+    }
+    mutate_lane(
+        registry,
+        path,
+        &input.session,
+        input.expected_revision,
+        |lane| {
+            if lane.generation_id != input.generation_id || lane.workflow == LaneWorkflow::Retired {
+                return Err("lane generation conflict or retired".into());
+            }
+            if input.workflow == LaneWorkflow::Retired {
+                return Err("use daemon retirement endpoint".into());
+            }
+            lane.workflow = input.workflow;
+            lane.quiesced = input.quiesced;
+            Ok(())
+        },
+    )
+    .await
+}
+
+async fn mutate_lane<F>(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    session: &str,
+    expected_revision: u64,
+    mutate: F,
+) -> Result<LaneSnapshot>
+where
+    F: FnOnce(&mut LaneEvidence) -> Result<()>,
+{
+    let _mutation = REGISTRY_MUTATION_LOCK.lock().await;
+    let mut next = registry.read().await.clone();
+    let registration = next.get_mut(session).ok_or("lane session not found")?;
+    let lane = registration
+        .lane
+        .as_mut()
+        .ok_or("session has no lane evidence")?;
+    if lane.revision != expected_revision {
+        return Err("lane revision conflict".into());
+    }
+    mutate(lane)?;
+    lane.revision = lane
+        .revision
+        .checked_add(1)
+        .ok_or("lane revision exhausted")?;
+    let snapshot = lane_snapshot(session, lane, None);
+    save_durable_tmux_registry(path, &next).await?;
+    *registry.write().await = next;
+    Ok(snapshot)
 }
 
 pub async fn tmux_registry_diagnostics(
@@ -836,6 +1978,13 @@ fn merge_active_config_registrations(
     for (session, mut registration) in active_config {
         if let Some(existing) = registry.get(&session) {
             if existing.active_wrapper_monitor {
+                continue;
+            }
+            if existing
+                .lane
+                .as_ref()
+                .is_some_and(|lane| lane.workflow != LaneWorkflow::Retired)
+            {
                 continue;
             }
             if existing.registration_source == RegistrationSource::ConfigMonitor {
@@ -1298,7 +2447,505 @@ mod tests {
             registration_source: RegistrationSource::ConfigMonitor,
             parent_process: None,
             active_wrapper_monitor: false,
+            lane: None,
         }
+    }
+
+    fn lane_input(session: &str, generation_id: &str) -> LaneRegistrationInput {
+        let mut registration = registration(Vec::new());
+        registration.session = session.into();
+        LaneRegistrationInput {
+            registration,
+            generation_id: generation_id.into(),
+            kickoff_operation_id: "k".into(),
+            launch_operation_id: "l".into(),
+            executor_id: "e".into(),
+            worker_effect_kind: WorkerEffectKind::CommandSubmission,
+            thread_id: Some("12345678901234567890".into()),
+            expect_absent_or_retired: true,
+        }
+    }
+
+    #[test]
+    fn verification_reason_outcome_pairs_are_sanitized() {
+        let input = |outcome: &str, reason: Option<&str>| LaneVerificationMutation {
+            session: "lane".into(),
+            expected_revision: 0,
+            checked_at: "2026-07-11T00:00:00Z".into(),
+            outcome: outcome.into(),
+            reason: reason.map(BoundedReason::new),
+            visibility: LaneVisibility::Unverified,
+            generation_id: "g".into(),
+        };
+        assert!(valid_verification(&input(
+            "unverified",
+            Some("unauthorized")
+        )));
+        assert!(valid_verification(&input("unverified", Some("timeout"))));
+        assert!(valid_verification(&input("unreachable", Some("forbidden"))));
+        assert!(valid_verification(&input(
+            "message-observed-unverified",
+            Some("kickoff-receipt-missing")
+        )));
+        assert!(!valid_verification(&input(
+            "unverified",
+            Some("private-target:secret")
+        )));
+    }
+
+    #[test]
+    fn delivery_categories_are_partitioned_by_disposition() {
+        let input = |disposition: Option<&str>, category: Option<&str>| LaneDeliveryMutation {
+            session: "lane".into(),
+            expected_revision: 0,
+            generation_id: "g".into(),
+            workflow: None,
+            message_id: None,
+            kind: Some("progress".into()),
+            delivered_at: None,
+            visibility: LaneVisibility::DeliveryFailed,
+            error_category: category.map(BoundedCategory::new),
+            disposition: disposition.map(str::to_owned),
+            initial_kickoff: false,
+            kickoff_operation_id: None,
+        };
+        assert!(valid_delivery(&input(
+            Some("definitive-failure"),
+            Some("forbidden")
+        )));
+        assert!(valid_delivery(&input(
+            Some("definitive-failure"),
+            Some("transport")
+        )));
+        let mut ambiguous = input(Some("ambiguous-acceptance"), Some("timeout"));
+        ambiguous.visibility = LaneVisibility::Unverified;
+        assert!(valid_delivery(&ambiguous));
+        assert!(!valid_delivery(&input(
+            Some("definitive-failure"),
+            Some("timeout")
+        )));
+        ambiguous.error_category = Some(BoundedCategory::new("forbidden"));
+        assert!(!valid_delivery(&ambiguous));
+        assert!(!valid_delivery(&input(None, None)));
+        let mut initial_empty = input(None, None);
+        initial_empty.initial_kickoff = true;
+        initial_empty.kind = Some("kickoff".into());
+        initial_empty.kickoff_operation_id = Some("k".into());
+        assert!(!valid_delivery(&initial_empty));
+    }
+
+    #[test]
+    fn success_and_pending_launch_states_reject_categories() {
+        let category = BoundedCategory::new("arbitrary");
+        for state in [
+            LaneLaunchState::Ready,
+            LaneLaunchState::Claimed,
+            LaneLaunchState::IdentityVerified,
+            LaneLaunchState::Launched,
+        ] {
+            assert!(terminal_category_is_valid(
+                WorkerEffectKind::CommandSubmission,
+                state,
+                None
+            ));
+            assert!(!terminal_category_is_valid(
+                WorkerEffectKind::CommandSubmission,
+                state,
+                Some(&category)
+            ));
+        }
+        assert!(!terminal_category_is_valid(
+            WorkerEffectKind::SessionCreation,
+            LaneLaunchState::NoWorkerEffect,
+            Some(&category)
+        ));
+    }
+
+    #[tokio::test]
+    async fn lane_registration_constructs_canonical_r0_and_rejects_legacy_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let detail = register_lane_registration(&registry, &path, lane_input("r0", "g0"))
+            .await
+            .unwrap();
+        assert_eq!(detail.snapshot.durable_launch_state, LaneLaunchState::Ready);
+        assert_eq!(detail.snapshot.revision, 0);
+        assert_eq!(detail.snapshot.workflow, LaneWorkflow::Active);
+        assert_eq!(detail.snapshot.visibility, Some(LaneVisibility::Unverified));
+        assert_eq!(detail.kickoff_message_id, None);
+        registry
+            .write()
+            .await
+            .insert("legacy".into(), registration(Vec::new()));
+        assert!(
+            register_lane_registration(&registry, &path, lane_input("legacy", "g1"))
+                .await
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ready_kickoff_failure_snapshot_retains_canonical_reason_and_json_null_worker() {
+        let mut registration = registration(Vec::new());
+        registration.lane = Some(LaneEvidence {
+            lane_version: 1,
+            generation_id: "g".into(),
+            kickoff_operation_id: "k".into(),
+            launch_operation_id: "l".into(),
+            executor_id: "e".into(),
+            worker_effect_kind: WorkerEffectKind::CommandSubmission,
+            launch_state: LaneLaunchState::Ready,
+            workflow: LaneWorkflow::Active,
+            revision: 0,
+            quiesced: false,
+            thread_id: Some("thread".into()),
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            visibility: Some(LaneVisibility::DeliveryFailed),
+            verification: None,
+            last_failure: Some(BoundedCategory::new("missing-message-id")),
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+            delivery_retry_count: 1,
+            delivery_disposition: Some("definitive-failure".into()),
+        });
+        let snapshot = lane_snapshot("lane", registration.lane.as_ref().unwrap(), None);
+        assert_eq!(snapshot.derived_status.as_deref(), Some("kickoff-failed"));
+        assert_eq!(
+            snapshot
+                .observation_reason
+                .as_ref()
+                .map(BoundedReason::as_str),
+            Some("missing-message-id")
+        );
+        assert_eq!(
+            snapshot.exit_category.as_ref().map(BoundedCategory::as_str),
+            Some("missing-message-id")
+        );
+        assert_eq!(snapshot.worker_started, None);
+        let json = serde_json::to_value(snapshot).unwrap();
+        assert_eq!(json["worker_started"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn committed_terminal_snapshots_serialize_exact_categories_and_null_worker() {
+        for (state, kind, category, status) in [
+            (
+                LaneLaunchState::SessionCreationAmbiguous,
+                WorkerEffectKind::SessionCreation,
+                "owner-aborted-before-r2",
+                "session-creation-ambiguous-blocked",
+            ),
+            (
+                LaneLaunchState::NoWorkerEffect,
+                WorkerEffectKind::CommandSubmission,
+                "launch-failed-no-worker-effect",
+                "launch-failed-no-worker-effect",
+            ),
+        ] {
+            let lane = LaneEvidence {
+                lane_version: 1,
+                generation_id: "g".into(),
+                kickoff_operation_id: "k".into(),
+                launch_operation_id: "l".into(),
+                executor_id: "e".into(),
+                worker_effect_kind: kind,
+                launch_state: state,
+                workflow: LaneWorkflow::Active,
+                revision: 0,
+                quiesced: false,
+                thread_id: None,
+                kickoff_message_id: None,
+                kickoff_delivered_at: None,
+                visibility: None,
+                verification: None,
+                last_failure: Some(BoundedCategory::new(category)),
+                latest_update_message_id: None,
+                latest_update_kind: None,
+                latest_update_delivered_at: None,
+                delivery_retry_count: 0,
+                delivery_disposition: None,
+            };
+            let value = serde_json::to_value(lane_snapshot("lane", &lane, None)).unwrap();
+            assert_eq!(value["derived_status"], status);
+            assert_eq!(value["observation_reason"], category);
+            assert_eq!(value["exit_category"], category);
+            assert_eq!(value["worker_started"], serde_json::Value::Null);
+            assert_eq!(value["evidence_commit"], true);
+            assert_eq!(value["repair_needed"], false);
+            assert_eq!(value["healthy"], false);
+        }
+    }
+
+    #[test]
+    fn ready_kickoff_ambiguity_snapshot_retains_canonical_reason() {
+        let mut registration = registration(Vec::new());
+        registration.lane = Some(LaneEvidence {
+            lane_version: 1,
+            generation_id: "g".into(),
+            kickoff_operation_id: "k".into(),
+            launch_operation_id: "l".into(),
+            executor_id: "e".into(),
+            worker_effect_kind: WorkerEffectKind::CommandSubmission,
+            launch_state: LaneLaunchState::Ready,
+            workflow: LaneWorkflow::Active,
+            revision: 0,
+            quiesced: false,
+            thread_id: Some("thread".into()),
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            visibility: Some(LaneVisibility::Unreachable),
+            verification: None,
+            last_failure: Some(BoundedCategory::new("transport-failed")),
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+            delivery_retry_count: 1,
+            delivery_disposition: Some("ambiguous-acceptance".into()),
+        });
+        let snapshot = lane_snapshot("lane", registration.lane.as_ref().unwrap(), None);
+        assert_eq!(
+            snapshot.derived_status.as_deref(),
+            Some("kickoff-ambiguous")
+        );
+        assert_eq!(
+            snapshot
+                .observation_reason
+                .as_ref()
+                .map(BoundedReason::as_str),
+            Some("transport-failed")
+        );
+        assert!(snapshot.evidence_commit && snapshot.repair_needed && !snapshot.healthy);
+    }
+
+    #[tokio::test]
+    async fn lane_detail_is_registry_only_and_reports_unknown_runtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        register_lane_registration(
+            &registry,
+            &dir.path().join("registry.json"),
+            lane_input("no-tmux-probe", "g"),
+        )
+        .await
+        .unwrap();
+        let detail = lane_detail_for_session(&registry, "no-tmux-probe")
+            .await
+            .unwrap();
+        assert!(!detail.snapshot.healthy);
+        assert_eq!(detail.snapshot.derived_status.as_deref(), Some("pending"));
+    }
+
+    #[tokio::test]
+    async fn retired_lane_replaces_but_generation_fences_and_retired_writes_reject() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        register_lane_registration(&registry, &path, lane_input("lane", "old"))
+            .await
+            .unwrap();
+        registry
+            .write()
+            .await
+            .get_mut("lane")
+            .unwrap()
+            .lane
+            .as_mut()
+            .unwrap()
+            .workflow = LaneWorkflow::Retired;
+        assert_eq!(
+            register_lane_registration(&registry, &path, lane_input("lane", "new"))
+                .await
+                .unwrap()
+                .snapshot
+                .generation_id,
+            "new"
+        );
+        assert!(
+            record_lane_verification(
+                &registry,
+                &path,
+                LaneVerificationMutation {
+                    session: "lane".into(),
+                    expected_revision: 0,
+                    generation_id: "old".into(),
+                    checked_at: "now".into(),
+                    outcome: "visible".into(),
+                    reason: None,
+                    visibility: LaneVisibility::Visible
+                }
+            )
+            .await
+            .is_err()
+        );
+        assert!(
+            update_lane_workflow(
+                &registry,
+                &path,
+                LaneWorkflowMutation {
+                    session: "lane".into(),
+                    generation_id: "old".into(),
+                    expected_revision: 0,
+                    workflow: LaneWorkflow::NeedsReview,
+                    quiesced: false
+                }
+            )
+            .await
+            .is_err()
+        );
+        registry
+            .write()
+            .await
+            .get_mut("lane")
+            .unwrap()
+            .lane
+            .as_mut()
+            .unwrap()
+            .workflow = LaneWorkflow::Retired;
+        assert!(
+            record_lane_delivery(
+                &registry,
+                &path,
+                LaneDeliveryMutation {
+                    session: "lane".into(),
+                    expected_revision: 0,
+                    generation_id: "new".into(),
+                    workflow: None,
+                    message_id: None,
+                    kind: None,
+                    delivered_at: None,
+                    visibility: LaneVisibility::Unverified,
+                    error_category: None,
+                    disposition: None,
+                    initial_kickoff: false,
+                    kickoff_operation_id: None,
+                }
+            )
+            .await
+            .is_err()
+        );
+        assert!(
+            record_lane_delivery(
+                &registry,
+                &path,
+                LaneDeliveryMutation {
+                    session: "lane".into(),
+                    expected_revision: 0,
+                    generation_id: "new".into(),
+                    workflow: Some(LaneWorkflow::Retired),
+                    message_id: Some("12345678901234567890".into()),
+                    kind: Some("progress".into()),
+                    delivered_at: Some("2026-07-11T00:00:00Z".into()),
+                    visibility: LaneVisibility::Visible,
+                    error_category: None,
+                    disposition: Some("accepted".into()),
+                    initial_kickoff: false,
+                    kickoff_operation_id: None,
+                }
+            )
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_response_loss_replay_and_retired_claim_rejection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        register_lane_registration(&registry, &path, lane_input("lane", "g"))
+            .await
+            .unwrap();
+        assert_eq!(
+            claim_lane(&registry, &path, "lane", "g", "e", 0)
+                .await
+                .unwrap()
+                .revision,
+            1
+        );
+        assert_eq!(
+            claim_lane(&registry, &path, "lane", "g", "e", 0)
+                .await
+                .unwrap()
+                .revision,
+            1
+        );
+        registry
+            .write()
+            .await
+            .get_mut("lane")
+            .unwrap()
+            .lane
+            .as_mut()
+            .unwrap()
+            .workflow = LaneWorkflow::Retired;
+        assert!(
+            claim_lane(&registry, &path, "lane", "g", "e", 1)
+                .await
+                .is_err()
+        );
+    }
+    #[tokio::test]
+    async fn evidence_replay_is_idempotent_and_immutable_facts_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        register_lane_registration(&registry, &path, lane_input("lane", "g"))
+            .await
+            .unwrap();
+        let replay = LaneEvidenceMutation {
+            session: "lane".into(),
+            expected_revision: 0,
+            generation_id: "g".into(),
+            launch_operation_id: "l".into(),
+            launch_state: LaneLaunchState::Ready,
+            failure_category: None,
+            executor_id: "e".into(),
+            worker_effect_kind: WorkerEffectKind::CommandSubmission,
+        };
+        assert_eq!(
+            update_lane_evidence(&registry, &path, replay.clone())
+                .await
+                .unwrap()
+                .revision,
+            0
+        );
+        let claimed = claim_lane(&registry, &path, "lane", "g", "e", 0)
+            .await
+            .unwrap();
+        let transition = LaneEvidenceMutation {
+            expected_revision: claimed.revision,
+            launch_state: LaneLaunchState::IdentityVerified,
+            ..replay.clone()
+        };
+        assert_eq!(
+            update_lane_evidence(&registry, &path, transition.clone())
+                .await
+                .unwrap()
+                .revision,
+            2
+        );
+        assert_eq!(
+            update_lane_evidence(&registry, &path, transition)
+                .await
+                .unwrap()
+                .revision,
+            2
+        );
+        assert!(
+            update_lane_evidence(
+                &registry,
+                &path,
+                LaneEvidenceMutation {
+                    executor_id: "other".into(),
+                    ..replay
+                }
+            )
+            .await
+            .is_err()
+        );
     }
 
     fn keyword_hit(keyword: &str, line: &str) -> KeywordHit {
@@ -1479,6 +3126,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             ),
             (
@@ -1499,6 +3147,7 @@ PR created #7",
                         name: Some("codex".into()),
                     }),
                     active_wrapper_monitor: true,
+                    lane: None,
                 },
             ),
             (
@@ -1516,6 +3165,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             ),
         ]);
@@ -1537,6 +3187,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             )]),
         );
@@ -1568,6 +3219,7 @@ PR created #7",
                     name: Some("codex".into()),
                 }),
                 active_wrapper_monitor: true,
+                lane: None,
             },
         )]);
 
@@ -1588,6 +3240,7 @@ PR created #7",
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             )]),
         );
@@ -1650,14 +3303,15 @@ PR created #7",
 
         let snapshot = registry.read().await.clone();
         save_durable_tmux_registry(&path, &snapshot).await.unwrap();
-        let loaded: BTreeMap<String, RegisteredTmuxSession> =
+        let loaded: BTreeMap<String, StoredTmuxRegistration> =
             serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
 
         assert_eq!(loaded.len(), 1);
         assert_eq!(
-            loaded["runtime"].registration_source,
+            loaded["runtime"].registration.registration_source,
             RegistrationSource::CliWatch
         );
+        assert!(loaded["runtime"].lane.is_none());
         assert!(!loaded.contains_key("config"));
     }
 
@@ -1685,10 +3339,12 @@ PR created #7",
         assert!(snapshot.contains_key("runtime-b"));
         drop(snapshot);
 
-        let loaded: BTreeMap<String, RegisteredTmuxSession> =
+        let loaded: BTreeMap<String, StoredTmuxRegistration> =
             serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
         assert!(loaded.contains_key("runtime-a"));
         assert!(loaded.contains_key("runtime-b"));
+        assert!(loaded["runtime-a"].lane.is_none());
+        assert!(loaded["runtime-b"].lane.is_none());
     }
 
     #[tokio::test]
@@ -2011,6 +3667,7 @@ error: failed";
                 registration_source: RegistrationSource::ConfigMonitor,
                 parent_process: None,
                 active_wrapper_monitor: false,
+                lane: None,
             }],
             Some(&available_sessions),
         );
@@ -2041,6 +3698,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
                 RegisteredTmuxSession {
                     session: "omx-*".into(),
@@ -2055,6 +3713,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             ],
             Some(&available_sessions),
@@ -2083,6 +3742,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
                 RegisteredTmuxSession {
                     session: "rcc-*".into(),
@@ -2097,6 +3757,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             ],
             None,
@@ -2124,6 +3785,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
                 RegisteredTmuxSession {
                     session: "rcc-api".into(),
@@ -2138,6 +3800,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             ],
             Some(&available_sessions),
@@ -2165,6 +3828,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
                 RegisteredTmuxSession {
                     session: "rcc-*".into(),
@@ -2179,6 +3843,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             ],
             Some(&available_sessions),
@@ -2211,6 +3876,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
                 RegisteredTmuxSession {
                     session: "abc*".into(),
@@ -2225,6 +3891,7 @@ error: failed";
                     registration_source: RegistrationSource::ConfigMonitor,
                     parent_process: None,
                     active_wrapper_monitor: false,
+                    lane: None,
                 },
             ],
             Some(&available_sessions),

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
@@ -9,17 +11,23 @@ use crate::Result;
 use crate::cli::{TmuxNewArgs, TmuxWatchArgs, TmuxWrapperFormat};
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
+use crate::discord::{DiscordClient, DiscordLaneDisposition};
 use crate::events::RoutingMetadata;
 use crate::router::resolve_tmux_session_channel_with_metadata;
 use crate::source::tmux::{
-    ParentProcessInfo, RegisteredTmuxSession, RegistrationSource, content_hash,
-    current_timestamp_rfc3339, monitor_registered_session, session_exists, tmux_bin,
+    BoundedCategory, LaneDeliveryMutation, LaneEvidence, LaneEvidenceMutation, LaneLaunchState,
+    LaneRegistrationInput, LaneVisibility, LaneWorkflow, ParentProcessInfo, RegisteredTmuxSession,
+    RegistrationSource, WorkerEffectKind, content_hash, current_timestamp_rfc3339,
+    monitor_registered_session, session_exists, tmux_bin,
 };
 
 pub async fn run(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
+    if args.thread.is_some() {
+        return launch_lane_session(args, config).await;
+    }
+
     launch_session(&args).await?;
     let monitor_args = TmuxMonitorArgs::from_new_args(&args, config);
-
     if args.follow {
         let monitor = register_and_start_monitor(monitor_args, config).await?;
         if args.attach {
@@ -125,6 +133,7 @@ impl TmuxMonitorArgs {
             registration_source: self.registration_source,
             parent_process: self.parent_process,
             active_wrapper_monitor,
+            lane: None,
         }
     }
 }
@@ -281,6 +290,1053 @@ async fn launch_session(args: &TmuxNewArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn lane_effect_kind(args: &TmuxNewArgs) -> WorkerEffectKind {
+    if args.command.is_empty() {
+        WorkerEffectKind::SessionCreation
+    } else {
+        WorkerEffectKind::CommandSubmission
+    }
+}
+
+fn new_lane_evidence(args: &TmuxNewArgs) -> LaneEvidence {
+    LaneEvidence {
+        lane_version: 1,
+        generation_id: uuid::Uuid::new_v4().to_string(),
+        kickoff_operation_id: uuid::Uuid::new_v4().to_string(),
+        launch_operation_id: uuid::Uuid::new_v4().to_string(),
+        executor_id: uuid::Uuid::new_v4().to_string(),
+        worker_effect_kind: lane_effect_kind(args),
+        launch_state: LaneLaunchState::Ready,
+        workflow: Default::default(),
+        revision: 0,
+        quiesced: false,
+        thread_id: args.thread.clone(),
+        kickoff_message_id: None,
+        kickoff_delivered_at: None,
+        visibility: Some(LaneVisibility::Unverified),
+        verification: None,
+        last_failure: None,
+        latest_update_message_id: None,
+        latest_update_kind: None,
+        latest_update_delivered_at: None,
+        delivery_retry_count: 0,
+        delivery_disposition: None,
+    }
+}
+
+fn validate_lane_args(args: &TmuxNewArgs) -> Result<()> {
+    let thread = args
+        .thread
+        .as_deref()
+        .ok_or("lane launch requires a thread")?;
+    if thread.trim().is_empty() {
+        return Err("lane thread must not be empty".into());
+    }
+    if args
+        .kickoff
+        .as_ref()
+        .is_some_and(|message| message.chars().count() > 2_000)
+    {
+        return Err("lane kickoff exceeds 2000 Unicode scalars".into());
+    }
+    Ok(())
+}
+
+#[derive(Clone)]
+pub(crate) struct LaneInspectionResult {
+    pub derived_status: Option<String>,
+    pub observation_reason: Option<String>,
+    pub worker_started: Option<bool>,
+    pub evidence_commit: bool,
+    pub repair_needed: bool,
+    pub healthy: bool,
+    pub exit_category: Option<String>,
+    pub runtime: &'static str,
+}
+
+fn overlay_from_snapshot(snapshot: &crate::source::tmux::LaneSnapshot) -> LaneInspectionResult {
+    LaneInspectionResult {
+        derived_status: snapshot.derived_status.clone(),
+        observation_reason: snapshot
+            .observation_reason
+            .as_ref()
+            .map(|reason| reason.as_str().to_string()),
+        worker_started: snapshot.worker_started,
+        evidence_commit: snapshot.evidence_commit,
+        repair_needed: snapshot.repair_needed,
+        healthy: snapshot.healthy,
+        exit_category: snapshot
+            .exit_category
+            .as_ref()
+            .map(|category| category.as_str().to_string()),
+        runtime: "unknown",
+    }
+}
+
+fn r2_overlay(
+    kind: WorkerEffectKind,
+    reason: &str,
+    identity_conflict: bool,
+) -> LaneInspectionResult {
+    let status = if identity_conflict {
+        "identity-conflict"
+    } else if matches!(kind, WorkerEffectKind::CommandSubmission) {
+        "launch-commit-ambiguous"
+    } else {
+        "session-creation-effect-uncommitted"
+    };
+    LaneInspectionResult {
+        derived_status: Some(status.into()),
+        observation_reason: Some(reason.into()),
+        worker_started: None,
+        evidence_commit: false,
+        repair_needed: true,
+        healthy: false,
+        exit_category: Some(reason.into()),
+        runtime: match reason {
+            "session-missing" => "tmux-missing",
+            "session-liveness-unavailable" => "unknown",
+            _ => "live",
+        },
+    }
+}
+
+fn kickoff_failure_overlay(
+    category: &BoundedCategory,
+    disposition: DiscordLaneDisposition,
+) -> LaneInspectionResult {
+    LaneInspectionResult {
+        derived_status: Some(
+            match disposition {
+                DiscordLaneDisposition::AmbiguousAcceptance => "kickoff-ambiguous",
+                DiscordLaneDisposition::DefinitiveFailure => "kickoff-failed",
+            }
+            .into(),
+        ),
+        observation_reason: Some(category.as_str().into()),
+        worker_started: None,
+        evidence_commit: true,
+        repair_needed: true,
+        healthy: false,
+        exit_category: Some(category.as_str().into()),
+        runtime: "tmux-missing",
+    }
+}
+
+fn durable_launch_state_name(state: LaneLaunchState) -> &'static str {
+    match state {
+        LaneLaunchState::Ready => "ready",
+        LaneLaunchState::Claimed => "claimed",
+        LaneLaunchState::IdentityVerified => "identity-markers-verified",
+        LaneLaunchState::Launched => "launched",
+        LaneLaunchState::NoWorkerEffect => "launch-failed-no-worker-effect",
+
+        LaneLaunchState::CommandSubmitAmbiguous => "blocked-command-submit-ambiguous",
+        LaneLaunchState::SessionCreationAmbiguous => "blocked-session-creation-ambiguous",
+    }
+}
+
+fn emit_lane_result(
+    args: &TmuxNewArgs,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+    overlay: &LaneInspectionResult,
+) {
+    if args.json {
+        println!("{}", {
+            let mut result = serde_json::json!({
+                "session": snapshot.session,
+                "worker_effect_kind": snapshot.worker_effect_kind,
+                "generation_id": snapshot.generation_id,
+                "kickoff_operation_id": snapshot.kickoff_operation_id,
+                "launch_operation_id": snapshot.launch_operation_id,
+                "executor_id": snapshot.executor_id,
+                "durable_launch_state": durable_launch_state_name(snapshot.durable_launch_state),
+                "derived_status": overlay.derived_status,
+                "observation_reason": overlay.observation_reason,
+                "worker_started": overlay.worker_started,
+                "evidence_commit": overlay.evidence_commit,
+                "repair_needed": overlay.repair_needed,
+                "healthy": overlay.healthy,
+                "exit_category": overlay.exit_category,
+            });
+            if args.thread.is_some() {
+                result["thread_id"] = serde_json::json!(args.thread);
+                result["kickoff_message_id"] = serde_json::json!(snapshot.kickoff_message_id);
+                result["kickoff_delivered_at"] = serde_json::json!(snapshot.kickoff_delivered_at);
+                result["watch_registered"] = serde_json::json!(true);
+                result["visibility"] = serde_json::json!(snapshot.visibility);
+                result["workflow"] = serde_json::json!(snapshot.workflow);
+                result["runtime"] = serde_json::json!(overlay.runtime);
+            }
+            result
+        });
+    } else {
+        let worker = match overlay.worker_started {
+            Some(true) => "yes",
+            Some(false) => "no",
+            None => "unknown",
+        };
+        let exit = overlay.exit_category.as_deref().unwrap_or("success");
+        println!(
+            "session={} status={} worker_started={} exit={}",
+            snapshot.session,
+            overlay.derived_status.as_deref().unwrap_or("—"),
+            worker,
+            exit
+        );
+    }
+}
+
+fn claim_response_loss_matches(
+    detail: &crate::source::tmux::LaneDetail,
+    lane: &LaneEvidence,
+    expected_revision: u64,
+) -> bool {
+    let snapshot = &detail.snapshot;
+    snapshot.generation_id == lane.generation_id
+        && snapshot.kickoff_operation_id == lane.kickoff_operation_id
+        && snapshot.launch_operation_id == lane.launch_operation_id
+        && snapshot.executor_id == lane.executor_id
+        && snapshot.worker_effect_kind == lane.worker_effect_kind
+        && detail.thread_id == lane.thread_id
+        && snapshot.durable_launch_state == LaneLaunchState::Claimed
+        && snapshot.revision == expected_revision.saturating_add(1)
+}
+
+fn register_response_loss_matches(
+    detail: &crate::source::tmux::LaneDetail,
+    lane: &LaneEvidence,
+) -> bool {
+    let snapshot = &detail.snapshot;
+    snapshot.generation_id == lane.generation_id
+        && snapshot.kickoff_operation_id == lane.kickoff_operation_id
+        && snapshot.launch_operation_id == lane.launch_operation_id
+        && snapshot.executor_id == lane.executor_id
+        && snapshot.worker_effect_kind == lane.worker_effect_kind
+        && detail.thread_id == lane.thread_id
+        && snapshot.durable_launch_state == LaneLaunchState::Ready
+        && snapshot.revision == 0
+        && snapshot.workflow == LaneWorkflow::Active
+        && snapshot.visibility == Some(LaneVisibility::Unverified)
+        && snapshot.kickoff_message_id.is_none()
+        && snapshot.kickoff_delivered_at.is_none()
+        && snapshot.latest_update_message_id.is_none()
+        && snapshot.latest_update_kind.is_none()
+        && snapshot.latest_update_delivered_at.is_none()
+        && detail.last_error.is_none()
+        && !detail.quiesced
+}
+
+fn kickoff_receipt_response_loss_matches(
+    detail: &crate::source::tmux::LaneDetail,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+    message_id: Option<&str>,
+    delivered_at: Option<&str>,
+    visibility: LaneVisibility,
+    category: Option<&str>,
+    disposition: &str,
+) -> bool {
+    detail.snapshot.generation_id == snapshot.generation_id
+        && detail.snapshot.kickoff_operation_id == snapshot.kickoff_operation_id
+        && detail.snapshot.revision == snapshot.revision.saturating_add(1)
+        && detail.kickoff_message_id.as_deref() == message_id
+        && detail.kickoff_delivered_at.as_deref() == delivered_at
+        && detail.snapshot.visibility == Some(visibility)
+        && detail.last_error.as_ref().map(BoundedCategory::as_str) == category
+        && detail
+            .snapshot
+            .exit_category
+            .as_ref()
+            .map(BoundedCategory::as_str)
+            == category
+        && match (category, disposition) {
+            (None, "accepted") => true,
+            (Some(category), "ambiguous-acceptance") => {
+                detail.snapshot.derived_status.as_deref() == Some("kickoff-ambiguous")
+                    && detail
+                        .snapshot
+                        .observation_reason
+                        .as_ref()
+                        .is_some_and(|reason| reason.as_str() == category)
+            }
+            (Some(category), "definitive-failure") => {
+                detail.snapshot.derived_status.as_deref() == Some("kickoff-failed")
+                    && detail
+                        .snapshot
+                        .observation_reason
+                        .as_ref()
+                        .is_some_and(|reason| reason.as_str() == category)
+            }
+            _ => false,
+        }
+}
+
+fn committed_transition_matches(
+    expected: &crate::source::tmux::LaneSnapshot,
+    expected_state: LaneLaunchState,
+    expected_category: Option<&str>,
+    actual: &crate::source::tmux::LaneSnapshot,
+) -> bool {
+    actual.generation_id == expected.generation_id
+        && actual.launch_operation_id == expected.launch_operation_id
+        && actual.executor_id == expected.executor_id
+        && actual.worker_effect_kind == expected.worker_effect_kind
+        && actual.revision == expected.revision.saturating_add(1)
+        && actual.durable_launch_state == expected_state
+        && match expected_category {
+            Some(category) => {
+                actual
+                    .exit_category
+                    .as_ref()
+                    .is_some_and(|actual| actual.as_str() == category)
+                    || actual
+                        .observation_reason
+                        .as_ref()
+                        .is_some_and(|actual| actual.as_str() == category)
+            }
+            None => true,
+        }
+}
+
+async fn transition_lane(
+    client: &DaemonClient,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+    launch_state: LaneLaunchState,
+    failure_category: Option<&str>,
+) -> Result<crate::source::tmux::LaneSnapshot> {
+    let input = LaneEvidenceMutation {
+        session: snapshot.session.clone(),
+        expected_revision: snapshot.revision,
+        generation_id: snapshot.generation_id.clone(),
+        launch_operation_id: snapshot.launch_operation_id.clone(),
+        launch_state,
+        failure_category: failure_category.map(BoundedCategory::new),
+        executor_id: snapshot.executor_id.clone(),
+        worker_effect_kind: snapshot.worker_effect_kind,
+    };
+    match client.update_lane_evidence(&input).await {
+        Ok(snapshot) => Ok(snapshot),
+        Err(error) => match client.lane_detail(&snapshot.session).await {
+            Ok(detail)
+                if committed_transition_matches(
+                    snapshot,
+                    launch_state,
+                    failure_category,
+                    &detail.snapshot,
+                ) =>
+            {
+                Ok(detail.snapshot)
+            }
+            _ => Err(error),
+        },
+    }
+}
+
+async fn finalize_existing_lane(args: &TmuxNewArgs, client: &DaemonClient) -> Result<()> {
+    let snapshot = client.lane_detail(&args.session).await?.snapshot;
+    if !matches!(
+        snapshot.durable_launch_state,
+        LaneLaunchState::IdentityVerified
+    ) {
+        let overlay = overlay_from_snapshot(&snapshot);
+        emit_lane_result(args, &snapshot, &overlay);
+        return if snapshot.worker_started == Some(true) {
+            Ok(())
+        } else {
+            Err("lane launch is retained without a confirmed worker".into())
+        };
+    }
+    match inspect_lane_markers(&args.session, &snapshot).await {
+        LaneInspection::Exact => {
+            let finalized =
+                transition_lane(client, &snapshot, LaneLaunchState::Launched, None).await?;
+            emit_lane_result(args, &finalized, &overlay_from_snapshot(&finalized));
+            Ok(())
+        }
+        LaneInspection::CommandTerminal(category) => {
+            let terminal = transition_lane(
+                client,
+                &snapshot,
+                LaneLaunchState::CommandSubmitAmbiguous,
+                Some(category),
+            )
+            .await?;
+            emit_lane_result(args, &terminal, &overlay_from_snapshot(&terminal));
+            Err("lane command submission proof is not exact".into())
+        }
+        LaneInspection::Observed(reason, conflict) => {
+            let overlay = r2_overlay(snapshot.worker_effect_kind, reason, conflict);
+            emit_lane_result(args, &snapshot, &overlay);
+            Err("lane worker proof is not exact".into())
+        }
+    }
+}
+
+fn delivery_failure_visibility(disposition: DiscordLaneDisposition) -> LaneVisibility {
+    match disposition {
+        DiscordLaneDisposition::DefinitiveFailure => LaneVisibility::DeliveryFailed,
+        DiscordLaneDisposition::AmbiguousAcceptance => LaneVisibility::Unverified,
+    }
+}
+fn discord_lane_category(error: &crate::discord::DiscordLaneError) -> BoundedCategory {
+    use crate::discord::DiscordLaneErrorCategory::*;
+    let category = match error.category {
+        ContentTooLong => "payload-too-large",
+
+        BadRequest => "bad-request",
+        Unauthorized => "unauthorized",
+        Forbidden => "forbidden",
+        NotFound => "not-found",
+        RateLimited => "rate-limited",
+        ArchivedOrNotWritable => "archived-or-not-writable",
+        Timeout => "timeout",
+        Transport => "transport",
+        MalformedSuccess => "malformed-success",
+        EmptyMessageId => "empty-message-id",
+        MissingMessageId => "missing-message-id",
+    };
+    BoundedCategory::new(category)
+}
+
+async fn deliver_kickoff(
+    args: &TmuxNewArgs,
+    client: &DaemonClient,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+    message: &str,
+    config: &AppConfig,
+) -> Result<crate::source::tmux::LaneSnapshot> {
+    let discord = DiscordClient::from_config(Arc::new(config.clone()))?;
+    match discord
+        .send_thread_with_receipt(
+            args.thread.as_deref().expect("validated lane thread"),
+            message,
+        )
+        .await
+    {
+        Ok(receipt) => {
+            let message_id = receipt.message_id;
+            let delivered_at = receipt.timestamp.to_string();
+            let mutation = LaneDeliveryMutation {
+                session: snapshot.session.clone(),
+                expected_revision: snapshot.revision,
+                workflow: None,
+                message_id: Some(message_id.clone()),
+                kind: Some("kickoff".into()),
+                delivered_at: Some(delivered_at.clone()),
+                visibility: LaneVisibility::Visible,
+                error_category: None,
+                disposition: Some("accepted".into()),
+                generation_id: snapshot.generation_id.clone(),
+                initial_kickoff: true,
+                kickoff_operation_id: Some(snapshot.kickoff_operation_id.clone()),
+            };
+            match client.record_lane_delivery(&mutation).await {
+                Ok(next) => Ok(next),
+                Err(error) => match client.lane_detail(&snapshot.session).await {
+                    Ok(detail)
+                        if kickoff_receipt_response_loss_matches(
+                            &detail,
+                            snapshot,
+                            Some(&message_id),
+                            Some(&delivered_at),
+                            LaneVisibility::Visible,
+                            None,
+                            "accepted",
+                        ) =>
+                    {
+                        Ok(detail.snapshot)
+                    }
+                    _ => Err(error),
+                },
+            }
+        }
+        Err(error) => {
+            let category = discord_lane_category(&error);
+            let visibility = delivery_failure_visibility(error.disposition);
+            let disposition = match error.disposition {
+                DiscordLaneDisposition::DefinitiveFailure => "definitive-failure",
+                DiscordLaneDisposition::AmbiguousAcceptance => "ambiguous-acceptance",
+            };
+            let mutation = LaneDeliveryMutation {
+                session: snapshot.session.clone(),
+                expected_revision: snapshot.revision,
+                workflow: None,
+                message_id: None,
+                kind: Some("kickoff".into()),
+                delivered_at: None,
+                visibility,
+                error_category: Some(category.clone()),
+                disposition: Some(disposition.into()),
+                generation_id: snapshot.generation_id.clone(),
+                initial_kickoff: true,
+                kickoff_operation_id: Some(snapshot.kickoff_operation_id.clone()),
+            };
+            let persisted = match client.record_lane_delivery(&mutation).await {
+                Ok(next) => next,
+                Err(error) => match client.lane_detail(&snapshot.session).await {
+                    Ok(detail)
+                        if kickoff_receipt_response_loss_matches(
+                            &detail,
+                            snapshot,
+                            None,
+                            None,
+                            visibility,
+                            Some(category.as_str()),
+                            disposition,
+                        ) =>
+                    {
+                        detail.snapshot
+                    }
+                    _ => return Err(error),
+                },
+            };
+            let overlay = kickoff_failure_overlay(&category, error.disposition);
+            emit_lane_result(args, &persisted, &overlay);
+            Err("lane kickoff delivery was not confirmed".into())
+        }
+    }
+}
+
+async fn launch_lane_session(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
+    validate_lane_args(&args)?;
+    let client = DaemonClient::from_config(config);
+    if let Ok(detail) = client.lane_detail(&args.session).await
+        && detail.snapshot.workflow != LaneWorkflow::Retired
+    {
+        if args.thread.as_deref() != detail.thread_id.as_deref() {
+            return Err("lane thread target conflicts with retained lane".into());
+        }
+        return finalize_existing_lane(&args, &client).await;
+    }
+    let registration = TmuxMonitorArgs::from_new_args(&args, config).into_registration(false);
+    let lane = new_lane_evidence(&args);
+    let input = LaneRegistrationInput {
+        registration,
+        generation_id: lane.generation_id.clone(),
+        kickoff_operation_id: lane.kickoff_operation_id.clone(),
+        launch_operation_id: lane.launch_operation_id.clone(),
+        executor_id: lane.executor_id.clone(),
+        worker_effect_kind: lane.worker_effect_kind,
+        thread_id: lane.thread_id.clone(),
+        expect_absent_or_retired: true,
+    };
+    let mut snapshot = match client.register_lane(&input).await {
+        Ok(detail) => detail.snapshot,
+        Err(error) => match client.lane_detail(&args.session).await {
+            Ok(detail) if register_response_loss_matches(&detail, &lane) => detail.snapshot,
+
+            _ => return Err(error),
+        },
+    };
+    if let Some(kickoff) = args.kickoff.as_deref() {
+        snapshot = deliver_kickoff(&args, &client, &snapshot, kickoff, config).await?;
+    }
+    snapshot = match client
+        .claim_lane(
+            &args.session,
+            &lane.generation_id,
+            &lane.executor_id,
+            snapshot.revision,
+        )
+        .await
+    {
+        Ok(claimed) => claimed,
+        Err(error) => match client.lane_detail(&args.session).await {
+            Ok(detail) if claim_response_loss_matches(&detail, &lane, snapshot.revision) => {
+                detail.snapshot
+            }
+            _ => return Err(error),
+        },
+    };
+    if snapshot.durable_launch_state != LaneLaunchState::Claimed {
+        return finalize_existing_lane(&args, &client).await;
+    }
+    match create_detached_lane_session(&args).await {
+        DetachedSessionOutcome::PreExecutionFailure => {
+            let state = if matches!(
+                snapshot.worker_effect_kind,
+                WorkerEffectKind::CommandSubmission
+            ) {
+                LaneLaunchState::NoWorkerEffect
+            } else {
+                LaneLaunchState::SessionCreationAmbiguous
+            };
+            let category = if matches!(
+                snapshot.worker_effect_kind,
+                WorkerEffectKind::CommandSubmission
+            ) {
+                "session-create-failed"
+            } else {
+                "owner-aborted-before-r2"
+            };
+            let terminal = transition_lane(&client, &snapshot, state, Some(category)).await?;
+            emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
+            return Err("lane tmux session creation failed".into());
+        }
+        DetachedSessionOutcome::PossiblyExecuted
+            if matches!(
+                snapshot.worker_effect_kind,
+                WorkerEffectKind::SessionCreation
+            ) =>
+        {
+            let terminal = transition_lane(
+                &client,
+                &snapshot,
+                LaneLaunchState::SessionCreationAmbiguous,
+                Some("owner-aborted-before-r2"),
+            )
+            .await?;
+            emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
+            return Err("lane tmux session creation outcome is ambiguous".into());
+        }
+        DetachedSessionOutcome::PossiblyExecuted | DetachedSessionOutcome::Created => {}
+    }
+    let identity_category = match write_lane_identity_markers(
+        &args.session,
+        &snapshot.generation_id,
+        &snapshot.launch_operation_id,
+    )
+    .await
+    {
+        IdentityProof::Exact => None,
+        IdentityProof::SetFailed => Some("identity-marker-set-failed"),
+        IdentityProof::ReadFailed => Some("identity-marker-read-failed"),
+        IdentityProof::Mismatch => Some("identity-marker-mismatch"),
+    };
+    if let Some(category) = identity_category {
+        let state = if matches!(
+            snapshot.worker_effect_kind,
+            WorkerEffectKind::CommandSubmission
+        ) {
+            LaneLaunchState::NoWorkerEffect
+        } else {
+            LaneLaunchState::SessionCreationAmbiguous
+        };
+        let terminal = transition_lane(&client, &snapshot, state, Some(category)).await?;
+        if matches!(
+            snapshot.worker_effect_kind,
+            WorkerEffectKind::CommandSubmission
+        ) {
+            cleanup_command_r1_session(&args.session).await;
+        }
+        emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
+        return Err("lane tmux identity marker proof failed".into());
+    }
+    snapshot = match transition_lane(&client, &snapshot, LaneLaunchState::IdentityVerified, None)
+        .await
+    {
+        Ok(committed) => committed,
+        Err(_) => match client.lane_detail(&args.session).await {
+            Ok(detail)
+                if committed_transition_matches(
+                    &snapshot,
+                    LaneLaunchState::IdentityVerified,
+                    None,
+                    &detail.snapshot,
+                ) =>
+            {
+                detail.snapshot
+            }
+            Ok(detail)
+                if detail.snapshot.generation_id == snapshot.generation_id
+                    && detail.snapshot.kickoff_operation_id == snapshot.kickoff_operation_id
+                    && detail.snapshot.launch_operation_id == snapshot.launch_operation_id
+                    && detail.snapshot.executor_id == snapshot.executor_id
+                    && detail.snapshot.worker_effect_kind == snapshot.worker_effect_kind
+                    && detail.thread_id == args.thread
+                    && detail.snapshot.durable_launch_state == LaneLaunchState::Claimed
+                    && detail.snapshot.revision == snapshot.revision =>
+            {
+                let state = if matches!(
+                    snapshot.worker_effect_kind,
+                    WorkerEffectKind::CommandSubmission
+                ) {
+                    LaneLaunchState::NoWorkerEffect
+                } else {
+                    LaneLaunchState::SessionCreationAmbiguous
+                };
+                if matches!(
+                    snapshot.worker_effect_kind,
+                    WorkerEffectKind::CommandSubmission
+                ) {
+                    cleanup_command_r1_session(&args.session).await;
+                }
+                let terminal = transition_lane(
+                    &client,
+                    &detail.snapshot,
+                    state,
+                    Some("r1-to-r2-persistence-failed-after-create"),
+                )
+                .await?;
+                emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
+                return Err("lane r1-to-r2 persistence failed after session creation".into());
+            }
+            _ => return Err("lane r1-to-r2 persistence outcome is unavailable".into()),
+        },
+    };
+    if snapshot.durable_launch_state == LaneLaunchState::Launched {
+        emit_lane_result(&args, &snapshot, &overlay_from_snapshot(&snapshot));
+        return Ok(());
+    }
+    match snapshot.worker_effect_kind {
+        WorkerEffectKind::SessionCreation => {
+            finalize_session_creation_owner(&args, &client, &snapshot).await
+        }
+        WorkerEffectKind::CommandSubmission => {
+            finalize_command_owner(&args, &client, &snapshot).await
+        }
+    }
+}
+const LANE_GENERATION_OPTION: &str = "@clawhip_lane_generation";
+const LANE_LAUNCH_OPERATION_OPTION: &str = "@clawhip_lane_launch_operation";
+const LANE_COMMAND_SUBMITTED_OPTION: &str = "@clawhip_lane_command_submitted";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdentityProof {
+    Exact,
+    SetFailed,
+    ReadFailed,
+    Mismatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MarkerRead {
+    Exact(String),
+    Missing,
+    Unreadable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LaneInspection {
+    Exact,
+    CommandTerminal(&'static str),
+    Observed(&'static str, bool),
+}
+
+fn normalize_lane_marker(value: &[u8]) -> String {
+    String::from_utf8_lossy(value).trim().to_string()
+}
+
+fn classify_submitted_value(value: Option<&str>, launch_operation_id: &str) -> LaneInspection {
+    match value.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(value) if value == launch_operation_id => LaneInspection::Exact,
+        Some(_) => LaneInspection::Observed("submitted-marker-mismatch", false),
+        None => LaneInspection::Observed("submitted-marker-missing", false),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarkerSetOutcome {
+    Confirmed,
+    PossiblyExecuted,
+    PreExecutionFailure,
+}
+
+async fn set_lane_marker(session: &str, option: &str, value: &str) -> MarkerSetOutcome {
+    let mut command = Command::new(tmux_bin());
+    command.args(["set-option", "-t", session, option, value]);
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(_) => return MarkerSetOutcome::PreExecutionFailure,
+    };
+    match child.wait_with_output().await {
+        Ok(output) if output.status.success() => MarkerSetOutcome::Confirmed,
+        Ok(_) | Err(_) => MarkerSetOutcome::PossiblyExecuted,
+    }
+}
+
+async fn read_lane_marker(session: &str, option: &str) -> MarkerRead {
+    match Command::new(tmux_bin())
+        .args(["show-options", "-v", "-t", session, option])
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => {
+            let value = normalize_lane_marker(&output.stdout);
+            if value.is_empty() {
+                MarkerRead::Missing
+            } else {
+                MarkerRead::Exact(value)
+            }
+        }
+        Ok(output)
+            if tmux_stderr(&output.stderr).contains("invalid option")
+                || tmux_stderr(&output.stderr).contains("not found") =>
+        {
+            MarkerRead::Missing
+        }
+        _ => MarkerRead::Unreadable,
+    }
+}
+
+async fn write_lane_identity_markers(
+    session: &str,
+    generation_id: &str,
+    operation_id: &str,
+) -> IdentityProof {
+    if matches!(
+        set_lane_marker(session, LANE_GENERATION_OPTION, generation_id).await,
+        MarkerSetOutcome::PreExecutionFailure
+    ) {
+        return IdentityProof::SetFailed;
+    }
+    match read_lane_marker(session, LANE_GENERATION_OPTION).await {
+        MarkerRead::Unreadable => return IdentityProof::ReadFailed,
+        MarkerRead::Exact(value) if value == generation_id => {}
+        MarkerRead::Missing | MarkerRead::Exact(_) => return IdentityProof::Mismatch,
+    }
+    if matches!(
+        set_lane_marker(session, LANE_LAUNCH_OPERATION_OPTION, operation_id).await,
+        MarkerSetOutcome::PreExecutionFailure
+    ) {
+        return IdentityProof::SetFailed;
+    }
+    match read_lane_marker(session, LANE_LAUNCH_OPERATION_OPTION).await {
+        MarkerRead::Unreadable => IdentityProof::ReadFailed,
+        MarkerRead::Exact(value) if value == operation_id => IdentityProof::Exact,
+        MarkerRead::Missing | MarkerRead::Exact(_) => IdentityProof::Mismatch,
+    }
+}
+
+async fn inspect_lane_markers(
+    session: &str,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+) -> LaneInspection {
+    match session_exists(session).await {
+        Err(_) => return LaneInspection::Observed("session-liveness-unavailable", false),
+        Ok(false) => return LaneInspection::Observed("session-missing", false),
+        Ok(true) => {}
+    }
+    match read_lane_marker(session, LANE_GENERATION_OPTION).await {
+        MarkerRead::Unreadable => return LaneInspection::Observed("identity-unreadable", false),
+        MarkerRead::Exact(value) if value == snapshot.generation_id => {}
+        MarkerRead::Missing | MarkerRead::Exact(_) => {
+            return LaneInspection::Observed("identity-mismatch", true);
+        }
+    }
+
+    match read_lane_marker(session, LANE_LAUNCH_OPERATION_OPTION).await {
+        MarkerRead::Unreadable => return LaneInspection::Observed("identity-unreadable", false),
+        MarkerRead::Exact(value) if value == snapshot.launch_operation_id => {}
+        MarkerRead::Missing | MarkerRead::Exact(_) => {
+            return LaneInspection::Observed("identity-mismatch", true);
+        }
+    }
+    match read_lane_marker(session, LANE_COMMAND_SUBMITTED_OPTION).await {
+        MarkerRead::Exact(value) => {
+            match classify_submitted_value(Some(&value), &snapshot.launch_operation_id) {
+                LaneInspection::Exact => LaneInspection::Exact,
+                LaneInspection::Observed("submitted-marker-mismatch", _)
+                    if matches!(
+                        snapshot.worker_effect_kind,
+                        WorkerEffectKind::CommandSubmission
+                    ) =>
+                {
+                    LaneInspection::CommandTerminal("submitted-marker-mismatch")
+                }
+                LaneInspection::Observed(reason, _) => LaneInspection::Observed(reason, false),
+                _ => unreachable!("submitted classifier is exhaustive"),
+            }
+        }
+        MarkerRead::Unreadable
+            if matches!(
+                snapshot.worker_effect_kind,
+                WorkerEffectKind::CommandSubmission
+            ) =>
+        {
+            LaneInspection::CommandTerminal("submitted-marker-read-failed")
+        }
+        MarkerRead::Unreadable => LaneInspection::Observed("submitted-marker-unreadable", false),
+        MarkerRead::Missing
+            if matches!(
+                snapshot.worker_effect_kind,
+                WorkerEffectKind::CommandSubmission
+            ) =>
+        {
+            LaneInspection::CommandTerminal("submitted-marker-missing")
+        }
+        MarkerRead::Missing => LaneInspection::Observed("submitted-marker-missing", false),
+    }
+}
+
+/// Read-only R2 inspector for lane status. It performs one sequential
+/// liveness/G/L/submitted observation and never writes options or effects.
+pub(crate) async fn inspect_lane_r2(
+    session: &str,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+) -> LaneInspectionResult {
+    match inspect_lane_markers(session, snapshot).await {
+        LaneInspection::Exact => {
+            let mut result = overlay_from_snapshot(snapshot);
+            result.runtime = "live";
+            result
+        }
+        LaneInspection::CommandTerminal(category) => {
+            r2_overlay(WorkerEffectKind::CommandSubmission, category, false)
+        }
+        LaneInspection::Observed(reason, conflict) => {
+            r2_overlay(snapshot.worker_effect_kind, reason, conflict)
+        }
+    }
+}
+
+async fn finalize_command_owner(
+    args: &TmuxNewArgs,
+    client: &DaemonClient,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+) -> Result<()> {
+    let command = build_command_to_send(args).unwrap_or_default();
+    if submit_lane_command_once(&args.session, &command)
+        .await
+        .is_err()
+    {
+        let terminal = transition_lane(
+            client,
+            snapshot,
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some("submission-attempt-error"),
+        )
+        .await?;
+        emit_lane_result(args, &terminal, &overlay_from_snapshot(&terminal));
+        return Err("lane command submission outcome is ambiguous".into());
+    }
+    let set_result = set_lane_marker(
+        &args.session,
+        LANE_COMMAND_SUBMITTED_OPTION,
+        &snapshot.launch_operation_id,
+    )
+    .await;
+    if matches!(set_result, MarkerSetOutcome::PreExecutionFailure) {
+        let terminal = transition_lane(
+            client,
+            snapshot,
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some("submitted-marker-set-failed"),
+        )
+        .await?;
+        emit_lane_result(args, &terminal, &overlay_from_snapshot(&terminal));
+        return Err("lane command submission marker failed".into());
+    }
+
+    match read_lane_marker(&args.session, LANE_COMMAND_SUBMITTED_OPTION).await {
+        MarkerRead::Exact(value) if value == snapshot.launch_operation_id => {
+            let finalized =
+                transition_lane(client, snapshot, LaneLaunchState::Launched, None).await?;
+            emit_lane_result(args, &finalized, &overlay_from_snapshot(&finalized));
+            Ok(())
+        }
+        MarkerRead::Unreadable => {
+            command_marker_terminal(args, client, snapshot, "submitted-marker-read-failed").await
+        }
+        MarkerRead::Missing => {
+            command_marker_terminal(args, client, snapshot, "submitted-marker-missing").await
+        }
+        MarkerRead::Exact(_) => {
+            command_marker_terminal(args, client, snapshot, "submitted-marker-mismatch").await
+        }
+    }
+}
+
+async fn command_marker_terminal(
+    args: &TmuxNewArgs,
+    client: &DaemonClient,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+    category: &str,
+) -> Result<()> {
+    let terminal = transition_lane(
+        client,
+        snapshot,
+        LaneLaunchState::CommandSubmitAmbiguous,
+        Some(category),
+    )
+    .await?;
+    emit_lane_result(args, &terminal, &overlay_from_snapshot(&terminal));
+    Err("lane command submission proof is not exact".into())
+}
+
+async fn finalize_session_creation_owner(
+    args: &TmuxNewArgs,
+    client: &DaemonClient,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+) -> Result<()> {
+    if matches!(
+        set_lane_marker(
+            &args.session,
+            LANE_COMMAND_SUBMITTED_OPTION,
+            &snapshot.launch_operation_id
+        )
+        .await,
+        MarkerSetOutcome::PreExecutionFailure
+    ) {
+        return session_uncommitted(args, snapshot, "submitted-marker-set-failed");
+    }
+    match read_lane_marker(&args.session, LANE_COMMAND_SUBMITTED_OPTION).await {
+        MarkerRead::Exact(value) if value == snapshot.launch_operation_id => {
+            let finalized =
+                transition_lane(client, snapshot, LaneLaunchState::Launched, None).await?;
+            emit_lane_result(args, &finalized, &overlay_from_snapshot(&finalized));
+            Ok(())
+        }
+        MarkerRead::Unreadable => {
+            session_uncommitted(args, snapshot, "submitted-marker-unreadable")
+        }
+        MarkerRead::Missing => session_uncommitted(args, snapshot, "submitted-marker-missing"),
+        MarkerRead::Exact(_) => session_uncommitted(args, snapshot, "submitted-marker-mismatch"),
+    }
+}
+
+fn session_uncommitted(
+    args: &TmuxNewArgs,
+    snapshot: &crate::source::tmux::LaneSnapshot,
+    reason: &str,
+) -> Result<()> {
+    let overlay = r2_overlay(WorkerEffectKind::SessionCreation, reason, false);
+    emit_lane_result(args, snapshot, &overlay);
+    Err("lane session creation proof is not exact".into())
+}
+
+async fn cleanup_command_r1_session(session: &str) {
+    let _ = Command::new(tmux_bin())
+        .args(["kill-session", "-t", session])
+        .output()
+        .await;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetachedSessionOutcome {
+    Created,
+    PossiblyExecuted,
+    PreExecutionFailure,
+}
+
+async fn create_detached_lane_session(args: &TmuxNewArgs) -> DetachedSessionOutcome {
+    let mut command = Command::new(tmux_bin());
+    command
+        .arg("new-session")
+        .arg("-d")
+        .arg("-s")
+        .arg(&args.session);
+    if let Some(window_name) = &args.window_name {
+        command.arg("-n").arg(window_name);
+    }
+    if let Some(cwd) = &args.cwd {
+        command.arg("-c").arg(cwd);
+    }
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(_) => return DetachedSessionOutcome::PreExecutionFailure,
+    };
+    match child.wait_with_output().await {
+        Ok(output) if output.status.success() => DetachedSessionOutcome::Created,
+        Ok(_) | Err(_) => DetachedSessionOutcome::PossiblyExecuted,
+    }
+}
+
+async fn submit_lane_command_once(session: &str, command: &str) -> Result<()> {
+    // Once a send-keys invocation starts its outcome is ambiguous on failure.
+    send_command_to_session(session, command).await
 }
 
 async fn send_command_to_session(session: &str, command: &str) -> Result<()> {
@@ -530,6 +1586,10 @@ mod tests {
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
             shell: None,
+            thread: None,
+            kickoff: None,
+            json: false,
+
             command: vec![
                 "zsh".into(),
                 "-c".into(),
@@ -560,6 +1620,10 @@ mod tests {
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
             shell: Some("/bin/zsh".into()),
+            thread: None,
+            kickoff: None,
+            json: false,
+
             command: vec!["source ~/.zshrc && omx --madmax".into()],
         };
 
@@ -586,6 +1650,10 @@ mod tests {
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
             shell: None,
+            thread: None,
+            kickoff: None,
+            json: false,
+
             command: vec!["source ~/.zshrc && omx --madmax".into()],
         };
 
@@ -612,6 +1680,10 @@ mod tests {
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
             shell: None,
+            thread: None,
+            kickoff: None,
+            json: false,
+
             command: vec!["false".into()],
         };
 
@@ -736,6 +1808,7 @@ mod tests {
                 name: Some("codex".into()),
             }),
             active_wrapper_monitor: true,
+            lane: None,
         });
 
         assert!(log.contains("session=issue-105"));
@@ -766,6 +1839,10 @@ mod tests {
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
             shell: None,
+            thread: None,
+            kickoff: None,
+            json: false,
+
             command: vec!["codex".into()],
         };
         let config = AppConfig {
@@ -816,6 +1893,10 @@ mod tests {
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
             shell: None,
+            thread: None,
+            kickoff: None,
+            json: false,
+
             command: vec!["codex".into()],
         };
         let repo_name = repo
@@ -876,6 +1957,9 @@ mod tests {
             retry_enter_count: crate::cli::DEFAULT_RETRY_ENTER_COUNT,
             retry_enter_delay_ms: crate::cli::DEFAULT_RETRY_ENTER_DELAY_MS,
             shell: None,
+            thread: None,
+            kickoff: None,
+            json: false,
             command: vec!["codex".into()],
         };
         let config = AppConfig {
@@ -1003,5 +2087,254 @@ mod tests {
             metadata.worktree_path.as_deref() != metadata.repo_path.as_deref(),
             "worktree_path and repo_path must differ for a worktree checkout"
         );
+    }
+    #[test]
+    fn submitted_marker_normalization_canonicalizes_absent_unset_and_empty() {
+        assert_eq!(
+            classify_submitted_value(None, "L"),
+            LaneInspection::Observed("submitted-marker-missing", false)
+        );
+        assert_eq!(
+            classify_submitted_value(Some(""), "L"),
+            LaneInspection::Observed("submitted-marker-missing", false)
+        );
+        assert_eq!(
+            classify_submitted_value(Some(" \n"), "L"),
+            LaneInspection::Observed("submitted-marker-missing", false)
+        );
+        assert_eq!(
+            classify_submitted_value(Some("other"), "L"),
+            LaneInspection::Observed("submitted-marker-mismatch", false)
+        );
+        assert_eq!(
+            classify_submitted_value(Some("L"), "L"),
+            LaneInspection::Exact
+        );
+    }
+
+    #[test]
+    fn durable_launch_state_mapper_uses_canonical_terminal_names() {
+        assert_eq!(
+            durable_launch_state_name(LaneLaunchState::NoWorkerEffect),
+            "launch-failed-no-worker-effect"
+        );
+        assert_eq!(
+            durable_launch_state_name(LaneLaunchState::SessionCreationAmbiguous),
+            "blocked-session-creation-ambiguous"
+        );
+        assert_eq!(
+            durable_launch_state_name(LaneLaunchState::CommandSubmitAmbiguous),
+            "blocked-command-submit-ambiguous"
+        );
+    }
+
+    #[test]
+    fn kickoff_failure_overlay_uses_timeout_for_ambiguous_evidence() {
+        let category = BoundedCategory::new("timeout");
+        let overlay =
+            kickoff_failure_overlay(&category, DiscordLaneDisposition::AmbiguousAcceptance);
+        assert_eq!(overlay.derived_status.as_deref(), Some("kickoff-ambiguous"));
+        assert_eq!(overlay.observation_reason.as_deref(), Some("timeout"));
+        assert_eq!(overlay.exit_category.as_deref(), Some("timeout"));
+        assert!(overlay.evidence_commit);
+        assert_eq!(overlay.worker_started, None);
+    }
+
+    #[test]
+    fn kickoff_failure_overlay_uses_malformed_success_for_definitive_evidence() {
+        let category = BoundedCategory::new("malformed-success");
+        let overlay = kickoff_failure_overlay(&category, DiscordLaneDisposition::DefinitiveFailure);
+        assert_eq!(overlay.derived_status.as_deref(), Some("kickoff-failed"));
+        assert_eq!(
+            overlay.observation_reason.as_deref(),
+            Some("malformed-success")
+        );
+        assert_eq!(overlay.exit_category.as_deref(), Some("malformed-success"));
+        assert!(overlay.evidence_commit);
+        assert!(!overlay.healthy);
+    }
+
+    fn response_loss_snapshot(
+        state: LaneLaunchState,
+        category: Option<&str>,
+    ) -> crate::source::tmux::LaneSnapshot {
+        crate::source::tmux::LaneSnapshot {
+            session: "lane".into(),
+            generation_id: "G".into(),
+            kickoff_operation_id: "K".into(),
+            launch_operation_id: "L".into(),
+            executor_id: "E".into(),
+            worker_effect_kind: WorkerEffectKind::CommandSubmission,
+            durable_launch_state: state,
+            derived_status: None,
+            observation_reason: category.map(crate::source::tmux::BoundedReason::new),
+            worker_started: None,
+            evidence_commit: false,
+            repair_needed: true,
+            healthy: false,
+            exit_category: category.map(BoundedCategory::new),
+            workflow: LaneWorkflow::Active,
+            visibility: None,
+            revision: 2,
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+        }
+    }
+    fn response_loss_expected_snapshot() -> crate::source::tmux::LaneSnapshot {
+        let mut snapshot = response_loss_snapshot(LaneLaunchState::Claimed, None);
+        snapshot.revision = 1;
+        snapshot
+    }
+
+    #[test]
+    fn response_loss_matchers_reject_stale_or_progressed_rows() {
+        let lane = LaneEvidence {
+            lane_version: 1,
+            generation_id: "G".into(),
+            kickoff_operation_id: "K".into(),
+            launch_operation_id: "L".into(),
+            executor_id: "E".into(),
+            worker_effect_kind: WorkerEffectKind::CommandSubmission,
+            launch_state: LaneLaunchState::Ready,
+            workflow: LaneWorkflow::Active,
+            revision: 0,
+            quiesced: false,
+            thread_id: None,
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            visibility: Some(LaneVisibility::Unverified),
+            verification: None,
+            last_failure: None,
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+            delivery_retry_count: 0,
+            delivery_disposition: None,
+        };
+        let mut ready = response_loss_snapshot(LaneLaunchState::Ready, None);
+        ready.revision = 0;
+        ready.visibility = Some(LaneVisibility::Unverified);
+        let detail = crate::source::tmux::LaneDetail {
+            snapshot: ready.clone(),
+            thread_id: None,
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            verification: None,
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+            last_error: None,
+            quiesced: false,
+        };
+        assert!(register_response_loss_matches(&detail, &lane));
+        let stale = crate::source::tmux::LaneDetail {
+            snapshot: response_loss_snapshot(LaneLaunchState::Ready, None),
+            ..detail.clone()
+        };
+        assert!(!register_response_loss_matches(&stale, &lane));
+        let progressed = crate::source::tmux::LaneDetail {
+            snapshot: response_loss_snapshot(LaneLaunchState::IdentityVerified, None),
+            ..detail
+        };
+        assert!(!claim_response_loss_matches(&progressed, &lane, 1));
+    }
+
+    #[test]
+    fn typed_effect_outcomes_keep_post_spawn_ambiguity_distinct() {
+        assert_ne!(
+            DetachedSessionOutcome::PreExecutionFailure,
+            DetachedSessionOutcome::PossiblyExecuted
+        );
+        assert_ne!(
+            MarkerSetOutcome::PreExecutionFailure,
+            MarkerSetOutcome::PossiblyExecuted
+        );
+    }
+
+    #[test]
+    fn response_loss_accepts_same_immutable_committed_transition() {
+        let snapshot = response_loss_snapshot(
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some("submission-attempt-error"),
+        );
+        assert!(committed_transition_matches(
+            &response_loss_expected_snapshot(),
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some("submission-attempt-error"),
+            &snapshot
+        ));
+    }
+
+    #[test]
+    fn response_loss_rejects_uncommitted_or_different_terminal_category() {
+        let claimed = response_loss_snapshot(LaneLaunchState::Claimed, None);
+        assert!(!committed_transition_matches(
+            &response_loss_expected_snapshot(),
+            LaneLaunchState::Launched,
+            None,
+            &claimed
+        ));
+        let different = response_loss_snapshot(
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some("submitted-marker-missing"),
+        );
+        assert!(!committed_transition_matches(
+            &response_loss_expected_snapshot(),
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some("submission-attempt-error"),
+            &different
+        ));
+        let mut progressed = response_loss_snapshot(
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some("submission-attempt-error"),
+        );
+        progressed.revision = 3;
+        assert!(!committed_transition_matches(
+            &response_loss_expected_snapshot(),
+            LaneLaunchState::CommandSubmitAmbiguous,
+            Some("submission-attempt-error"),
+            &progressed
+        ));
+    }
+
+    #[test]
+    fn kickoff_failure_partitions_definitive_and_ambiguous_visibility() {
+        assert_eq!(
+            delivery_failure_visibility(DiscordLaneDisposition::DefinitiveFailure),
+            LaneVisibility::DeliveryFailed,
+        );
+        assert_eq!(
+            delivery_failure_visibility(DiscordLaneDisposition::AmbiguousAcceptance),
+            LaneVisibility::Unverified,
+        );
+    }
+    #[test]
+    fn launch_json_extension_is_privacy_safe_and_complete() {
+        let value = serde_json::json!({
+            "thread_id": "thread-1",
+            "kickoff_message_id": "message-1",
+            "kickoff_delivered_at": "2026-07-11T00:00:00Z",
+            "watch_registered": true,
+            "visibility": "visible",
+            "workflow": "active",
+            "runtime": "live",
+        });
+        for field in [
+            "thread_id",
+            "kickoff_message_id",
+            "kickoff_delivered_at",
+            "watch_registered",
+            "visibility",
+            "workflow",
+            "runtime",
+        ] {
+            assert!(value.get(field).is_some(), "missing {field}");
+        }
+        let serialized = value.to_string();
+        assert!(!serialized.contains("token"));
+        assert!(!serialized.contains("message body"));
     }
 }

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -1,0 +1,1534 @@
+//! Process-level proof for the lane state/effect protocol.  The fixture deliberately
+//! records only operation names and counters: credentials and Discord bodies are never
+//! persisted or printed by this test.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use serial_test::serial;
+use tempfile::TempDir;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clawhip")
+}
+
+fn write_file(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(path, body).expect("write fixture");
+}
+
+fn executable(path: &Path, body: &str) {
+    write_file(path, body);
+    let mut mode = fs::metadata(path).expect("metadata").permissions();
+    mode.set_mode(0o755);
+    fs::set_permissions(path, mode).expect("chmod");
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind port")
+        .local_addr()
+        .expect("address")
+        .port()
+}
+
+fn output(command: &mut Command) -> Output {
+    command.output().expect("run clawhip")
+}
+
+fn text(output: &Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn successful(output: &Output) {
+    assert!(
+        output.status.success(),
+        "status={:?}; output={}",
+        output.status.code(),
+        text(output)
+    );
+}
+
+fn failed(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "unexpected success: {}",
+        text(output)
+    );
+}
+
+struct Daemon(Child);
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+struct MockDiscord {
+    port: u16,
+    calls: Arc<Mutex<Vec<String>>>,
+    alive: Arc<AtomicBool>,
+    join: Option<thread::JoinHandle<()>>,
+}
+impl MockDiscord {
+    fn start(mode: &'static str) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind Discord mock");
+        listener.set_nonblocking(true).expect("nonblocking");
+        let port = listener.local_addr().expect("mock address").port();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let alive = Arc::new(AtomicBool::new(true));
+        let thread_calls = Arc::clone(&calls);
+        let thread_alive = Arc::clone(&alive);
+        let join = thread::spawn(move || {
+            while thread_alive.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut bytes = [0; 4096];
+                        let read = stream.read(&mut bytes).unwrap_or(0);
+                        let line = String::from_utf8_lossy(&bytes[..read])
+                            .lines()
+                            .next()
+                            .unwrap_or("")
+                            .to_owned();
+                        thread_calls.lock().expect("calls").push(line.clone());
+                        if mode == "timeout" {
+                            thread::sleep(Duration::from_secs(6));
+                            continue;
+                        }
+                        let response = if line.starts_with("POST") && mode == "malformed" {
+                            "HTTP/1.1 200 OK\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx"
+                        } else if line.starts_with("POST") {
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 62\r\nConnection: close\r\n\r\n{\"id\":\"987654321098765432\",\"timestamp\":\"2026-01-01T00:00:00Z\"}"
+                        } else if mode == "receipt" && line.contains("/messages/987654321098765432")
+                        {
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 27\r\nConnection: close\r\n\r\n{\"id\":\"987654321098765432\"}"
+                        } else if line.contains("messages?limit=1") {
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n[]"
+                        } else {
+                            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}"
+                        };
+                        let _ = stream.write_all(response.as_bytes());
+                        let _ = stream.shutdown(Shutdown::Both);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10))
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        Self {
+            port,
+            calls,
+            alive,
+            join: Some(join),
+        }
+    }
+    fn api_base(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+    fn count(&self, method: &str) -> usize {
+        self.calls
+            .lock()
+            .expect("calls")
+            .iter()
+            .filter(|line| line.starts_with(method))
+            .count()
+    }
+    fn count_path(&self, needle: &str) -> usize {
+        self.calls
+            .lock()
+            .expect("calls")
+            .iter()
+            .filter(|line| line.contains(needle))
+            .count()
+    }
+}
+impl Drop for MockDiscord {
+    fn drop(&mut self) {
+        self.alive.store(false, Ordering::SeqCst);
+        let _ = TcpStream::connect(("127.0.0.1", self.port));
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+struct ResponseLossProxy {
+    port: u16,
+    paths: Arc<Mutex<Vec<String>>>,
+    alive: Arc<AtomicBool>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl ResponseLossProxy {
+    fn start(backend_port: u16, drop_path: &'static str, drop_occurrence: usize) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind response-loss proxy");
+        listener.set_nonblocking(true).expect("nonblocking proxy");
+        let port = listener.local_addr().expect("proxy address").port();
+        let paths = Arc::new(Mutex::new(Vec::new()));
+        let alive = Arc::new(AtomicBool::new(true));
+        let thread_paths = Arc::clone(&paths);
+        let thread_alive = Arc::clone(&alive);
+        let join = thread::spawn(move || {
+            let mut occurrences = HashMap::<String, usize>::new();
+            while thread_alive.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((mut client, _)) => {
+                        let request = read_http_message(&mut client).expect("proxy request");
+                        let line = request.lines().next().unwrap_or("");
+                        let path = line.split_whitespace().nth(1).unwrap_or("").to_owned();
+                        thread_paths.lock().expect("proxy paths").push(path.clone());
+                        let occurrence = occurrences.entry(path.clone()).or_default();
+                        *occurrence += 1;
+                        let mut backend =
+                            TcpStream::connect(("127.0.0.1", backend_port)).expect("proxy backend");
+                        backend
+                            .write_all(request.as_bytes())
+                            .expect("forward request");
+                        let response = read_http_message(&mut backend).expect("backend response");
+                        if path == drop_path && *occurrence == drop_occurrence {
+                            continue;
+                        }
+                        let _ = client.write_all(response.as_bytes());
+                        let _ = client.shutdown(Shutdown::Both);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10))
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        Self {
+            port,
+            paths,
+            alive,
+            join: Some(join),
+        }
+    }
+
+    fn path_count(&self, path: &str) -> usize {
+        self.paths
+            .lock()
+            .expect("proxy paths")
+            .iter()
+            .filter(|value| value.as_str() == path)
+            .count()
+    }
+}
+
+impl Drop for ResponseLossProxy {
+    fn drop(&mut self) {
+        self.alive.store(false, Ordering::SeqCst);
+        let _ = TcpStream::connect(("127.0.0.1", self.port));
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+fn read_http_message(stream: &mut TcpStream) -> std::io::Result<String> {
+    stream.set_read_timeout(Some(Duration::from_secs(8)))?;
+    let mut bytes = Vec::new();
+    let mut chunk = [0; 4096];
+    let header_end = loop {
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            return Ok(String::from_utf8_lossy(&bytes).into_owned());
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+        if let Some(end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break end + 4;
+        }
+    };
+    let headers = String::from_utf8_lossy(&bytes[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Content-Length:")
+                .or_else(|| line.strip_prefix("content-length:"))
+                .and_then(|value| value.trim().parse::<usize>().ok())
+        })
+        .unwrap_or(0);
+    while bytes.len() < header_end + content_length {
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn fake_tmux(path: &Path, state: &Path) {
+    let quoted = state.display().to_string().replace('\'', "'\\''");
+    executable(
+        path,
+        &format!(
+            r#"#!/usr/bin/env bash
+set -eu
+S='{quoted}'
+mkdir -p "$S"
+printf '%s\n' "$1" >> "$S/calls"
+case "$1" in
+  new-session) test -f "$S/fail_new_session" && exit 1; session=""; while [ $# -gt 0 ]; do case "$1" in -s) session="$2"; shift 2 ;; *) shift ;; esac; done; printf '%s' "$session" > "$S/session"; printf '1' > "$S/live" ;;
+  has-session) test -f "$S/live" ;;
+  set-option) key="$4"; value="$5"; test "$key" = "@clawhip_lane_generation" && test -f "$S/fail_generation_set" && exit 1; printf '%s' "$value" > "$S/${{key#@}}"; test "$key" = "@clawhip_lane_generation" && test -f "$S/mismatch_generation" && printf 'different-generation' > "$S/${{key#@}}" ;;
+  show-options) key="$5"; safe="${{key#@}}"; test -f "$S/unreadable_$safe" && exit 1; file="$S/$safe"; if test -f "$file"; then printf '%s\n' "$(cat "$file")"; else echo 'invalid option' >&2; exit 1; fi ;;
+  send-keys) test "${{4:-}}" = "-l" || printf '1' >> "$S/sends" ;;
+  display-message) printf 'lane\t%%1\t1\tcodex\t/tmp\n' ;;
+  kill-session) rm -f "$S/live" ;;
+  list-sessions) test -f "$S/live" && test -f "$S/session" && cat "$S/session" ;;
+  *) : ;;
+esac
+"#
+        ),
+    );
+}
+
+fn config(path: &Path, port: u16) {
+    write_file(
+        path,
+        &format!(
+            "[daemon]\nbind_host = \"127.0.0.1\"\nport = {port}\nbase_url = \"http://127.0.0.1:{port}\"\n\n[providers.discord]\ntoken = \"fixture-token\"\n\n[defaults]\nformat = \"compact\"\n"
+        ),
+    );
+}
+
+fn config_with_base_url(path: &Path, port: u16, base_port: u16) {
+    write_file(
+        path,
+        &format!(
+            "[daemon]\nbind_host = \"127.0.0.1\"\nport = {port}\nbase_url = \"http://127.0.0.1:{base_port}\"\n\n[providers.discord]\ntoken = \"fixture-token\"\n\n[defaults]\nformat = \"compact\"\n"
+        ),
+    );
+}
+
+fn start(config_path: &Path, home: &Path, tmux: &Path, discord: &MockDiscord, port: u16) -> Daemon {
+    let child = Command::new(bin())
+        .arg("--config")
+        .arg(config_path)
+        .arg("start")
+        .arg("--port")
+        .arg(port.to_string())
+        .env("HOME", home)
+        .env("CLAWHIP_TMUX_BIN", tmux)
+        .env("CLAWHIP_DISCORD_API_BASE", discord.api_base())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start daemon");
+    let deadline = Instant::now() + Duration::from_secs(8);
+    while Instant::now() < deadline {
+        if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) {
+            let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
+            let _ = stream
+                .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+            let mut response = String::new();
+            let _ = stream.read_to_string(&mut response);
+            if response.starts_with("HTTP/1.1 200") {
+                return Daemon(child);
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("daemon did not become healthy");
+}
+
+fn lane_command(
+    config: &Path,
+    home: &Path,
+    tmux: &Path,
+    discord: &MockDiscord,
+    args: &[&str],
+) -> Output {
+    output(
+        Command::new(bin())
+            .arg("--config")
+            .arg(config)
+            .args(args)
+            .env("HOME", home)
+            .env("CLAWHIP_TMUX_BIN", tmux)
+            .env("CLAWHIP_DISCORD_API_BASE", discord.api_base()),
+    )
+}
+
+fn registry_path(config: &Path) -> std::path::PathBuf {
+    config
+        .parent()
+        .expect("config parent")
+        .join("tmux-watch-registry.json")
+}
+
+fn registry(config: &Path) -> Value {
+    serde_json::from_slice(&fs::read(registry_path(config)).expect("registry bytes"))
+        .expect("registry json")
+}
+
+fn assert_marker_gate(command_effect: bool, marker: &str, value: Option<&str>, unreadable: bool) {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let session = if command_effect {
+        "marker-command"
+    } else {
+        "marker-create"
+    };
+    let generation_id = format!("generation-{session}");
+    let kickoff_operation_id = format!("kickoff-{session}");
+    let launch_operation_id = format!("launch-{session}");
+    let executor_id = format!("executor-{session}");
+    let worker_effect_kind = if command_effect {
+        "command-submission"
+    } else {
+        "session-creation"
+    };
+    write_file(&state.join("live"), "1");
+    write_file(&state.join("session"), session);
+    write_file(&state.join("clawhip_lane_generation"), &generation_id);
+    write_file(
+        &state.join("clawhip_lane_launch_operation"),
+        &launch_operation_id,
+    );
+    let marker_path = state.join(marker);
+    if let Some(value) = value {
+        write_file(&marker_path, value);
+    } else {
+        let _ = fs::remove_file(&marker_path);
+    }
+    if unreadable {
+        write_file(&state.join(format!("unreadable_{marker}")), "1");
+    }
+    let registered = http_json_value(
+        port,
+        "POST",
+        "/api/lane/register",
+        json!({
+            "registration": {"session":session,"channel":null,"mention":null,"keywords":[],"keyword_window_secs":30,"stale_minutes":10,"format":null,"active_wrapper_monitor":false},
+            "generation_id":generation_id,"kickoff_operation_id":kickoff_operation_id,"launch_operation_id":launch_operation_id,"executor_id":executor_id,"worker_effect_kind":worker_effect_kind,"thread_id":"123456789012345678","expect_absent_or_retired":true
+        }),
+    );
+    let claimed = http_json_value(
+        port,
+        "POST",
+        "/api/lane/claim",
+        json!({
+            "session":session,"generation_id":generation_id,"executor_id":executor_id,"expected_revision":registered["snapshot"]["revision"]
+        }),
+    );
+    let identity_verified = http_json_value(
+        port,
+        "POST",
+        "/api/lane/evidence",
+        json!({
+            "session":session,"generation_id":generation_id,"launch_operation_id":launch_operation_id,"expected_revision":claimed["revision"],"launch_state":"identity-verified","failure_category":null,"executor_id":executor_id,"worker_effect_kind":worker_effect_kind
+        }),
+    );
+    assert_eq!(
+        identity_verified["durable_launch_state"],
+        "identity-verified"
+    );
+    let mut args = vec![
+        "tmux",
+        "new",
+        "--session",
+        session,
+        "--thread",
+        "123456789012345678",
+        "--json",
+    ];
+    if command_effect {
+        args.extend(["--", "worker"]);
+    }
+    let baseline = fs::read_to_string(state.join("calls")).unwrap_or_default();
+    let inspected = lane_command(&config_path, &home, &tmux, &discord, &args);
+    failed(&inspected);
+    let json: Value = serde_json::from_slice(&inspected.stdout).expect("inspector json");
+    let expected = if unreadable {
+        if command_effect {
+            "submitted-marker-read-failed"
+        } else {
+            "submitted-marker-unreadable"
+        }
+    } else if value.is_some_and(|v| v.is_empty()) || value.is_none() {
+        "submitted-marker-missing"
+    } else {
+        "submitted-marker-mismatch"
+    };
+    assert_eq!(json["exit_category"], expected);
+    if command_effect {
+        assert_eq!(
+            registry(&config_path)[session]["lane"]["launch_state"],
+            "command-submit-ambiguous",
+            "daemon serializes the R2 terminal transition before returning"
+        );
+    }
+    let delta = calls_after(&state, &baseline);
+    assert_eq!(command_count(&delta, "has-session"), 1);
+    assert_eq!(
+        command_count(&delta, "show-options"),
+        3,
+        "inspector reads G/L/submitted exactly once"
+    );
+    assert!(
+        !delta
+            .lines()
+            .any(|call| matches!(call, "send-keys" | "set-option")),
+        "restart inspection must not write markers or submit work"
+    );
+}
+
+fn http_json(port: u16, method: &str, path: &str, body: Value) -> String {
+    let payload = serde_json::to_string(&body).expect("request json");
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect daemon");
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .expect("write daemon request");
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("read daemon response");
+    response
+}
+
+fn http_json_value(port: u16, method: &str, path: &str, body: Value) -> Value {
+    let response = http_json(port, method, path, body);
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "daemon endpoint rejected fixture request"
+    );
+    let payload = response
+        .split_once("\r\n\r\n")
+        .expect("HTTP response body")
+        .1;
+    serde_json::from_str(payload).expect("daemon JSON response")
+}
+
+fn calls_after(state: &Path, baseline: &str) -> String {
+    let calls = fs::read_to_string(state.join("calls")).unwrap_or_default();
+    calls
+        .strip_prefix(baseline)
+        .expect("tmux call log is append-only")
+        .to_owned()
+}
+
+fn command_count(calls: &str, command: &str) -> usize {
+    calls.lines().filter(|call| *call == command).count()
+}
+
+fn count(path: &Path, name: &str) -> usize {
+    fs::read_to_string(path.join(name))
+        .unwrap_or_default()
+        .lines()
+        .count()
+}
+
+#[test]
+#[serial]
+fn kickoff_command_launch_persists_receipts_markers_and_reloadable_status() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let result = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "lane-success",
+            "--thread",
+            "123456789012345678",
+            "--kickoff",
+            "fixture kickoff",
+            "--json",
+            "--",
+            "worker",
+        ],
+    );
+    successful(&result);
+    let json: Value = serde_json::from_slice(&result.stdout).expect("launch json");
+    assert_eq!(json["durable_launch_state"], "launched");
+    assert!(json.get("exit_category").is_some_and(Value::is_null));
+    assert_eq!(discord.count("POST"), 1);
+    assert_eq!(count(&state, "sends"), 1);
+    assert!(state.join("clawhip_lane_generation").is_file());
+    assert!(state.join("clawhip_lane_launch_operation").is_file());
+    assert_eq!(
+        fs::read_to_string(state.join("clawhip_lane_command_submitted"))
+            .expect("submitted")
+            .trim(),
+        json["launch_operation_id"].as_str().expect("L")
+    );
+    let durable = registry(&config_path);
+    assert!(durable.to_string().contains("kickoff_message_id"));
+    let status = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &["lane", "status", "--session", "lane-success", "--json"],
+    );
+    successful(&status);
+    let public = String::from_utf8_lossy(&status.stdout);
+    assert!(!public.contains("123456789012345678"));
+}
+
+#[test]
+#[serial]
+fn session_creation_and_restart_inspection_do_not_send_commands_or_kickoff_twice() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let first = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "lane-create",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    );
+    successful(&first);
+    let snapshot: Value = serde_json::from_slice(&first.stdout).expect("json");
+    assert_eq!(snapshot["worker_effect_kind"], "session-creation");
+    assert_eq!(count(&state, "sends"), 0);
+    assert_eq!(discord.count("POST"), 0);
+    let baseline = fs::read_to_string(state.join("calls")).unwrap_or_default();
+    let restart = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "lane-create",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    );
+    successful(&restart);
+    assert_eq!(discord.count("POST"), 0);
+    let delta = calls_after(&state, &baseline);
+    assert!(
+        !delta
+            .lines()
+            .any(|call| matches!(call, "new-session" | "set-option" | "send-keys")),
+        "restart inspector must not create or mutate a lane"
+    );
+}
+
+#[test]
+#[serial]
+fn marker_gates_and_ambiguous_delivery_are_terminal_without_resend() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("malformed");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let launch = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "lane-ambiguous",
+            "--thread",
+            "123456789012345678",
+            "--kickoff",
+            "fixture",
+            "--json",
+            "--",
+            "worker",
+        ],
+    );
+    failed(&launch);
+    assert_eq!(discord.count("POST"), 1);
+    assert_eq!(count(&state, "sends"), 0);
+    let combined = text(&launch);
+    assert!(combined.contains("malformed-success") || combined.contains("ambiguous"));
+    assert!(!combined.contains("fixture"));
+    let retry = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "lane-ambiguous",
+            "--thread",
+            "123456789012345678",
+            "--json",
+            "--",
+            "worker",
+        ],
+    );
+    failed(&retry);
+    assert_eq!(
+        discord.count("POST"),
+        1,
+        "ambiguous kickoff is never retried"
+    );
+}
+
+#[test]
+#[serial]
+fn verification_status_and_human_null_mapping_are_public_safe() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let launch = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "lane-verify",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    );
+    successful(&launch);
+    let verify = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "lane",
+            "verify-thread",
+            "--session",
+            "lane-verify",
+            "--json",
+        ],
+    );
+    failed(&verify);
+    let json: Value = serde_json::from_slice(&verify.stdout).expect("verification json");
+    assert_eq!(json["outcome"], "unverified");
+    assert_eq!(json["visibility"], "unverified");
+    assert!(!String::from_utf8_lossy(&verify.stdout).contains("123456789012345678"));
+    let human = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &["lane", "status", "--session", "lane-verify"],
+    );
+    successful(&human);
+    let public = String::from_utf8_lossy(&human.stdout);
+    assert!(public.contains("unknown") || public.contains("unverified"));
+    assert!(!public.contains("null"));
+    assert!(!public.contains("123456789012345678"));
+}
+
+#[test]
+#[serial]
+fn submitted_marker_gates_cover_missing_empty_mismatch_and_unreadable_for_both_effect_kinds() {
+    for command_effect in [true, false] {
+        assert_marker_gate(
+            command_effect,
+            "clawhip_lane_command_submitted",
+            None,
+            false,
+        );
+        assert_marker_gate(
+            command_effect,
+            "clawhip_lane_command_submitted",
+            Some(""),
+            false,
+        );
+        assert_marker_gate(
+            command_effect,
+            "clawhip_lane_command_submitted",
+            Some("other-operation"),
+            false,
+        );
+        assert_marker_gate(
+            command_effect,
+            "clawhip_lane_command_submitted",
+            Some("ignored"),
+            true,
+        );
+    }
+}
+
+#[test]
+#[serial]
+fn timeout_and_malformed_kickoffs_have_one_post_and_no_command_effect() {
+    for mode in ["malformed", "timeout"] {
+        let temp = TempDir::new().expect("temp");
+        let home = temp.path().join("home");
+        let config_path = temp.path().join("config.toml");
+        let state = temp.path().join("tmux");
+        let tmux = temp.path().join("tmux.sh");
+        fs::create_dir_all(&home).expect("home");
+        fake_tmux(&tmux, &state);
+        let discord = MockDiscord::start(mode);
+        let port = free_port();
+        config(&config_path, port);
+        let _daemon = start(&config_path, &home, &tmux, &discord, port);
+        let result = lane_command(
+            &config_path,
+            &home,
+            &tmux,
+            &discord,
+            &[
+                "tmux",
+                "new",
+                "--session",
+                "delivery-once",
+                "--thread",
+                "123456789012345678",
+                "--kickoff",
+                "redacted",
+                "--json",
+                "--",
+                "worker",
+            ],
+        );
+        failed(&result);
+        let rendered = text(&result);
+        assert!(rendered.contains(if mode == "timeout" {
+            "timeout"
+        } else {
+            "malformed-success"
+        }));
+        assert!(!rendered.contains("redacted"));
+        assert_eq!(discord.count("POST"), 1);
+        assert_eq!(count(&state, "sends"), 0);
+    }
+}
+
+#[test]
+#[serial]
+fn exact_receipt_verification_fetches_once_while_empty_fallback_remains_unverified() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("receipt");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    successful(&lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "receipt-lane",
+            "--thread",
+            "123456789012345678",
+            "--kickoff",
+            "redacted",
+            "--json",
+            "--",
+            "worker",
+        ],
+    ));
+    let exact = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "lane",
+            "verify-thread",
+            "--session",
+            "receipt-lane",
+            "--json",
+        ],
+    );
+    successful(&exact);
+    let exact_json: Value = serde_json::from_slice(&exact.stdout).expect("exact verification json");
+    assert_eq!(exact_json["outcome"], "kickoff-visible");
+    assert_eq!(discord.count_path("/messages/987654321098765432"), 1);
+    successful(&lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "empty-lane",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    ));
+    let fallback = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &["lane", "verify-thread", "--session", "empty-lane", "--json"],
+    );
+    failed(&fallback);
+    let fallback_json: Value =
+        serde_json::from_slice(&fallback.stdout).expect("fallback verification json");
+    assert_eq!(fallback_json["outcome"], "unverified");
+    assert_eq!(fallback_json["reason"], "no-message-observed");
+    assert_eq!(discord.count_path("messages?limit=1"), 1);
+}
+
+#[test]
+#[serial]
+fn remote_lane_client_is_denied_before_network_and_private_targets_are_not_in_errors() {
+    let temp = TempDir::new().expect("temp");
+    let config_path = temp.path().join("remote.toml");
+    write_file(
+        &config_path,
+        "[daemon]\nbind_host = \"127.0.0.1\"\nport = 9\nbase_url = \"http://192.0.2.1:9\"\n\n[providers.discord]\ntoken = \"fixture-token\"\n",
+    );
+    let fake = temp.path().join("tmux.sh");
+    fake_tmux(&fake, &temp.path().join("state"));
+    let discord = MockDiscord::start("success");
+    let result = lane_command(
+        &config_path,
+        temp.path(),
+        &fake,
+        &discord,
+        &["lane", "status", "--session", "private-target"],
+    );
+    failed(&result);
+    let rendered = text(&result);
+    assert!(rendered.contains("loopback") || rendered.contains("local"));
+    assert!(!rendered.contains("123456789012345678"));
+}
+
+#[test]
+#[serial]
+fn legacy_registry_projection_is_loaded_without_lane_private_fields() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    write_file(&state.join("session"), "legacy-session");
+    write_file(&state.join("live"), "1");
+    config(&config_path, free_port());
+    write_file(&registry_path(&config_path), &json!({"legacy-session": {"session":"legacy-session","channel":"alerts","mention":"<@123>","keywords":["panic"],"keyword_window_secs":30,"stale_minutes":10,"format":"compact","active_wrapper_monitor":false}}).to_string());
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let api_projection = http_json(port, "GET", "/api/tmux", json!({}));
+    assert!(api_projection.starts_with("HTTP/1.1 200"));
+    assert!(api_projection.contains("legacy-session"));
+    assert!(!api_projection.contains("thread_id"));
+    let listed = lane_command(&config_path, &home, &tmux, &discord, &["tmux", "list"]);
+    successful(&listed);
+    let public = String::from_utf8_lossy(&listed.stdout);
+    assert!(public.contains("legacy-session"));
+    assert!(!public.contains("thread_id"));
+    assert!(!public.contains("123456789012345678"));
+}
+
+#[test]
+#[serial]
+fn absent_lane_can_retire_then_replace_while_old_generation_is_fenced() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let first = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "replace-lane",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    );
+    successful(&first);
+    let old: Value = serde_json::from_slice(&first.stdout).expect("first lane json");
+    fs::remove_file(state.join("live")).expect("simulate missing tmux");
+    let before = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &["lane", "status", "--session", "replace-lane", "--json"],
+    );
+    successful(&before);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&before.stdout).expect("missing status")[0]["runtime"],
+        "tmux-missing"
+    );
+    let retired = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "lane",
+            "update",
+            "--session",
+            "replace-lane",
+            "--message",
+            "redacted",
+            "--kind",
+            "handoff",
+            "--workflow",
+            "retired",
+            "--json",
+        ],
+    );
+    successful(&retired);
+    let replacement = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "replace-lane",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    );
+    successful(&replacement);
+    let new: Value = serde_json::from_slice(&replacement.stdout).expect("replacement json");
+    assert_ne!(old["generation_id"], new["generation_id"]);
+    let current_revision = registry(&config_path)["replace-lane"]["lane"]["revision"].clone();
+    assert!(
+        current_revision.is_u64(),
+        "durable replacement revision is present"
+    );
+    let stale = http_json(
+        port,
+        "POST",
+        "/api/lane/workflow",
+        json!({"session":"replace-lane","generation_id":old["generation_id"],"expected_revision":current_revision,"workflow":"active","quiesced":false}),
+    );
+    assert!(
+        stale.starts_with("HTTP/1.1 409"),
+        "stale generation must be fenced"
+    );
+}
+
+#[test]
+#[serial]
+fn active_missing_and_handoff_missing_keep_distinct_status_semantics() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    successful(&lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "workflow-lane",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    ));
+    fs::remove_file(state.join("live")).expect("simulate missing tmux");
+    let active = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &["lane", "status", "--session", "workflow-lane", "--json"],
+    );
+    successful(&active);
+    let active_json: Value = serde_json::from_slice(&active.stdout).expect("active status");
+    assert_eq!(active_json[0]["runtime"], "tmux-missing");
+    assert_eq!(active_json[0]["derived_status"], "tmux-missing");
+    successful(&lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "lane",
+            "update",
+            "--session",
+            "workflow-lane",
+            "--message",
+            "redacted",
+            "--kind",
+            "handoff",
+            "--workflow",
+            "awaiting-human",
+            "--json",
+        ],
+    ));
+    let handoff = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &["lane", "status", "--session", "workflow-lane", "--json"],
+    );
+    successful(&handoff);
+    let handoff_json: Value = serde_json::from_slice(&handoff.stdout).expect("handoff status");
+    assert_eq!(handoff_json[0]["derived_status"], "workflow-handoff");
+    assert!(!String::from_utf8_lossy(&handoff.stdout).contains("123456789012345678"));
+}
+
+#[test]
+#[serial]
+fn invalid_thread_target_is_rejected_before_daemon_registration_or_effects() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let baseline = fs::read_to_string(state.join("calls")).unwrap_or_default();
+    let output = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "invalid-target",
+            "--thread",
+            "not-a-snowflake",
+            "--json",
+        ],
+    );
+    failed(&output);
+    assert_eq!(discord.count("POST"), 0);
+    let delta = calls_after(&state, &baseline);
+    assert!(
+        !delta
+            .lines()
+            .any(|call| matches!(call, "new-session" | "set-option" | "send-keys"))
+    );
+    assert!(
+        !registry_path(&config_path).is_file(),
+        "invalid target must not register a lane"
+    );
+}
+
+#[test]
+#[serial]
+fn session_creation_new_session_failure_is_ambiguous_without_command_submission() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    write_file(&state.join("fail_new_session"), "1");
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let output = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "create-fault",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    );
+    failed(&output);
+    let json: Value = serde_json::from_slice(&output.stdout).expect("fault json");
+    assert_eq!(
+        json["durable_launch_state"],
+        "blocked-session-creation-ambiguous"
+    );
+    assert_eq!(json["exit_category"], "owner-aborted-before-r2");
+    assert_eq!(count(&state, "sends"), 0);
+}
+
+#[test]
+#[serial]
+fn post_spawn_generation_identity_faults_are_durable_and_command_cleanup_differs_from_session_retention()
+ {
+    for (flag, category) in [
+        ("fail_generation_set", "identity-marker-mismatch"),
+        (
+            "unreadable_clawhip_lane_generation",
+            "identity-marker-read-failed",
+        ),
+        ("mismatch_generation", "identity-marker-mismatch"),
+    ] {
+        for command in [true, false] {
+            let temp = TempDir::new().expect("temp");
+            let home = temp.path().join("home");
+            let config_path = temp.path().join("config.toml");
+            let state = temp.path().join("tmux");
+            let tmux = temp.path().join("tmux.sh");
+            fs::create_dir_all(&home).expect("home");
+            fake_tmux(&tmux, &state);
+            write_file(&state.join(flag), "1");
+            let discord = MockDiscord::start("success");
+            let port = free_port();
+            config(&config_path, port);
+            let _daemon = start(&config_path, &home, &tmux, &discord, port);
+            let mut args = vec![
+                "tmux",
+                "new",
+                "--session",
+                "identity-fault",
+                "--thread",
+                "123456789012345678",
+                "--json",
+            ];
+            if command {
+                args.extend(["--", "worker"]);
+            }
+            let output = lane_command(&config_path, &home, &tmux, &discord, &args);
+            failed(&output);
+            let json: Value = serde_json::from_slice(&output.stdout).expect("identity fault json");
+            assert_eq!(json["exit_category"], category);
+            assert_eq!(
+                json["durable_launch_state"],
+                if command {
+                    "launch-failed-no-worker-effect"
+                } else {
+                    "blocked-session-creation-ambiguous"
+                }
+            );
+            assert_eq!(count(&state, "sends"), 0);
+            assert_eq!(
+                state.join("live").is_file(),
+                !command,
+                "command cleanup removes R1 session while session effect is retained"
+            );
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn retained_target_mismatch_and_invalid_session_names_have_no_effects() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    successful(&lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "retained-target",
+            "--thread",
+            "123456789012345678",
+            "--json",
+        ],
+    ));
+    let baseline = fs::read_to_string(state.join("calls")).unwrap_or_default();
+    let mismatch = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "retained-target",
+            "--thread",
+            "234567890123456789",
+            "--json",
+        ],
+    );
+    failed(&mismatch);
+    assert!(!text(&mismatch).contains("234567890123456789"));
+    assert!(
+        calls_after(&state, &baseline)
+            .lines()
+            .all(|call| !matches!(call, "new-session" | "set-option" | "send-keys"))
+    );
+    let oversized = "x".repeat(129);
+    for bad in ["bad/name", "bad?name", "bad\nname", oversized.as_str()] {
+        let output = lane_command(
+            &config_path,
+            &home,
+            &tmux,
+            &discord,
+            &[
+                "tmux",
+                "new",
+                "--session",
+                bad,
+                "--thread",
+                "123456789012345678",
+                "--json",
+            ],
+        );
+        failed(&output);
+    }
+}
+
+#[test]
+#[serial]
+fn kickoff_update_preserves_original_receipt_and_records_latest_update() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    successful(&lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "update-kickoff",
+            "--thread",
+            "123456789012345678",
+            "--kickoff",
+            "redacted",
+            "--json",
+            "--",
+            "worker",
+        ],
+    ));
+    let before = registry(&config_path)["update-kickoff"]["lane"]["kickoff_message_id"].clone();
+    successful(&lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "lane",
+            "update",
+            "--session",
+            "update-kickoff",
+            "--message",
+            "redacted",
+            "--kind",
+            "kickoff",
+            "--json",
+        ],
+    ));
+    let durable = registry(&config_path);
+    let lane = &durable["update-kickoff"]["lane"];
+    assert_eq!(lane["kickoff_message_id"], before);
+    assert_eq!(lane["latest_update_kind"], "kickoff");
+    assert_eq!(lane["latest_update_message_id"], "987654321098765432");
+}
+
+#[test]
+#[serial]
+fn response_loss_reconciles_each_lane_mutation_without_duplicate_effects() {
+    for (drop_path, occurrence) in [
+        ("/api/lane/register", 1),
+        ("/api/lane/claim", 1),
+        ("/api/lane/delivery", 1),
+        ("/api/lane/evidence", 1),
+        ("/api/lane/evidence", 2),
+    ] {
+        let temp = TempDir::new().expect("temp");
+        let home = temp.path().join("home");
+        let config_path = temp.path().join("config.toml");
+        let state = temp.path().join("tmux");
+        let tmux = temp.path().join("tmux.sh");
+        fs::create_dir_all(&home).expect("home");
+        fake_tmux(&tmux, &state);
+        let discord = MockDiscord::start("success");
+        let backend_port = free_port();
+        let proxy = ResponseLossProxy::start(backend_port, drop_path, occurrence);
+        config_with_base_url(&config_path, backend_port, proxy.port);
+        let _daemon = start(&config_path, &home, &tmux, &discord, backend_port);
+        let output = lane_command(
+            &config_path,
+            &home,
+            &tmux,
+            &discord,
+            &[
+                "tmux",
+                "new",
+                "--session",
+                "loss-lane",
+                "--thread",
+                "123456789012345678",
+                "--kickoff",
+                "redacted",
+                "--json",
+                "--",
+                "worker",
+            ],
+        );
+        successful(&output);
+        let result: Value = serde_json::from_slice(&output.stdout).expect("reconciled launch json");
+        assert_eq!(result["durable_launch_state"], "launched");
+        assert_eq!(discord.count("POST"), 1);
+        assert_eq!(
+            command_count(
+                &fs::read_to_string(state.join("calls")).unwrap_or_default(),
+                "new-session"
+            ),
+            1
+        );
+        assert_eq!(count(&state, "sends"), 1);
+        assert_eq!(
+            fs::read_to_string(state.join("clawhip_lane_command_submitted"))
+                .expect("submitted marker")
+                .trim(),
+            result["launch_operation_id"]
+                .as_str()
+                .expect("launch operation")
+        );
+        let lane = &registry(&config_path)["loss-lane"]["lane"];
+        assert_eq!(lane["launch_state"], "launched");
+        assert!(lane["revision"].is_u64());
+        assert_eq!(proxy.path_count("/api/lane/register"), 1);
+        assert_eq!(proxy.path_count("/api/lane/claim"), 1);
+        assert_eq!(proxy.path_count("/api/lane/delivery"), 1);
+        assert_eq!(proxy.path_count("/api/lane/evidence"), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the maintainer-owned first PR for #285 with a daemon-owned, backward-compatible extension of `tmux-watch-registry.json`.

- adds verifiable Discord kickoff receipts and read-only thread verification
- adds durable lane lifecycle/status/update commands without exposing private thread targets through legacy projections
- models immutable generation/kickoff/launch/executor identities and command-vs-session worker effects
- gates worker truth through durable R0/R1/R2/R3 transitions plus exact tmux generation, launch, and submitted markers
- classifies missing active runtimes as `tmux-missing` and retained workflow transitions as `workflow-handoff`
- keeps ambiguous effects blocked with explicit operator-quiesced retirement rather than retry/takeover
- restricts private target-bearing APIs to actual loopback peers

## Compatibility and privacy

Legacy registry JSON, `/api/tmux`, `tmux list`, config parsing, and existing tmux watch behavior remain compatible. Private Discord targets, message bodies, full commands, and raw Discord error bodies are excluded from routine output, telemetry, registry projections, and errors.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test` — 727 tests passed, including 17 real-daemon/fake-tmux/mock-Discord E2E tests
- `git diff --check`
- resolved adversarial QA: PASS

The E2E suite covers registry reload, legacy projection, kickoff/verification/update, R0/R1/kickoff/R2/R3 response loss without duplicate effects, marker missing/empty/mismatch/unreadable cases for both effect kinds, retirement/replacement/fencing, privacy, workflow-handoff classification, and cleanup partitioning.

## Attribution

The narrow `workflow-handoff` classifier rule was reimplemented from `jaeyunha/clawhip#2` (`d85e41cc262d930ad123318d9e43e2cb39ce9be9`). The fork-only ledger subsystem was not imported because it diverges from current `dev` and the existing daemon-owned registry authority.

## Deferred issue items

Discord thread creation/discovery, controller/Hermes repair automation, automatic retry/takeover, definitive empty-thread classification without permission proof, a live Mac-mini/Discord canary, two supervisor cycles, patch release, merge, and release policy remain follow-ups. This PR intentionally does not merge itself.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*