### PR TITLE
Fix lane launch ownership, privacy, and attach regressions

### DIFF
--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -524,13 +524,7 @@ fn terminal_category_is_valid(
         ) | (
             WorkerEffectKind::CommandSubmission,
             LaneLaunchState::NoWorkerEffect,
-            Some(
-                "session-create-failed"
-                    | "identity-marker-set-failed"
-                    | "identity-marker-read-failed"
-                    | "identity-marker-mismatch"
-                    | "r1-to-r2-persistence-failed-after-create",
-            ),
+            Some("session-create-failed"),
         ) | (
             WorkerEffectKind::CommandSubmission,
             LaneLaunchState::CommandSubmitAmbiguous,
@@ -542,7 +536,7 @@ fn terminal_category_is_valid(
                     | "submitted-marker-mismatch",
             ),
         ) | (
-            WorkerEffectKind::SessionCreation,
+            _,
             LaneLaunchState::SessionCreationAmbiguous,
             Some(
                 "identity-marker-set-failed"
@@ -2559,6 +2553,99 @@ mod tests {
             LaneLaunchState::NoWorkerEffect,
             Some(&category)
         ));
+        assert!(!terminal_category_is_valid(
+            WorkerEffectKind::CommandSubmission,
+            LaneLaunchState::NoWorkerEffect,
+            Some(&BoundedCategory::new("identity-marker-mismatch"))
+        ));
+    }
+
+    #[test]
+    fn command_session_creation_ambiguity_has_valid_terminal_categories_and_snapshot() {
+        for category in [
+            "owner-aborted-before-r2",
+            "identity-marker-set-failed",
+            "identity-marker-read-failed",
+            "identity-marker-mismatch",
+            "r1-to-r2-persistence-failed-after-create",
+        ] {
+            assert!(terminal_category_is_valid(
+                WorkerEffectKind::CommandSubmission,
+                LaneLaunchState::SessionCreationAmbiguous,
+                Some(&BoundedCategory::new(category)),
+            ));
+        }
+
+        let lane = LaneEvidence {
+            lane_version: 1,
+            generation_id: "g".into(),
+            kickoff_operation_id: "k".into(),
+            launch_operation_id: "l".into(),
+            executor_id: "e".into(),
+            worker_effect_kind: WorkerEffectKind::CommandSubmission,
+            launch_state: LaneLaunchState::SessionCreationAmbiguous,
+            workflow: LaneWorkflow::Active,
+            revision: 0,
+            quiesced: false,
+            thread_id: None,
+            kickoff_message_id: None,
+            kickoff_delivered_at: None,
+            visibility: None,
+            verification: None,
+            last_failure: Some(BoundedCategory::new("identity-marker-mismatch")),
+            latest_update_message_id: None,
+            latest_update_kind: None,
+            latest_update_delivered_at: None,
+            delivery_retry_count: 0,
+            delivery_disposition: None,
+        };
+        let snapshot = lane_snapshot("lane", &lane, None);
+        assert_eq!(
+            snapshot.derived_status.as_deref(),
+            Some("session-creation-ambiguous-blocked")
+        );
+        assert_eq!(
+            snapshot.exit_category.as_ref().map(BoundedCategory::as_str),
+            Some("identity-marker-mismatch")
+        );
+        assert_eq!(snapshot.worker_started, None);
+    }
+
+    #[tokio::test]
+    async fn command_session_creation_ambiguity_transition_is_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        register_lane_registration(&registry, &path, lane_input("lane", "g"))
+            .await
+            .unwrap();
+        let claimed = claim_lane(&registry, &path, "lane", "g", "e", 0)
+            .await
+            .unwrap();
+        let snapshot = update_lane_evidence(
+            &registry,
+            &path,
+            LaneEvidenceMutation {
+                session: "lane".into(),
+                expected_revision: claimed.revision,
+                generation_id: "g".into(),
+                launch_operation_id: "l".into(),
+                launch_state: LaneLaunchState::SessionCreationAmbiguous,
+                failure_category: Some(BoundedCategory::new("identity-marker-mismatch")),
+                executor_id: "e".into(),
+                worker_effect_kind: WorkerEffectKind::CommandSubmission,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            snapshot.durable_launch_state,
+            LaneLaunchState::SessionCreationAmbiguous
+        );
+        assert_eq!(
+            snapshot.exit_category.as_ref().map(BoundedCategory::as_str),
+            Some("identity-marker-mismatch")
+        );
     }
 
     #[tokio::test]
