### PR TITLE
feat(monitors): GitHub Actions platform status via Statuspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+
+### Added
+
+- add `monitors.github_status` poller for GitHub Actions platform incidents via the public Statuspage API (`www.githubstatus.com/api/v2`), emitting `github.actions-status` and `github.actions-incident` with baseline/dedupe anti-spam; independent from websocket `[[subscriptions]]`
 ### Fixed
 
 - config saves retire only strictly recognized stale legacy root-level snapshots alongside managed backups under the shared newest-10-or-newer-than-30-days retention policy. On Unix, temp commit, managed snapshot creation, and candidate deletion use directory-handle-relative exclusive/no-follow primitives so preplaced temp collisions, post-write temp replacement, managed-directory path swaps, and post-check candidate replacement cannot redirect writes or unlinks outside the validated objects; on platforms without those primitives, saves continue while cleanup preserves every candidate. Unknown, malformed, symlinked, directory, and unsafe linked entries remain untouched. No config schema migration or startup cleanup is required.

--- a/README.md
+++ b/README.md
@@ -978,6 +978,52 @@ clawhip includes a [`geobench`](https://github.com/NomaDamas/geobench) product s
 - Spec: [`geobench/clawhip.yaml`](geobench/clawhip.yaml)
 - Runbook: [`docs/geobench.md`](docs/geobench.md)
 
+## GitHub Actions platform status monitor
+
+Poll the public GitHub Statuspage machine-readable API for GitHub Actions (and optionally other components) without using GitHub API tokens or websocket subscriptions.
+
+This is a daemon monitor (`monitors.github_status`), **not** a `[[subscriptions]]` websocket worker. Keep it separate from GJC workflow-gate / question subscriptions.
+
+Official public endpoints (no auth, no secrets):
+
+- `https://www.githubstatus.com/api/v2/summary.json`
+- `https://www.githubstatus.com/api/v2/status.json`
+- `https://www.githubstatus.com/api/v2/components.json`
+- `https://www.githubstatus.com/api/v2/incidents.json`
+
+`status.github.com` serves the same Statuspage surface; clawhip defaults to the `www.githubstatus.com` API base.
+
+```toml
+[monitors.github_status]
+enabled = true
+# Public Statuspage API; no token. Override only for tests/mirrors.
+api_base = "https://www.githubstatus.com/api/v2"
+components = ["Actions"]
+poll_interval_secs = 60
+# Optional direct channel; prefer an explicit route for gajae-code dev.
+# channel = "YOUR_GAJAE_CODE_DEV_CHANNEL_ID"
+# channel_name = "gajae-code-dev"
+format = "alert"
+
+[[routes]]
+event = "github.actions-*"
+sink = "discord"
+channel = "YOUR_GAJAE_CODE_DEV_CHANNEL_ID"
+channel_name = "gajae-code-dev"
+format = "alert"
+```
+
+Events:
+
+- `github.actions-status` — watched component transitions among `degraded_performance`, `partial_outage`, `major_outage`, `under_maintenance`, and recovery to `operational`
+- `github.actions-incident` — incident opened / update / resolved for incidents that affect a watched component
+
+Anti-spam:
+
+- first successful poll establishes a baseline and emits nothing
+- stable component status and identical incident update IDs do not re-alert
+- only lifecycle deltas (status change, new update id, resolve) emit
+
 ## Websocket subscriptions
 
 Subscriptions are daemon-owned, guarded local ingress for a configured websocket event stream. Keep endpoint credentials outside the TOML file: the configuration names an environment variable, and `clawhip subscribe`, health, and API responses never print that name, its value, the endpoint URL, adapter arguments, adapter stderr, frames, or adapter output.

--- a/src/binding_verify.rs
+++ b/src/binding_verify.rs
@@ -44,6 +44,7 @@ pub enum BindingSource {
     GitMonitor { index: usize },
     TmuxMonitor { index: usize },
     WorkspaceMonitor { index: usize },
+    GitHubStatusMonitor,
 }
 
 impl fmt::Display for BindingSource {
@@ -54,6 +55,7 @@ impl fmt::Display for BindingSource {
             Self::GitMonitor { index } => write!(f, "monitors.git.repos[{}]", index + 1),
             Self::TmuxMonitor { index } => write!(f, "monitors.tmux.sessions[{}]", index + 1),
             Self::WorkspaceMonitor { index } => write!(f, "monitors.workspace[{}]", index + 1),
+            Self::GitHubStatusMonitor => write!(f, "monitors.github_status"),
         }
     }
 }
@@ -162,6 +164,19 @@ pub fn collect_bindings(config: &AppConfig) -> Vec<ChannelBinding> {
                 label: format!("workspace:{}", workspace.path),
             });
         }
+    }
+
+    // github status monitor (platform Statuspage; not repo CI)
+    if config.monitors.github_status.enabled
+        && let Some(channel) = config.monitors.github_status.channel.as_deref()
+        && !channel.is_empty()
+    {
+        bindings.push(ChannelBinding {
+            channel_id: channel.to_string(),
+            expected_name: config.monitors.github_status.channel_name.clone(),
+            source: BindingSource::GitHubStatusMonitor,
+            label: "github_status".to_string(),
+        });
     }
 
     bindings

--- a/src/config.rs
+++ b/src/config.rs
@@ -530,6 +530,10 @@ pub struct MonitorConfig {
     pub tmux: TmuxMonitorConfig,
     #[serde(default)]
     pub workspace: Vec<WorkspaceMonitor>,
+    /// Public GitHub Statuspage monitor for platform components (default: Actions).
+    /// Independent from websocket `[[subscriptions]]` and per-repo GitHub API monitors.
+    #[serde(default, skip_serializing_if = "GitHubStatusMonitorConfig::is_default")]
+    pub github_status: GitHubStatusMonitorConfig,
 }
 
 impl Default for MonitorConfig {
@@ -541,6 +545,7 @@ impl Default for MonitorConfig {
             git: GitMonitorConfig::default(),
             tmux: TmuxMonitorConfig::default(),
             workspace: Vec::new(),
+            github_status: GitHubStatusMonitorConfig::default(),
         }
     }
 }
