### PR TITLE
feat(setup): add official GJC question opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,14 +325,32 @@ clawhip setup \
   --daemon-base-url "http://127.0.0.1:25294"
 ```
 
-`clawhip setup` stays non-interactive and intentionally limited to five presets only:
+`clawhip setup` stays non-interactive and intentionally limited to the supported presets:
 - Discord webhook quickstart route
 - Discord bot token
 - Default channel
 - Default message format
 - Daemon base URL
+- Official GJC question subscription and repository-scoped route (channel, mention, fallback)
 
-Advanced routes and monitor definitions are still edited manually in the config file or revisited through the bounded `clawhip config` editor surface.
+
+To opt into the official GJC question bridge from a repository checkout, provide a destination channel (or explicitly reuse the configured default channel):
+
+```bash
+clawhip setup \
+  --question-channel "QUESTIONS_CHANNEL_ID" \
+  --question-mention "<@OPERATOR_ID>"
+
+# Equivalent fallback form when [defaults].channel is already configured.
+clawhip setup --question-fallback
+```
+
+This setup path converges the setup-owned `gjc-question` websocket subscription and one
+`workflow.question` route filtered by the current repository identity. It never edits an
+existing `workflow.gate` route. Re-running setup updates those same named entries instead of
+duplicating them. Question setup only owns the destination channel, optional mention, and
+fallback-to-default choice; the subscription endpoint remains `GJC_QUESTION_WS` and is read
+only by the daemon environment.
 
 Route example:
 
@@ -1024,8 +1042,8 @@ question_id = "/question/id"
 summary = "/question/summary"
 
 [subscriptions.adapter]
-program = "/absolute/path/to/gjc-question-adapter"
-args = []
+program = "<path-to-clawhip>"
+args = ["subscribe", "adapter", "question"]
 
 [[routes]]
 event = "workflow.question"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -264,6 +264,16 @@ pub struct SetupArgs {
     /// before writing the config. Fails the command if any binding drifts.
     #[arg(long = "verify-bindings", default_value_t = false)]
     pub verify_bindings: bool,
+    /// Opt in to the official GJC question subscription and route questions to this channel.
+    /// The value is a Discord channel ID. Use --question-fallback to reuse [defaults].channel.
+    #[arg(long = "question-channel")]
+    pub question_channel: Option<String>,
+    /// Mention to prepend to question notifications created by official GJC setup.
+    #[arg(long = "question-mention")]
+    pub question_mention: Option<String>,
+    /// Use the configured default channel when no --question-channel is supplied.
+    #[arg(long = "question-fallback", default_value_t = false)]
+    pub question_fallback: bool,
 }
 
 #[derive(Debug, Clone, Default, Args)]
@@ -352,6 +362,8 @@ fn parse_emit_value(raw: &str) -> Value {
 
 #[derive(Debug, Subcommand)]
 pub enum SubscribeCommands {
+    /// Adapt the official GJC question projection into a restricted clawhip event.
+    Adapter { kind: String },
     /// Validate configured subscriptions without exposing endpoint environment details.
     Validate,
     /// List public-safe subscription lifecycle snapshots from the local daemon.

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,8 @@ pub struct SubscriptionConfig {
     pub name: String,
     #[serde(default)]
     pub enabled: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub setup_owned: bool,
     pub kind: String,
     pub endpoint_env: String,
     #[serde(default = "default_subscription_max_frame_bytes")]
@@ -138,6 +140,9 @@ pub struct SubscriptionRoutingConfig {
     #[serde(default)]
     pub branch: Option<String>,
 }
+
+pub const GJC_QUESTION_SUBSCRIPTION_NAME: &str = "gjc-question";
+pub const GJC_QUESTION_ENDPOINT_ENV: &str = "GJC_QUESTION_WS";
 
 fn default_subscription_max_frame_bytes() -> usize {
     65_536
@@ -1549,6 +1554,124 @@ impl AppConfig {
             self.daemon.base_url = daemon_base_url;
         }
 
+        Ok(())
+    }
+    pub fn apply_gjc_question_setup(
+        &mut self,
+        channel: Option<String>,
+        mention: Option<String>,
+        fallback: bool,
+        repo: String,
+        adapter_program: String,
+    ) -> Result<()> {
+        let channel = normalize_text(channel).or_else(|| {
+            fallback
+                .then(|| normalize_text(self.defaults.channel.clone()))
+                .flatten()
+        });
+        let channel = channel.ok_or_else(|| {
+            "question setup requires --question-channel or --question-fallback with [defaults].channel"
+                .to_string()
+        })?;
+        let repo = normalize_text(Some(repo))
+            .ok_or_else(|| "question setup requires a non-empty repository identity".to_string())?;
+        let adapter_program = normalize_text(Some(adapter_program))
+            .ok_or_else(|| "question setup requires the clawhip executable path".to_string())?;
+        let mention = normalize_text(mention);
+
+        let route_matches = self
+            .routes
+            .iter()
+            .enumerate()
+            .filter(|(_, route)| {
+                route.event == "workflow.question"
+                    && route.filter.len() == 1
+                    && route.filter.get("repo_name") == Some(&repo)
+            })
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if route_matches.len() > 1 {
+            return Err(format!(
+                "multiple setup-owned question routes found for repo '{repo}'; clean up duplicates before updating"
+            )
+            .into());
+        }
+
+        match route_matches.as_slice() {
+            [index] => {
+                let route = &mut self.routes[*index];
+                route.channel = Some(channel.clone());
+                route.mention = mention.clone();
+                route.format = Some(MessageFormat::Alert);
+            }
+            [] => {
+                let mut filter = BTreeMap::new();
+                filter.insert("repo_name".to_string(), repo.clone());
+                self.routes.push(RouteRule {
+                    event: "workflow.question".into(),
+                    filter,
+                    sink: default_sink_name(),
+                    channel: Some(channel),
+                    mention,
+                    format: Some(MessageFormat::Alert),
+                    ..RouteRule::default()
+                });
+            }
+            _ => unreachable!(),
+        }
+
+        let subscription_matches = self
+            .subscriptions
+            .iter()
+            .enumerate()
+            .filter(|(_, subscription)| subscription.name == GJC_QUESTION_SUBSCRIPTION_NAME)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if subscription_matches.len() > 1 {
+            return Err("multiple setup-owned GJC question subscriptions found; clean up duplicates before updating".into());
+        }
+
+        let projection = [
+            ("question_id", "/question/id"),
+            ("summary", "/question/summary"),
+        ]
+        .into_iter()
+        .map(|(name, pointer)| (name.to_string(), pointer.to_string()))
+        .collect();
+        let subscription = SubscriptionConfig {
+            name: GJC_QUESTION_SUBSCRIPTION_NAME.into(),
+            enabled: true,
+            setup_owned: true,
+            kind: "websocket".into(),
+            endpoint_env: GJC_QUESTION_ENDPOINT_ENV.into(),
+            max_frame_bytes: default_subscription_max_frame_bytes(),
+            max_json_depth: default_subscription_max_json_depth(),
+            filter: SubscriptionFilterConfig {
+                discriminator_pointer: "/type".into(),
+                discriminator_equals: "question".into(),
+                predicates: Vec::new(),
+            },
+            projection,
+            adapter: SubscriptionAdapterConfig {
+                program: adapter_program,
+                args: vec!["subscribe".into(), "adapter".into(), "question".into()],
+                timeout_ms: default_subscription_timeout_ms(),
+                max_stdin_bytes: default_subscription_stdin_bytes(),
+                max_stdout_bytes: default_subscription_stdout_bytes(),
+                max_stderr_bytes: default_subscription_stderr_bytes(),
+            },
+            reconnect: SubscriptionReconnectConfig::default(),
+            routing: SubscriptionRoutingConfig {
+                tool: Some("gjc".into()),
+                repo_name: Some(repo),
+                ..SubscriptionRoutingConfig::default()
+            },
+        };
+        match subscription_matches.as_slice() {
+            [index] => self.subscriptions[*index] = subscription,
+            [] => self.subscriptions.push(subscription),
+            _ => unreachable!(),
+        }
         Ok(())
     }
 
@@ -3903,6 +4026,92 @@ thread = "123456789012345678"
 
         assert!(config.validate().is_ok());
         assert_eq!(config.webhook_route_count(), 1);
+    }
+
+    #[test]
+    fn gjc_question_setup_is_idempotent_and_preserves_workflow_route() {
+        let mut config = AppConfig {
+            routes: vec![RouteRule {
+                event: "workflow.gate".into(),
+                channel: Some("workflow-channel".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        config
+            .apply_gjc_question_setup(
+                Some("question-channel".into()),
+                Some("<@123>".into()),
+                false,
+                "owner/repo".into(),
+                "/usr/bin/clawhip".into(),
+            )
+            .unwrap();
+        config
+            .apply_gjc_question_setup(
+                Some("updated-question-channel".into()),
+                None,
+                false,
+                "owner/repo".into(),
+                "/usr/bin/clawhip".into(),
+            )
+            .unwrap();
+
+        assert_eq!(config.subscriptions.len(), 1);
+        assert_eq!(config.subscriptions[0].name, GJC_QUESTION_SUBSCRIPTION_NAME);
+        assert!(config.subscriptions[0].setup_owned);
+        assert_eq!(config.routes.len(), 2);
+        assert_eq!(config.routes[0].event, "workflow.gate");
+        let question = config
+            .routes
+            .iter()
+            .find(|route| route.event == "workflow.question")
+            .expect("question route");
+        assert_eq!(
+            question.filter.get("repo_name").map(String::as_str),
+            Some("owner/repo")
+        );
+        assert_eq!(
+            question.channel.as_deref(),
+            Some("updated-question-channel")
+        );
+        assert_eq!(question.mention, None);
+        assert_eq!(
+            config.subscriptions[0].routing.repo_name.as_deref(),
+            Some("owner/repo")
+        );
+    }
+
+    #[test]
+    fn gjc_question_setup_requires_explicit_or_default_channel() {
+        let mut config = AppConfig::default();
+        let error = config
+            .apply_gjc_question_setup(
+                None,
+                None,
+                true,
+                "owner/repo".into(),
+                "/usr/bin/clawhip".into(),
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("--question-channel"));
+        assert!(config.subscriptions.is_empty());
+        assert!(config.routes.is_empty());
+    }
+
+    #[test]
+    fn legacy_config_without_gjc_subscription_remains_valid_and_unchanged() {
+        let config: AppConfig = toml::from_str(
+            "[[routes]]\nevent = \"custom\"\nsink = \"localfile\"\nlocal_path = \"/tmp/events.jsonl\"\n",
+        )
+        .unwrap();
+        assert!(config.subscriptions.is_empty());
+        assert!(config.validate().is_ok());
+        let serialized = config.to_pretty_toml().unwrap();
+        assert!(!serialized.contains("gjc-question"));
+        assert!(!serialized.contains("[[subscriptions]]"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,7 +79,7 @@ pub struct SubscriptionFilterConfig {
     pub predicates: Vec<SubscriptionPredicateConfig>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct SubscriptionPredicateConfig {
     pub pointer: String,
@@ -1579,6 +1579,22 @@ impl AppConfig {
             .ok_or_else(|| "question setup requires the clawhip executable path".to_string())?;
         let mention = normalize_text(mention);
 
+        let subscription_matches = self
+            .subscriptions
+            .iter()
+            .enumerate()
+            .filter(|(_, subscription)| subscription.name == GJC_QUESTION_SUBSCRIPTION_NAME)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if subscription_matches.len() > 1 {
+            return Err("multiple setup-owned GJC question subscriptions found; clean up duplicates before updating".into());
+        }
+        if let Some(index) = subscription_matches.first()
+            && !self.subscriptions[*index].setup_owned
+        {
+            return Err("manual GJC question subscription ownership conflict; remove --question setup or mark the entry setup-owned".into());
+        }
+
         let route_matches = self
             .routes
             .iter()
@@ -1620,17 +1636,6 @@ impl AppConfig {
             _ => unreachable!(),
         }
 
-        let subscription_matches = self
-            .subscriptions
-            .iter()
-            .enumerate()
-            .filter(|(_, subscription)| subscription.name == GJC_QUESTION_SUBSCRIPTION_NAME)
-            .map(|(index, _)| index)
-            .collect::<Vec<_>>();
-        if subscription_matches.len() > 1 {
-            return Err("multiple setup-owned GJC question subscriptions found; clean up duplicates before updating".into());
-        }
-
         let projection = [
             ("question_id", "/question/id"),
             ("summary", "/question/summary"),
@@ -1649,7 +1654,10 @@ impl AppConfig {
             filter: SubscriptionFilterConfig {
                 discriminator_pointer: "/type".into(),
                 discriminator_equals: "question".into(),
-                predicates: Vec::new(),
+                predicates: vec![SubscriptionPredicateConfig {
+                    pointer: "/context/repo_name".into(),
+                    equals: repo.clone(),
+                }],
             },
             projection,
             adapter: SubscriptionAdapterConfig {
@@ -1663,7 +1671,6 @@ impl AppConfig {
             reconnect: SubscriptionReconnectConfig::default(),
             routing: SubscriptionRoutingConfig {
                 tool: Some("gjc".into()),
-                repo_name: Some(repo),
                 ..SubscriptionRoutingConfig::default()
             },
         };
@@ -4077,9 +4084,13 @@ thread = "123456789012345678"
             Some("updated-question-channel")
         );
         assert_eq!(question.mention, None);
+        assert_eq!(config.subscriptions[0].routing.repo_name, None);
         assert_eq!(
-            config.subscriptions[0].routing.repo_name.as_deref(),
-            Some("owner/repo")
+            config.subscriptions[0].filter.predicates,
+            vec![SubscriptionPredicateConfig {
+                pointer: "/context/repo_name".into(),
+                equals: "owner/repo".into(),
+            }]
         );
     }
 
@@ -4099,6 +4110,37 @@ thread = "123456789012345678"
         assert!(error.contains("--question-channel"));
         assert!(config.subscriptions.is_empty());
         assert!(config.routes.is_empty());
+    }
+
+    #[test]
+    fn gjc_question_setup_rejects_manual_subscription_without_mutation() {
+        let mut config = AppConfig::default();
+        config
+            .apply_gjc_question_setup(
+                Some("question-channel".into()),
+                None,
+                false,
+                "owner/repo".into(),
+                "/usr/bin/clawhip".into(),
+            )
+            .unwrap();
+        config.subscriptions[0].setup_owned = false;
+        config.subscriptions[0].adapter.args = vec!["manual-adapter".into()];
+        let before = config.to_pretty_toml().unwrap();
+
+        let error = config
+            .apply_gjc_question_setup(
+                Some("new-channel".into()),
+                None,
+                false,
+                "owner/repo".into(),
+                "/usr/bin/clawhip".into(),
+            )
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("ownership conflict"));
+        assert_eq!(config.to_pretty_toml().unwrap(), before);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2835,6 +2835,7 @@ mod tests {
         crate::config::SubscriptionConfig {
             name: "workflow-gate".into(),
             enabled: true,
+            setup_owned: false,
             kind: "websocket".into(),
             endpoint_env: "!".into(),
             max_frame_bytes: 65_536,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod tmux_wrapper;
 
 mod update;
 
+use std::io::Read;
 use std::sync::Arc;
 
 use clap::Parser;
@@ -88,6 +89,27 @@ fn prepare_event(event: IncomingEvent) -> Result<IncomingEvent> {
     Ok(event)
 }
 
+fn run_subscription_adapter(kind: &str) -> Result<()> {
+    if kind != "question" {
+        return Err(format!("unsupported subscription adapter '{kind}'").into());
+    }
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input)?;
+    let payload: serde_json::Value = serde_json::from_str(&input)
+        .map_err(|_| "subscription adapter received malformed projection")?;
+    if !payload.is_object() {
+        return Err("subscription adapter projection must be an object".into());
+    }
+    println!(
+        "{}",
+        serde_json::json!({
+            "type": "workflow.question",
+            "payload": payload,
+        })
+    );
+    Ok(())
+}
+
 fn load_config_for_cli(config_path: &std::path::Path) -> Result<Arc<AppConfig>> {
     AppConfig::load_or_default(config_path)
         .map(Arc::new)
@@ -110,32 +132,36 @@ async fn real_main(cli: Cli) -> Result<()> {
             println!("{}", serde_json::to_string_pretty(&health)?);
             Ok(())
         }
-        Commands::Subscribe { command } => {
-            let client = DaemonClient::from_config(config.as_ref());
-            match command {
-                SubscribeCommands::Validate => {
-                    config.validate()?;
-                    println!("Subscription configuration is valid.");
+        Commands::Subscribe { command } => match command {
+            SubscribeCommands::Adapter { kind } => run_subscription_adapter(&kind),
+            command => {
+                let client = DaemonClient::from_config(config.as_ref());
+                match command {
+                    SubscribeCommands::Validate => {
+                        config.validate()?;
+                        println!("Subscription configuration is valid.");
+                    }
+                    SubscribeCommands::List => println!(
+                        "{}",
+                        serde_json::to_string_pretty(&client.list_subscriptions().await?)?
+                    ),
+                    SubscribeCommands::Status { name } => println!(
+                        "{}",
+                        serde_json::to_string_pretty(&client.subscription_status(&name).await?)?
+                    ),
+                    SubscribeCommands::Start { name } => println!(
+                        "{}",
+                        serde_json::to_string_pretty(&client.start_subscription(&name).await?)?
+                    ),
+                    SubscribeCommands::Stop { name } => println!(
+                        "{}",
+                        serde_json::to_string_pretty(&client.stop_subscription(&name).await?)?
+                    ),
+                    SubscribeCommands::Adapter { .. } => unreachable!(),
                 }
-                SubscribeCommands::List => println!(
-                    "{}",
-                    serde_json::to_string_pretty(&client.list_subscriptions().await?)?
-                ),
-                SubscribeCommands::Status { name } => println!(
-                    "{}",
-                    serde_json::to_string_pretty(&client.subscription_status(&name).await?)?
-                ),
-                SubscribeCommands::Start { name } => println!(
-                    "{}",
-                    serde_json::to_string_pretty(&client.start_subscription(&name).await?)?
-                ),
-                SubscribeCommands::Stop { name } => println!(
-                    "{}",
-                    serde_json::to_string_pretty(&client.stop_subscription(&name).await?)?
-                ),
+                Ok(())
             }
-            Ok(())
-        }
+        },
         Commands::Deliver(args) => crate::hooks::prompt_deliver::run(args).await,
         Commands::Emit(args) => {
             let client = DaemonClient::from_config(config.as_ref());
@@ -725,6 +751,19 @@ fn remote_repo_identity(remote: &str) -> Option<String> {
     Some(format!("{owner}/{repo}"))
 }
 
+fn current_setup_repo_identity() -> Result<String> {
+    let cwd = std::env::current_dir()?;
+    let output = std::process::Command::new("git")
+        .args(["config", "--get", "remote.origin.url"])
+        .current_dir(cwd)
+        .output()?;
+    if !output.status.success() {
+        return Err("question setup could not resolve the current repository remote".into());
+    }
+    remote_repo_identity(String::from_utf8_lossy(&output.stdout).trim())
+        .ok_or_else(|| "question setup could not resolve owner/repo from remote.origin.url".into())
+}
+
 async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()> {
     let mut editable = (*load_config_for_cli(config_path)?).clone();
 
@@ -742,13 +781,30 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
     let expect_map = parse_expect_name_overrides(&args.expect_name)?;
 
     // Must have at least one meaningful action.
-    if standard_edits.is_empty() && binds.is_empty() && !args.verify_bindings {
+    let question_setup_requested = args.question_channel.is_some() || args.question_fallback;
+    if standard_edits.is_empty()
+        && binds.is_empty()
+        && !args.verify_bindings
+        && !question_setup_requested
+    {
         return Err("setup requires at least one non-empty setup flag".into());
     }
 
     // Apply standard setup edits first (only if any are set).
     if !standard_edits.is_empty() {
         editable.apply_setup_edits(standard_edits)?;
+    }
+
+    if question_setup_requested || args.question_mention.is_some() {
+        let repo = current_setup_repo_identity()?;
+        let adapter_program = std::env::current_exe()?.to_string_lossy().into_owned();
+        editable.apply_gjc_question_setup(
+            args.question_channel,
+            args.question_mention,
+            args.question_fallback,
+            repo,
+            adapter_program,
+        )?;
     }
 
     // Process --bind entries: resolve each channel against Discord and write a

--- a/src/source/subscription.rs
+++ b/src/source/subscription.rs
@@ -873,6 +873,30 @@ mod tests {
     }
 
     #[test]
+    fn question_projection_drops_foreign_repository_frames() {
+        let mut config = config();
+        config.filter = SubscriptionFilterConfig {
+            discriminator_pointer: "/type".into(),
+            discriminator_equals: "question".into(),
+            predicates: vec![SubscriptionPredicateConfig {
+                pointer: "/context/repo_name".into(),
+                equals: "owner/repo".into(),
+            }],
+        };
+        config.projection = BTreeMap::from([
+            (String::from("question_id"), String::from("/question/id")),
+            (String::from("summary"), String::from("/question/summary")),
+        ]);
+
+        let matching = r#"{"type":"question","context":{"repo_name":"owner/repo"},"question":{"id":"q1","summary":"Approve?"}}"#;
+        assert!(project_frame(&config, matching).unwrap().is_some());
+        let foreign = r#"{"type":"question","context":{"repo_name":"other/repo"},"question":{"id":"q2","summary":"Leak?"}}"#;
+        assert!(project_frame(&config, foreign).unwrap().is_none());
+        let missing_metadata = r#"{"type":"question","question":{"id":"q3","summary":"Unknown?"}}"#;
+        assert!(project_frame(&config, missing_metadata).is_err());
+    }
+
+    #[test]
     fn rejects_reserved_projection_and_adapter_payload() {
         let mut invalid_config = config();
         invalid_config

--- a/src/source/subscription.rs
+++ b/src/source/subscription.rs
@@ -826,6 +826,7 @@ mod tests {
     fn config() -> SubscriptionConfig {
         SubscriptionConfig {
             name: "gjc-workflow-gate".into(),
+            setup_owned: false,
             enabled: true,
             kind: "websocket".into(),
             endpoint_env: "GJC_WS_URL".into(),


### PR DESCRIPTION
Closes #303

## Summary
- add official `clawhip setup` opt-in for the setup-owned `gjc-question` subscription
- add one repo-scoped `workflow.question` route without changing workflow-gate routes
- make reruns converge and keep legacy configs unchanged
- add a built-in bounded question adapter and documentation

## Verification
- `cargo fmt --all -- --check`
- `cargo test --bin clawhip`
- `cargo test --test config_backup_cleanup`
- `cargo test --test provider_native_docs_regression`
- `cargo test --test runtime_config`
- `cargo test --test setup_bind_legacy_route_only`
- live setup/adapter replay in the dedicated worktree

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*