@@ -2632,6 +2719,12 @@ mod tests {
     #[test]
     fn committed_terminal_snapshots_serialize_exact_categories_and_null_worker() {
         for (state, kind, category, status) in [
+            (
+                LaneLaunchState::SessionCreationAmbiguous,
+                WorkerEffectKind::CommandSubmission,
+                "identity-marker-mismatch",
+                "session-creation-ambiguous-blocked",
+            ),
             (
                 LaneLaunchState::SessionCreationAmbiguous,
                 WorkerEffectKind::SessionCreation,

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -14,6 +14,9 @@ use crate::config::AppConfig;
 use crate::discord::{DiscordClient, DiscordLaneDisposition};
 use crate::events::RoutingMetadata;
 use crate::router::resolve_tmux_session_channel_with_metadata;
+use crate::sink::SinkTarget;
+use crate::telemetry;
+
 use crate::source::tmux::{
     BoundedCategory, LaneDeliveryMutation, LaneEvidence, LaneEvidenceMutation, LaneLaunchState,
     LaneRegistrationInput, LaneVisibility, LaneWorkflow, ParentProcessInfo, RegisteredTmuxSession,
@@ -23,7 +26,13 @@ use crate::source::tmux::{
 
 pub async fn run(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
     if args.thread.is_some() {
-        return launch_lane_session(args, config).await;
+        let requested_session = args.session.clone();
+        let attach = args.attach;
+        launch_lane_session(args, config).await?;
+        if attach {
+            attach_session(&requested_session).await?;
+        }
+        return Ok(());
     }
 
     launch_session(&args).await?;
@@ -438,40 +447,51 @@ fn durable_launch_state_name(state: LaneLaunchState) -> &'static str {
     }
 }
 
+fn lane_result_json(
+    snapshot: &crate::source::tmux::LaneSnapshot,
+    overlay: &LaneInspectionResult,
+    thread: Option<&str>,
+) -> serde_json::Value {
+    let mut result = serde_json::json!({
+        "session": snapshot.session,
+        "worker_effect_kind": snapshot.worker_effect_kind,
+        "generation_id": snapshot.generation_id,
+        "kickoff_operation_id": snapshot.kickoff_operation_id,
+        "launch_operation_id": snapshot.launch_operation_id,
+        "executor_id": snapshot.executor_id,
+        "durable_launch_state": durable_launch_state_name(snapshot.durable_launch_state),
+        "derived_status": overlay.derived_status,
+        "observation_reason": overlay.observation_reason,
+        "worker_started": overlay.worker_started,
+        "evidence_commit": overlay.evidence_commit,
+        "repair_needed": overlay.repair_needed,
+        "healthy": overlay.healthy,
+        "exit_category": overlay.exit_category,
+    });
+    if let Some(thread) = thread {
+        result["thread_id"] = serde_json::json!(telemetry::safe_target_id(
+            &SinkTarget::DiscordThread(thread.to_owned()),
+        ));
+        result["kickoff_message_id"] = serde_json::json!(snapshot.kickoff_message_id);
+        result["kickoff_delivered_at"] = serde_json::json!(snapshot.kickoff_delivered_at);
+        result["watch_registered"] = serde_json::json!(true);
+        result["visibility"] = serde_json::json!(snapshot.visibility);
+        result["workflow"] = serde_json::json!(snapshot.workflow);
+        result["runtime"] = serde_json::json!(overlay.runtime);
+    }
+    result
+}
+
 fn emit_lane_result(
     args: &TmuxNewArgs,
     snapshot: &crate::source::tmux::LaneSnapshot,
     overlay: &LaneInspectionResult,
 ) {
     if args.json {
-        println!("{}", {
-            let mut result = serde_json::json!({
-                "session": snapshot.session,
-                "worker_effect_kind": snapshot.worker_effect_kind,
-                "generation_id": snapshot.generation_id,
-                "kickoff_operation_id": snapshot.kickoff_operation_id,
-                "launch_operation_id": snapshot.launch_operation_id,
-                "executor_id": snapshot.executor_id,
-                "durable_launch_state": durable_launch_state_name(snapshot.durable_launch_state),
-                "derived_status": overlay.derived_status,
-                "observation_reason": overlay.observation_reason,
-                "worker_started": overlay.worker_started,
-                "evidence_commit": overlay.evidence_commit,
-                "repair_needed": overlay.repair_needed,
-                "healthy": overlay.healthy,
-                "exit_category": overlay.exit_category,
-            });
-            if args.thread.is_some() {
-                result["thread_id"] = serde_json::json!(args.thread);
-                result["kickoff_message_id"] = serde_json::json!(snapshot.kickoff_message_id);
-                result["kickoff_delivered_at"] = serde_json::json!(snapshot.kickoff_delivered_at);
-                result["watch_registered"] = serde_json::json!(true);
-                result["visibility"] = serde_json::json!(snapshot.visibility);
-                result["workflow"] = serde_json::json!(snapshot.workflow);
-                result["runtime"] = serde_json::json!(overlay.runtime);
-            }
-            result
-        });
+        println!(
+            "{}",
+            lane_result_json(snapshot, overlay, args.thread.as_deref())
+        );
     } else {
         let worker = match overlay.worker_started {
             Some(true) => "yes",
@@ -875,23 +895,28 @@ async fn launch_lane_session(args: TmuxNewArgs, config: &AppConfig) -> Result<()
             emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
             return Err("lane tmux session creation failed".into());
         }
-        DetachedSessionOutcome::PossiblyExecuted
-            if matches!(
+        DetachedSessionOutcome::PossiblyExecuted => {
+            let (state, category, error) = if matches!(
                 snapshot.worker_effect_kind,
-                WorkerEffectKind::SessionCreation
-            ) =>
-        {
-            let terminal = transition_lane(
-                &client,
-                &snapshot,
-                LaneLaunchState::SessionCreationAmbiguous,
-                Some("owner-aborted-before-r2"),
-            )
-            .await?;
+                WorkerEffectKind::CommandSubmission
+            ) {
+                (
+                    LaneLaunchState::NoWorkerEffect,
+                    "session-create-failed",
+                    "lane tmux session creation failed",
+                )
+            } else {
+                (
+                    LaneLaunchState::SessionCreationAmbiguous,
+                    "owner-aborted-before-r2",
+                    "lane tmux session creation outcome is ambiguous",
+                )
+            };
+            let terminal = transition_lane(&client, &snapshot, state, Some(category)).await?;
             emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
-            return Err("lane tmux session creation outcome is ambiguous".into());
+            return Err(error.into());
         }
-        DetachedSessionOutcome::PossiblyExecuted | DetachedSessionOutcome::Created => {}
+        DetachedSessionOutcome::Created => {}
     }
     let identity_category = match write_lane_identity_markers(
         &args.session,
@@ -2312,29 +2337,13 @@ mod tests {
         );
     }
     #[test]
-    fn launch_json_extension_is_privacy_safe_and_complete() {
-        let value = serde_json::json!({
-            "thread_id": "thread-1",
-            "kickoff_message_id": "message-1",
-            "kickoff_delivered_at": "2026-07-11T00:00:00Z",
-            "watch_registered": true,
-            "visibility": "visible",
-            "workflow": "active",
-            "runtime": "live",
-        });
-        for field in [
-            "thread_id",
-            "kickoff_message_id",
-            "kickoff_delivered_at",
-            "watch_registered",
-            "visibility",
-            "workflow",
-            "runtime",
-        ] {
-            assert!(value.get(field).is_some(), "missing {field}");
-        }
-        let serialized = value.to_string();
-        assert!(!serialized.contains("token"));
-        assert!(!serialized.contains("message body"));
+    fn lane_result_json_delegates_thread_id_to_canonical_safe_target() {
+        let snapshot = response_loss_snapshot(LaneLaunchState::Launched, None);
+        let result = lane_result_json(&snapshot, &overlay_from_snapshot(&snapshot), Some("1"));
+
+        assert_eq!(
+            result["thread_id"],
+            telemetry::safe_target_id(&SinkTarget::DiscordThread("1".into()))
+        );
     }
 }

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -30,7 +30,7 @@ pub async fn run(args: TmuxNewArgs, config: &AppConfig) -> Result<()> {
         let attach = args.attach;
         launch_lane_session(args, config).await?;
         if attach {
-            attach_session(&requested_session).await?;
+            attach_lane_session(&requested_session).await?;
         }
         return Ok(());
     }
@@ -660,6 +660,21 @@ async fn finalize_existing_lane(args: &TmuxNewArgs, client: &DaemonClient) -> Re
         snapshot.durable_launch_state,
         LaneLaunchState::IdentityVerified
     ) {
+        if snapshot.durable_launch_state == LaneLaunchState::Launched && args.attach {
+            match inspect_lane_markers(&args.session, &snapshot).await {
+                LaneInspection::Exact => {}
+                LaneInspection::CommandTerminal(category) => {
+                    let overlay = r2_overlay(WorkerEffectKind::CommandSubmission, category, false);
+                    emit_lane_result(args, &snapshot, &overlay);
+                    return Err("retained lane ownership proof is not exact".into());
+                }
+                LaneInspection::Observed(reason, conflict) => {
+                    let overlay = r2_overlay(snapshot.worker_effect_kind, reason, conflict);
+                    emit_lane_result(args, &snapshot, &overlay);
+                    return Err("retained lane ownership proof is not exact".into());
+                }
+            }
+        }
         let overlay = overlay_from_snapshot(&snapshot);
         emit_lane_result(args, &snapshot, &overlay);
         return if snapshot.worker_started == Some(true) {
@@ -895,26 +910,32 @@ async fn launch_lane_session(args: TmuxNewArgs, config: &AppConfig) -> Result<()
             emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
             return Err("lane tmux session creation failed".into());
         }
-        DetachedSessionOutcome::PossiblyExecuted => {
-            let (state, category, error) = if matches!(
+        DetachedSessionOutcome::DefinitiveFailure => {
+            let (state, category) = if matches!(
                 snapshot.worker_effect_kind,
                 WorkerEffectKind::CommandSubmission
             ) {
-                (
-                    LaneLaunchState::NoWorkerEffect,
-                    "session-create-failed",
-                    "lane tmux session creation failed",
-                )
+                (LaneLaunchState::NoWorkerEffect, "session-create-failed")
             } else {
                 (
                     LaneLaunchState::SessionCreationAmbiguous,
                     "owner-aborted-before-r2",
-                    "lane tmux session creation outcome is ambiguous",
                 )
             };
             let terminal = transition_lane(&client, &snapshot, state, Some(category)).await?;
             emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
-            return Err(error.into());
+            return Err("lane tmux session creation failed".into());
+        }
+        DetachedSessionOutcome::PossiblyExecuted => {
+            let terminal = transition_lane(
+                &client,
+                &snapshot,
+                LaneLaunchState::SessionCreationAmbiguous,
+                Some("owner-aborted-before-r2"),
+            )
+            .await?;
+            emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
+            return Err("lane tmux session creation outcome is ambiguous".into());
         }
         DetachedSessionOutcome::Created => {}
     }
@@ -931,21 +952,13 @@ async fn launch_lane_session(args: TmuxNewArgs, config: &AppConfig) -> Result<()
         IdentityProof::Mismatch => Some("identity-marker-mismatch"),
     };
     if let Some(category) = identity_category {
-        let state = if matches!(
-            snapshot.worker_effect_kind,
-            WorkerEffectKind::CommandSubmission
-        ) {
-            LaneLaunchState::NoWorkerEffect
-        } else {
-            LaneLaunchState::SessionCreationAmbiguous
-        };
-        let terminal = transition_lane(&client, &snapshot, state, Some(category)).await?;
-        if matches!(
-            snapshot.worker_effect_kind,
-            WorkerEffectKind::CommandSubmission
-        ) {
-            cleanup_command_r1_session(&args.session).await;
-        }
+        let terminal = transition_lane(
+            &client,
+            &snapshot,
+            LaneLaunchState::SessionCreationAmbiguous,
+            Some(category),
+        )
+        .await?;
         emit_lane_result(&args, &terminal, &overlay_from_snapshot(&terminal));
         return Err("lane tmux identity marker proof failed".into());
     }
@@ -974,24 +987,10 @@ async fn launch_lane_session(args: TmuxNewArgs, config: &AppConfig) -> Result<()
                     && detail.snapshot.durable_launch_state == LaneLaunchState::Claimed
                     && detail.snapshot.revision == snapshot.revision =>
             {
-                let state = if matches!(
-                    snapshot.worker_effect_kind,
-                    WorkerEffectKind::CommandSubmission
-                ) {
-                    LaneLaunchState::NoWorkerEffect
-                } else {
-                    LaneLaunchState::SessionCreationAmbiguous
-                };
-                if matches!(
-                    snapshot.worker_effect_kind,
-                    WorkerEffectKind::CommandSubmission
-                ) {
-                    cleanup_command_r1_session(&args.session).await;
-                }
                 let terminal = transition_lane(
                     &client,
                     &detail.snapshot,
-                    state,
+                    LaneLaunchState::SessionCreationAmbiguous,
                     Some("r1-to-r2-persistence-failed-after-create"),
                 )
                 .await?;
@@ -1322,18 +1321,22 @@ fn session_uncommitted(
     Err("lane session creation proof is not exact".into())
 }
 
-async fn cleanup_command_r1_session(session: &str) {
-    let _ = Command::new(tmux_bin())
-        .args(["kill-session", "-t", session])
-        .output()
-        .await;
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DetachedSessionOutcome {
     Created,
+    DefinitiveFailure,
     PossiblyExecuted,
     PreExecutionFailure,
+}
+
+fn detached_session_outcome_from_wait(
+    result: std::io::Result<std::process::ExitStatus>,
+) -> DetachedSessionOutcome {
+    match result {
+        Ok(status) if status.success() => DetachedSessionOutcome::Created,
+        Ok(_) => DetachedSessionOutcome::DefinitiveFailure,
+        Err(_) => DetachedSessionOutcome::PossiblyExecuted,
+    }
 }
 
 async fn create_detached_lane_session(args: &TmuxNewArgs) -> DetachedSessionOutcome {
@@ -1353,10 +1356,7 @@ async fn create_detached_lane_session(args: &TmuxNewArgs) -> DetachedSessionOutc
         Ok(child) => child,
         Err(_) => return DetachedSessionOutcome::PreExecutionFailure,
     };
-    match child.wait_with_output().await {
-        Ok(output) if output.status.success() => DetachedSessionOutcome::Created,
-        Ok(_) | Err(_) => DetachedSessionOutcome::PossiblyExecuted,
-    }
+    detached_session_outcome_from_wait(child.wait_with_output().await.map(|output| output.status))
 }
 
 async fn submit_lane_command_once(session: &str, command: &str) -> Result<()> {
@@ -1504,17 +1504,21 @@ fn tmux_stderr(stderr: &[u8]) -> String {
     String::from_utf8_lossy(stderr).trim().to_string()
 }
 
+async fn attach_lane_session(session: &str) -> Result<()> {
+    attach_session(&format!("={session}")).await
+}
+
 async fn attach_session(session: &str) -> Result<()> {
-    let output = Command::new(tmux_bin())
+    let status = Command::new(tmux_bin())
         .arg("attach-session")
         .arg("-t")
         .arg(session)
-        .output()
+        .status()
         .await?;
-    if output.status.success() {
+    if status.success() {
         Ok(())
     } else {
-        Err(tmux_stderr(&output.stderr).into())
+        Err(format!("tmux attach session '{session}' failed").into())
     }
 }
 
@@ -2268,9 +2272,22 @@ mod tests {
     }
 
     #[test]
+    fn detached_session_wait_classifies_result_loss_as_ambiguous() {
+        let result = Err(std::io::Error::other("wait result lost"));
+        assert_eq!(
+            detached_session_outcome_from_wait(result),
+            DetachedSessionOutcome::PossiblyExecuted
+        );
+    }
+
+    #[test]
     fn typed_effect_outcomes_keep_post_spawn_ambiguity_distinct() {
         assert_ne!(
             DetachedSessionOutcome::PreExecutionFailure,
+            DetachedSessionOutcome::PossiblyExecuted
+        );
+        assert_ne!(
+            DetachedSessionOutcome::DefinitiveFailure,
             DetachedSessionOutcome::PossiblyExecuted
         );
         assert_ne!(

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -296,7 +296,7 @@ case "$1" in
   set-option) key="$4"; value="$5"; test "$key" = "@clawhip_lane_generation" && test -f "$S/fail_generation_set" && exit 1; printf '%s' "$value" > "$S/${{key#@}}"; test "$key" = "@clawhip_lane_generation" && test -f "$S/mismatch_generation" && printf 'different-generation' > "$S/${{key#@}}" ;;
   show-options) key="$5"; safe="${{key#@}}"; test -f "$S/unreadable_$safe" && exit 1; file="$S/$safe"; if test -f "$file"; then printf '%s\n' "$(cat "$file")"; else echo 'invalid option' >&2; exit 1; fi ;;
   send-keys) test "${{4:-}}" = "-l" || printf '1' >> "$S/sends" ;;
-  attach-session) printf '%s\n' "$3" >> "$S/attach_targets"; if test -f "$S/fail_attach_session"; then echo 'fixture-attach-failed' >&2; exit 1; fi ;;
+  attach-session) expected="$(cat "$S/session")"; if test -f "$S/prefix_collision" && test "$3" != "=$expected"; then echo 'fixture-prefix-collision' >&2; exit 1; fi; if test -f "$S/require_attach_tty"; then test -t 0 && test -t 1 && test -t 2 || {{ echo 'fixture-attach-not-a-tty' >&2; exit 1; }}; printf '0 1 2\n' >> "$S/attach_ttys"; fi; echo 'fixture-attach-stdio' >&2; printf '%s\n' "$3" >> "$S/attach_targets"; if test -f "$S/fail_attach_session"; then echo 'fixture-attach-failed' >&2; exit 1; fi ;;
   display-message) printf 'lane\t%%1\t1\tcodex\t/tmp\n' ;;
   kill-session) rm -f "$S/live" ;;
   list-sessions) test -f "$S/live" && test -f "$S/session" && cat "$S/session" ;;
@@ -305,6 +305,11 @@ esac
 "#
         ),
     );
+}
+
+#[cfg(target_os = "linux")]
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn config(path: &Path, port: u16) {
@@ -1283,8 +1288,7 @@ fn session_creation_new_session_failure_is_ambiguous_without_command_submission(
 
 #[test]
 #[serial]
-fn post_spawn_generation_identity_faults_are_durable_and_command_cleanup_differs_from_session_retention()
- {
+fn post_spawn_generation_identity_faults_are_durable_and_retain_sessions_for_both_effect_kinds() {
     for (flag, category) in [
         ("fail_generation_set", "identity-marker-mismatch"),
         (
@@ -1314,6 +1318,7 @@ fn post_spawn_generation_identity_faults_are_durable_and_command_cleanup_differs
                 "--thread",
                 "123456789012345678",
                 "--json",
+                "--attach",
             ];
             if command {
                 args.extend(["--", "worker"]);
@@ -1324,18 +1329,17 @@ fn post_spawn_generation_identity_faults_are_durable_and_command_cleanup_differs
             assert_eq!(json["exit_category"], category);
             assert_eq!(
                 json["durable_launch_state"],
-                if command {
-                    "launch-failed-no-worker-effect"
-                } else {
-                    "blocked-session-creation-ambiguous"
-                }
+                "blocked-session-creation-ambiguous"
             );
+            assert_eq!(json["worker_started"], Value::Null);
             assert_eq!(count(&state, "sends"), 0);
-            assert_eq!(
+            assert_eq!(count(&state, "attach_targets"), 0);
+            assert!(
                 state.join("live").is_file(),
-                !command,
-                "command cleanup removes R1 session while session effect is retained"
+                "marker proof failures retain the created session for quarantine"
             );
+            let calls = fs::read_to_string(state.join("calls")).expect("calls");
+            assert_eq!(command_count(&calls, "kill-session"), 0);
         }
     }
 }
@@ -1653,7 +1657,7 @@ fn lane_launch_json_uses_canonical_safe_thread_target() {
 
 #[test]
 #[serial]
-fn lane_attach_is_exact_once_after_fresh_retained_success_and_never_failure() {
+fn lane_attach_uses_exact_target_and_rejects_unproven_retained_ownership() {
     let temp = TempDir::new().expect("temp");
     let home = temp.path().join("home");
     let config_path = temp.path().join("config.toml");
@@ -1692,7 +1696,11 @@ fn lane_attach_is_exact_once_after_fresh_retained_success_and_never_failure() {
         fs::read_to_string(state.join("attach_targets"))
             .expect("target")
             .trim(),
-        "fresh-attach"
+        "=fresh-attach"
+    );
+    assert!(
+        String::from_utf8_lossy(&fresh.stderr).contains("fixture-attach-stdio"),
+        "attach-session must inherit the wrapper stderr"
     );
     let calls = fs::read_to_string(state.join("calls")).expect("calls");
     assert!(
@@ -1744,6 +1752,7 @@ fn lane_attach_is_exact_once_after_fresh_retained_success_and_never_failure() {
     assert_eq!(seeded["durable_launch_state"], "identity-verified");
     let send_baseline = count(&state, "sends");
     let attach_baseline = count(&state, "attach_targets");
+    write_file(&state.join("prefix_collision"), "1");
     let retained = lane_command(
         &config_path,
         &home,
@@ -1772,8 +1781,64 @@ fn lane_attach_is_exact_once_after_fresh_retained_success_and_never_failure() {
             .expect("targets")
             .lines()
             .last(),
-        Some(session)
+        Some("=retained-attach")
     );
+
+    write_file(&state.join("clawhip_lane_generation"), "stale-generation");
+    let attach_before_unproven_retained = count(&state, "attach_targets");
+    let unproven_retained = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            session,
+            "--thread",
+            "1",
+            "--json",
+            "--attach",
+            "--",
+            "worker",
+        ],
+    );
+    failed(&unproven_retained);
+    let unproven_json: Value =
+        serde_json::from_slice(&unproven_retained.stdout).expect("unproven retained json");
+    assert_eq!(unproven_json["derived_status"], "identity-conflict");
+    assert_eq!(
+        count(&state, "attach_targets"),
+        attach_before_unproven_retained
+    );
+    assert_eq!(count(&state, "sends"), send_baseline);
+
+    fs::remove_file(state.join("clawhip_lane_generation")).expect("remove stale marker");
+    let missing_marker = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            session,
+            "--thread",
+            "1",
+            "--json",
+            "--attach",
+            "--",
+            "worker",
+        ],
+    );
+    failed(&missing_marker);
+    assert_eq!(
+        count(&state, "attach_targets"),
+        attach_before_unproven_retained
+    );
+    assert_eq!(count(&state, "sends"), send_baseline);
 
     write_file(&state.join("fail_new_session"), "1");
     let attach_before_failure = count(&state, "attach_targets");
@@ -1840,7 +1905,7 @@ fn lane_attach_helper_failure_is_propagated_after_successful_launch() {
         fs::read_to_string(state.join("attach_targets"))
             .expect("target")
             .trim(),
-        "attach-error"
+        "=attach-error"
     );
     assert_eq!(count(&state, "sends"), 1);
     assert_eq!(
@@ -1853,4 +1918,70 @@ fn lane_attach_helper_failure_is_propagated_after_successful_launch() {
         last_command_position(&calls, "attach-session")
             > last_command_position(&calls, "send-keys")
     );
+}
+
+// Linux-only: util-linux `script` allocates the real PTY needed to verify inherited stdio.
+#[cfg(target_os = "linux")]
+#[test]
+#[serial]
+fn linux_pty_attach_inherits_all_stdio_and_preserves_lane_targeting() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    write_file(&state.join("require_attach_tty"), "1");
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+
+    let run_under_pty = |args: &[&str]| {
+        let mut words = vec![
+            bin().to_owned(),
+            "--config".to_owned(),
+            config_path.display().to_string(),
+        ];
+        words.extend(args.iter().map(|arg| (*arg).to_owned()));
+        let command_line = words
+            .iter()
+            .map(|word| shell_quote(word))
+            .collect::<Vec<_>>()
+            .join(" ");
+        output(
+            Command::new("script")
+                .args(["-qefc", command_line.as_str(), "/dev/null"])
+                .env("HOME", &home)
+                .env("CLAWHIP_TMUX_BIN", &tmux)
+                .env("CLAWHIP_DISCORD_API_BASE", discord.api_base()),
+        )
+    };
+
+    let lane = run_under_pty(&[
+        "tmux",
+        "new",
+        "--session",
+        "pty-lane",
+        "--thread",
+        "1",
+        "--attach",
+        "--",
+        "worker",
+    ]);
+    successful(&lane);
+    let legacy = run_under_pty(&["tmux", "new", "--session", "pty-legacy", "--attach"]);
+    successful(&legacy);
+
+    assert_eq!(
+        fs::read_to_string(state.join("attach_targets")).expect("attach targets"),
+        "=pty-lane\npty-legacy\n"
+    );
+    assert_eq!(
+        fs::read_to_string(state.join("attach_ttys")).expect("attach tty evidence"),
+        "0 1 2\n0 1 2\n"
+    );
+    let calls = fs::read_to_string(state.join("calls")).expect("calls");
+    assert_eq!(command_count(&calls, "attach-session"), 2);
 }

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -296,6 +296,7 @@ case "$1" in
   set-option) key="$4"; value="$5"; test "$key" = "@clawhip_lane_generation" && test -f "$S/fail_generation_set" && exit 1; printf '%s' "$value" > "$S/${{key#@}}"; test "$key" = "@clawhip_lane_generation" && test -f "$S/mismatch_generation" && printf 'different-generation' > "$S/${{key#@}}" ;;
   show-options) key="$5"; safe="${{key#@}}"; test -f "$S/unreadable_$safe" && exit 1; file="$S/$safe"; if test -f "$file"; then printf '%s\n' "$(cat "$file")"; else echo 'invalid option' >&2; exit 1; fi ;;
   send-keys) test "${{4:-}}" = "-l" || printf '1' >> "$S/sends" ;;
+  attach-session) printf '%s\n' "$3" >> "$S/attach_targets"; if test -f "$S/fail_attach_session"; then echo 'fixture-attach-failed' >&2; exit 1; fi ;;
   display-message) printf 'lane\t%%1\t1\tcodex\t/tmp\n' ;;
   kill-session) rm -f "$S/live" ;;
   list-sessions) test -f "$S/live" && test -f "$S/session" && cat "$S/session" ;;
