### PR TITLE
fix(runtime): reconcile stale tmux watch registrations

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2524,9 +2524,10 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[serial]
-    #[tokio::test]
-    async fn accepted_terminal_session_event_expires_matching_tmux_registration() {
+    async fn assert_terminal_event_registry_presence(
+        tmux_bin: &std::path::Path,
+        expected_present: bool,
+    ) {
         let (tx, mut rx) = mpsc::channel(1);
         let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
         registry
@@ -2538,18 +2539,9 @@ mod tests {
             .await
             .insert("still-active".into(), tmux_registration("still-active"));
         let dir = tempdir().expect("tempdir");
-        let stub = dir.path().join("tmux-expiry-stub.sh");
-        fs::write(
-            &stub,
-            "#!/bin/sh\nif [ \"$1\" = \"has-session\" ]; then exit 1; fi\nexit 1\n",
-        )
-        .expect("write tmux expiry stub");
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755))
-            .expect("chmod tmux expiry stub");
         let prior_tmux_bin = std::env::var("CLAWHIP_TMUX_BIN").ok();
         unsafe {
-            std::env::set_var("CLAWHIP_TMUX_BIN", &stub);
+            std::env::set_var("CLAWHIP_TMUX_BIN", tmux_bin);
         }
         let state = AppState {
             config: Arc::new(AppConfig::default()),
@@ -2589,7 +2581,7 @@ mod tests {
         );
         {
             let registry = registry.read().await;
-            assert!(!registry.contains_key("issue-221"));
+            assert_eq!(registry.contains_key("issue-221"), expected_present);
             assert!(registry.contains_key("still-active"));
         }
         unsafe {
@@ -2598,7 +2590,49 @@ mod tests {
                 None => std::env::remove_var("CLAWHIP_TMUX_BIN"),
             }
         }
-        let _ = fs::remove_file(stub);
+    }
+
+    #[cfg(unix)]
+    #[serial]
+    #[tokio::test]
+    async fn accepted_terminal_session_event_expires_matching_tmux_registration() {
+        let dir = tempdir().expect("tempdir");
+        let stub = dir.path().join("tmux-expiry-stub.sh");
+        fs::write(
+            &stub,
+            "#!/bin/sh\nif [ \"$1\" = \"has-session\" ]; then exit 1; fi\nexit 1\n",
+        )
+        .expect("write tmux expiry stub");
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755))
+            .expect("chmod tmux expiry stub");
+        assert_terminal_event_registry_presence(&stub, false).await;
+    }
+
+    #[cfg(unix)]
+    #[serial]
+    #[tokio::test]
+    async fn accepted_terminal_session_event_preserves_live_tmux_registration() {
+        let dir = tempdir().expect("tempdir");
+        let stub = dir.path().join("tmux-live-stub.sh");
+        fs::write(
+            &stub,
+            "#!/bin/sh\nif [ \"$1\" = \"has-session\" ]; then exit 0; fi\nexit 0\n",
+        )
+        .expect("write tmux live stub");
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755))
+            .expect("chmod tmux live stub");
+        assert_terminal_event_registry_presence(&stub, true).await;
+    }
+
+    #[cfg(unix)]
+    #[serial]
+    #[tokio::test]
+    async fn accepted_terminal_session_event_preserves_registration_on_probe_error() {
+        let dir = tempdir().expect("tempdir");
+        let missing_tmux = dir.path().join("missing-tmux");
+        assert_terminal_event_registry_presence(&missing_tmux, true).await;
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2600,7 +2600,8 @@ mod tests {
         let stub = dir.path().join("tmux-expiry-stub.sh");
         fs::write(
             &stub,
-            "#!/bin/sh\nif [ \"$1\" = \"has-session\" ]; then exit 1; fi\nexit 1\n",
+            "#!/bin/sh\nif [ \"$1\" = \"has-session\" ]; then echo \"can't find session: issue-221\" >&2; exit 1; fi\nexit 1\n",
+
         )
         .expect("write tmux expiry stub");
         use std::os::unix::fs::PermissionsExt;
@@ -2633,6 +2634,23 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let missing_tmux = dir.path().join("missing-tmux");
         assert_terminal_event_registry_presence(&missing_tmux, true).await;
+    }
+
+    #[cfg(unix)]
+    #[serial]
+    #[tokio::test]
+    async fn accepted_terminal_session_event_preserves_registration_on_unknown_probe_status() {
+        let dir = tempdir().expect("tempdir");
+        let stub = dir.path().join("tmux-unknown-stub.sh");
+        fs::write(
+            &stub,
+            "#!/bin/sh\nif [ \"$1\" = \"has-session\" ]; then echo \"tmux server unavailable\" >&2; exit 1; fi\nexit 1\n",
+        )
+        .expect("write tmux unknown stub");
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755))
+            .expect("chmod tmux unknown stub");
+        assert_terminal_event_registry_presence(&stub, true).await;
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2045,8 +2045,8 @@ mod tests {
     use crate::sink::SinkTarget;
     use crate::source::tmux::{ParentProcessInfo, RegistrationSource};
     use axum::body::to_bytes;
-    #[cfg(unix)]
     use serial_test::serial;
+
     use std::fs;
     use tempfile::tempdir;
 
@@ -3867,6 +3867,7 @@ mod tests {
         assert!(rx.try_recv().is_err(), "non-git payload should not enqueue");
     }
 
+    #[serial]
     #[tokio::test]
     async fn list_tmux_returns_registered_sessions_with_metadata() {
         // Use a stub tmux binary that reports issue-105 as a live session so

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -24,20 +24,24 @@ use crate::render::{DefaultRenderer, Renderer};
 use crate::router::Router;
 use crate::sink::{DiscordSink, LocalFileSink, Sink, SlackSink};
 use crate::source::tmux::{
+    AbsentRegistrationCandidate, prune_absent_dynamic_registrations, session_exists,
+};
+use crate::source::tmux::{
     BoundedCategory, BoundedReason, LaneDeliveryMutation, LaneEvidenceMutation, LaneLaunchState,
     LaneRegistrationInput, LaneRetirementMutation, LaneVerificationMutation, LaneVisibility,
     LaneWorkflow, LaneWorkflowMutation, claim_lane, lane_detail_for_session, list_lane_snapshots,
     record_lane_delivery, record_lane_verification, register_lane_registration,
     retire_lane_if_absent, update_lane_evidence, update_lane_workflow,
 };
+
 use crate::source::{
     GitHubSource, GitMonitorLifecycleCounts, GitSource, RegisteredTmuxSession,
     SharedGitMonitorDiagnostics, SharedTmuxRegistry, Source, SubscriptionSnapshot,
     SubscriptionState, SubscriptionWorker, TmuxSource, WorkspaceSource,
     default_registry_state_path, inspect_tmux_registry_state, list_active_tmux_registrations,
     load_tmux_registry_state, new_shared_git_monitor_diagnostics,
-    register_runtime_tmux_registration, remove_tmux_registrations,
-    snapshot_git_monitor_diagnostics, tmux_registry_diagnostics,
+    register_runtime_tmux_registration, snapshot_git_monitor_diagnostics,
+    tmux_registry_diagnostics,
 };
 use crate::telemetry;
 use crate::update::{self, SharedPendingUpdate};
@@ -1236,20 +1240,58 @@ async fn expire_terminal_tmux_registration(state: &AppState, event: &IncomingEve
         return;
     }
 
-    let candidates = terminal_session_candidates(&event.payload);
-    if candidates.is_empty() {
+    let candidate_sessions = terminal_session_candidates(&event.payload);
+    if candidate_sessions.is_empty() {
+        return;
+    }
+
+    let observed_candidates = {
+        let snapshot = state.tmux_registry.read().await;
+        candidate_sessions
+            .iter()
+            .filter_map(|session| {
+                snapshot
+                    .get(session)
+                    .filter(|registration| registration.lane.is_none())
+                    .map(|registration| AbsentRegistrationCandidate {
+                        session: session.clone(),
+                        registration_generation: registration.registration_generation,
+                    })
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut absent_candidates = Vec::new();
+    for candidate in observed_candidates {
+        match session_exists(&candidate.session).await {
+            Ok(false) => absent_candidates.push(candidate),
+            Ok(true) => {}
+            Err(error) => {
+                eprintln!(
+                    "clawhip tmux terminal expiry liveness probe failed for {}: {error}",
+                    candidate.session
+                );
+                return;
+            }
+        }
+    }
+    if absent_candidates.is_empty() {
         return;
     }
 
     let registry_state_path = default_registry_state_path(&state.cron_state_path);
-    match remove_tmux_registrations(&state.tmux_registry, &registry_state_path, &candidates).await {
+    match prune_absent_dynamic_registrations(
+        &state.tmux_registry,
+        &registry_state_path,
+        &absent_candidates,
+    )
+    .await
+    {
         Ok(removed) => {
             if removed > 0 {
-                for session in candidates {
-                    telemetry::emit(tmux_terminal_expiry_record(&session));
-                }
+                telemetry::emit(tmux_terminal_expiry_record(removed));
             }
         }
+
         Err(error) => {
             eprintln!("clawhip tmux registry expiry save failed: {error}");
         }
@@ -1263,14 +1305,14 @@ fn is_terminal_session_event(kind: &str) -> bool {
     )
 }
 
-fn tmux_terminal_expiry_record(session: &str) -> serde_json::Map<String, Value> {
+fn tmux_terminal_expiry_record(removed_count: usize) -> serde_json::Map<String, Value> {
     let mut record = telemetry::record(
         telemetry::event_name::SOURCE_INVENTORY,
         "terminal_session_expired",
-        format!("source:tmux:{session}"),
+        "source:tmux:terminal",
     );
     record.insert("source".to_string(), json!("tmux"));
-    record.insert("session".to_string(), json!(session));
+    record.insert("removed_count".to_string(), json!(removed_count));
     record
 }
 
@@ -2003,8 +2045,11 @@ mod tests {
     use crate::sink::SinkTarget;
     use crate::source::tmux::{ParentProcessInfo, RegistrationSource};
     use axum::body::to_bytes;
+    #[cfg(unix)]
+    use serial_test::serial;
     use std::fs;
     use tempfile::tempdir;
+
     use tokio::time::{Duration, timeout};
 
     fn native_hook_test_state() -> (AppState, mpsc::Receiver<IncomingEvent>) {
@@ -2478,6 +2523,8 @@ mod tests {
             .insert(path[path.len() - 1].to_string(), Value::String(value));
     }
 
+    #[cfg(unix)]
+    #[serial]
     #[tokio::test]
     async fn accepted_terminal_session_event_expires_matching_tmux_registration() {
         let (tx, mut rx) = mpsc::channel(1);
@@ -2491,6 +2538,19 @@ mod tests {
             .await
             .insert("still-active".into(), tmux_registration("still-active"));
         let dir = tempdir().expect("tempdir");
+        let stub = dir.path().join("tmux-expiry-stub.sh");
+        fs::write(
+            &stub,
+            "#!/bin/sh\nif [ \"$1\" = \"has-session\" ]; then exit 1; fi\nexit 1\n",
+        )
+        .expect("write tmux expiry stub");
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755))
+            .expect("chmod tmux expiry stub");
+        let prior_tmux_bin = std::env::var("CLAWHIP_TMUX_BIN").ok();
+        unsafe {
+            std::env::set_var("CLAWHIP_TMUX_BIN", &stub);
+        }
         let state = AppState {
             config: Arc::new(AppConfig::default()),
             port: 25294,
@@ -2527,9 +2587,18 @@ mod tests {
             rx.recv().await.expect("queued event").kind,
             "session.finished"
         );
-        let registry = registry.read().await;
-        assert!(!registry.contains_key("issue-221"));
-        assert!(registry.contains_key("still-active"));
+        {
+            let registry = registry.read().await;
+            assert!(!registry.contains_key("issue-221"));
+            assert!(registry.contains_key("still-active"));
+        }
+        unsafe {
+            match prior_tmux_bin {
+                Some(value) => std::env::set_var("CLAWHIP_TMUX_BIN", value),
+                None => std::env::remove_var("CLAWHIP_TMUX_BIN"),
+            }
+        }
+        let _ = fs::remove_file(stub);
     }
 
     #[tokio::test]
@@ -3796,11 +3865,16 @@ mod tests {
                 lane: None,
             },
         );
+        registry
+            .write()
+            .await
+            .insert("stale-wrapper".into(), tmux_registration("stale-wrapper"));
+
         let state = AppState {
             config: Arc::new(AppConfig::default()),
             port: 25294,
             tx,
-            tmux_registry: registry,
+            tmux_registry: registry.clone(),
             pending_update: update::new_shared_pending_update(),
             native_observability: new_shared_native_hook_observability(),
             cron_state_path: PathBuf::from("cron-state.json"),
@@ -3830,6 +3904,7 @@ mod tests {
             registrations[0]["parent_process"]["name"],
             Value::from("codex")
         );
+        assert!(!registry.read().await.contains_key("stale-wrapper"));
         // Safety: single-threaded test context; restore prior env state.
         unsafe {
             match &prior_tmux_bin {

--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -250,7 +250,7 @@ fn is_tmux_watch_command_echo(line: &str) -> bool {
         .or_else(|| line.strip_prefix("> "))
         .unwrap_or(line);
     command.starts_with("clawhip tmux watch ")
-        && command.contains(" --session ")
+        && (command.contains(" --session ") || command.contains(" -s "))
         && command.contains(" --keywords ")
 }
 
@@ -406,6 +406,26 @@ good output",
         assert_eq!(
             hits[0].provenance.as_ref().and_then(|value| value.cursor),
             Some(3)
+        );
+    }
+
+    #[test]
+    fn collect_keyword_hits_ignores_short_form_detached_watch_command() {
+        let hits = collect_keyword_hits(
+            "boot",
+            "boot
+clawhip tmux watch -s clawhip-issue-299 --keywords owner-endpoint-unreachable
+owner-endpoint-unreachable: runtime owner failed",
+            &["owner-endpoint-unreachable".into()],
+        );
+
+        assert_eq!(
+            hits,
+            vec![KeywordHit {
+                keyword: "owner-endpoint-unreachable".into(),
+                line: "owner-endpoint-unreachable: runtime owner failed".into(),
+                provenance: None,
+            }]
         );
     }
 

--- a/src/keyword_window.rs
+++ b/src/keyword_window.rs
@@ -240,6 +240,18 @@ fn should_ignore_launcher_line(line: &str) -> bool {
     LAUNCHER_NOISE_PATTERNS
         .iter()
         .any(|pattern| trimmed.contains(pattern))
+        || is_tmux_watch_command_echo(trimmed)
+}
+
+fn is_tmux_watch_command_echo(line: &str) -> bool {
+    let command = line
+        .strip_prefix("$ ")
+        .or_else(|| line.strip_prefix("% "))
+        .or_else(|| line.strip_prefix("> "))
+        .unwrap_or(line);
+    command.starts_with("clawhip tmux watch ")
+        && command.contains(" --session ")
+        && command.contains(" --keywords ")
 }
 
 fn appended_lines_with_cursors<'a>(previous: &'a str, current: &'a str) -> Vec<(usize, &'a str)> {
@@ -365,6 +377,35 @@ mod tests {
                 line: "error: real failure".into(),
                 provenance: None,
             }]
+        );
+    }
+
+    #[test]
+    fn collect_keyword_hits_ignores_detached_watch_command_but_keeps_owner_failure() {
+        let hits = collect_keyword_hits_with_provenance(
+            "boot",
+            "boot
+$ clawhip tmux watch --session clawhip-issue-299 --stale-minutes 60 --keywords owner-endpoint-unreachable
+owner-endpoint-unreachable: runtime owner failed
+good output",
+            &["owner-endpoint-unreachable".into()],
+            KeywordMatchProvenance {
+                pane_id: "%29".into(),
+                pane_name: "0.0".into(),
+                cursor: None,
+                source: KeywordMatchSource::FreshOutput,
+            },
+        );
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].keyword, "owner-endpoint-unreachable");
+        assert_eq!(
+            hits[0].line,
+            "owner-endpoint-unreachable: runtime owner failed"
+        );
+        assert_eq!(
+            hits[0].provenance.as_ref().and_then(|value| value.cursor),
+            Some(3)
         );
     }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -18,7 +18,7 @@ pub use subscription::{SubscriptionSnapshot, SubscriptionState, SubscriptionWork
 pub use tmux::{
     RegisteredTmuxSession, SharedTmuxRegistry, TmuxSource, default_registry_state_path,
     inspect_tmux_registry_state, list_active_tmux_registrations, load_tmux_registry_state,
-    register_runtime_tmux_registration, remove_tmux_registrations, tmux_registry_diagnostics,
+    register_runtime_tmux_registration, tmux_registry_diagnostics,
 };
 pub use workspace::WorkspaceSource;
 

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -1152,8 +1152,9 @@ pub async fn remove_tmux_registrations(
             registration
                 .lane
                 .as_ref()
-                .is_none_or(|lane| lane.workflow == LaneWorkflow::Retired)
+                .is_none_or(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced)
         });
+
         if removable && next.remove(session).is_some() {
             removed += 1;
         }
@@ -1176,9 +1177,9 @@ pub struct AbsentRegistrationCandidate {
     pub registration_generation: u64,
 }
 
-/// Prune daemon-owned dynamic registrations (cli-watch / cli-new) whose tmux
-/// session has been observed absent. Only non-lane entries are eligible;
-/// lane-bearing registrations are preserved regardless of liveness to avoid
+/// Prune daemon-owned dynamic registrations and explicitly retired/quiesced
+/// lane registrations whose tmux session has been observed absent. Active and
+/// handoff lane evidence is preserved regardless of liveness to avoid
 /// destroying in-flight R0/R1/R2 lane evidence that is expected to exist
 /// before the tmux session is created.
 ///
@@ -1201,8 +1202,12 @@ pub async fn prune_absent_dynamic_registrations(
         let removable = next.get(&candidate.session).is_some_and(|registration| {
             registration.registration_generation == candidate.registration_generation
                 && registration.registration_source != RegistrationSource::ConfigMonitor
-                && registration.lane.is_none()
+                && registration
+                    .lane
+                    .as_ref()
+                    .is_none_or(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced)
         });
+
         if removable && next.remove(&candidate.session).is_some() {
             if first_removed.is_none() {
                 first_removed = Some(candidate.session.as_str());
@@ -1792,28 +1797,33 @@ pub async fn list_active_tmux_registrations(
             // reconciliation so the generation captured for each candidate
             // matches the liveness observation.
             let snapshot = registry.read().await;
-            let stale_sessions: Vec<String> = snapshot
-                .iter()
-                .filter(|(session, registration)| {
-                    registration.active_wrapper_monitor && !available_sessions.contains(*session)
-                })
-                .map(|(session, _)| session.clone())
-                .collect();
-            let orphaned_candidates: Vec<AbsentRegistrationCandidate> = snapshot
+            let retired_lane_candidates: Vec<AbsentRegistrationCandidate> = snapshot
                 .iter()
                 .filter(|(session, registration)| {
                     !available_sessions.contains(*session)
-                        && registration.registration_source != RegistrationSource::ConfigMonitor
-                        && registration.lane.is_none()
-                        && !registration.active_wrapper_monitor
+                        && registration.lane.as_ref().is_some_and(|lane| {
+                            lane.workflow == LaneWorkflow::Retired && lane.quiesced
+                        })
                 })
                 .map(|(session, registration)| AbsentRegistrationCandidate {
                     session: session.clone(),
                     registration_generation: registration.registration_generation,
                 })
                 .collect();
+            let mut orphaned_candidates: Vec<AbsentRegistrationCandidate> = snapshot
+                .iter()
+                .filter(|(session, registration)| {
+                    !available_sessions.contains(*session)
+                        && registration.registration_source != RegistrationSource::ConfigMonitor
+                        && registration.lane.is_none()
+                })
+                .map(|(session, registration)| AbsentRegistrationCandidate {
+                    session: session.clone(),
+                    registration_generation: registration.registration_generation,
+                })
+                .collect();
+            orphaned_candidates.extend(retired_lane_candidates);
             drop(snapshot);
-            remove_tmux_registrations(registry, registry_state_path, &stale_sessions).await?;
             prune_absent_dynamic_registrations(registry, registry_state_path, &orphaned_candidates)
                 .await?;
         }
@@ -1883,9 +1893,12 @@ async fn poll_tmux(
                     Some(session_name),
                     None,
                 ));
+                let retired_lane = registration
+                    .lane
+                    .as_ref()
+                    .is_some_and(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced);
                 if registration.registration_source != RegistrationSource::ConfigMonitor
-                    && registration.lane.is_none()
-                    && !registration.active_wrapper_monitor
+                    && (registration.lane.is_none() || retired_lane)
                 {
                     dynamic_prune_candidates.push(AbsentRegistrationCandidate {
                         session: session_name.clone(),
@@ -4227,7 +4240,8 @@ error: failed";
             registration_source: RegistrationSource::CliWatch,
             parent_process: None,
             registration_generation: 0,
-            active_wrapper_monitor: false,
+            active_wrapper_monitor: true,
+
             lane: None,
         };
         registry
@@ -4386,6 +4400,80 @@ error: failed";
         assert_eq!(removed, 0);
         assert!(registry.read().await.get("lane-session").is_some());
         let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn remove_tmux_registrations_requires_quiesced_retirement() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        register_lane_registration(&registry, &path, lane_input("retained-lane", "g"))
+            .await
+            .unwrap();
+        {
+            let mut snapshot = registry.write().await;
+            let lane = snapshot
+                .get_mut("retained-lane")
+                .and_then(|registration| registration.lane.as_mut())
+                .unwrap();
+            lane.workflow = LaneWorkflow::Retired;
+            assert!(!lane.quiesced);
+        }
+
+        assert_eq!(
+            remove_tmux_registrations(&registry, &path, &["retained-lane".into()])
+                .await
+                .unwrap(),
+            0
+        );
+        assert!(registry.read().await.contains_key("retained-lane"));
+
+        registry
+            .write()
+            .await
+            .get_mut("retained-lane")
+            .and_then(|registration| registration.lane.as_mut())
+            .unwrap()
+            .quiesced = true;
+        assert_eq!(
+            remove_tmux_registrations(&registry, &path, &["retained-lane".into()])
+                .await
+                .unwrap(),
+            1
+        );
+        assert!(!registry.read().await.contains_key("retained-lane"));
+    }
+
+    #[tokio::test]
+    async fn prune_absent_dynamic_removes_retired_quiesced_lane() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        register_lane_registration(&registry, &path, lane_input("retired-lane", "g2"))
+            .await
+            .unwrap();
+        let generation = {
+            let mut snapshot = registry.write().await;
+            let registration = snapshot.get_mut("retired-lane").unwrap();
+            let generation = registration.registration_generation;
+            let lane = registration.lane.as_mut().unwrap();
+            lane.workflow = LaneWorkflow::Retired;
+            lane.quiesced = true;
+            generation
+        };
+
+        let removed = prune_absent_dynamic_registrations(
+            &registry,
+            &path,
+            &[AbsentRegistrationCandidate {
+                session: "retired-lane".into(),
+                registration_generation: generation,
+            }],
+        )
+        .await
+        .unwrap();
+        assert_eq!(removed, 1);
+        assert!(!registry.read().await.contains_key("retired-lane"));
     }
 
     #[tokio::test]

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -2475,7 +2475,7 @@ pub(crate) async fn session_exists(session: &str) -> Result<bool> {
     let output = Command::new(tmux_bin())
         .arg("has-session")
         .arg("-t")
-        .arg(session)
+        .arg(format!("={session}"))
         .output()
         .await?;
     if output.status.success() {
@@ -2596,6 +2596,8 @@ mod tests {
     use super::*;
     use crate::event::{EventBody, compat::from_incoming_event};
     use crate::keyword_window::{KeywordHit, collect_keyword_hits};
+    use serial_test::serial;
+    use tempfile::tempdir;
 
     fn registration(keywords: Vec<&str>) -> RegisteredTmuxSession {
         RegisteredTmuxSession {
@@ -3551,6 +3553,36 @@ PR created #7",
     fn default_registry_state_path_sits_beside_cron_state() {
         let path = default_registry_state_path(Path::new("/tmp/clawhip/cron-state.json"));
         assert_eq!(path, PathBuf::from("/tmp/clawhip/tmux-watch-registry.json"));
+    }
+
+    #[cfg(unix)]
+    #[serial]
+    #[tokio::test]
+    async fn session_exists_requires_exact_job_target_not_job_old_prefix() {
+        let dir = tempdir().expect("tempdir");
+        let stub = dir.path().join("tmux-prefix-stub.sh");
+        std::fs::write(
+            &stub,
+            "#!/bin/sh\nif [ \"$1\" = \"has-session\" ]; then\n  if [ \"$3\" = \"job\" ]; then exit 0; fi\n  if [ \"$3\" = \"=job\" ]; then echo \"can't find session: job\" >&2; exit 1; fi\nfi\nexit 1\n",
+        )
+        .expect("write tmux prefix stub");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod tmux prefix stub");
+
+        let prior_tmux_bin = std::env::var("CLAWHIP_TMUX_BIN").ok();
+        unsafe {
+            std::env::set_var("CLAWHIP_TMUX_BIN", &stub);
+        }
+        let live = session_exists("job").await.unwrap();
+        unsafe {
+            match prior_tmux_bin {
+                Some(value) => std::env::set_var("CLAWHIP_TMUX_BIN", value),
+                None => std::env::remove_var("CLAWHIP_TMUX_BIN"),
+            }
+        }
+
+        assert!(!live, "job must not match the live job-old prefix");
     }
 
     #[tokio::test]

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -2478,7 +2478,18 @@ pub(crate) async fn session_exists(session: &str) -> Result<bool> {
         .arg(session)
         .output()
         .await?;
-    Ok(output.status.success())
+    if output.status.success() {
+        return Ok(true);
+    }
+
+    let stderr = tmux_stderr(&output.stderr);
+    if stderr == format!("can't find session: {session}") {
+        Ok(false)
+    } else if stderr.is_empty() {
+        Err("tmux has-session failed without diagnostics".into())
+    } else {
+        Err(stderr.into())
+    }
 }
 
 async fn list_tmux_sessions() -> Result<HashSet<String>> {

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -1034,6 +1034,69 @@ fn legacy_registry_projection_is_loaded_without_lane_private_fields() {
 
 #[test]
 #[serial]
+fn restart_reconciles_stale_terminal_watch_registry_without_duplicate_live_watch() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    write_file(&state.join("session"), "live-watch");
+    write_file(&state.join("live"), "1");
+    config(&config_path, free_port());
+    write_file(
+        &registry_path(&config_path),
+        &json!({
+            "stale-watch": {
+                "session": "stale-watch",
+                "channel": "alerts",
+                "mention": null,
+                "keywords": ["owner-endpoint-unreachable"],
+                "keyword_window_secs": 30,
+                "stale_minutes": 60,
+                "format": "compact",
+                "registered_at": "2026-08-01T00:00:00Z",
+                "registration_source": "cli-watch",
+                "parent_process": null,
+                "registration_generation": 7,
+                "active_wrapper_monitor": true
+            },
+            "live-watch": {
+                "session": "live-watch",
+                "channel": "alerts",
+                "mention": null,
+                "keywords": ["owner-endpoint-unreachable"],
+                "keyword_window_secs": 30,
+                "stale_minutes": 60,
+                "format": "compact",
+                "registered_at": "2026-08-01T00:00:01Z",
+                "registration_source": "cli-watch",
+                "parent_process": null,
+                "registration_generation": 8,
+                "active_wrapper_monitor": true
+            }
+        })
+        .to_string(),
+    );
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+
+    let listed = lane_command(&config_path, &home, &tmux, &discord, &["tmux", "list"]);
+    successful(&listed);
+    let public = String::from_utf8_lossy(&listed.stdout);
+    assert!(public.contains("live-watch"));
+    assert!(!public.contains("stale-watch"));
+
+    let persisted = registry(&config_path);
+    assert!(persisted.get("stale-watch").is_none());
+    assert!(persisted.get("live-watch").is_some());
+}
+
+#[test]
+#[serial]
 fn absent_lane_can_retire_then_replace_while_old_generation_is_fenced() {
     let temp = TempDir::new().expect("temp");
     let home = temp.path().join("home");

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -292,7 +292,7 @@ mkdir -p "$S"
 printf '%s\n' "$1" >> "$S/calls"
 case "$1" in
   new-session) test -f "$S/fail_new_session" && exit 1; session=""; while [ $# -gt 0 ]; do case "$1" in -s) session="$2"; shift 2 ;; *) shift ;; esac; done; printf '%s' "$session" > "$S/session"; printf '1' > "$S/live" ;;
-  has-session) if test -f "$S/live"; then if test -f "$S/strict_has_session" && test "$3" != "$(cat "$S/session")"; then echo "can't find session: $3" >&2; exit 1; fi; exit 0; else echo "can't find session: ${{3:-unknown}}" >&2; exit 1; fi ;;
+  has-session) target="${{3#=}}"; if test -f "$S/live"; then if test -f "$S/strict_has_session" && test "$target" != "$(cat "$S/session")"; then echo "can't find session: $target" >&2; exit 1; fi; exit 0; else echo "can't find session: $target" >&2; exit 1; fi ;;
   set-option) key="$4"; value="$5"; test "$key" = "@clawhip_lane_generation" && test -f "$S/fail_generation_set" && exit 1; printf '%s' "$value" > "$S/${{key#@}}"; test "$key" = "@clawhip_lane_generation" && test -f "$S/mismatch_generation" && printf 'different-generation' > "$S/${{key#@}}" ;;
   show-options) key="$5"; safe="${{key#@}}"; test -f "$S/unreadable_$safe" && exit 1; file="$S/$safe"; if test -f "$file"; then printf '%s\n' "$(cat "$file")"; else echo 'invalid option' >&2; exit 1; fi ;;
   send-keys) test "${{4:-}}" = "-l" || printf '1' >> "$S/sends" ;;

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -292,7 +292,7 @@ mkdir -p "$S"
 printf '%s\n' "$1" >> "$S/calls"
 case "$1" in
   new-session) test -f "$S/fail_new_session" && exit 1; session=""; while [ $# -gt 0 ]; do case "$1" in -s) session="$2"; shift 2 ;; *) shift ;; esac; done; printf '%s' "$session" > "$S/session"; printf '1' > "$S/live" ;;
-  has-session) if test -f "$S/live"; then exit 0; else echo "can't find session: ${{3:-unknown}}" >&2; exit 1; fi ;;
+  has-session) if test -f "$S/live"; then if test -f "$S/strict_has_session" && test "$3" != "$(cat "$S/session")"; then echo "can't find session: $3" >&2; exit 1; fi; exit 0; else echo "can't find session: ${{3:-unknown}}" >&2; exit 1; fi ;;
   set-option) key="$4"; value="$5"; test "$key" = "@clawhip_lane_generation" && test -f "$S/fail_generation_set" && exit 1; printf '%s' "$value" > "$S/${{key#@}}"; test "$key" = "@clawhip_lane_generation" && test -f "$S/mismatch_generation" && printf 'different-generation' > "$S/${{key#@}}" ;;
   show-options) key="$5"; safe="${{key#@}}"; test -f "$S/unreadable_$safe" && exit 1; file="$S/$safe"; if test -f "$file"; then printf '%s\n' "$(cat "$file")"; else echo 'invalid option' >&2; exit 1; fi ;;
   send-keys) test "${{4:-}}" = "-l" || printf '1' >> "$S/sends" ;;
@@ -1082,7 +1082,25 @@ fn restart_reconciles_stale_terminal_watch_registry_without_duplicate_live_watch
     let discord = MockDiscord::start("success");
     let port = free_port();
     config(&config_path, port);
+    let mut config_contents = fs::read_to_string(&config_path).expect("read config");
+    config_contents.push_str("\n[monitors]\npoll_interval_secs = 1\n");
+    write_file(&config_path, &config_contents);
+    write_file(&state.join("strict_has_session"), "1");
+
     let _daemon = start(&config_path, &home, &tmux, &discord, port);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(content) = fs::read_to_string(registry_path(&config_path))
+            && let Ok(persisted) = serde_json::from_str::<Value>(&content)
+            && persisted.get("stale-watch").is_none()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    let reconciled = registry(&config_path);
+    assert!(reconciled.get("stale-watch").is_none());
+    assert!(reconciled.get("live-watch").is_some());
 
     let listed = lane_command(&config_path, &home, &tmux, &discord, &["tmux", "list"]);
     successful(&listed);
@@ -1093,6 +1111,19 @@ fn restart_reconciles_stale_terminal_watch_registry_without_duplicate_live_watch
     let persisted = registry(&config_path);
     assert!(persisted.get("stale-watch").is_none());
     assert!(persisted.get("live-watch").is_some());
+    let baseline = fs::read_to_string(state.join("calls")).unwrap_or_default();
+    thread::sleep(Duration::from_secs(2));
+    assert_eq!(registry(&config_path), reconciled);
+    assert_eq!(
+        command_count(&calls_after(&state, &baseline), "new-session"),
+        0
+    );
+
+    let listed_again = lane_command(&config_path, &home, &tmux, &discord, &["tmux", "list"]);
+    successful(&listed_again);
+    let public_again = String::from_utf8_lossy(&listed_again.stdout);
+    assert!(public_again.contains("live-watch"));
+    assert!(!public_again.contains("stale-watch"));
 }
 
 #[test]

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -292,7 +292,7 @@ mkdir -p "$S"
 printf '%s\n' "$1" >> "$S/calls"
 case "$1" in
   new-session) test -f "$S/fail_new_session" && exit 1; session=""; while [ $# -gt 0 ]; do case "$1" in -s) session="$2"; shift 2 ;; *) shift ;; esac; done; printf '%s' "$session" > "$S/session"; printf '1' > "$S/live" ;;
-  has-session) test -f "$S/live" ;;
+  has-session) if test -f "$S/live"; then exit 0; else echo "can't find session: ${{3:-unknown}}" >&2; exit 1; fi ;;
   set-option) key="$4"; value="$5"; test "$key" = "@clawhip_lane_generation" && test -f "$S/fail_generation_set" && exit 1; printf '%s' "$value" > "$S/${{key#@}}"; test "$key" = "@clawhip_lane_generation" && test -f "$S/mismatch_generation" && printf 'different-generation' > "$S/${{key#@}}" ;;
   show-options) key="$5"; safe="${{key#@}}"; test -f "$S/unreadable_$safe" && exit 1; file="$S/$safe"; if test -f "$file"; then printf '%s\n' "$(cat "$file")"; else echo 'invalid option' >&2; exit 1; fi ;;
   send-keys) test "${{4:-}}" = "-l" || printf '1' >> "$S/sends" ;;


### PR DESCRIPTION
## Summary

Closes #299.

- Generation-fences absent daemon-owned `CliWatch`/`CliNew` cleanup, including active wrapper watches, across list/poll/restart reconciliation.
- Preserves config projections and active/nonterminal lane evidence; removes lane records only with `Retired + quiesced` proof and absent runtime.
- Liveness-fences terminal event expiry and preserves re-registered/live sessions.
- Filters the detached `clawhip tmux watch --keywords owner-endpoint-unreachable` self-echo while retaining a real owner-endpoint failure line.

The 04:16 alert was confirmed as a false-positive self-match from the live watcher command; this change does not restart or duplicate the live GJC owner.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build --release`
- Focused keyword, registry, terminal-expiry, retirement, and restart-reconciliation regressions
- `git diff --check`

Commit: `e267e8a`
Base: `dev@95e1a6c70bb8a49ca3bb16b9c3fa7fbbf2332217`

Do not merge; review only.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*