### PR TITLE
feat: add daemon websocket subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "async-trait",
  "axum",
  "clap",
+ "futures-util",
  "reqwest",
  "serde",
  "serde_json",
@@ -238,6 +239,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "toml",
  "uuid",
 ]
@@ -266,6 +268,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
@@ -367,6 +375,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +404,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -535,7 +562,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1041,7 +1068,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1250,6 +1277,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1478,6 +1516,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1645,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1698,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -1795,6 +1874,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ async-trait = "0.1"
 axum = "0.8"
 clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+tokio-tungstenite = { version = "0.26", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+futures-util = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -958,3 +958,81 @@ clawhip includes a [`geobench`](https://github.com/NomaDamas/geobench) product s
 
 - Spec: [`geobench/clawhip.yaml`](geobench/clawhip.yaml)
 - Runbook: [`docs/geobench.md`](docs/geobench.md)
+
+## Websocket subscriptions
+
+Subscriptions are daemon-owned, guarded local ingress for a configured websocket event stream. Keep endpoint credentials outside the TOML file: the configuration names an environment variable, and `clawhip subscribe`, health, and API responses never print that name, its value, the endpoint URL, adapter arguments, adapter stderr, frames, or adapter output.
+
+Set the endpoint only in the daemon environment, then keep the subscription policy and route ownership in `~/.clawhip/config.toml`:
+
+```bash
+export GJC_WORKFLOW_GATE_WS='wss://localhost:9443/gjc-events'
+clawhip subscribe validate
+clawhip start
+```
+
+```toml
+[[subscriptions]]
+name = "gjc-workflow-gate"
+enabled = true
+kind = "websocket"
+endpoint_env = "GJC_WORKFLOW_GATE_WS"
+
+[subscriptions.filter]
+discriminator_pointer = "/type"
+discriminator_equals = "workflow_gate"
+
+[[subscriptions.filter.predicates]]
+pointer = "/gate/state"
+equals = "ready"
+
+[subscriptions.projection]
+workflow_id = "/workflow/id"
+gate_state = "/gate/state"
+
+[subscriptions.adapter]
+program = "/absolute/path/to/gjc-workflow-gate-adapter"
+args = []
+
+[subscriptions.routing]
+tool = "gjc"
+project = "my-project"
+
+[[routes]]
+event = "workflow.gate"
+sink = "discord"
+channel = "WORKFLOW_GATE_CHANNEL_ID"
+format = "alert"
+```
+
+A separate `question` subscription remains explicit and route-owned; it must not share a workflow-gate filter or silently inherit its channel:
+
+```toml
+[[subscriptions]]
+name = "gjc-question"
+enabled = true
+kind = "websocket"
+endpoint_env = "GJC_QUESTION_WS"
+
+[subscriptions.filter]
+discriminator_pointer = "/type"
+discriminator_equals = "question"
+
+[subscriptions.projection]
+question_id = "/question/id"
+summary = "/question/summary"
+
+[subscriptions.adapter]
+program = "/absolute/path/to/gjc-question-adapter"
+args = []
+
+[[routes]]
+event = "workflow.question"
+sink = "discord"
+channel = "QUESTIONS_CHANNEL_ID"
+format = "compact"
+```
+
+Use `clawhip subscribe list`, `clawhip subscribe status <name>`, `clawhip subscribe start <name>`, and `clawhip subscribe stop <name>` only against a loopback daemon. The daemon also enforces the loopback peer and numeric loopback `Host` checks. `start` and `stop` additionally require the fixed `x-clawhip-local-control: 1` request header (sent automatically by `clawhip`) and reject non-loopback `Origin` headers; this is a local browser-CSRF and DNS-rebinding guard, not a credential. Redirects are not followed. `start` and `stop` are idempotent and return a reason code. Enabled subscriptions reconnect with their configured bounded backoff; daemon shutdown cancels workers and waits a bounded time before aborting remaining work.
+
+Adapters receive only the selected projection on stdin and must emit exactly one bounded JSON object with `type` and object `payload` on stdout. They run with a cleared environment; do not depend on inherited credentials or emit logs on stdout. Route channels belong in `[[routes]]`, not in subscription frames or adapter output.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,11 @@ pub enum Commands {
     },
     /// Check daemon health/status.
     Status,
+    /// Inspect, validate, and control daemon-owned websocket subscriptions through the local daemon.
+    Subscribe {
+        #[command(subcommand)]
+        command: SubscribeCommands,
+    },
     #[command(
         about = "Scaffold common setup presets without editing advanced routes or monitors",
         long_about = "Scaffold the bounded quickstart preset catalog.\n\nAdvanced routes and monitors still require manual config editing or the bounded clawhip config editor."
@@ -343,6 +348,20 @@ fn normalize_emit_key(key: &str) -> &str {
 
 fn parse_emit_value(raw: &str) -> Value {
     serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SubscribeCommands {
+    /// Validate configured subscriptions without exposing endpoint environment details.
+    Validate,
+    /// List public-safe subscription lifecycle snapshots from the local daemon.
+    List,
+    /// Show one public-safe subscription lifecycle snapshot.
+    Status { name: String },
+    /// Request the configured subscription worker be running.
+    Start { name: String },
+    /// Request the configured subscription worker stop.
+    Stop { name: String },
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,8 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::Result;
+use crate::daemon::LOCAL_CONTROL_HEADER;
+
 use crate::config::AppConfig;
 use crate::events::IncomingEvent;
 use crate::source::tmux::RegisteredTmuxSession;
@@ -15,6 +17,46 @@ use crate::source::tmux::{
 pub struct DaemonClient {
     http: reqwest::Client,
     base_url: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SubscriptionStatus {
+    pub schema: String,
+    pub name: String,
+    pub enabled: bool,
+    pub state: String,
+    pub desired_running: bool,
+    pub started_at: Option<String>,
+    pub last_connected_at: Option<String>,
+    pub last_event_enqueued_at: Option<String>,
+    pub last_state_transition_at: String,
+    pub connection_attempts_total: u64,
+    pub connection_failures_total: u64,
+    pub reconnects_total: u64,
+    pub frames_received_total: u64,
+    pub frames_rejected_total: u64,
+    pub frames_matched_total: u64,
+    pub adapters_started_total: u64,
+    pub adapters_rejected_total: u64,
+    pub events_enqueued_total: u64,
+    pub last_reason_code: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SubscriptionListResponse {
+    pub schema: String,
+    pub subscriptions: Vec<SubscriptionStatus>,
+}
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SubscriptionDetailResponse {
+    pub schema: String,
+    pub subscription: SubscriptionStatus,
+}
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct SubscriptionActionResponse {
+    pub ok: bool,
+    pub name: String,
+    pub reason: String,
 }
 
 impl DaemonClient {
@@ -91,6 +133,7 @@ impl DaemonClient {
         let response = self
             .http
             .post(format!("{}/api/update/{action}", self.base_url))
+            .header(LOCAL_CONTROL_HEADER, "1")
             .json(&serde_json::json!({}))
             .send()
             .await?;
@@ -107,6 +150,7 @@ impl DaemonClient {
         let response = self
             .http
             .post(format!("{}{}", self.base_url, path))
+            .header(LOCAL_CONTROL_HEADER, "1")
             .json(payload)
             .send()
             .await?;
@@ -179,6 +223,34 @@ impl DaemonClient {
         }
     }
 
+    pub async fn list_subscriptions(&self) -> Result<SubscriptionListResponse> {
+        self.private_get_json("/api/subscriptions").await
+    }
+
+    pub async fn subscription_status(&self, name: &str) -> Result<SubscriptionDetailResponse> {
+        self.private_get_json(&format!(
+            "/api/subscriptions/{}",
+            subscription_path_name(name)
+        ))
+        .await
+    }
+
+    pub async fn start_subscription(&self, name: &str) -> Result<SubscriptionActionResponse> {
+        self.private_post_typed(
+            &format!("/api/subscriptions/{}/start", subscription_path_name(name)),
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    pub async fn stop_subscription(&self, name: &str) -> Result<SubscriptionActionResponse> {
+        self.private_post_typed(
+            &format!("/api/subscriptions/{}/stop", subscription_path_name(name)),
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
     async fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
         let response = self
             .http
@@ -213,6 +285,7 @@ impl DaemonClient {
         let response = self
             .http
             .post(format!("{}{}", self.base_url, path))
+            .header(LOCAL_CONTROL_HEADER, "1")
             .json(payload)
             .send()
             .await?;
@@ -254,6 +327,17 @@ impl DaemonClient {
     }
 }
 
+fn subscription_path_name(name: &str) -> String {
+    name.bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                vec![byte as char]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,7 +345,8 @@ mod tests {
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
-    use tokio::io::AsyncWriteExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
     use tokio::time::{Duration, timeout};
 
     #[test]
@@ -293,7 +378,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn private_lane_requests_do_not_follow_redirects() {
+    async fn private_subscription_requests_do_not_follow_redirects() {
         let target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let target_address = target.local_addr().unwrap();
         let target_hits = Arc::new(AtomicUsize::new(0));
@@ -322,9 +407,50 @@ mod tests {
                 .unwrap(),
             base_url: format!("http://{redirector_address}"),
         };
-        assert!(client.lane_detail("safe-session").await.is_err());
+        assert!(client.subscription_status("safe-session").await.is_err());
         redirect_task.await.unwrap();
         target_task.await.unwrap();
         assert_eq!(target_hits.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn subscription_path_name_escapes_unsafe_text() {
+        assert_eq!(subscription_path_name("a/b?c#d"), "a%2Fb%3Fc%23d");
+    }
+
+    #[tokio::test]
+    async fn subscription_requests_reject_remote_daemons() {
+        let client = DaemonClient {
+            http: reqwest::Client::new(),
+            base_url: "http://example.com".into(),
+        };
+        assert!(client.subscription_status("safe").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn subscription_client_sends_the_fixed_local_control_header() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4_096];
+            let size = stream.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..size]);
+            assert!(request.starts_with("POST /api/subscriptions/safe/start HTTP/1.1"));
+            assert!(request.contains("x-clawhip-local-control: 1\r\n"));
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 44\r\nConnection: close\r\n\r\n{\"ok\":true,\"name\":\"safe\",\"reason\":\"started\"}",
+                )
+                .await
+                .unwrap();
+        });
+        let client = DaemonClient {
+            http: reqwest::Client::new(),
+            base_url: format!("http://{address}"),
+        };
+        let response = client.start_subscription("safe").await.unwrap();
+        assert_eq!(response.reason, "started");
+        server.await.unwrap();
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,128 @@ pub struct AppConfig {
     pub update: crate::update::UpdateConfig,
     #[serde(default, skip_serializing_if = "GajaeConfig::is_empty")]
     pub gajae: GajaeConfig,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subscriptions: Vec<SubscriptionConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionConfig {
+    pub name: String,
+    #[serde(default)]
+    pub enabled: bool,
+    pub kind: String,
+    pub endpoint_env: String,
+    #[serde(default = "default_subscription_max_frame_bytes")]
+    pub max_frame_bytes: usize,
+    #[serde(default = "default_subscription_max_json_depth")]
+    pub max_json_depth: usize,
+    pub filter: SubscriptionFilterConfig,
+    pub projection: BTreeMap<String, String>,
+    pub adapter: SubscriptionAdapterConfig,
+    #[serde(default)]
+    pub reconnect: SubscriptionReconnectConfig,
+    #[serde(default)]
+    pub routing: SubscriptionRoutingConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionFilterConfig {
+    pub discriminator_pointer: String,
+    pub discriminator_equals: String,
+    #[serde(default)]
+    pub predicates: Vec<SubscriptionPredicateConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionPredicateConfig {
+    pub pointer: String,
+    pub equals: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionAdapterConfig {
+    pub program: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default = "default_subscription_timeout_ms")]
+    pub timeout_ms: u64,
+    #[serde(default = "default_subscription_stdin_bytes")]
+    pub max_stdin_bytes: usize,
+    #[serde(default = "default_subscription_stdout_bytes")]
+    pub max_stdout_bytes: usize,
+    #[serde(default = "default_subscription_stderr_bytes")]
+    pub max_stderr_bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionReconnectConfig {
+    #[serde(default = "default_subscription_initial_delay_ms")]
+    pub initial_delay_ms: u64,
+    #[serde(default = "default_subscription_max_delay_ms")]
+    pub max_delay_ms: u64,
+    #[serde(default = "default_subscription_max_attempts")]
+    pub max_attempts: u64,
+}
+impl Default for SubscriptionReconnectConfig {
+    fn default() -> Self {
+        Self {
+            initial_delay_ms: default_subscription_initial_delay_ms(),
+            max_delay_ms: default_subscription_max_delay_ms(),
+            max_attempts: default_subscription_max_attempts(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionRoutingConfig {
+    #[serde(default)]
+    pub tool: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub repo_name: Option<String>,
+    #[serde(default)]
+    pub repo_path: Option<String>,
+    #[serde(default)]
+    pub worktree_path: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
+}
+
+fn default_subscription_max_frame_bytes() -> usize {
+    65_536
+}
+fn default_subscription_max_json_depth() -> usize {
+    16
+}
+fn default_subscription_timeout_ms() -> u64 {
+    5_000
+}
+fn default_subscription_stdin_bytes() -> usize {
+    16_384
+}
+fn default_subscription_stdout_bytes() -> usize {
+    16_384
+}
+fn default_subscription_stderr_bytes() -> usize {
+    4_096
+}
+fn default_subscription_initial_delay_ms() -> u64 {
+    250
+}
+fn default_subscription_max_delay_ms() -> u64 {
+    5_000
+}
+fn default_subscription_max_attempts() -> u64 {
+    5
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -968,9 +1090,76 @@ impl AppConfig {
                 .any(|route| route.event.trim() == "*" && route.filter.is_empty())
     }
 
+    fn validate_subscription_config(subscription: &SubscriptionConfig) -> Result<()> {
+        let name = &subscription.name;
+        let valid_name = !name.is_empty()
+            && name == name.trim()
+            && name.len() <= 63
+            && name.as_bytes()[0].is_ascii_lowercase()
+            && name
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-');
+        if !valid_name || subscription.kind != "websocket" {
+            return Err("invalid_subscription_config".into());
+        }
+        let endpoint = &subscription.endpoint_env;
+        if endpoint.is_empty()
+            || endpoint.len() > 128
+            || (!endpoint.as_bytes()[0].is_ascii_uppercase() && endpoint.as_bytes()[0] != b'_')
+            || !endpoint
+                .bytes()
+                .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+        {
+            return Err("invalid_subscription_config".into());
+        }
+        if !(1024..=1_048_576).contains(&subscription.max_frame_bytes)
+            || !(1..=16).contains(&subscription.max_json_depth)
+            || subscription.filter.discriminator_equals.is_empty()
+            || subscription.filter.discriminator_equals.len() > 128
+            || subscription.filter.predicates.len() > 8
+            || !(1..=16).contains(&subscription.projection.len())
+        {
+            return Err("invalid_subscription_config".into());
+        }
+        if !subscription.adapter.program.starts_with('/')
+            || subscription.adapter.program.len() > 4096
+            || subscription.adapter.args.len() > 16
+            || subscription.adapter.args.iter().any(|arg| arg.len() > 256)
+            || !(100..=30_000).contains(&subscription.adapter.timeout_ms)
+            || !(1..=65_536).contains(&subscription.adapter.max_stdin_bytes)
+            || !(1..=65_536).contains(&subscription.adapter.max_stdout_bytes)
+            || !(1..=16_384).contains(&subscription.adapter.max_stderr_bytes)
+            || !(1..=10).contains(&subscription.reconnect.max_attempts)
+            || !(10..=5_000).contains(&subscription.reconnect.initial_delay_ms)
+            || subscription.reconnect.max_delay_ms < subscription.reconnect.initial_delay_ms
+            || subscription.reconnect.max_delay_ms > 30_000
+        {
+            return Err("invalid_subscription_config".into());
+        }
+        if subscription.enabled
+            && !crate::source::subscription::is_regular_executable(&subscription.adapter.program)
+        {
+            return Err("invalid_subscription_config".into());
+        }
+        crate::source::subscription::validate_projection_policy(subscription)?;
+        crate::source::subscription::validate_filter_policy(subscription)?;
+
+        Ok(())
+    }
+
     pub fn validate(&self) -> Result<()> {
         if self.dispatch.ci_batch_window_secs == 0 {
             return Err("dispatch.ci_batch_window_secs must be at least 1".into());
+        }
+        if self.subscriptions.len() > 32 {
+            return Err("invalid_subscription_config".into());
+        }
+        let mut subscription_names = std::collections::BTreeSet::new();
+        for subscription in &self.subscriptions {
+            Self::validate_subscription_config(subscription)?;
+            if !subscription_names.insert(subscription.name.trim().to_ascii_lowercase()) {
+                return Err("invalid_subscription_config".into());
+            }
         }
         if self.cron.poll_interval_secs == 0 {
             return Err("cron.poll_interval_secs must be at least 1".into());
@@ -2978,5 +3167,114 @@ name = "general"
             .collect::<std::result::Result<Vec<_>, _>>()
             .unwrap();
         assert_eq!(remaining.len(), 10);
+    }
+}
+
+#[cfg(test)]
+mod subscription_config_tests {
+    use super::AppConfig;
+
+    #[test]
+    fn rejects_unknown_subscription_and_endpoint_fields() {
+        let config = r#"
+[[subscriptions]]
+name = "gjc-workflow-gate"
+enabled = false
+kind = "websocket"
+endpoint_env = "GJC_WS_URL"
+endpoint = "wss://secret.invalid"
+[subscriptions.filter]
+discriminator_pointer = "/type"
+discriminator_equals = "workflow_gate"
+[subscriptions.projection]
+workflow_id = "/workflow/id"
+[subscriptions.adapter]
+program = "/bin/true"
+"#;
+        assert!(toml::from_str::<AppConfig>(config).is_err());
+    }
+
+    #[test]
+    fn rejects_subscription_names_with_surrounding_whitespace() {
+        let config: AppConfig = toml::from_str(
+            r#"
+[[subscriptions]]
+name = " workflow-gate "
+enabled = false
+kind = "websocket"
+endpoint_env = "WORKFLOW_GATE_URL"
+[subscriptions.filter]
+discriminator_pointer = "/type"
+discriminator_equals = "workflow_gate"
+[subscriptions.projection]
+workflow_id = "/workflow/id"
+[subscriptions.adapter]
+program = "/bin/true"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.validate().unwrap_err().to_string(),
+            "invalid_subscription_config"
+        );
+    }
+
+    #[test]
+    fn documented_workflow_gate_and_question_subscriptions_parse_and_validate() {
+        let config: AppConfig = toml::from_str(
+            r#"
+[providers.discord]
+token = "fixture-token"
+[[subscriptions]]
+name = "gjc-workflow-gate"
+enabled = false
+kind = "websocket"
+endpoint_env = "GJC_WORKFLOW_GATE_WS"
+[subscriptions.filter]
+discriminator_pointer = "/type"
+discriminator_equals = "workflow_gate"
+[[subscriptions.filter.predicates]]
+pointer = "/gate/state"
+equals = "ready"
+[subscriptions.projection]
+workflow_id = "/workflow/id"
+gate_state = "/gate/state"
+[subscriptions.adapter]
+program = "/bin/true"
+[subscriptions.routing]
+tool = "gjc"
+project = "my-project"
+
+[[subscriptions]]
+name = "gjc-question"
+enabled = false
+kind = "websocket"
+endpoint_env = "GJC_QUESTION_WS"
+[subscriptions.filter]
+discriminator_pointer = "/type"
+discriminator_equals = "question"
+[subscriptions.projection]
+question_id = "/question/id"
+summary = "/question/summary"
+[subscriptions.adapter]
+program = "/bin/true"
+
+[[routes]]
+event = "workflow.gate"
+sink = "discord"
+channel = "WORKFLOW_GATE_CHANNEL_ID"
+format = "alert"
+
+[[routes]]
+event = "workflow.question"
+sink = "discord"
+channel = "QUESTIONS_CHANNEL_ID"
+format = "compact"
+"#,
+        )
+        .unwrap();
+
+        config.validate().unwrap();
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,17 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-
-use axum::extract::{ConnectInfo, FromRequestParts, State};
-use axum::http::{HeaderMap, StatusCode};
-use axum::response::IntoResponse;
-use axum::routing::{get, post};
-use axum::{Json, Router as AxumRouter};
-use serde_json::{Value, json};
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
-use tokio::sync::{Mutex, RwLock, mpsc};
 
 use crate::Result;
 use crate::VERSION;
@@ -40,15 +31,28 @@ use crate::source::tmux::{
     retire_lane_if_absent, update_lane_evidence, update_lane_workflow,
 };
 use crate::source::{
-    GitHubSource, GitSource, RegisteredTmuxSession, SharedTmuxRegistry, Source, TmuxSource,
-    WorkspaceSource, default_registry_state_path, inspect_tmux_registry_state,
-    list_active_tmux_registrations, load_tmux_registry_state, register_runtime_tmux_registration,
-    remove_tmux_registrations, tmux_registry_diagnostics,
+    GitHubSource, GitSource, RegisteredTmuxSession, SharedTmuxRegistry, Source,
+    SubscriptionSnapshot, SubscriptionState, SubscriptionWorker, TmuxSource, WorkspaceSource,
+    default_registry_state_path, inspect_tmux_registry_state, list_active_tmux_registrations,
+    load_tmux_registry_state, register_runtime_tmux_registration, remove_tmux_registrations,
+    tmux_registry_diagnostics,
 };
 use crate::telemetry;
 use crate::update::{self, SharedPendingUpdate};
+use axum::extract::{ConnectInfo, FromRequestParts, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router as AxumRouter};
+use serde_json::{Value, json};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use tokio::sync::{Mutex, RwLock, mpsc, watch};
 
 const EVENT_QUEUE_CAPACITY: usize = 256;
+pub const LOCAL_CONTROL_HEADER: &str = "x-clawhip-local-control";
+const LOCAL_CONTROL_HEADER_VALUE: &str = "1";
+const LOCAL_CONTROL_REJECTED: &str = "local_control_rejected";
+
 const STALE_NATIVE_REPLAY_GRACE: Duration = Duration::from_secs(5 * 60);
 const STALE_NATIVE_REPLAY_REASON: &str = "stale_replay";
 const NATIVE_REPLAY_TIMESTAMP_POINTERS: &[&str] = &[
@@ -77,6 +81,22 @@ struct AppState {
     native_observability: SharedNativeHookObservability,
     cron_state_path: PathBuf,
     discord_watch_lock: Arc<Mutex<()>>,
+    subscriptions: SharedSubscriptionRegistry,
+}
+
+type SharedSubscriptionRegistry = Arc<RwLock<BTreeMap<String, SubscriptionEntry>>>;
+
+struct SubscriptionEntry {
+    config: Arc<crate::config::SubscriptionConfig>,
+    snapshot: Arc<Mutex<SubscriptionSnapshot>>,
+    cancel: watch::Sender<bool>,
+    worker: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl AppState {
+    fn subscription_registry(&self) -> SharedSubscriptionRegistry {
+        self.subscriptions.clone()
+    }
 }
 
 pub async fn run(
@@ -114,6 +134,7 @@ pub async fn run(
     load_tmux_registry_state(&tmux_registry_state_path, &tmux_registry).await;
     let (tx, rx) = mpsc::channel(EVENT_QUEUE_CAPACITY);
     let native_observability = new_shared_native_hook_observability();
+    let subscriptions = new_subscription_registry(config.as_ref(), tx.clone()).await;
 
     let ci_batch_window = config.dispatch.ci_batch_window();
     let routine_batch_window = config.dispatch.routine_batch_window();
@@ -183,7 +204,11 @@ pub async fn run(
             post(record_lane_verification_handler),
         )
         .route("/api/lane/delivery", post(record_lane_delivery_handler))
-        .route("/api/lane/retire", post(retire_lane_handler));
+        .route("/api/lane/retire", post(retire_lane_handler))
+        .route("/api/subscriptions", get(list_subscriptions))
+        .route("/api/subscriptions/{name}", get(subscription_detail))
+        .route("/api/subscriptions/{name}/start", post(start_subscription))
+        .route("/api/subscriptions/{name}/stop", post(stop_subscription));
     let port = port_override.unwrap_or(config.daemon.port);
 
     let app = app.with_state(AppState {
@@ -195,6 +220,7 @@ pub async fn run(
         native_observability,
         cron_state_path,
         discord_watch_lock: Arc::new(Mutex::new(())),
+        subscriptions: subscriptions.clone(),
     });
     let addr: SocketAddr = format!("{}:{}", config.daemon.bind_host, port).parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
@@ -211,7 +237,9 @@ pub async fn run(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
+    .with_graceful_shutdown(daemon_shutdown_signal())
     .await?;
+    shutdown_subscriptions(&subscriptions).await;
     Ok(())
 }
 
@@ -319,12 +347,14 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let registry_state =
         inspect_tmux_registry_state(&default_registry_state_path(&state.cron_state_path)).await;
     let tmux = tmux_registry_diagnostics(&state.tmux_registry, registry_state).await;
+    let subscriptions = subscription_snapshots(&state.subscription_registry()).await;
     Json(health_payload(
         state.config.as_ref(),
         state.port,
         registered,
         native_hooks,
         json!(tmux),
+        &subscriptions,
     ))
 }
 
@@ -334,15 +364,20 @@ fn health_payload(
     registered_tmux_sessions: usize,
     native_hooks: Value,
     tmux: Value,
+    subscriptions: &[SubscriptionSnapshot],
 ) -> Value {
+    let degraded = subscriptions.iter().any(|subscription| {
+        subscription.enabled
+            && subscription.desired_running
+            && subscription.state == SubscriptionState::Exhausted
+    });
     json!({
-        "ok": true,
+        "ok": !degraded,
         "version": VERSION,
         "token_source": config.discord_token_source(),
         "token_precedence_warning": config.discord_token_env_shadow().map(discord_token_shadow_warning),
         "webhook_routes_configured": config.has_webhook_routes(),
         "port": port,
-        "daemon_base_url": config.daemon.base_url,
         "configured_git_monitors": config.monitors.git.repos.len(),
         "configured_tmux_monitors": config.monitors.tmux.sessions.len(),
         "configured_workspace_monitors": config.monitors.workspace.len(),
@@ -350,6 +385,7 @@ fn health_payload(
         "registered_tmux_sessions": registered_tmux_sessions,
         "tmux": tmux,
         "native_hooks": native_hooks,
+        "subscriptions": {"configured": subscriptions.len(), "degraded": degraded},
     })
 }
 
@@ -357,6 +393,253 @@ async fn status(State(state): State<AppState>) -> impl IntoResponse {
     health(State(state)).await
 }
 
+async fn daemon_shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{SignalKind, signal};
+        if let Ok(mut signal) = signal(SignalKind::terminate()) {
+            signal.recv().await;
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! { _ = ctrl_c => {}, _ = terminate => {} }
+}
+
+async fn new_subscription_registry(
+    config: &AppConfig,
+    tx: mpsc::Sender<IncomingEvent>,
+) -> SharedSubscriptionRegistry {
+    let registry = Arc::new(RwLock::new(BTreeMap::new()));
+    for subscription in &config.subscriptions {
+        let config = Arc::new(subscription.clone());
+        let snapshot = Arc::new(Mutex::new(SubscriptionSnapshot::new(&config)));
+        let (cancel, receiver) = watch::channel(false);
+        let worker = config.enabled.then(|| {
+            spawn_subscription_worker(config.clone(), snapshot.clone(), receiver, tx.clone())
+        });
+        registry.write().await.insert(
+            config.name.clone(),
+            SubscriptionEntry {
+                config,
+                snapshot,
+                cancel,
+                worker,
+            },
+        );
+    }
+    registry
+}
+
+fn spawn_subscription_worker(
+    config: Arc<crate::config::SubscriptionConfig>,
+    snapshot: Arc<Mutex<SubscriptionSnapshot>>,
+    cancel: watch::Receiver<bool>,
+    tx: mpsc::Sender<IncomingEvent>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        {
+            let mut status = snapshot.lock().await;
+            status.mark_started();
+            status.transition(SubscriptionState::Connecting, "connecting");
+        }
+        let cancellation = cancel.clone();
+        let result = SubscriptionWorker {
+            config,
+            snapshot: snapshot.clone(),
+            cancel,
+        }
+        .run(tx)
+        .await;
+        let mut status = snapshot.lock().await;
+        if result.is_err() {
+            if status.state != SubscriptionState::Exhausted {
+                status.transition(SubscriptionState::Exhausted, "worker_failed");
+            }
+        } else if *cancellation.borrow() {
+            status.transition(SubscriptionState::Stopped, "cancelled");
+        }
+    })
+}
+
+async fn subscription_snapshots(
+    registry: &SharedSubscriptionRegistry,
+) -> Vec<SubscriptionSnapshot> {
+    let snapshots: Vec<_> = registry
+        .read()
+        .await
+        .values()
+        .map(|entry| entry.snapshot.clone())
+        .collect();
+    let mut values = Vec::with_capacity(snapshots.len());
+    for snapshot in snapshots {
+        values.push(snapshot.lock().await.clone());
+    }
+    values
+}
+
+fn subscription_error(status: StatusCode, reason: &'static str) -> axum::response::Response {
+    (status, Json(json!({"ok": false, "reason": reason}))).into_response()
+}
+
+async fn list_subscriptions(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+) -> axum::response::Response {
+    Json(json!({"schema": "clawhip.subscriptions.v1", "subscriptions": subscription_snapshots(&state.subscription_registry()).await})).into_response()
+}
+
+async fn subscription_detail(
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> axum::response::Response {
+    let snapshot = state
+        .subscription_registry()
+        .read()
+        .await
+        .get(&name)
+        .map(|entry| entry.snapshot.clone());
+    match snapshot {
+        Some(snapshot) => Json(json!({"schema": "clawhip.subscription.v1", "subscription": snapshot.lock().await.clone()})).into_response(),
+        None => subscription_error(StatusCode::NOT_FOUND, "unknown_subscription"),
+    }
+}
+
+async fn start_subscription(
+    _control: SubscriptionControlRequest,
+
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> axum::response::Response {
+    let registry_handle = state.subscription_registry();
+    let mut registry = registry_handle.write().await;
+    let Some(entry) = registry.get_mut(&name) else {
+        return subscription_error(StatusCode::NOT_FOUND, "unknown_subscription");
+    };
+    if !entry.config.enabled {
+        return subscription_error(StatusCode::CONFLICT, "disabled_subscription");
+    }
+    if entry
+        .worker
+        .as_ref()
+        .is_some_and(|worker| worker.is_finished())
+    {
+        entry.worker = None;
+    }
+    if entry.worker.is_some() {
+        return Json(json!({"ok": true, "name": name, "reason": "already_running"}))
+            .into_response();
+    }
+    let (cancel, receiver) = watch::channel(false);
+    entry.cancel = cancel;
+    {
+        let mut snapshot = entry.snapshot.lock().await;
+        snapshot.desired_running = true;
+        snapshot.transition(SubscriptionState::Starting, "start_requested");
+    }
+    entry.worker = Some(spawn_subscription_worker(
+        entry.config.clone(),
+        entry.snapshot.clone(),
+        receiver,
+        state.tx.clone(),
+    ));
+    Json(json!({"ok": true, "name": name, "reason": "started"})).into_response()
+}
+
+async fn stop_subscription_entry(
+    registry: &SharedSubscriptionRegistry,
+    name: &str,
+) -> std::result::Result<&'static str, (StatusCode, &'static str)> {
+    let (mut worker, snapshot) = {
+        let mut registry = registry.write().await;
+        let Some(entry) = registry.get_mut(name) else {
+            return Err((StatusCode::NOT_FOUND, "unknown_subscription"));
+        };
+        if !entry.config.enabled {
+            return Err((StatusCode::CONFLICT, "disabled_subscription"));
+        }
+        let snapshot = entry.snapshot.clone();
+        let Some(worker) = entry.worker.take() else {
+            let mut status = snapshot.lock().await;
+            status.desired_running = false;
+            status.transition(SubscriptionState::Stopped, "already_stopped");
+            return Ok("already_stopped");
+        };
+        let _ = entry.cancel.send(true);
+        {
+            let mut status = snapshot.lock().await;
+            status.desired_running = false;
+            status.transition(SubscriptionState::Stopping, "stop_requested");
+        }
+        (worker, snapshot)
+    };
+    let reason = if tokio::time::timeout(Duration::from_secs(5), &mut worker)
+        .await
+        .is_ok()
+    {
+        "stopped"
+    } else {
+        worker.abort();
+        let _ = worker.await;
+        "stop_timeout"
+    };
+    let mut status = snapshot.lock().await;
+    status.desired_running = false;
+    status.transition(SubscriptionState::Stopped, reason);
+    Ok(reason)
+}
+
+async fn stop_subscription(
+    _control: SubscriptionControlRequest,
+
+    _peer: LoopbackLanePeer,
+    State(state): State<AppState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> axum::response::Response {
+    match stop_subscription_entry(&state.subscription_registry(), &name).await {
+        Ok(reason) => Json(json!({"ok": true, "name": name, "reason": reason})).into_response(),
+        Err((status, reason)) => subscription_error(status, reason),
+    }
+}
+
+async fn shutdown_subscriptions(registry: &SharedSubscriptionRegistry) {
+    let workers: Vec<_> = {
+        let mut entries = registry.write().await;
+        let mut workers = Vec::new();
+        for entry in entries.values_mut() {
+            let _ = entry.cancel.send(true);
+            if let Some(worker) = entry.worker.take() {
+                workers.push((worker, entry.snapshot.clone()));
+            }
+        }
+        workers
+    };
+    for (mut worker, snapshot) in workers {
+        {
+            let mut snapshot = snapshot.lock().await;
+            snapshot.desired_running = false;
+            if snapshot.state != SubscriptionState::Exhausted {
+                snapshot.transition(SubscriptionState::Stopping, "shutdown_requested");
+            }
+        }
+        if tokio::time::timeout(Duration::from_secs(5), &mut worker)
+            .await
+            .is_err()
+        {
+            worker.abort();
+            let _ = worker.await;
+            let mut snapshot = snapshot.lock().await;
+            if snapshot.state != SubscriptionState::Exhausted {
+                snapshot.transition(SubscriptionState::Stopped, "shutdown_timeout");
+            }
+        }
+    }
+}
 async fn post_event(
     State(state): State<AppState>,
     Json(event): Json<IncomingEvent>,
@@ -1063,6 +1346,79 @@ struct LaneWorkflowDto {
     generation_id: String,
 }
 
+fn local_control_error() -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({"ok": false, "reason": LOCAL_CONTROL_REJECTED})),
+    )
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let host = host.trim_matches(['[', ']']);
+    host.parse::<std::net::IpAddr>().is_ok_and(|ip| {
+        ip.is_loopback()
+            || matches!(ip, std::net::IpAddr::V6(ip) if ip.to_ipv4().is_some_and(|ip| ip.is_loopback()))
+    })
+}
+
+fn request_host_is_loopback(headers: &HeaderMap) -> bool {
+    let Some(host) = headers
+        .get(axum::http::header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    reqwest::Url::parse(&format!("http://{host}"))
+        .ok()
+        .and_then(|url| url.host_str().map(is_loopback_host))
+        .unwrap_or(false)
+}
+
+fn origin_is_loopback(headers: &HeaderMap) -> bool {
+    let Some(origin) = headers.get(axum::http::header::ORIGIN) else {
+        return true;
+    };
+    origin
+        .to_str()
+        .ok()
+        .and_then(|origin| reqwest::Url::parse(origin).ok())
+        .and_then(|url| url.host_str().map(is_loopback_host))
+        .unwrap_or(false)
+}
+
+#[derive(Debug)]
+struct SubscriptionControlRequest;
+
+impl<S: Send + Sync> FromRequestParts<S> for SubscriptionControlRequest {
+    type Rejection = (StatusCode, Json<Value>);
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        let peer_is_loopback = parts
+            .extensions
+            .get::<ConnectInfo<SocketAddr>>()
+            .is_some_and(|peer| {
+                peer.0.ip().is_loopback()
+                    || matches!(peer.0.ip(), std::net::IpAddr::V6(ip) if ip.to_ipv4().is_some_and(|ip| ip.is_loopback()))
+            });
+        let has_control_header = parts
+            .headers
+            .get(LOCAL_CONTROL_HEADER)
+            .is_some_and(|value| value.as_bytes() == LOCAL_CONTROL_HEADER_VALUE.as_bytes());
+        if peer_is_loopback
+            && has_control_header
+            && request_host_is_loopback(&parts.headers)
+            && origin_is_loopback(&parts.headers)
+        {
+            Ok(Self)
+        } else {
+            Err(local_control_error())
+        }
+    }
+}
+
 struct LoopbackLanePeer;
 impl<S: Send + Sync> FromRequestParts<S> for LoopbackLanePeer {
     type Rejection = (StatusCode, Json<Value>);
@@ -1650,6 +2006,7 @@ mod tests {
                 native_observability: new_shared_native_hook_observability(),
                 cron_state_path: PathBuf::from("cron-state.json"),
                 discord_watch_lock: Arc::new(Mutex::new(())),
+                subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             },
             rx,
         )
@@ -1685,6 +2042,84 @@ mod tests {
         );
     }
 
+    fn subscription_control_parts(
+        peer: Option<&str>,
+        host: Option<&str>,
+        origin: Option<&str>,
+        control_header: Option<&str>,
+    ) -> axum::http::request::Parts {
+        let mut parts = axum::http::Request::new(()).into_parts().0;
+        if let Some(peer) = peer {
+            parts
+                .extensions
+                .insert(ConnectInfo(peer.parse::<SocketAddr>().unwrap()));
+        }
+        if let Some(host) = host {
+            parts
+                .headers
+                .insert(axum::http::header::HOST, host.parse().unwrap());
+        }
+        if let Some(origin) = origin {
+            parts
+                .headers
+                .insert(axum::http::header::ORIGIN, origin.parse().unwrap());
+        }
+        if let Some(value) = control_header {
+            parts
+                .headers
+                .insert(LOCAL_CONTROL_HEADER, value.parse().unwrap());
+        }
+        parts
+    }
+
+    #[tokio::test]
+    async fn subscription_control_requires_loopback_peer_header_host_and_origin() {
+        for (peer, host, origin, header) in [
+            (
+                Some("192.0.2.1:1"),
+                Some("127.0.0.1:25294"),
+                None,
+                Some("1"),
+            ),
+            (None, Some("127.0.0.1:25294"), None, Some("1")),
+            (Some("127.0.0.1:1"), Some("127.0.0.1:25294"), None, None),
+            (
+                Some("127.0.0.1:1"),
+                Some("example.invalid:25294"),
+                None,
+                Some("1"),
+            ),
+            (
+                Some("127.0.0.1:1"),
+                Some("127.0.0.1:25294"),
+                Some("https://example.invalid"),
+                Some("1"),
+            ),
+        ] {
+            let mut parts = subscription_control_parts(peer, host, origin, header);
+            let rejection = SubscriptionControlRequest::from_request_parts(&mut parts, &())
+                .await
+                .unwrap_err();
+            assert_eq!(rejection.0, StatusCode::FORBIDDEN);
+            assert_eq!(
+                (rejection.1).0["reason"],
+                Value::String(LOCAL_CONTROL_REJECTED.into())
+            );
+        }
+
+        let mut valid = subscription_control_parts(
+            Some("127.0.0.1:1"),
+            Some("127.0.0.1:25294"),
+            Some("http://127.0.0.1:3000"),
+            Some("1"),
+        );
+        assert!(
+            SubscriptionControlRequest::from_request_parts(&mut valid, &())
+                .await
+                .is_ok()
+        );
+    }
+
     #[test]
     fn bare_lane_registration_payload_matches_client_wire_schema() {
         let input = LaneRegistrationInput {
@@ -1715,6 +2150,7 @@ mod tests {
                 native_observability: new_shared_native_hook_observability(),
                 cron_state_path: PathBuf::from("cron-state.json"),
                 discord_watch_lock: Arc::new(Mutex::new(())),
+                subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             },
             rx,
         )
@@ -2048,6 +2484,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: dir.path().join("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = accept_event(
@@ -2095,6 +2532,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = accept_event(
@@ -2136,6 +2574,7 @@ mod tests {
             3,
             snapshot_shared(&new_shared_native_hook_observability()),
             json!({}),
+            &[],
         );
 
         assert_eq!(payload["ok"], Value::Bool(true));
@@ -2148,6 +2587,215 @@ mod tests {
         assert_eq!(payload["registered_tmux_sessions"], Value::from(3));
         assert!(payload["native_hooks"]["totals"]["received"].is_number());
         assert_eq!(payload["token_precedence_warning"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn subscription_errors_are_safe_and_health_degrades_only_for_enabled_exhaustion() {
+        let response = subscription_error(StatusCode::NOT_FOUND, "unknown_subscription");
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).unwrap(),
+            json!({"ok": false, "reason": "unknown_subscription"})
+        );
+
+        let mut config = AppConfig::default();
+        config.providers.discord.bot_token = Some("secret-token".into());
+        let snapshot = SubscriptionSnapshot {
+            schema: "clawhip.subscription.v1",
+            name: "workflow-gate".into(),
+            enabled: true,
+            state: SubscriptionState::Exhausted,
+            desired_running: true,
+            started_at: Some("2026-01-01T00:00:00Z".into()),
+            last_connected_at: None,
+            last_event_enqueued_at: None,
+            last_state_transition_at: "2026-01-01T00:00:00Z".into(),
+            connection_attempts_total: 1,
+            connection_failures_total: 1,
+            reconnects_total: 0,
+            frames_received_total: 0,
+            frames_rejected_total: 0,
+            frames_matched_total: 0,
+            adapters_started_total: 0,
+            adapters_rejected_total: 0,
+            events_enqueued_total: 0,
+            last_reason_code: "retry_exhausted",
+        };
+        let payload = health_payload(&config, 25294, 0, json!({}), json!({}), &[snapshot]);
+        assert_eq!(payload["ok"], Value::Bool(false));
+        assert_eq!(payload["subscriptions"]["degraded"], Value::Bool(true));
+        assert!(!payload.to_string().contains("secret-token"));
+    }
+
+    fn subscription_test_config() -> crate::config::SubscriptionConfig {
+        crate::config::SubscriptionConfig {
+            name: "workflow-gate".into(),
+            enabled: true,
+            kind: "websocket".into(),
+            endpoint_env: "!".into(),
+            max_frame_bytes: 65_536,
+            max_json_depth: 16,
+            filter: crate::config::SubscriptionFilterConfig {
+                discriminator_pointer: "/type".into(),
+                discriminator_equals: "workflow_gate".into(),
+                predicates: vec![],
+            },
+            projection: [("workflow_id".into(), "/workflow/id".into())]
+                .into_iter()
+                .collect(),
+            adapter: crate::config::SubscriptionAdapterConfig {
+                program: "/bin/true".into(),
+                args: vec![],
+                timeout_ms: 5_000,
+                max_stdin_bytes: 16_384,
+                max_stdout_bytes: 16_384,
+                max_stderr_bytes: 4_096,
+            },
+            reconnect: crate::config::SubscriptionReconnectConfig::default(),
+            routing: crate::config::SubscriptionRoutingConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscription_handlers_use_the_real_registry_and_keep_responses_redacted() {
+        let (state, _rx) = native_hook_test_state();
+        let enabled = Arc::new(subscription_test_config());
+        let enabled_snapshot = Arc::new(Mutex::new(SubscriptionSnapshot::new(&enabled)));
+        let (enabled_cancel, _) = watch::channel(false);
+        let mut disabled_config = subscription_test_config();
+        disabled_config.name = "disabled-gate".into();
+        disabled_config.enabled = false;
+        let disabled = Arc::new(disabled_config);
+        let disabled_snapshot = Arc::new(Mutex::new(SubscriptionSnapshot::new(&disabled)));
+        let (disabled_cancel, _) = watch::channel(false);
+        let registry = state.subscription_registry();
+        let mut entries = registry.write().await;
+        entries.insert(
+            enabled.name.clone(),
+            SubscriptionEntry {
+                config: enabled,
+                snapshot: enabled_snapshot,
+                cancel: enabled_cancel,
+                worker: None,
+            },
+        );
+        entries.insert(
+            disabled.name.clone(),
+            SubscriptionEntry {
+                config: disabled,
+                snapshot: disabled_snapshot,
+                cancel: disabled_cancel,
+                worker: None,
+            },
+        );
+        drop(entries);
+
+        let list = list_subscriptions(LoopbackLanePeer, State(state.clone())).await;
+        let list_body = to_bytes(list.into_body(), usize::MAX).await.unwrap();
+        let list_json: Value = serde_json::from_slice(&list_body).unwrap();
+        assert_eq!(list_json["subscriptions"].as_array().unwrap().len(), 2);
+        assert!(!list_json.to_string().contains("endpoint_env"));
+        assert!(!list_json.to_string().contains("/bin/true"));
+
+        let detail = subscription_detail(
+            LoopbackLanePeer,
+            State(state.clone()),
+            axum::extract::Path("workflow-gate".into()),
+        )
+        .await;
+        assert_eq!(detail.status(), StatusCode::OK);
+        let unknown = subscription_detail(
+            LoopbackLanePeer,
+            State(state.clone()),
+            axum::extract::Path("missing".into()),
+        )
+        .await;
+        assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+
+        let disabled_start = start_subscription(
+            SubscriptionControlRequest,
+            LoopbackLanePeer,
+            State(state.clone()),
+            axum::extract::Path("disabled-gate".into()),
+        )
+        .await;
+        assert_eq!(disabled_start.status(), StatusCode::CONFLICT);
+        let unknown_stop = stop_subscription(
+            SubscriptionControlRequest,
+            LoopbackLanePeer,
+            State(state),
+            axum::extract::Path("missing".into()),
+        )
+        .await;
+        assert_eq!(unknown_stop.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn subscription_worker_preserves_exhaustion_and_degrades_health() {
+        let config = Arc::new(subscription_test_config());
+        let snapshot = Arc::new(Mutex::new(SubscriptionSnapshot::new(&config)));
+        let (_cancel, receiver) = watch::channel(false);
+        let (tx, _rx) = mpsc::channel(1);
+
+        spawn_subscription_worker(config.clone(), snapshot.clone(), receiver, tx)
+            .await
+            .expect("worker joins");
+
+        let status = snapshot.lock().await.clone();
+        assert_eq!(status.state, SubscriptionState::Exhausted);
+        assert_eq!(status.last_reason_code, "endpoint_unavailable");
+        assert!(status.desired_running);
+        let payload = health_payload(
+            &AppConfig::default(),
+            25294,
+            0,
+            json!({}),
+            json!({}),
+            &[status],
+        );
+        assert_eq!(payload["ok"], Value::Bool(false));
+        assert_eq!(payload["subscriptions"]["degraded"], Value::Bool(true));
+    }
+
+    #[tokio::test]
+    async fn stopping_an_already_finished_subscription_worker_is_stable() {
+        let config = Arc::new(subscription_test_config());
+        let snapshot = Arc::new(Mutex::new(SubscriptionSnapshot::new(&config)));
+        let (cancel, _receiver) = watch::channel(false);
+        snapshot
+            .lock()
+            .await
+            .transition(SubscriptionState::Exhausted, "retry_exhausted");
+        let worker = tokio::spawn(async {});
+        tokio::task::yield_now().await;
+        assert!(worker.is_finished());
+        let registry: SharedSubscriptionRegistry = Arc::new(RwLock::new(BTreeMap::new()));
+        registry.write().await.insert(
+            config.name.clone(),
+            SubscriptionEntry {
+                config,
+                snapshot: snapshot.clone(),
+                cancel,
+                worker: Some(worker),
+            },
+        );
+
+        assert_eq!(
+            stop_subscription_entry(&registry, "workflow-gate")
+                .await
+                .expect("stop succeeds"),
+            "stopped"
+        );
+        let status = snapshot.lock().await.clone();
+        assert_eq!(status.state, SubscriptionState::Stopped);
+        assert!(!status.desired_running);
+        assert_eq!(status.last_reason_code, "stopped");
+        assert_eq!(
+            stop_subscription_entry(&registry, "workflow-gate")
+                .await
+                .expect("second stop succeeds"),
+            "already_stopped"
+        );
     }
 
     #[test]
@@ -2248,6 +2896,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
         let event = IncomingEvent {
             kind: "tool.post".into(),
@@ -2287,6 +2936,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
         let event = IncomingEvent {
             kind: "tool.post".into(),
@@ -2319,6 +2969,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
         let event = IncomingEvent::agent_started(
             "worker-1".into(),
@@ -2363,6 +3014,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = accept_event(
@@ -2418,6 +3070,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: dir.path().join("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = accept_event(
@@ -2478,6 +3131,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: dir.path().join("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = accept_event(
@@ -2536,6 +3190,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: dir.path().join("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let event = |id: &str| IncomingEvent {
@@ -2592,6 +3247,7 @@ mod tests {
             native_observability: observability.clone(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = post_native_hook(State(state), Json(payload))
@@ -2620,6 +3276,7 @@ mod tests {
             native_observability: observability.clone(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
         let payload = json!({"provider": "codex", "event_name": "Bogus"});
 
@@ -2647,6 +3304,7 @@ mod tests {
             native_observability: observability.clone(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
         let dir = tempdir().expect("tempdir");
         let payload = json!({
@@ -2688,6 +3346,7 @@ mod tests {
             native_observability: observability.clone(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = post_native_hook(State(state), Json(payload))
@@ -2728,6 +3387,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
         let payload = json!({
             "provider": "codex",
@@ -2797,6 +3457,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
         let payload = json!({
             "provider": "claude-code",
@@ -2963,6 +3624,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
         let dir = tempdir().expect("tempdir");
         let payload = json!({
@@ -3020,6 +3682,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = list_tmux(State(state)).await.into_response();
@@ -3057,6 +3720,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = update_status(State(state)).await.into_response();
@@ -3088,6 +3752,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = update_status(State(state)).await.into_response();
@@ -3112,6 +3777,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = approve_update(State(state)).await.into_response();
@@ -3148,6 +3814,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = dismiss_update(State(state)).await.into_response();
@@ -3172,6 +3839,7 @@ mod tests {
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
             discord_watch_lock: Arc::new(Mutex::new(())),
+            subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
         };
 
         let response = dismiss_update(State(state)).await.into_response();

--- a/src/events.rs
+++ b/src/events.rs
@@ -762,6 +762,50 @@ impl IncomingEvent {
         self
     }
 
+    /// Constructs a route-neutral event after a subscription adapter has passed its restricted output checks.
+    pub fn subscription(
+        kind: String,
+        payload: Value,
+        routing: &RoutingMetadata,
+        name: &str,
+    ) -> Self {
+        let mut event = Self {
+            kind,
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload,
+        };
+        if let Some(object) = event.payload.as_object_mut() {
+            object.insert("event_id".to_string(), json!(Uuid::new_v4().to_string()));
+            object.insert(
+                "correlation_id".to_string(),
+                json!(Uuid::new_v4().to_string()),
+            );
+            object.insert(
+                "first_seen_at".to_string(),
+                json!(
+                    OffsetDateTime::now_utc()
+                        .format(&Rfc3339)
+                        .unwrap_or_default()
+                ),
+            );
+            object.insert("contract_event".to_string(), json!(event.kind.clone()));
+            object.insert("subscription_name".to_string(), json!(name));
+            object.insert("subscription_transport".to_string(), json!("websocket"));
+            object.insert(
+                "subscription_received_at".to_string(),
+                json!(
+                    OffsetDateTime::now_utc()
+                        .format(&Rfc3339)
+                        .unwrap_or_default()
+                ),
+            );
+        }
+        event.with_routing_metadata(routing)
+    }
+
     pub fn canonical_kind(&self) -> &str {
         match self.kind.as_str() {
             "issue-opened" => "github.issue-opened",

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,8 @@ use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs,
     GajaeCheckpointCommands, GajaeCommands, GajaeMutationPlanCommands, GajaeProfileCommands,
     GajaeReceiptCommands, GitCommands, GithubCommands, HooksCommands, LaneCommands, MemoryCommands,
-    NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, TmuxCommands, UpdateCommands,
-    VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
+    NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, SubscribeCommands, TmuxCommands,
+    UpdateCommands, VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
 };
 
 use crate::client::DaemonClient;
@@ -88,9 +88,15 @@ fn prepare_event(event: IncomingEvent) -> Result<IncomingEvent> {
     Ok(event)
 }
 
+fn load_config_for_cli(config_path: &std::path::Path) -> Result<Arc<AppConfig>> {
+    AppConfig::load_or_default(config_path)
+        .map(Arc::new)
+        .map_err(|_| "config_invalid".into())
+}
+
 async fn real_main(cli: Cli) -> Result<()> {
     let config_path = cli.config_path();
-    let config = Arc::new(AppConfig::load_or_default(&config_path)?);
+    let config = load_config_for_cli(&config_path)?;
     let cron_state_path = crate::cron::default_state_path(&config_path);
 
     match cli.command.unwrap_or(Commands::Start {
@@ -102,6 +108,32 @@ async fn real_main(cli: Cli) -> Result<()> {
             let client = DaemonClient::from_config(config.as_ref());
             let health = client.health().await?;
             println!("{}", serde_json::to_string_pretty(&health)?);
+            Ok(())
+        }
+        Commands::Subscribe { command } => {
+            let client = DaemonClient::from_config(config.as_ref());
+            match command {
+                SubscribeCommands::Validate => {
+                    config.validate()?;
+                    println!("Subscription configuration is valid.");
+                }
+                SubscribeCommands::List => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&client.list_subscriptions().await?)?
+                ),
+                SubscribeCommands::Status { name } => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&client.subscription_status(&name).await?)?
+                ),
+                SubscribeCommands::Start { name } => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&client.start_subscription(&name).await?)?
+                ),
+                SubscribeCommands::Stop { name } => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&client.stop_subscription(&name).await?)?
+                ),
+            }
             Ok(())
         }
         Commands::Deliver(args) => crate::hooks::prompt_deliver::run(args).await,
@@ -331,7 +363,7 @@ async fn real_main(cli: Cli) -> Result<()> {
         },
         Commands::Config { command } => match command.unwrap_or(ConfigCommand::Interactive) {
             ConfigCommand::Interactive => {
-                let mut editable = AppConfig::load_or_default(&config_path)?;
+                let mut editable = (*load_config_for_cli(&config_path)?).clone();
                 editable.run_interactive_editor(&config_path)
             }
             ConfigCommand::Show => {
@@ -694,7 +726,7 @@ fn remote_repo_identity(remote: &str) -> Option<String> {
 }
 
 async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()> {
-    let mut editable = AppConfig::load_or_default(config_path)?;
+    let mut editable = (*load_config_for_cli(config_path)?).clone();
 
     let standard_edits = SetupEdits {
         webhook: args.webhook,
@@ -989,13 +1021,45 @@ fn tmux_empty_list_detail(health: Option<&serde_json::Value>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_tmux_list, parse_bind_checkout_overrides, parse_bind_overrides,
+        format_tmux_list, load_config_for_cli, parse_bind_checkout_overrides, parse_bind_overrides,
         parse_expect_name_overrides, validate_bind_checkout_repos, verify_bindings_json,
     };
     use crate::binding_verify::{BindingAudit, BindingDriftAudit};
     use crate::events::RoutingMetadata;
     use crate::source::tmux::{ParentProcessInfo, RegisteredTmuxSession, RegistrationSource};
+    use std::fs;
 
+    #[test]
+    fn cli_config_errors_are_bounded_without_source_content() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"[[subscriptions]]
+name = "safe-subscription"
+enabled = false
+kind = "websocket"
+endpoint_env = "SAFE_ENDPOINT"
+endpoint = "wss://private.invalid?token=secret-token"
+
+[subscriptions.filter]
+discriminator_pointer = "/type"
+discriminator_equals = "workflow_gate"
+
+[subscriptions.projection]
+workflow_id = "/workflow/id"
+
+[subscriptions.adapter]
+program = "/bin/true"
+"#,
+        )
+        .unwrap();
+
+        let error = load_config_for_cli(&path).unwrap_err().to_string();
+        assert_eq!(error, "config_invalid");
+        assert!(!error.contains("secret-token"));
+        assert!(!error.contains("private.invalid"));
+    }
     #[test]
     fn parse_expect_name_overrides_accepts_well_formed_entries() {
         let entries = vec![

--- a/src/router.rs
+++ b/src/router.rs
@@ -104,6 +104,9 @@ impl Router {
         let mut deliveries = Vec::with_capacity(matched_routes.len().max(1));
 
         if matched_routes.is_empty() {
+            if is_subscription_event(event) {
+                return Err("no configured route for subscription event".into());
+            }
             deliveries.push(self.resolve_delivery(event, None, None)?);
         } else {
             for route in matched_routes {
@@ -314,9 +317,13 @@ impl Router {
                 .collect();
 
         let deliveries = if ordered_matched_indices.is_empty() {
-            match self.resolve_delivery(event, None, None) {
-                Ok(d) => vec![delivery_explanation(&d, None)],
-                Err(_) => vec![],
+            if is_subscription_event(event) {
+                vec![]
+            } else {
+                match self.resolve_delivery(event, None, None) {
+                    Ok(d) => vec![delivery_explanation(&d, None)],
+                    Err(_) => vec![],
+                }
             }
         } else {
             ordered_matched_indices
@@ -492,6 +499,14 @@ fn delivery_explanation(
         template: delivery.template.clone(),
         matched_route_index,
     }
+}
+
+fn is_subscription_event(event: &IncomingEvent) -> bool {
+    event
+        .payload
+        .get("subscription_transport")
+        .and_then(serde_json::Value::as_str)
+        == Some("websocket")
 }
 
 fn route_candidates(kind: &str) -> Vec<&str> {
@@ -2684,5 +2699,68 @@ mod tests {
             assert!(rendered.contains("discord:thread:redacted:"));
             assert!(!rendered.contains(raw_thread_id));
         }
+    }
+
+    #[tokio::test]
+    async fn subscription_routing_metadata_selects_configured_route_without_delivery_controls() {
+        let config = AppConfig {
+            routes: vec![RouteRule {
+                event: "workflow.gate".into(),
+                sink: "discord".into(),
+                filter: [("project".to_string(), "clawhip".to_string())]
+                    .into_iter()
+                    .collect(),
+                channel: Some("workflow-gates".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let event = IncomingEvent::subscription(
+            "workflow.gate".into(),
+            json!({"gate": "ready"}),
+            &RoutingMetadata {
+                project: Some("clawhip".into()),
+                ..RoutingMetadata::default()
+            },
+            "workflow-gate",
+        );
+
+        assert!(event.channel.is_none());
+        assert!(event.mention.is_none());
+        assert!(event.format.is_none());
+        assert!(event.template.is_none());
+
+        let delivery = Router::new(Arc::new(config))
+            .preview_delivery(&event)
+            .await
+            .unwrap();
+        assert_eq!(
+            delivery.target,
+            SinkTarget::DiscordChannel("workflow-gates".into())
+        );
+        assert_eq!(delivery.trace.result, RouteTraceResult::Matched);
+    }
+
+    #[tokio::test]
+    async fn subscription_without_matching_route_does_not_use_default_channel() {
+        let config = AppConfig {
+            defaults: crate::config::DefaultsConfig {
+                channel: Some("default-channel".into()),
+                ..crate::config::DefaultsConfig::default()
+            },
+            ..AppConfig::default()
+        };
+        let event = IncomingEvent::subscription(
+            "workflow.gate".into(),
+            json!({"gate": "ready"}),
+            &RoutingMetadata::default(),
+            "workflow-gate",
+        );
+        let error = Router::new(Arc::new(config))
+            .resolve(&event)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_eq!(error, "no configured route for subscription event");
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,11 +5,13 @@ use crate::events::IncomingEvent;
 
 pub mod git;
 pub mod github;
+pub mod subscription;
 pub mod tmux;
 pub mod workspace;
 
 pub use git::GitSource;
 pub use github::GitHubSource;
+pub use subscription::{SubscriptionSnapshot, SubscriptionState, SubscriptionWorker};
 pub use tmux::{
     RegisteredTmuxSession, SharedTmuxRegistry, TmuxSource, default_registry_state_path,
     inspect_tmux_registry_state, list_active_tmux_registrations, load_tmux_registry_state,

--- a/src/source/subscription.rs
+++ b/src/source/subscription.rs
@@ -1,0 +1,1031 @@
+use std::collections::HashSet;
+use std::net::IpAddr;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use reqwest::Url;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tokio::sync::{Mutex, mpsc, watch};
+use tokio::time::Instant;
+use tokio_tungstenite::tungstenite::{Message, protocol::WebSocketConfig};
+
+use crate::Result;
+use crate::config::{SubscriptionConfig, SubscriptionRoutingConfig};
+use crate::events::{IncomingEvent, RoutingMetadata};
+
+fn subscription_error(reason: &'static str) -> crate::DynError {
+    Box::new(std::io::Error::other(reason))
+}
+
+const SENSITIVE_KEYS: &[&str] = &[
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "authorization",
+    "cookie",
+    "credential",
+    "credentials",
+    "api_key",
+    "apikey",
+    "access_token",
+    "refresh_token",
+    "private_key",
+    "client_secret",
+    "endpoint",
+    "url",
+    "uri",
+    "webhook",
+];
+const RESERVED_KEYS: &[&str] = &[
+    "channel",
+    "mention",
+    "format",
+    "template",
+    "type",
+    "kind",
+    "event",
+    "event_id",
+    "correlation_id",
+    "first_seen_at",
+    "raw_event",
+    "contract_event",
+    "event_timestamp",
+    "timestamp",
+    "observed_at",
+    "created_at",
+    "tool",
+    "project",
+    "repo",
+    "repo_name",
+    "repo_path",
+    "worktree",
+    "worktree_path",
+    "directory",
+    "session",
+    "session_name",
+    "session_id",
+    "branch",
+    "provider",
+    "source",
+    "subscription_name",
+    "subscription_transport",
+    "subscription_received_at",
+    "ingress_source",
+    "_clawhip",
+    "clawhip",
+    "routing",
+    "metadata",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriptionState {
+    Disabled,
+    Stopped,
+    Starting,
+    Connecting,
+    Connected,
+    BackingOff,
+    Exhausted,
+    Stopping,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SubscriptionSnapshot {
+    pub schema: &'static str,
+    pub name: String,
+    pub enabled: bool,
+    pub state: SubscriptionState,
+    pub desired_running: bool,
+    pub started_at: Option<String>,
+    pub last_connected_at: Option<String>,
+    pub last_event_enqueued_at: Option<String>,
+    pub last_state_transition_at: String,
+    pub connection_attempts_total: u64,
+    pub connection_failures_total: u64,
+    pub reconnects_total: u64,
+    pub frames_received_total: u64,
+    pub frames_rejected_total: u64,
+    pub frames_matched_total: u64,
+    pub adapters_started_total: u64,
+    pub adapters_rejected_total: u64,
+    pub events_enqueued_total: u64,
+    pub last_reason_code: &'static str,
+}
+
+impl SubscriptionSnapshot {
+    pub fn new(config: &SubscriptionConfig) -> Self {
+        Self {
+            schema: "clawhip.subscription.v1",
+            name: config.name.clone(),
+            enabled: config.enabled,
+            state: if config.enabled {
+                SubscriptionState::Stopped
+            } else {
+                SubscriptionState::Disabled
+            },
+            desired_running: config.enabled,
+            started_at: None,
+            last_connected_at: None,
+            last_event_enqueued_at: None,
+            last_state_transition_at: subscription_timestamp(),
+            connection_attempts_total: 0,
+            connection_failures_total: 0,
+            reconnects_total: 0,
+            frames_received_total: 0,
+            frames_rejected_total: 0,
+            frames_matched_total: 0,
+            adapters_started_total: 0,
+            adapters_rejected_total: 0,
+            events_enqueued_total: 0,
+            last_reason_code: if config.enabled {
+                "start_requested"
+            } else {
+                "configured_disabled"
+            },
+        }
+    }
+
+    pub fn transition(&mut self, state: SubscriptionState, reason: &'static str) {
+        self.state = state;
+        self.last_reason_code = reason;
+        self.last_state_transition_at = subscription_timestamp();
+    }
+
+    pub fn mark_started(&mut self) {
+        self.started_at = Some(subscription_timestamp());
+    }
+
+    fn connection_attempt(&mut self) {
+        self.connection_attempts_total = self.connection_attempts_total.saturating_add(1);
+    }
+
+    fn connection_failed(&mut self) {
+        self.connection_failures_total = self.connection_failures_total.saturating_add(1);
+    }
+}
+
+fn subscription_timestamp() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+pub fn validate_endpoint(endpoint: &str) -> Result<()> {
+    if endpoint.len() > 4096 {
+        return Err(subscription_error("endpoint_unavailable"));
+    }
+    let url = Url::parse(endpoint).map_err(|_| subscription_error("endpoint_unavailable"))?;
+    if !url.username().is_empty() || url.password().is_some() || url.fragment().is_some() {
+        return Err(subscription_error("endpoint_unavailable"));
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| subscription_error("endpoint_unavailable"))?;
+    match url.scheme() {
+        "wss" => Ok(()),
+        "ws" => {
+            let ip: IpAddr = host
+                .parse()
+                .map_err(|_| subscription_error("endpoint_unavailable"))?;
+            if ip.is_loopback() {
+                Ok(())
+            } else {
+                Err(subscription_error("endpoint_unavailable"))
+            }
+        }
+        _ => Err(subscription_error("endpoint_unavailable")),
+    }
+}
+
+pub fn parse_pointer(pointer: &str) -> Result<Vec<String>> {
+    if pointer.is_empty() || !pointer.starts_with('/') || pointer.len() > 256 {
+        return Err(subscription_error("invalid_subscription_pointer"));
+    }
+    let parts: Vec<String> = pointer[1..]
+        .split('/')
+        .map(|part| {
+            let mut decoded = String::new();
+            let mut chars = part.chars();
+            while let Some(ch) = chars.next() {
+                if ch == '~' {
+                    match chars.next() {
+                        Some('0') => decoded.push('~'),
+                        Some('1') => decoded.push('/'),
+                        _ => return Err(subscription_error("invalid_subscription_pointer")),
+                    }
+                } else {
+                    decoded.push(ch);
+                }
+            }
+            Ok(decoded)
+        })
+        .collect::<Result<_>>()?;
+    if parts.len() > 8 {
+        return Err(subscription_error("invalid_subscription_pointer"));
+    }
+    Ok(parts)
+}
+
+fn value_at<'a>(value: &'a Value, pointer: &str) -> Result<&'a Value> {
+    let mut current = value;
+    for part in parse_pointer(pointer)? {
+        current = current
+            .get(&part)
+            .ok_or_else(|| subscription_error("projection_rejected"))?;
+    }
+    Ok(current)
+}
+
+fn forbidden_key(key: &str) -> bool {
+    let components: Vec<String> = key
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .flat_map(|component| {
+            let mut components = Vec::new();
+            let mut current = String::new();
+            for character in component.chars() {
+                if character.is_ascii_uppercase() && !current.is_empty() {
+                    components.push(std::mem::take(&mut current));
+                }
+                current.extend(character.to_lowercase());
+            }
+            if !current.is_empty() {
+                components.push(current);
+            }
+            components
+        })
+        .collect();
+    let canonical = components.join("_");
+    SENSITIVE_KEYS.contains(&canonical.as_str())
+        || RESERVED_KEYS.contains(&canonical.as_str())
+        || components.iter().any(|component| {
+            SENSITIVE_KEYS.contains(&component.as_str())
+                || RESERVED_KEYS.contains(&component.as_str())
+        })
+}
+
+fn validate_filter_pointer(pointer: &str) -> Result<()> {
+    parse_pointer(pointer).map(|_| ())
+}
+
+pub fn project_frame(config: &SubscriptionConfig, frame: &str) -> Result<Option<Vec<u8>>> {
+    if frame.len() > config.max_frame_bytes {
+        return Err(subscription_error("frame_oversized"));
+    }
+    let value: Value =
+        serde_json::from_str(frame).map_err(|_| subscription_error("frame_malformed"))?;
+    if !value.is_object() || json_depth(&value) > config.max_json_depth {
+        return Err(subscription_error("frame_depth_exceeded"));
+    }
+    let filter = &config.filter;
+    if value_at(&value, &filter.discriminator_pointer)?
+        != &Value::String(filter.discriminator_equals.clone())
+    {
+        return Ok(None);
+    }
+    for predicate in &filter.predicates {
+        if value_at(&value, &predicate.pointer)? != &Value::String(predicate.equals.clone()) {
+            return Ok(None);
+        }
+    }
+    let mut projection = Map::new();
+    for (name, pointer) in &config.projection {
+        let selected = value_at(&value, pointer)?;
+        if selected.is_null()
+            || !selected.is_string() && !selected.is_number() && !selected.is_boolean()
+        {
+            return Err(subscription_error("projection_rejected"));
+        }
+        projection.insert(name.clone(), selected.clone());
+    }
+    let bytes = serde_json::to_vec(&Value::Object(projection))?;
+    if bytes.len() > config.adapter.max_stdin_bytes {
+        return Err(subscription_error("projection_rejected"));
+    }
+    Ok(Some(bytes))
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RestrictedAdapterEvent {
+    #[serde(rename = "type")]
+    kind: String,
+    payload: Value,
+}
+
+pub fn adapter_event(stdout: &[u8], config: &SubscriptionConfig) -> Result<IncomingEvent> {
+    if stdout.is_empty() || stdout.len() > config.adapter.max_stdout_bytes {
+        return Err(subscription_error("adapter_invalid_output"));
+    }
+    let mut de = serde_json::Deserializer::from_slice(stdout);
+    let output = RestrictedAdapterEvent::deserialize(&mut de)
+        .map_err(|_| subscription_error("adapter_invalid_output"))?;
+    de.end()
+        .map_err(|_| subscription_error("adapter_invalid_output"))?;
+    if !valid_event_kind(&output.kind)
+        || !output.payload.is_object()
+        || json_depth(&output.payload) > 8
+        || !safe_payload(&output.payload)
+    {
+        return Err(subscription_error("adapter_reserved_field"));
+    }
+    Ok(IncomingEvent {
+        kind: output.kind,
+        channel: None,
+        mention: None,
+        format: None,
+        template: None,
+        payload: output.payload,
+    })
+}
+
+fn valid_event_kind(kind: &str) -> bool {
+    if kind.is_empty() || kind.len() > 96 || kind.contains("://") || kind.contains('@') {
+        return false;
+    }
+    let mut last_separator = true;
+    for byte in kind.bytes() {
+        let is_alnum = byte.is_ascii_lowercase() || byte.is_ascii_digit();
+        if !is_alnum && byte != b'.' && byte != b'-' {
+            return false;
+        }
+        if byte == b'.' || byte == b'-' {
+            if last_separator {
+                return false;
+            }
+            last_separator = true;
+        } else {
+            last_separator = false;
+        }
+    }
+    !last_separator && kind.as_bytes()[0].is_ascii_lowercase()
+}
+fn json_depth(value: &Value) -> usize {
+    match value {
+        Value::Array(values) => 1 + values.iter().map(json_depth).max().unwrap_or(0),
+        Value::Object(values) => 1 + values.values().map(json_depth).max().unwrap_or(0),
+        _ => 0,
+    }
+}
+fn safe_payload(value: &Value) -> bool {
+    match value {
+        Value::Object(values) => {
+            values.len() <= 32
+                && values
+                    .iter()
+                    .all(|(k, v)| !forbidden_key(k) && safe_payload(v))
+        }
+        Value::Array(values) => values.iter().all(safe_payload),
+        _ => true,
+    }
+}
+
+async fn run_adapter(
+    config: &SubscriptionConfig,
+    input: &[u8],
+    cancel: &mut watch::Receiver<bool>,
+) -> Result<IncomingEvent> {
+    let deadline = Instant::now() + Duration::from_millis(config.adapter.timeout_ms);
+    let mut command = Command::new(&config.adapter.program);
+    command
+        .args(&config.adapter.args)
+        .env_clear()
+        .env("LANG", "C")
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command
+        .spawn()
+        .map_err(|_| subscription_error("adapter_spawn_failed"))?;
+    if Instant::now() >= deadline {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        return Err(subscription_error("adapter_timeout"));
+    }
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| subscription_error("adapter_stdin_failed"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| subscription_error("adapter_invalid_output"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| subscription_error("adapter_invalid_output"))?;
+    let stdout_cap = config.adapter.max_stdout_bytes + 1;
+    let stderr_cap = config.adapter.max_stderr_bytes + 1;
+    let mut stdout_task = tokio::spawn(async move {
+        let mut output = Vec::new();
+        stdout
+            .take(stdout_cap as u64)
+            .read_to_end(&mut output)
+            .await
+            .map(|_| output)
+    });
+    let mut stderr_task = tokio::spawn(async move {
+        let mut output = Vec::new();
+        stderr
+            .take(stderr_cap as u64)
+            .read_to_end(&mut output)
+            .await
+            .map(|_| output)
+    });
+    let result = tokio::select! {
+        result = async {
+            stdin.write_all(input).await.map_err(|_| subscription_error("adapter_stdin_failed"))?;
+            stdin.shutdown().await.map_err(|_| subscription_error("adapter_stdin_failed"))?;
+            let status = child.wait().await.map_err(|_| subscription_error("adapter_invalid_output"))?;
+            let output = (&mut stdout_task)
+                .await
+                .map_err(|_| subscription_error("adapter_invalid_output"))?
+                .map_err(|_| subscription_error("adapter_invalid_output"))?;
+            let stderr = (&mut stderr_task)
+                .await
+                .map_err(|_| subscription_error("adapter_invalid_output"))?
+                .map_err(|_| subscription_error("adapter_invalid_output"))?;
+            Ok((status, output, stderr))
+        } => result,
+        _ = tokio::time::sleep_until(deadline) => Err(subscription_error("adapter_timeout")),
+        _ = cancel.changed() => Err(subscription_error("cancelled")),
+    };
+    let (status, output, stderr) = match result {
+        Ok(result) => result,
+        Err(error) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            stdout_task.abort();
+            stderr_task.abort();
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+            return Err(error);
+        }
+    };
+    if stderr.len() > config.adapter.max_stderr_bytes {
+        return Err(subscription_error("adapter_stderr_oversized"));
+    }
+    if output.len() > config.adapter.max_stdout_bytes {
+        return Err(subscription_error("adapter_stdout_oversized"));
+    }
+    if !status.success() {
+        return Err(subscription_error("adapter_nonzero_exit"));
+    }
+    adapter_event(&output, config)
+}
+
+pub struct SubscriptionWorker {
+    pub config: Arc<SubscriptionConfig>,
+    pub snapshot: Arc<Mutex<SubscriptionSnapshot>>,
+    pub cancel: watch::Receiver<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconnectDecision {
+    Backoff,
+    Exhausted,
+}
+
+fn reconnect_delay_ms(config: &SubscriptionConfig, attempts: u64) -> u64 {
+    let multiplier = 1u64
+        .checked_shl(attempts.saturating_sub(1).min(63) as u32)
+        .unwrap_or(u64::MAX);
+    config
+        .reconnect
+        .initial_delay_ms
+        .saturating_mul(multiplier)
+        .min(config.reconnect.max_delay_ms)
+}
+
+fn reconnect_decision(attempts: u64, max_attempts: u64) -> ReconnectDecision {
+    if attempts >= max_attempts {
+        ReconnectDecision::Exhausted
+    } else {
+        ReconnectDecision::Backoff
+    }
+}
+
+fn safe_reject_reason(error: &(dyn std::error::Error + Send + Sync)) -> &'static str {
+    match error.to_string().as_str() {
+        "frame_oversized" => "frame_oversized",
+        "frame_malformed" => "frame_malformed",
+        "frame_depth_exceeded" => "frame_depth_exceeded",
+        "projection_rejected" => "projection_rejected",
+        "adapter_stderr_oversized" => "adapter_stderr_oversized",
+        "adapter_stdout_oversized" => "adapter_stdout_oversized",
+        "adapter_nonzero_exit" => "adapter_nonzero_exit",
+        "adapter_invalid_output" => "adapter_invalid_output",
+        "adapter_reserved_field" => "adapter_reserved_field",
+        _ => "adapter_rejected",
+    }
+}
+
+fn socket_error_reason(error: &tokio_tungstenite::tungstenite::Error) -> &'static str {
+    match error {
+        tokio_tungstenite::tungstenite::Error::Capacity(_) => "frame_oversized",
+        _ => "protocol_error",
+    }
+}
+
+impl SubscriptionWorker {
+    async fn stop(&self) {
+        self.snapshot
+            .lock()
+            .await
+            .transition(SubscriptionState::Stopped, "cancelled");
+    }
+
+    async fn reject_frame(&self, reason: &'static str) {
+        let mut snapshot = self.snapshot.lock().await;
+        snapshot.frames_rejected_total = snapshot.frames_rejected_total.saturating_add(1);
+        snapshot.transition(SubscriptionState::Connected, reason);
+    }
+
+    async fn reject_adapter(&self, reason: &'static str) {
+        let mut snapshot = self.snapshot.lock().await;
+        snapshot.adapters_rejected_total = snapshot.adapters_rejected_total.saturating_add(1);
+        snapshot.transition(SubscriptionState::Connected, reason);
+    }
+
+    async fn reconnect_or_exhaust(&self, attempts: u64, reason: &'static str) -> bool {
+        let mut snapshot = self.snapshot.lock().await;
+        snapshot.connection_failed();
+        match reconnect_decision(attempts, self.config.reconnect.max_attempts) {
+            ReconnectDecision::Exhausted => {
+                snapshot.transition(SubscriptionState::Exhausted, "retry_exhausted");
+                true
+            }
+            ReconnectDecision::Backoff => {
+                snapshot.transition(SubscriptionState::BackingOff, reason);
+                false
+            }
+        }
+    }
+
+    async fn wait_to_reconnect(&mut self, attempts: u64) -> bool {
+        let delay = reconnect_delay_ms(&self.config, attempts);
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(delay)) => {
+                self.snapshot.lock().await.transition(SubscriptionState::Connecting, "reconnect_requested");
+                false
+            }
+            _ = self.cancel.changed() => true,
+        }
+    }
+
+    pub async fn run(mut self, tx: mpsc::Sender<IncomingEvent>) -> Result<()> {
+        if *self.cancel.borrow() {
+            self.stop().await;
+            return Ok(());
+        }
+        let endpoint = match std::env::var(&self.config.endpoint_env) {
+            Ok(endpoint) if validate_endpoint(&endpoint).is_ok() => endpoint,
+            _ => {
+                self.snapshot
+                    .lock()
+                    .await
+                    .transition(SubscriptionState::Exhausted, "endpoint_unavailable");
+                return Err(subscription_error("endpoint_unavailable"));
+            }
+        };
+        let mut attempts = 0u64;
+        let mut has_attempted = false;
+        loop {
+            if *self.cancel.borrow() {
+                self.stop().await;
+                return Ok(());
+            }
+            attempts = attempts.saturating_add(1);
+            {
+                let mut snapshot = self.snapshot.lock().await;
+                snapshot.connection_attempt();
+                if has_attempted {
+                    snapshot.reconnects_total = snapshot.reconnects_total.saturating_add(1);
+                }
+                has_attempted = true;
+                snapshot.transition(SubscriptionState::Connecting, "connecting");
+            }
+            let ws_config = WebSocketConfig::default()
+                .max_message_size(Some(self.config.max_frame_bytes))
+                .max_frame_size(Some(self.config.max_frame_bytes));
+            let connect = tokio_tungstenite::connect_async_with_config(
+                endpoint.as_str(),
+                Some(ws_config),
+                false,
+            );
+            let stream = match tokio::select! { result = connect => result.map(|stream| stream.0), _ = self.cancel.changed() => { self.stop().await; return Ok(()); } }
+            {
+                Ok(stream) => stream,
+                Err(_) => {
+                    if self.reconnect_or_exhaust(attempts, "connect_failed").await {
+                        return Err(subscription_error("retry_exhausted"));
+                    }
+                    if self.wait_to_reconnect(attempts).await {
+                        self.stop().await;
+                        return Ok(());
+                    }
+                    continue;
+                }
+            };
+            {
+                let mut snapshot = self.snapshot.lock().await;
+                snapshot.last_connected_at = Some(subscription_timestamp());
+                snapshot.transition(SubscriptionState::Connected, "connected");
+            }
+            let (_, mut reader) = stream.split();
+            let mut reconnect_reason = "peer_closed";
+            loop {
+                let message = tokio::select! { message = reader.next() => message, _ = self.cancel.changed() => { self.stop().await; return Ok(()); } };
+                let Some(message) = message else { break };
+                let message = match message {
+                    Ok(message) => message,
+                    Err(error) => {
+                        reconnect_reason = socket_error_reason(&error);
+                        break;
+                    }
+                };
+                match message {
+                    Message::Text(text) => {
+                        {
+                            let mut snapshot = self.snapshot.lock().await;
+                            snapshot.frames_received_total =
+                                snapshot.frames_received_total.saturating_add(1);
+                        }
+                        let input = match project_frame(&self.config, &text) {
+                            Ok(Some(input)) => {
+                                let mut snapshot = self.snapshot.lock().await;
+                                snapshot.frames_matched_total =
+                                    snapshot.frames_matched_total.saturating_add(1);
+                                input
+                            }
+                            Ok(None) => {
+                                self.reject_frame("frame_not_matched").await;
+                                continue;
+                            }
+                            Err(error) => {
+                                self.reject_frame(safe_reject_reason(error.as_ref())).await;
+                                continue;
+                            }
+                        };
+                        {
+                            let mut snapshot = self.snapshot.lock().await;
+                            snapshot.adapters_started_total =
+                                snapshot.adapters_started_total.saturating_add(1);
+                        }
+                        let event = match run_adapter(&self.config, &input, &mut self.cancel).await
+                        {
+                            Ok(event) => event,
+                            Err(_) if *self.cancel.borrow() => {
+                                self.stop().await;
+                                return Ok(());
+                            }
+                            Err(error) => {
+                                self.reject_adapter(safe_reject_reason(error.as_ref()))
+                                    .await;
+                                continue;
+                            }
+                        };
+                        let event = IncomingEvent::subscription(
+                            event.kind,
+                            event.payload,
+                            &subscription_routing(&self.config.routing),
+                            &self.config.name,
+                        );
+                        match tokio::select! { sent = tx.send(event) => sent, _ = self.cancel.changed() => { self.stop().await; return Ok(()); } }
+                        {
+                            Ok(()) => {
+                                let mut snapshot = self.snapshot.lock().await;
+                                snapshot.events_enqueued_total =
+                                    snapshot.events_enqueued_total.saturating_add(1);
+                                snapshot.last_event_enqueued_at = Some(subscription_timestamp());
+                                attempts = 0;
+                            }
+                            Err(_) => {
+                                self.snapshot
+                                    .lock()
+                                    .await
+                                    .transition(SubscriptionState::Exhausted, "queue_closed");
+                                return Err(subscription_error("queue_closed"));
+                            }
+                        }
+                    }
+                    Message::Binary(_) => {
+                        {
+                            let mut snapshot = self.snapshot.lock().await;
+                            snapshot.frames_received_total =
+                                snapshot.frames_received_total.saturating_add(1);
+                        }
+                        self.reject_frame("binary_frame_rejected").await;
+                    }
+                    Message::Close(_) => {
+                        reconnect_reason = "peer_closed";
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            if self.reconnect_or_exhaust(attempts, reconnect_reason).await {
+                return Err(subscription_error("retry_exhausted"));
+            }
+            if self.wait_to_reconnect(attempts).await {
+                self.stop().await;
+                return Ok(());
+            }
+        }
+    }
+}
+
+pub fn validate_filter_policy(config: &SubscriptionConfig) -> Result<()> {
+    validate_filter_pointer(&config.filter.discriminator_pointer)?;
+    for predicate in &config.filter.predicates {
+        validate_filter_pointer(&predicate.pointer)?;
+    }
+    Ok(())
+}
+
+pub fn validate_projection_policy(config: &SubscriptionConfig) -> Result<()> {
+    fn valid_projection_name(name: &str) -> bool {
+        !name.is_empty()
+            && name.len() <= 64
+            && name.as_bytes()[0].is_ascii_lowercase()
+            && name
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+    }
+
+    let mut names = HashSet::new();
+    for (name, pointer) in &config.projection {
+        if !valid_projection_name(name)
+            || forbidden_key(name)
+            || !names.insert(name.to_ascii_lowercase())
+        {
+            return Err(subscription_error("invalid_subscription_projection"));
+        }
+        if parse_pointer(pointer)?
+            .iter()
+            .any(|part| forbidden_key(part))
+        {
+            return Err(subscription_error("invalid_subscription_pointer"));
+        }
+    }
+    Ok(())
+}
+
+pub fn subscription_routing(routing: &SubscriptionRoutingConfig) -> RoutingMetadata {
+    RoutingMetadata {
+        tool: routing.tool.clone(),
+        project: routing.project.clone(),
+        repo_name: routing.repo_name.clone(),
+        repo_path: routing.repo_path.clone(),
+        worktree_path: routing.worktree_path.clone(),
+        session_id: routing.session_id.clone(),
+        branch: routing.branch.clone(),
+    }
+}
+
+pub fn is_regular_executable(path: &str) -> bool {
+    let path = Path::new(path);
+    path.is_absolute()
+        && std::fs::metadata(path)
+            .map(|metadata| metadata.is_file() && has_execute_permission(&metadata))
+            .unwrap_or(false)
+}
+
+#[cfg(unix)]
+fn has_execute_permission(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn has_execute_permission(_: &std::fs::Metadata) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        SubscriptionAdapterConfig, SubscriptionFilterConfig, SubscriptionPredicateConfig,
+        SubscriptionReconnectConfig,
+    };
+    use std::collections::BTreeMap;
+
+    fn config() -> SubscriptionConfig {
+        SubscriptionConfig {
+            name: "gjc-workflow-gate".into(),
+            enabled: true,
+            kind: "websocket".into(),
+            endpoint_env: "GJC_WS_URL".into(),
+            max_frame_bytes: 65_536,
+            max_json_depth: 16,
+            filter: SubscriptionFilterConfig {
+                discriminator_pointer: "/type".into(),
+                discriminator_equals: "workflow_gate".into(),
+                predicates: vec![SubscriptionPredicateConfig {
+                    pointer: "/gate/state".into(),
+                    equals: "ready".into(),
+                }],
+            },
+            projection: BTreeMap::from([
+                (String::from("workflow_id"), String::from("/workflow/id")),
+                (String::from("gate_state"), String::from("/gate/state")),
+            ]),
+            adapter: SubscriptionAdapterConfig {
+                program: "/bin/true".into(),
+                args: vec!["--literal;$(not-a-shell)".into()],
+                timeout_ms: 5_000,
+                max_stdin_bytes: 16_384,
+                max_stdout_bytes: 16_384,
+                max_stderr_bytes: 4_096,
+            },
+            reconnect: SubscriptionReconnectConfig::default(),
+            routing: SubscriptionRoutingConfig::default(),
+        }
+    }
+
+    #[test]
+    fn projects_matching_gjc_workflow_gate_but_not_questions() {
+        let config = config();
+        let frame = r#"{"type":"workflow_gate","workflow":{"id":"wf-1"},"gate":{"state":"ready"},"secret":"never"}"#;
+        assert_eq!(
+            project_frame(&config, frame).unwrap().unwrap(),
+            br#"{"gate_state":"ready","workflow_id":"wf-1"}"#
+        );
+        assert!(
+            project_frame(&config, r#"{"type":"question","gate":{"state":"ready"}}"#)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_projection_and_adapter_payload() {
+        let mut invalid_config = config();
+        invalid_config
+            .projection
+            .insert("token".into(), "/workflow/id".into());
+        assert!(validate_projection_policy(&invalid_config).is_err());
+        let config = config();
+        assert!(
+            adapter_event(
+                br#"{"type":"workflow.gate","payload":{"correlation_id":"secret"}}"#,
+                &config
+            )
+            .is_err()
+        );
+        assert!(
+            adapter_event(
+                br#"{"type":"workflow.gate","payload":{"nested":{"token":"secret"}}}"#,
+                &config
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn filter_pointers_allow_discriminators_and_predicates_while_projections_remain_redacted() {
+        let config = config();
+        assert!(validate_filter_policy(&config).is_ok());
+        assert!(validate_projection_policy(&config).is_ok());
+
+        let mut sensitive_projection = config.clone();
+        sensitive_projection
+            .projection
+            .insert("safe_name".into(), "/credentials/token".into());
+        assert!(validate_projection_policy(&sensitive_projection).is_err());
+    }
+
+    #[test]
+    fn validates_redacted_transport_and_strict_output() {
+        assert!(validate_endpoint("wss://example.invalid/path?token=secret").is_ok());
+        assert!(validate_endpoint("ws://localhost:9000").is_err());
+        assert!(validate_endpoint("wss://user:secret@example.invalid").is_err());
+        let config = config();
+        assert!(
+            adapter_event(
+                br#"{"type":"workflow.gate","payload":{}} {"type":"workflow.gate","payload":{}}"#,
+                &config
+            )
+            .is_err()
+        );
+        assert!(adapter_event(br#"{"type":"Workflow.Gate","payload":{}}"#, &config).is_err());
+    }
+    #[test]
+    fn snapshot_transitions_and_counters_are_deterministic() {
+        let config = config();
+        let mut snapshot = SubscriptionSnapshot::new(&config);
+        let initial_transition = snapshot.last_state_transition_at.clone();
+        snapshot.connection_attempt();
+        snapshot.connection_failed();
+        snapshot.transition(SubscriptionState::BackingOff, "connect_failed");
+        assert_eq!(snapshot.connection_attempts_total, 1);
+        assert_eq!(snapshot.connection_failures_total, 1);
+        assert_eq!(snapshot.state, SubscriptionState::BackingOff);
+        assert_eq!(snapshot.last_reason_code, "connect_failed");
+        assert!(OffsetDateTime::parse(&initial_transition, &Rfc3339).is_ok());
+        assert!(OffsetDateTime::parse(&snapshot.last_state_transition_at, &Rfc3339).is_ok());
+    }
+
+    #[test]
+    fn reconnect_helpers_preserve_attempts_until_an_event_is_enqueued() {
+        let config = config();
+
+        assert_eq!(
+            [1, 2, 3, 4, 5, 6]
+                .into_iter()
+                .map(|attempt| reconnect_delay_ms(&config, attempt))
+                .collect::<Vec<_>>(),
+            vec![250, 500, 1_000, 2_000, 4_000, 5_000]
+        );
+        assert_eq!(
+            reconnect_decision(4, config.reconnect.max_attempts),
+            ReconnectDecision::Backoff
+        );
+        assert_eq!(
+            reconnect_decision(5, config.reconnect.max_attempts),
+            ReconnectDecision::Exhausted
+        );
+    }
+
+    #[test]
+    fn rejects_decorated_sensitive_keys_at_every_payload_depth() {
+        let config = config();
+        for key in [
+            "github_token",
+            "auth_token",
+            "accessToken",
+            "credentials",
+            "webhook_url",
+        ] {
+            let output = format!(
+                r#"{{"type":"workflow.gate","payload":{{"nested":{{"{key}":"secret"}}}}}}"#
+            );
+            assert!(adapter_event(output.as_bytes(), &config).is_err(), "{key}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_check_requires_an_executable_regular_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("adapter");
+        std::fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+        assert!(!is_regular_executable(path.to_str().unwrap()));
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        assert!(is_regular_executable(path.to_str().unwrap()));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn adapter_deadline_kills_and_reaps_a_non_reading_child() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let script = directory.path().join("non-reading-adapter");
+        let pid_file = directory.path().join("adapter.pid");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\necho $$ > {}\nexec sleep 30\n",
+                pid_file.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&script, permissions).unwrap();
+        let mut config = config();
+        config.adapter.program = script.to_string_lossy().into_owned();
+        config.adapter.timeout_ms = 100;
+        let (_sender, mut cancel) = watch::channel(false);
+        let error = run_adapter(&config, br#"{"workflow_id":"wf-1"}"#, &mut cancel)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_eq!(error, "adapter_timeout");
+        let pid = std::fs::read_to_string(pid_file).unwrap();
+        let process_exists = std::process::Command::new("kill")
+            .args(["-0", pid.trim()])
+            .status()
+            .unwrap()
+            .success();
+        assert!(!process_exists, "timed-out adapter must be reaped");
+    }
+}


### PR DESCRIPTION
## Summary
- add first-class `clawhip subscribe validate|list|status|start|stop`
- run config-backed Rustls WebSocket subscriptions inside the daemon with deterministic bounded reconnect and graceful cancellation
- filter and allowlist-project local frames into env-cleared argv adapters, then enqueue restricted `IncomingEvent` values through the existing Router
- protect lifecycle controls with loopback peer, Host/Origin, and fixed non-simple control-header checks
- expose only redacted stable lifecycle snapshots and document guarded GJC `workflow_gate`/`question` examples

## Security boundaries
- endpoint values remain daemon-environment-only and never appear in status, health, logs, or emitted events
- raw frames, unprojected fields, stderr, rejected output, and inherited daemon secrets never cross the adapter/event boundary
- adapter delivery controls and reserved metadata are rejected recursively
- unmatched subscription events cannot fall back to the default channel

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- focused subscription/config/daemon/client/router tests
- `cargo test` (705 unit tests plus all integration suites)
- `cargo build --release`
- `scripts/internal-pr-format-gate.sh`
- hermetic release-daemon list/status replay with endpoint/token absence checks

Closes #289
—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*