@@ -546,6 +547,14 @@ fn calls_after(state: &Path, baseline: &str) -> String {
 
 fn command_count(calls: &str, command: &str) -> usize {
     calls.lines().filter(|call| *call == command).count()
+}
+
+fn last_command_position(calls: &str, command: &str) -> Option<usize> {
+    calls
+        .lines()
+        .enumerate()
+        .filter_map(|(index, call)| (call == command).then_some(index))
+        .last()
 }
 
 fn count(path: &Path, name: &str) -> usize {
@@ -862,7 +871,7 @@ fn timeout_and_malformed_kickoffs_have_one_post_and_no_command_effect() {
                 "--thread",
                 "123456789012345678",
                 "--kickoff",
-                "redacted",
+                "private-kickoff-body",
                 "--json",
                 "--",
                 "worker",
@@ -875,7 +884,7 @@ fn timeout_and_malformed_kickoffs_have_one_post_and_no_command_effect() {
         } else {
             "malformed-success"
         }));
-        assert!(!rendered.contains("redacted"));
+        assert!(!rendered.contains("private-kickoff-body"));
         assert_eq!(discord.count("POST"), 1);
         assert_eq!(count(&state, "sends"), 0);
     }
@@ -1531,4 +1540,317 @@ fn response_loss_reconciles_each_lane_mutation_without_duplicate_effects() {
         assert_eq!(proxy.path_count("/api/lane/delivery"), 1);
         assert_eq!(proxy.path_count("/api/lane/evidence"), 2);
     }