@@ -667,6 +672,59 @@ impl Default for WorkspaceMonitor {
             poll_interval_secs: None,
             debounce_ms: default_workspace_debounce_ms(),
         }
+    }
+}
+
+/// Monitor GitHub platform component/incident status via the public Statuspage API.
+///
+/// Uses machine-readable endpoints under `api_base` (default
+/// `https://www.githubstatus.com/api/v2`). No authentication is required or stored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubStatusMonitorConfig {
+    /// When false (default), the monitor does not run.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Public Statuspage API base. Override only for tests or mirrors.
+    #[serde(default = "default_github_status_api_base")]
+    pub api_base: String,
+    /// Component names to watch (Statuspage `components[].name`). Default: `["Actions"]`.
+    #[serde(default = "default_github_status_components")]
+    pub components: Vec<String>,
+    /// Poll interval for the status monitor (independent of git/tmux poll interval).
+    #[serde(default = "default_github_status_poll_interval")]
+    pub poll_interval_secs: u64,
+    pub channel: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_name: Option<String>,
+    pub mention: Option<String>,
+    pub format: Option<MessageFormat>,
+}
+
+impl Default for GitHubStatusMonitorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            api_base: default_github_status_api_base(),
+            components: default_github_status_components(),
+            poll_interval_secs: default_github_status_poll_interval(),
+            channel: None,
+            channel_name: None,
+            mention: None,
+            format: None,
+        }
+    }
+}
+
+impl GitHubStatusMonitorConfig {
+    fn is_default(&self) -> bool {
+        !self.enabled
+            && self.api_base == default_github_status_api_base()
+            && self.components == default_github_status_components()
+            && self.poll_interval_secs == default_github_status_poll_interval()
+            && self.channel.is_none()
+            && self.channel_name.is_none()
+            && self.mention.is_none()
+            && self.format.is_none()
     }
 }
 
@@ -843,6 +901,15 @@ fn default_poll_interval() -> u64 {
 }
 fn default_github_api_base() -> String {
     "https://api.github.com".to_string()
+}
+fn default_github_status_api_base() -> String {
+    "https://www.githubstatus.com/api/v2".to_string()
+}
+fn default_github_status_components() -> Vec<String> {
+    vec!["Actions".to_string()]
+}
+fn default_github_status_poll_interval() -> u64 {
+    60
 }
 fn default_remote() -> String {
     "origin".to_string()
@@ -1337,6 +1404,13 @@ impl AppConfig {
                     .as_ref()
                     .is_some_and(|channel| !channel.trim().is_empty())
             })
+            || (self.monitors.github_status.enabled
+                && self
+                    .monitors
+                    .github_status
+                    .channel
+                    .as_ref()
+                    .is_some_and(|channel| !channel.trim().is_empty()))
     }
 
     fn default_channel_can_fallback_to_discord(&self) -> bool {
@@ -1594,6 +1668,26 @@ impl AppConfig {
                     index + 1
                 )
                 .into());
+            }
+        }
+        if self.monitors.github_status.enabled {
+            if self.monitors.github_status.poll_interval_secs == 0 {
+                return Err("monitors.github_status.poll_interval_secs must be at least 1".into());
+            }
+            if self.monitors.github_status.api_base.trim().is_empty() {
+                return Err("monitors.github_status.api_base must not be empty".into());
+            }
+            if self
+                .monitors
+                .github_status
+                .components
+                .iter()
+                .all(|name| name.trim().is_empty())
+            {
+                return Err(
+                    "monitors.github_status.components must list at least one component name"
+                        .into(),
+                );
             }
         }
 
@@ -6828,6 +6922,80 @@ local_path = "/tmp/clawhip-ledger-test.jsonl"
                 .unwrap_err()
                 .to_string()
                 .contains("ledger")