+}
+
+#[test]
+#[serial]
+fn command_lane_name_collision_has_no_unowned_tmux_effects() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    write_file(&state.join("session"), "owned-lane");
+    write_file(&state.join("live"), "1");
+    write_file(&state.join("fail_new_session"), "1");
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let baseline = fs::read_to_string(state.join("calls")).unwrap_or_default();
+
+    let output = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "owned-lane",
+            "--thread",
+            "1",
+            "--json",
+            "--",
+            "worker",
+        ],
+    );
+    failed(&output);
+    let json: Value = serde_json::from_slice(&output.stdout).expect("collision json");
+    assert_eq!(
+        json["durable_launch_state"],
+        "launch-failed-no-worker-effect"
+    );
+    assert_eq!(json["exit_category"], "session-create-failed");
+    assert_eq!(
+        json["thread_id"],
+        "discord:thread:redacted:af63ac4c86019afc"
+    );
+    assert!(!text(&output).contains("\"thread_id\":\"1\""));
+    assert_eq!(
+        fs::read_to_string(state.join("session")).expect("session"),
+        "owned-lane"
+    );
+    assert!(state.join("live").is_file());
+    for marker in [
+        "clawhip_lane_generation",
+        "clawhip_lane_launch_operation",
+        "clawhip_lane_command_submitted",
+    ] {
+        assert!(!state.join(marker).exists(), "unexpected marker {marker}");
+    }
+    let calls = calls_after(&state, &baseline);
+    assert_eq!(command_count(&calls, "new-session"), 1);
+    assert!(calls.lines().all(|call| !matches!(
+        call,
+        "set-option" | "show-options" | "send-keys" | "kill-session" | "attach-session"
+    )));
+    assert_eq!(count(&state, "sends"), 0);
+    assert_eq!(discord.count("POST"), 0);
+}
+
+#[test]
+#[serial]
+fn lane_launch_json_uses_canonical_safe_thread_target() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let output = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "safe-json",
+            "--thread",
+            "1",
+            "--json",
+        ],
+    );
+    successful(&output);
+    let json: Value = serde_json::from_slice(&output.stdout).expect("launch json");
+    assert_eq!(
+        json["thread_id"],
+        "discord:thread:redacted:af63ac4c86019afc"
+    );
+    assert_ne!(json["thread_id"], "1");
+    assert!(!text(&output).contains("\"thread_id\":\"1\""));
+}
+
+#[test]
+#[serial]
+fn lane_attach_is_exact_once_after_fresh_retained_success_and_never_failure() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let fresh = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "fresh-attach",
+            "--thread",
+            "1",
+            "--json",
+            "--attach",
+            "--",
+            "worker",
+        ],
+    );
+    successful(&fresh);
+    let fresh_json: Value = serde_json::from_slice(&fresh.stdout).expect("fresh json");
+    assert_eq!(fresh_json["durable_launch_state"], "launched");
+    assert_eq!(count(&state, "sends"), 1);
+    assert_eq!(count(&state, "attach_targets"), 1);
+    assert_eq!(
+        fs::read_to_string(state.join("attach_targets"))
+            .expect("target")
+            .trim(),
+        "fresh-attach"
+    );
+    let calls = fs::read_to_string(state.join("calls")).expect("calls");
+    assert!(
+        last_command_position(&calls, "attach-session")
+            > last_command_position(&calls, "send-keys")
+    );
+
+    let session = "retained-attach";
+    let generation_id = "generation-retained";
+    let kickoff_operation_id = "kickoff-retained";
+    let launch_operation_id = "launch-retained";
+    let executor_id = "executor-retained";
+    write_file(&state.join("session"), session);
+    write_file(&state.join("live"), "1");
+    write_file(&state.join("clawhip_lane_generation"), generation_id);
+    write_file(
+        &state.join("clawhip_lane_launch_operation"),
+        launch_operation_id,
+    );
+    write_file(
+        &state.join("clawhip_lane_command_submitted"),
+        launch_operation_id,
+    );
+    let registered = http_json_value(
+        port,
+        "POST",
+        "/api/lane/register",
+        json!({
+            "registration": {"session":session,"channel":null,"mention":null,"keywords":[],"keyword_window_secs":30,"stale_minutes":10,"format":null,"active_wrapper_monitor":false},
+            "generation_id":generation_id,"kickoff_operation_id":kickoff_operation_id,"launch_operation_id":launch_operation_id,"executor_id":executor_id,"worker_effect_kind":"command-submission","thread_id":"1","expect_absent_or_retired":true
+        }),
+    );
+    let claimed = http_json_value(
+        port,
+        "POST",
+        "/api/lane/claim",
+        json!({
+            "session":session,"generation_id":generation_id,"executor_id":executor_id,"expected_revision":registered["snapshot"]["revision"]
+        }),
+    );
+    let seeded = http_json_value(
+        port,
+        "POST",
+        "/api/lane/evidence",
+        json!({
+            "session":session,"generation_id":generation_id,"launch_operation_id":launch_operation_id,"expected_revision":claimed["revision"],"launch_state":"identity-verified","failure_category":null,"executor_id":executor_id,"worker_effect_kind":"command-submission"
+        }),
+    );
+    assert_eq!(seeded["durable_launch_state"], "identity-verified");
+    let send_baseline = count(&state, "sends");
+    let attach_baseline = count(&state, "attach_targets");
+    let retained = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            session,
+            "--thread",
+            "1",
+            "--json",
+            "--attach",
+            "--",
+            "worker",
+        ],
+    );
+    successful(&retained);
+    let retained_json: Value = serde_json::from_slice(&retained.stdout).expect("retained json");
+    assert_eq!(retained_json["durable_launch_state"], "launched");
+    assert_eq!(count(&state, "sends"), send_baseline);
+    assert_eq!(count(&state, "attach_targets"), attach_baseline + 1);
+    assert_eq!(
+        fs::read_to_string(state.join("attach_targets"))
+            .expect("targets")
+            .lines()
+            .last(),
+        Some(session)
+    );
+
+    write_file(&state.join("fail_new_session"), "1");
+    let attach_before_failure = count(&state, "attach_targets");
+    let failed_launch = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "failed-attach",
+            "--thread",
+            "1",
+            "--json",
+            "--attach",
+            "--",
+            "worker",
+        ],
+    );
+    failed(&failed_launch);
+    assert_eq!(count(&state, "attach_targets"), attach_before_failure);
+}
+
+#[test]
+#[serial]
+fn lane_attach_helper_failure_is_propagated_after_successful_launch() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    write_file(&state.join("fail_attach_session"), "1");
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let output = lane_command(
+        &config_path,
+        &home,
+        &tmux,
+        &discord,
+        &[
+            "tmux",
+            "new",
+            "--session",
+            "attach-error",
+            "--thread",
+            "1",
+            "--json",
+            "--attach",
+            "--",
+            "worker",
+        ],
+    );
+    failed(&output);
+    assert!(text(&output).contains("fixture-attach-failed"));
+    assert!(!text(&output).contains("\"thread_id\":\"1\""));
+    assert_eq!(count(&state, "attach_targets"), 1);
+    assert_eq!(
+        fs::read_to_string(state.join("attach_targets"))
+            .expect("target")
+            .trim(),
+        "attach-error"
+    );
+    assert_eq!(count(&state, "sends"), 1);
+    assert_eq!(
+        registry(&config_path)["attach-error"]["lane"]["launch_state"],
+        "launched"
+    );
+    let calls = fs::read_to_string(state.join("calls")).expect("calls");
+    assert_eq!(command_count(&calls, "attach-session"), 1);
+    assert!(
+        last_command_position(&calls, "attach-session")
+            > last_command_position(&calls, "send-keys")
+    );
 }


### PR DESCRIPTION
Closes #287.

## Summary
- stop command lanes on unconfirmed detached tmux creation before marker, command, cleanup, or attach effects
- emit the canonical fingerprinted Discord thread target in lane launch JSON instead of the raw thread ID
- restore lane-aware `--attach` through the existing attach helper after successful owned/finalized launches, with failure propagation

## Regression coverage
- same-name unrelated session collision has zero tmux effects
- exact canonical JSON target and raw-ID absence
- fresh and retained-success attach, failed-launch no-attach, and attach-helper failure propagation

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test` (679 unit tests plus all integration targets; lane suite 21/21)
- `git diff --check`
- adversarial Architect review: CLEAR / APPROVE
- executor CLI red-team: passed

## Gates
Do not merge until exact-head GJC review and CI are green. The live Mac-mini/PTY/Discord canary remains a post-review/merge release gate and was not performed or claimed here. No release is included.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*