+        );
+    }
+
+    #[test]
+    fn github_status_monitor_parses_and_validates_without_secrets() {
+        let config: AppConfig = toml::from_str(
+            r#"
+[monitors.github_status]
+enabled = true
+api_base = "https://www.githubstatus.com/api/v2"
+components = ["Actions"]
+poll_interval_secs = 90
+channel = "1480171113253175356"
+channel_name = "gajae-code-dev"
+format = "alert"
+
+[[routes]]
+event = "github.actions-*"
+sink = "discord"
+channel = "1480171113253175356"
+channel_name = "gajae-code-dev"
+format = "alert"
+
+[providers.discord]
+token = "test-token"
+"#,
+        )
+        .expect("github_status config parses");
+        config.validate().expect("github_status config validates");
+        assert!(config.monitors.github_status.enabled);
+        assert_eq!(
+            config.monitors.github_status.api_base,
+            "https://www.githubstatus.com/api/v2"
+        );
+        assert_eq!(config.monitors.github_status.components, vec!["Actions"]);
+        assert_eq!(config.monitors.github_status.poll_interval_secs, 90);
+        assert_eq!(
+            config.monitors.github_status.channel_name.as_deref(),
+            Some("gajae-code-dev")
+        );
+        // Ensure disabled-by-default keeps old configs valid.
+        let old: AppConfig = toml::from_str(
+            r#"
+[[routes]]
+event = "custom"
+sink = "localfile"
+local_path = "/tmp/clawhip/events.jsonl"
+"#,
+        )
+        .expect("old config");
+        assert!(!old.monitors.github_status.enabled);
+        assert!(old.validate().is_ok());
+    }
+
+    #[test]
+    fn github_status_monitor_rejects_empty_components_when_enabled() {
+        let config: AppConfig = toml::from_str(
+            r#"
+[monitors.github_status]
+enabled = true
+components = ["", "  "]
+poll_interval_secs = 60
+
+[[routes]]
+event = "*"
+sink = "localfile"
+local_path = "/tmp/clawhip/events.jsonl"
+"#,
+        )
+        .expect("parses");
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("monitors.github_status.components"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -38,7 +38,7 @@ use crate::source::tmux::{
 };
 
 use crate::source::{
-    GitHubSource, GitMonitorLifecycleCounts, GitSource, RegisteredTmuxSession,
+    GitHubSource, GitHubStatusSource, GitMonitorLifecycleCounts, GitSource, RegisteredTmuxSession,
     SharedGitMonitorDiagnostics, SharedTmuxRegistry, Source, SubscriptionSnapshot,
     SubscriptionState, SubscriptionWorker, TmuxSource, WorkspaceSource,
     default_registry_state_path, inspect_tmux_registry_state, list_active_tmux_registrations,
@@ -197,6 +197,7 @@ pub async fn run(
         tx.clone(),
     );
     spawn_source(GitHubSource::new(config.clone()), tx.clone());
+    spawn_source(GitHubStatusSource::new(config.clone()), tx.clone());
     spawn_source(
         TmuxSource::new(
             config.clone(),
@@ -499,6 +500,7 @@ fn health_payload(
         "git_monitors": git_monitors,
         "configured_tmux_monitors": config.monitors.tmux.sessions.len(),
         "configured_workspace_monitors": config.monitors.workspace.len(),
+        "configured_github_status_monitor": config.monitors.github_status.enabled,
         "configured_cron_jobs": config.cron.jobs.len(),
         "registered_tmux_sessions": registered_tmux_sessions,
         "tmux": tmux,

--- a/src/events.rs
+++ b/src/events.rs
@@ -523,6 +523,80 @@ impl IncomingEvent {
         }
     }
 
+    /// GitHub Actions (or other watched Statuspage component) status transition.
+    pub fn github_actions_status(
+        component: String,
+        old_status: String,
+        new_status: String,
+        url: String,
+        channel: Option<String>,
+    ) -> Self {
+        Self {
+            kind: "github.actions-status".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "component": component,
+                "old_status": old_status,
+                "new_status": new_status,
+                "url": url,
+                "provider": "github-statuspage",
+            }),
+        }
+    }
+
+    /// GitHub platform incident lifecycle update for watched Statuspage components.
+    #[allow(clippy::too_many_arguments)]
+    pub fn github_actions_incident(
+        incident_id: String,
+        name: String,
+        status: String,
+        impact: String,
+        change: String,
+        old_status: Option<String>,
+        update_id: Option<String>,
+        update_status: Option<String>,
+        update_body: Option<String>,
+        affected_components: Vec<String>,
+        url: String,
+        channel: Option<String>,
+    ) -> Self {
+        let mut payload = Map::new();
+        payload.insert("incident_id".to_string(), json!(incident_id));
+        payload.insert("name".to_string(), json!(name));
+        payload.insert("status".to_string(), json!(status));
+        payload.insert("impact".to_string(), json!(impact));
+        payload.insert("change".to_string(), json!(change));
+        payload.insert("url".to_string(), json!(url));
+        payload.insert("provider".to_string(), json!("github-statuspage"));
+        payload.insert(
+            "affected_components".to_string(),
+            json!(affected_components),
+        );
+        if let Some(old_status) = old_status {
+            payload.insert("old_status".to_string(), json!(old_status));
+        }
+        if let Some(update_id) = update_id {
+            payload.insert("update_id".to_string(), json!(update_id));
+        }
+        if let Some(update_status) = update_status {
+            payload.insert("update_status".to_string(), json!(update_status));
+        }
+        if let Some(update_body) = update_body {
+            payload.insert("update_body".to_string(), json!(update_body));
+        }
+        Self {
+            kind: "github.actions-incident".to_string(),
+            channel,
+            mention: None,
+            format: None,
+            template: None,
+            payload: Value::Object(payload),
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn gajae_release_hold(
         repo: String,

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -201,6 +201,44 @@ impl Renderer for DefaultRenderer {
                 serde_json::to_string_pretty(payload)?
             }
 
+            ("github.actions-status", MessageFormat::Compact) => format!(
+                "GitHub {}: {} -> {} ({})",
+                string_field(payload, "component")?,
+                string_field(payload, "old_status")?,
+                string_field(payload, "new_status")?,
+                string_field(payload, "url")?
+            ),
+            ("github.actions-status", MessageFormat::Alert) => format!(
+                "🚨 GitHub platform {}: {} -> {} ({})",
+                string_field(payload, "component")?,
+                string_field(payload, "old_status")?,
+                string_field(payload, "new_status")?,
+                string_field(payload, "url")?
+            ),
+            ("github.actions-status", MessageFormat::Inline) => format!(
+                "[status:{}] {} -> {}",
+                string_field(payload, "component")?,
+                string_field(payload, "old_status")?,
+                string_field(payload, "new_status")?
+            ),
+            ("github.actions-status", MessageFormat::Raw) => serde_json::to_string_pretty(payload)?,
+
+            ("github.actions-incident", MessageFormat::Compact) => {
+                render_github_actions_incident(payload, false)?
+            }
+            ("github.actions-incident", MessageFormat::Alert) => {
+                format!("🚨 {}", render_github_actions_incident(payload, true)?)
+            }
+            ("github.actions-incident", MessageFormat::Inline) => format!(
+                "[incident:{}] {} ({})",
+                string_field(payload, "change")?,
+                string_field(payload, "name")?,
+                string_field(payload, "status")?
+            ),
+            ("github.actions-incident", MessageFormat::Raw) => {
+                serde_json::to_string_pretty(payload)?
+            }
+
             (
                 "github.ci-started"
                 | "github.ci-failed"
@@ -672,6 +710,30 @@ fn render_github_release(payload: &Value, kind: &str) -> Result<String> {
     Ok(parts.join(" · "))
 }
 
+fn render_github_actions_incident(payload: &Value, include_body: bool) -> Result<String> {
+    let name = string_field(payload, "name")?;
+    let change = string_field(payload, "change")?;
+    let status = string_field(payload, "status")?;
+    let impact = string_field(payload, "impact")?;
+    let url = optional_string_field(payload, "url").unwrap_or_default();
+    let mut parts = vec![format!(
+        "GitHub incident {change}: {name} ({status}, impact={impact})"
+    )];
+    if include_body && let Some(body) = optional_string_field(payload, "update_body") {
+        let trimmed = if body.chars().count() > 180 {
+            let clipped: String = body.chars().take(177).collect();
+            format!("{clipped}...")
+        } else {
+            body
+        };
+        parts.push(trimmed);
+    }
+    if !url.is_empty() {
+        parts.push(url);
+    }
+    Ok(parts.join(" · "))
+}
+
 fn render_gajae_hold(payload: &Value, kind: &str) -> Result<String> {
     let repo = string_field(payload, "repo")?;
     let action = string_field(payload, "action")?;
@@ -1082,5 +1144,43 @@ mod tests {
         assert!(rendered.contains("blocked action: merge pull request #252 into main"));
         assert!(rendered.contains("autonomous execution disallowed"));
         assert!(rendered.contains("owner/maintainer approval"));
+    }
+
+    #[test]
+    fn renders_github_actions_status_and_incident() {
+        let status = IncomingEvent::github_actions_status(
+            "Actions".into(),
+            "operational".into(),
+            "degraded_performance".into(),
+            "https://www.githubstatus.com".into(),
+            Some("dev".into()),
+        );
+        let rendered = DefaultRenderer
+            .render(&status, &MessageFormat::Alert)
+            .unwrap();
+        assert!(rendered.starts_with("🚨"));
+        assert!(rendered.contains("Actions"));
+        assert!(rendered.contains("degraded_performance"));
+
+        let incident = IncomingEvent::github_actions_incident(
+            "inc-1".into(),
+            "Incident with Actions".into(),
+            "monitoring".into(),
+            "critical".into(),
+            "updated".into(),
+            Some("investigating".into()),
+            Some("upd-2".into()),
+            Some("monitoring".into()),
+            Some("Mitigated; monitoring".into()),
+            vec!["Actions".into()],
+            "https://stspg.io/example".into(),
+            Some("dev".into()),
+        );
+        let rendered = DefaultRenderer
+            .render(&incident, &MessageFormat::Compact)
+            .unwrap();
+        assert!(rendered.contains("Incident with Actions"));
+        assert!(rendered.contains("updated"));
+        assert!(rendered.contains("impact=critical"));
     }
 }

--- a/src/source/github_status.rs
+++ b/src/source/github_status.rs
@@ -104,8 +104,6 @@ struct ComponentEntry {
     name: String,
     #[serde(default)]
     status: String,
-    #[serde(default)]
-    description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -667,7 +665,6 @@ mod tests {
                 components: vec![ComponentEntry {
                     name: "Actions".into(),
                     status: "degraded_performance".into(),
-                    description: None,
                 }],
                 incident_updates: vec![IncidentUpdateEntry {
                     id: "u1".into(),
@@ -684,7 +681,6 @@ mod tests {
                 components: vec![ComponentEntry {
                     name: "Pages".into(),
                     status: "degraded_performance".into(),
-                    description: None,
                 }],
                 incident_updates: vec![],
             },

--- a/src/source/github_status.rs
+++ b/src/source/github_status.rs
@@ -1,0 +1,819 @@
+//! GitHub platform status monitor (Statuspage public API).
+//!
+//! Polls the public GitHub Statuspage machine-readable endpoints and emits
+//! lifecycle events for watched components (default: Actions) and related
+//! incidents. This is intentionally separate from websocket `[[subscriptions]]`
+//! (for example GJC workflow-gate ingress) and from per-repo GitHub API monitors.
+//!
+//! Endpoint is public; no authentication is used or required.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::header::{ACCEPT, HeaderMap, HeaderValue, USER_AGENT};
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use crate::Result;
+use crate::config::{AppConfig, GitHubStatusMonitorConfig};
+use crate::events::IncomingEvent;
+use crate::source::Source;
+
+const DEFAULT_PAGE_URL: &str = "https://www.githubstatus.com";
+
+pub struct GitHubStatusSource {
+    config: Arc<AppConfig>,
+}
+
+impl GitHubStatusSource {
+    pub fn new(config: Arc<AppConfig>) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait::async_trait]
+impl Source for GitHubStatusSource {
+    fn name(&self) -> &str {
+        "github_status"
+    }
+
+    async fn run(&self, tx: mpsc::Sender<IncomingEvent>) -> Result<()> {
+        if !self.config.monitors.github_status.enabled {
+            return Ok(());
+        }
+
+        let client = match build_status_client() {
+            Ok(client) => client,
+            Err(error) => {
+                eprintln!("clawhip source github_status: failed to build HTTP client: {error}");
+                return Ok(());
+            }
+        };
+
+        let mut state = MonitorState::default();
+        loop {
+            if let Err(error) = poll_once(self.config.as_ref(), &client, &tx, &mut state).await {
+                eprintln!("clawhip source github_status poll failed: {error}");
+            }
+            let secs = self.config.monitors.github_status.poll_interval_secs.max(1);
+            sleep(Duration::from_secs(secs)).await;
+        }
+    }
+}
+
+#[derive(Default)]
+struct MonitorState {
+    baseline_established: bool,
+    components: HashMap<String, String>,
+    incidents: HashMap<String, IncidentSnapshot>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct IncidentSnapshot {
+    name: String,
+    status: String,
+    impact: String,
+    shortlink: Option<String>,
+    last_update_id: Option<String>,
+    last_update_status: Option<String>,
+    last_update_body: Option<String>,
+    affected_components: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SummaryResponse {
+    #[serde(default)]
+    page: PageInfo,
+    #[serde(default)]
+    components: Vec<ComponentEntry>,
+    #[serde(default)]
+    incidents: Vec<IncidentEntry>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PageInfo {
+    #[serde(default)]
+    url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ComponentEntry {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct IncidentEntry {
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    impact: String,
+    #[serde(default)]
+    shortlink: Option<String>,
+    #[serde(default)]
+    components: Vec<ComponentEntry>,
+    #[serde(default)]
+    incident_updates: Vec<IncidentUpdateEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct IncidentUpdateEntry {
+    id: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    body: String,
+}
+
+fn build_status_client() -> Result<reqwest::Client> {
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_static(concat!("clawhip/", env!("CARGO_PKG_VERSION"))),
+    );
+    Ok(reqwest::Client::builder()
+        .default_headers(headers)
+        .timeout(Duration::from_secs(15))
+        .build()?)
+}
+
+async fn poll_once(
+    config: &AppConfig,
+    client: &reqwest::Client,
+    tx: &mpsc::Sender<IncomingEvent>,
+    state: &mut MonitorState,
+) -> Result<()> {
+    let monitor = &config.monitors.github_status;
+    if !monitor.enabled {
+        return Ok(());
+    }
+
+    let summary = fetch_summary(client, &monitor.api_base).await?;
+    let page_url = summary
+        .page
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_PAGE_URL)
+        .to_string();
+
+    let watched = watched_component_set(monitor);
+    let current_components = watched_component_statuses(&summary.components, &watched);
+    let current_incidents = watched_incidents(&summary.incidents, &watched);
+
+    let events = if !state.baseline_established {
+        // Prime baseline without replaying historical operational noise.
+        state.components = current_components;
+        state.incidents = current_incidents;
+        state.baseline_established = true;
+        Vec::new()
+    } else {
+        let events = collect_events(
+            monitor,
+            &page_url,
+            state,
+            &current_components,
+            &current_incidents,
+        );
+        state.components = current_components;
+        state.incidents = current_incidents;
+        events
+    };
+
+    for event in events {
+        tx.send(event)
+            .await
+            .map_err(|error| format!("github_status source channel closed: {error}"))?;
+    }
+    Ok(())
+}
+
+async fn fetch_summary(client: &reqwest::Client, api_base: &str) -> Result<SummaryResponse> {
+    let url = format!("{}/summary.json", api_base.trim_end_matches('/'));
+    let response = client.get(&url).send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("statuspage summary request failed with {status}: {body}").into());
+    }
+    Ok(response.json().await?)
+}
+
+fn watched_component_set(monitor: &GitHubStatusMonitorConfig) -> HashSet<String> {
+    monitor
+        .components
+        .iter()
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .collect()
+}
+
+fn watched_component_statuses(
+    components: &[ComponentEntry],
+    watched: &HashSet<String>,
+) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for component in components {
+        let name = component.name.trim();
+        if name.is_empty() || !watched.contains(name) {
+            continue;
+        }
+        let status = normalize_status(&component.status);
+        out.insert(name.to_string(), status);
+    }
+    out
+}
+
+fn watched_incidents(
+    incidents: &[IncidentEntry],
+    watched: &HashSet<String>,
+) -> HashMap<String, IncidentSnapshot> {
+    let mut out = HashMap::new();
+    for incident in incidents {
+        let affected: Vec<String> = incident
+            .components
+            .iter()
+            .map(|component| component.name.trim().to_string())
+            .filter(|name| !name.is_empty() && watched.contains(name))
+            .collect();
+        if affected.is_empty() {
+            continue;
+        }
+        let latest = incident.incident_updates.first();
+        out.insert(
+            incident.id.clone(),
+            IncidentSnapshot {
+                name: incident.name.trim().to_string(),
+                status: normalize_status(&incident.status),
+                impact: normalize_status(&incident.impact),
+                shortlink: incident
+                    .shortlink
+                    .as_ref()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty()),
+                last_update_id: latest.map(|update| update.id.clone()),
+                last_update_status: latest.map(|update| normalize_status(&update.status)),
+                last_update_body: latest
+                    .map(|update| update.body.trim().to_string())
+                    .filter(|body| !body.is_empty()),
+                affected_components: affected,
+            },
+        );
+    }
+    out
+}
+
+fn collect_events(
+    monitor: &GitHubStatusMonitorConfig,
+    page_url: &str,
+    previous: &MonitorState,
+    current_components: &HashMap<String, String>,
+    current_incidents: &HashMap<String, IncidentSnapshot>,
+) -> Vec<IncomingEvent> {
+    let mut events = Vec::new();
+
+    let mut component_names: Vec<&String> = current_components.keys().collect();
+    component_names.sort();
+    for name in component_names {
+        let new_status = current_components
+            .get(name)
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        match previous.components.get(name).map(String::as_str) {
+            Some(old_status) if old_status == new_status => {}
+            Some(old_status) => {
+                if should_emit_component_transition(old_status, new_status) {
+                    events.push(
+                        IncomingEvent::github_actions_status(
+                            name.clone(),
+                            old_status.to_string(),
+                            new_status.to_string(),
+                            page_url.to_string(),
+                            monitor.channel.clone(),
+                        )
+                        .with_mention(monitor.mention.clone())
+                        .with_format(monitor.format.clone()),
+                    );
+                }
+            }
+            None => {
+                // Newly observed watched component after baseline: emit only if
+                // currently degraded/outage/maintenance.
+                if is_actionable_component_status(new_status) {
+                    events.push(
+                        IncomingEvent::github_actions_status(
+                            name.clone(),
+                            "unknown".to_string(),
+                            new_status.to_string(),
+                            page_url.to_string(),
+                            monitor.channel.clone(),
+                        )
+                        .with_mention(monitor.mention.clone())
+                        .with_format(monitor.format.clone()),
+                    );
+                }
+            }
+        }
+    }
+
+    // Recovery of a watched component that disappeared from the payload is rare;
+    // if Statuspage omits it we leave previous state until it reappears.
+
+    let mut incident_ids: Vec<&String> = current_incidents.keys().collect();
+    incident_ids.sort();
+    for id in incident_ids {
+        let current = &current_incidents[id];
+        match previous.incidents.get(id) {
+            None => {
+                events.push(incident_event(
+                    monitor, id, current, "opened", None, page_url,
+                ));
+            }
+            Some(old)
+                if old.status != current.status
+                    || old.last_update_id != current.last_update_id
+                    || old.impact != current.impact =>
+            {
+                events.push(incident_event(
+                    monitor,
+                    id,
+                    current,
+                    "updated",
+                    Some(old.status.as_str()),
+                    page_url,
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+
+    let mut resolved_ids: Vec<&String> = previous
+        .incidents
+        .keys()
+        .filter(|id| !current_incidents.contains_key(id.as_str()))
+        .collect();
+    resolved_ids.sort();
+    for id in resolved_ids {
+        let previous_incident = &previous.incidents[id];
+        let mut resolved = previous_incident.clone();
+        resolved.status = "resolved".to_string();
+        events.push(incident_event(
+            monitor,
+            id,
+            &resolved,
+            "resolved",
+            Some(previous_incident.status.as_str()),
+            page_url,
+        ));
+    }
+
+    events
+}
+
+fn incident_event(
+    monitor: &GitHubStatusMonitorConfig,
+    incident_id: &str,
+    incident: &IncidentSnapshot,
+    change: &str,
+    old_status: Option<&str>,
+    page_url: &str,
+) -> IncomingEvent {
+    IncomingEvent::github_actions_incident(
+        incident_id.to_string(),
+        incident.name.clone(),
+        incident.status.clone(),
+        incident.impact.clone(),
+        change.to_string(),
+        old_status.map(str::to_string),
+        incident.last_update_id.clone(),
+        incident.last_update_status.clone(),
+        incident.last_update_body.clone(),
+        incident.affected_components.clone(),
+        incident
+            .shortlink
+            .clone()
+            .unwrap_or_else(|| page_url.to_string()),
+        monitor.channel.clone(),
+    )
+    .with_mention(monitor.mention.clone())
+    .with_format(monitor.format.clone())
+}
+
+fn normalize_status(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn is_actionable_component_status(status: &str) -> bool {
+    matches!(
+        status,
+        "degraded_performance" | "partial_outage" | "major_outage" | "under_maintenance"
+    )
+}
+
+fn should_emit_component_transition(old_status: &str, new_status: &str) -> bool {
+    if old_status == new_status {
+        return false;
+    }
+    // Emit degradations, outages, maintenance, and recovery back to operational.
+    is_actionable_component_status(new_status)
+        || (is_actionable_component_status(old_status) && new_status == "operational")
+}
+
+/// Pure helper used by tests and future diagnostics: summarize component ranks.
+#[cfg(test)]
+fn severity_rank(status: &str) -> u8 {
+    match status {
+        "major_outage" => 4,
+        "partial_outage" => 3,
+        "degraded_performance" => 2,
+        "under_maintenance" => 1,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::MessageFormat;
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn monitor_config() -> GitHubStatusMonitorConfig {
+        GitHubStatusMonitorConfig {
+            enabled: true,
+            api_base: "https://www.githubstatus.com/api/v2".into(),
+            components: vec!["Actions".into()],
+            poll_interval_secs: 60,
+            channel: Some("gajae-code-dev".into()),
+            channel_name: Some("gajae-code-dev".into()),
+            mention: None,
+            format: Some(MessageFormat::Alert),
+        }
+    }
+
+    fn empty_state() -> MonitorState {
+        MonitorState {
+            baseline_established: true,
+            components: HashMap::new(),
+            incidents: HashMap::new(),
+        }
+    }
+
+    fn primed_operational() -> MonitorState {
+        MonitorState {
+            baseline_established: true,
+            components: HashMap::from([("Actions".into(), "operational".into())]),
+            incidents: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn baseline_poll_emits_nothing() {
+        let monitor = monitor_config();
+        let mut state = MonitorState::default();
+        let components = HashMap::from([("Actions".into(), "degraded_performance".into())]);
+        let incidents = HashMap::from([(
+            "inc-1".into(),
+            IncidentSnapshot {
+                name: "Incident with Actions".into(),
+                status: "investigating".into(),
+                impact: "major".into(),
+                shortlink: Some("https://stspg.io/example".into()),
+                last_update_id: Some("upd-1".into()),
+                last_update_status: Some("investigating".into()),
+                last_update_body: Some("We are investigating".into()),
+                affected_components: vec!["Actions".into()],
+            },
+        )]);
+
+        // Simulate first-poll baseline path.
+        assert!(!state.baseline_established);
+        state.components = components.clone();
+        state.incidents = incidents.clone();
+        state.baseline_established = true;
+        let events = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &state,
+            &components,
+            &incidents,
+        );
+        assert!(
+            events.is_empty(),
+            "unchanged post-baseline state must not spam"
+        );
+    }
+
+    #[test]
+    fn component_degraded_and_recovery_emit_once_each() {
+        let monitor = monitor_config();
+        let mut previous = primed_operational();
+        let degraded = HashMap::from([("Actions".into(), "degraded_performance".into())]);
+        let events = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &previous,
+            &degraded,
+            &HashMap::new(),
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "github.actions-status");
+        assert_eq!(events[0].payload["component"], "Actions");
+        assert_eq!(events[0].payload["old_status"], "operational");
+        assert_eq!(events[0].payload["new_status"], "degraded_performance");
+        assert_eq!(events[0].channel.as_deref(), Some("gajae-code-dev"));
+
+        previous.components = degraded.clone();
+        let same = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &previous,
+            &degraded,
+            &HashMap::new(),
+        );
+        assert!(same.is_empty(), "stable degraded state must not re-alert");
+
+        let recovered = HashMap::from([("Actions".into(), "operational".into())]);
+        let recovery = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &previous,
+            &recovered,
+            &HashMap::new(),
+        );
+        assert_eq!(recovery.len(), 1);
+        assert_eq!(recovery[0].payload["new_status"], "operational");
+        assert_eq!(recovery[0].payload["old_status"], "degraded_performance");
+    }
+
+    #[test]
+    fn major_outage_is_actionable() {
+        assert!(is_actionable_component_status("major_outage"));
+        assert!(is_actionable_component_status("partial_outage"));
+        assert!(is_actionable_component_status("degraded_performance"));
+        assert!(!is_actionable_component_status("operational"));
+        assert!(severity_rank("major_outage") > severity_rank("degraded_performance"));
+    }
+
+    #[test]
+    fn incident_lifecycle_emits_open_update_resolve_without_duplicates() {
+        let monitor = monitor_config();
+        let mut previous = primed_operational();
+        let open = HashMap::from([(
+            "inc-1".into(),
+            IncidentSnapshot {
+                name: "Incident with Actions".into(),
+                status: "investigating".into(),
+                impact: "critical".into(),
+                shortlink: Some("https://stspg.io/rcz3fcm83sff".into()),
+                last_update_id: Some("upd-1".into()),
+                last_update_status: Some("investigating".into()),
+                last_update_body: Some("Investigating Actions degradation".into()),
+                affected_components: vec!["Actions".into()],
+            },
+        )]);
+
+        let opened = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &previous,
+            &previous.components,
+            &open,
+        );
+        assert_eq!(opened.len(), 1);
+        assert_eq!(opened[0].kind, "github.actions-incident");
+        assert_eq!(opened[0].payload["change"], "opened");
+        assert_eq!(opened[0].payload["impact"], "critical");
+
+        previous.incidents = open.clone();
+        let unchanged = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &previous,
+            &previous.components,
+            &open,
+        );
+        assert!(unchanged.is_empty());
+
+        let mut updated_map = open.clone();
+        updated_map.get_mut("inc-1").unwrap().status = "monitoring".into();
+        updated_map.get_mut("inc-1").unwrap().last_update_id = Some("upd-2".into());
+        updated_map.get_mut("inc-1").unwrap().last_update_status = Some("monitoring".into());
+        updated_map.get_mut("inc-1").unwrap().last_update_body =
+            Some("Mitigated; monitoring".into());
+
+        let updated = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &previous,
+            &previous.components,
+            &updated_map,
+        );
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].payload["change"], "updated");
+        assert_eq!(updated[0].payload["old_status"], "investigating");
+        assert_eq!(updated[0].payload["status"], "monitoring");
+        assert_eq!(updated[0].payload["update_id"], "upd-2");
+
+        previous.incidents = updated_map;
+        let resolved = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &previous,
+            &previous.components,
+            &HashMap::new(),
+        );
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].payload["change"], "resolved");
+        assert_eq!(resolved[0].payload["status"], "resolved");
+    }
+
+    #[test]
+    fn incidents_for_unwatched_components_are_ignored() {
+        let monitor = monitor_config();
+        let previous = primed_operational();
+        // Empty current map: unwatched components never enter collect_events.
+        let events = collect_events(
+            &monitor,
+            "https://www.githubstatus.com",
+            &previous,
+            &previous.components,
+            &HashMap::new(),
+        );
+        assert!(events.is_empty());
+        let _ = empty_state();
+    }
+
+    #[test]
+    fn watched_incidents_filters_to_actions() {
+        let incidents = vec![
+            IncidentEntry {
+                id: "a".into(),
+                name: "Actions".into(),
+                status: "investigating".into(),
+                impact: "major".into(),
+                shortlink: None,
+                components: vec![ComponentEntry {
+                    name: "Actions".into(),
+                    status: "degraded_performance".into(),
+                    description: None,
+                }],
+                incident_updates: vec![IncidentUpdateEntry {
+                    id: "u1".into(),
+                    status: "investigating".into(),
+                    body: "looking".into(),
+                }],
+            },
+            IncidentEntry {
+                id: "b".into(),
+                name: "Pages".into(),
+                status: "investigating".into(),
+                impact: "minor".into(),
+                shortlink: None,
+                components: vec![ComponentEntry {
+                    name: "Pages".into(),
+                    status: "degraded_performance".into(),
+                    description: None,
+                }],
+                incident_updates: vec![],
+            },
+        ];
+        let watched = HashSet::from(["Actions".to_string()]);
+        let filtered = watched_incidents(&incidents, &watched);
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered.contains_key("a"));
+    }
+
+    #[tokio::test]
+    async fn poll_once_primes_baseline_then_emits_component_change() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hits_server = hits.clone();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = vec![0_u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let n = hits_server.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let status = if n == 0 {
+                    "operational"
+                } else {
+                    "major_outage"
+                };
+                let body = json!({
+                    "page": {"url": "https://www.githubstatus.com"},
+                    "components": [{
+                        "name": "Actions",
+                        "status": status,
+                        "description": "Workflows"
+                    }],
+                    "incidents": []
+                })
+                .to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let mut config = AppConfig::default();
+        config.monitors.github_status = GitHubStatusMonitorConfig {
+            enabled: true,
+            api_base: format!("http://{addr}"),
+            components: vec!["Actions".into()],
+            poll_interval_secs: 60,
+            channel: Some("dev-channel".into()),
+            channel_name: Some("gajae-code-dev".into()),
+            mention: None,
+            format: Some(MessageFormat::Alert),
+        };
+        let client = build_status_client().unwrap();
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut state = MonitorState::default();
+
+        poll_once(&config, &client, &tx, &mut state).await.unwrap();
+        assert!(state.baseline_established);
+        assert!(
+            rx.try_recv().is_err(),
+            "first poll must establish baseline without alert spam"
+        );
+
+        poll_once(&config, &client, &tx, &mut state).await.unwrap();
+        let event = rx.try_recv().expect("component outage event");
+        assert_eq!(event.kind, "github.actions-status");
+        assert_eq!(event.payload["new_status"], "major_outage");
+        assert_eq!(event.channel.as_deref(), Some("dev-channel"));
+
+        // Third poll with same major_outage should not re-emit.
+        poll_once(&config, &client, &tx, &mut state).await.unwrap();
+        assert!(rx.try_recv().is_err());
+
+        server.abort();
+    }
+
+    #[test]
+    fn parse_live_summary_shape() {
+        let sample = r#"{
+          "page": {"id":"kctbh9vrtdwd","name":"GitHub","url":"https://www.githubstatus.com"},
+          "status": {"indicator":"none","description":"All Systems Operational"},
+          "components": [
+            {"id":"br0l2tvcx85d","name":"Actions","status":"operational","description":"Workflows"}
+          ],
+          "incidents": []
+        }"#;
+        let parsed: SummaryResponse = serde_json::from_str(sample).unwrap();
+        assert_eq!(parsed.components[0].name, "Actions");
+        let watched = HashSet::from(["Actions".to_string()]);
+        let statuses = watched_component_statuses(&parsed.components, &watched);
+        assert_eq!(
+            statuses.get("Actions").map(String::as_str),
+            Some("operational")
+        );
+    }
+
+    #[test]
+    fn collect_events_keeps_deterministic_order() {
+        let monitor = monitor_config();
+        let previous = MonitorState {
+            baseline_established: true,
+            components: HashMap::from([
+                ("Actions".into(), "operational".into()),
+                ("Packages".into(), "operational".into()),
+            ]),
+            incidents: HashMap::new(),
+        };
+        let current = HashMap::from([
+            ("Packages".into(), "partial_outage".into()),
+            ("Actions".into(), "degraded_performance".into()),
+        ]);
+        let mut multi = monitor.clone();
+        multi.components = vec!["Actions".into(), "Packages".into()];
+        let events = collect_events(
+            &multi,
+            "https://www.githubstatus.com",
+            &previous,
+            &current,
+            &HashMap::new(),
+        );
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].payload["component"], "Actions");
+        assert_eq!(events[1].payload["component"], "Packages");
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,6 +5,7 @@ use crate::events::IncomingEvent;
 
 pub mod git;
 pub mod github;
+pub mod github_status;
 pub mod subscription;
 pub mod tmux;
 pub mod workspace;
@@ -14,6 +15,7 @@ pub use git::{
     new_shared_git_monitor_diagnostics, snapshot_git_monitor_diagnostics,
 };
 pub use github::GitHubSource;
+pub use github_status::GitHubStatusSource;
 pub use subscription::{SubscriptionSnapshot, SubscriptionState, SubscriptionWorker};
 pub use tmux::{
     RegisteredTmuxSession, SharedTmuxRegistry, TmuxSource, default_registry_state_path,


### PR DESCRIPTION
## Summary
- Add `monitors.github_status` poller against the public GitHub Statuspage machine-readable API (`https://www.githubstatus.com/api/v2/summary.json` and related endpoints). No auth/tokens; no secrets in config.
- Emit `github.actions-status` for watched component transitions (`degraded_performance` / `partial_outage` / `major_outage` / `under_maintenance` + recovery to `operational`) and `github.actions-incident` for open/update/resolve lifecycle when incidents affect watched components (default: `Actions`).
- Anti-spam: first successful poll baselines without replay; stable status and identical update IDs do not re-alert.
- Explicitly separate from websocket `[[subscriptions]]` / GJC workflow-gate ingress.
- Route example for gajae-code dev Discord channel documented in README (`github.actions-*`).

## Scope boundary
Does **not** change or share filter/channel ownership with GJC workflow-gate or question websocket subscriptions.

## Test plan
- [x] `cargo test github_status` (source + config validation)
- [x] `cargo test --bins` (790 passed)
- [x] Render coverage for status + incident formats
- [ ] CI green on PR
- [ ] Red-team review: secret leakage (none expected), alert spam, route isolation from subscriptions, Statuspage field resilience

## Operator config (gajae-code dev)
```toml
[monitors.github_status]
enabled = true
api_base = "https://www.githubstatus.com/api/v2"
components = ["Actions"]
poll_interval_secs = 60
format = "alert"

[[routes]]
event = "github.actions-*"
sink = "discord"
channel = "YOUR_GAJAE_CODE_DEV_CHANNEL_ID"
channel_name = "gajae-code-dev"
format = "alert"
```

## Red-team review asks
1. Confirm no endpoint secrets/env names are logged or returned by health/API.
2. Confirm baseline/dedupe prevents restart/poll spam.
3. Confirm unwatched components/incidents never route.
4. Confirm this path cannot be confused with `[[subscriptions]]` workers.