### PR TITLE
fix(config): bound backup retention labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,16 @@ jobs:
           done
       - run: cargo test
 
+  windows-backup-cleanup:
+    name: Windows backup cleanup
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --test config_backup_cleanup
+
   clippy:
     name: Clippy
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - config saves retire only strictly recognized stale legacy root-level snapshots alongside managed backups under the shared newest-10-or-newer-than-30-days retention policy. On Unix, temp commit, managed snapshot creation, and candidate deletion use directory-handle-relative exclusive/no-follow primitives so preplaced temp collisions, post-write temp replacement, managed-directory path swaps, and post-check candidate replacement cannot redirect writes or unlinks outside the validated objects; on platforms without those primitives, saves continue while cleanup preserves every candidate. Unknown, malformed, symlinked, directory, and unsafe linked entries remain untouched. No config schema migration or startup cleanup is required.
+- restrict root-level config-backup cleanup to a finite set of evidenced clawhip labels, preserve lookalikes and unknown labels, and report public-safe classified/deleted/preserved counts after config saves.
 
 ## 0.6.11 - 2026-06-16
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1103,7 +1103,12 @@ impl AppConfig {
         Ok(toml::to_string_pretty(self)?)
     }
 
+    #[allow(dead_code)] // Retained for callers that do not need cleanup observation.
     pub fn save_with_backup(&self, path: &Path) -> Result<()> {
+        self.save_with_backup_reporting(path).map(|_| ())
+    }
+
+    pub fn save_with_backup_reporting(&self, path: &Path) -> Result<CleanupSummary> {
         let mut before_delete = |_: &BackupCandidate| Ok(());
         self.save_with_backup_at(path, OffsetDateTime::now_utc(), &mut before_delete)
     }
@@ -1113,7 +1118,7 @@ impl AppConfig {
         path: &Path,
         now: OffsetDateTime,
         before_delete: &mut F,
-    ) -> Result<()>
+    ) -> Result<CleanupSummary>
     where
         F: FnMut(&BackupCandidate) -> Result<()>,
     {
@@ -1135,7 +1140,7 @@ impl AppConfig {
         before_rename: &mut G,
         before_snapshot: &mut H,
         before_delete: &mut F,
-    ) -> Result<()>
+    ) -> Result<CleanupSummary>
     where
         F: FnMut(&BackupCandidate) -> Result<()>,
         G: FnMut() -> Result<()>,
@@ -1161,7 +1166,7 @@ impl AppConfig {
         before_snapshot: &mut H,
         before_delete: &mut F,
         after_preflight: &mut P,
-    ) -> Result<()>
+    ) -> Result<CleanupSummary>
     where
         F: FnMut(&BackupCandidate) -> Result<()>,
         G: FnMut() -> Result<()>,
@@ -1190,7 +1195,7 @@ impl AppConfig {
         before_delete: &mut F,
         after_preflight: &mut P,
         after_check: &mut A,
-    ) -> Result<()>
+    ) -> Result<CleanupSummary>
     where
         F: FnMut(&BackupCandidate) -> Result<()>,
         G: FnMut() -> Result<()>,
@@ -1225,7 +1230,7 @@ impl AppConfig {
                     ))
                 })?;
             let protected_identities = active.identity().into_iter().collect::<Vec<_>>();
-            cleanup_config_backups_with_hooks(
+            return cleanup_config_backups_with_hooks(
                 &parent_dir.path,
                 parent_dir.identity,
                 filename,
@@ -1240,8 +1245,8 @@ impl AppConfig {
                 io::Error::other(format!(
                     "config was already current; backup retention cleanup remains incomplete: {error}"
                 ))
-            })?;
-            return Ok(());
+            })
+            .map_err(Into::into);
         }
 
         revalidate_config_parent_dir(&parent_dir)?;
@@ -1300,8 +1305,8 @@ impl AppConfig {
             io::Error::other(format!(
                 "config was saved; backup retention cleanup remains incomplete: {error}"
             ))
-        })?;
-        Ok(())
+        })
+        .map_err(Into::into)
     }
 
     pub fn effective_token(&self) -> Option<String> {
@@ -2210,8 +2215,9 @@ impl AppConfig {
                     self.scaffold_webhook_quickstart(webhook)?;
                 }
                 "6" => {
-                    self.save_with_backup(path)?;
+                    let cleanup = self.save_with_backup_reporting(path)?;
                     println!("Saved {}", path.display());
+                    print_cleanup_summary(cleanup);
                     break;
                 }
                 "7" => {
@@ -2472,6 +2478,13 @@ impl BackupOrigin {
             Self::Managed => 1,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CleanupSummary {
+    pub classified: usize,
+    pub deleted: usize,
+    pub preserved: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -3491,18 +3504,17 @@ fn parse_compact_backup_date(value: &str) -> Option<OffsetDateTime> {
         .map(|date| date.midnight().assume_utc())
 }
 
+/// Root backup labels are prune-eligible only when provenance is evidenced by
+/// historical clawhip backup producers (commits 25ba837 and 1e17b35).
 fn valid_legacy_backup_label_prefix(prefix: &str) -> bool {
     if prefix.is_empty() {
         return true;
     }
-    let Some(label) = prefix.strip_suffix('-') else {
-        return false;
-    };
-    !label.is_empty()
-        && label.bytes().any(|byte| byte.is_ascii_alphanumeric())
-        && label
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+
+    matches!(
+        prefix.strip_suffix('-'),
+        Some("gajae-runtime-rename" | "release-radar" | "gp-mention")
+    )
 }
 
 fn parse_root_legacy_backup_name(name: &str, filename: &str) -> Option<OffsetDateTime> {
@@ -3820,6 +3832,7 @@ where
         &mut after_preflight,
         &mut after_check,
     )
+    .map(|_| ())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3833,7 +3846,7 @@ fn cleanup_config_backups_with_hooks<F, P, A>(
     before_delete: &mut F,
     after_preflight: &mut P,
     after_delete_check: &mut A,
-) -> Result<()>
+) -> Result<CleanupSummary>
 where
     F: FnMut(&BackupCandidate) -> Result<()>,
     P: FnMut(&BackupCandidate) -> Result<()>,
@@ -3848,7 +3861,7 @@ where
         .into());
     }
     if parent_dir.identity.is_none() {
-        return Ok(());
+        return Ok(CleanupSummary::default());
     }
     let cutoff = now - TimeDuration::days(30);
     let mut candidates =
@@ -3865,7 +3878,9 @@ where
                 right.entry_name.as_str(),
             ))
     });
-    let keep_from = candidates.len().saturating_sub(10);
+    let classified = candidates.len();
+    let keep_from = classified.saturating_sub(10);
+    let mut deleted = 0;
     for (index, candidate) in candidates.iter().enumerate() {
         if index < keep_from && candidate.created_at <= cutoff {
             before_delete(candidate)?;
@@ -3877,16 +3892,30 @@ where
                 after_preflight,
                 after_delete_check,
             )? {
-                CandidateDeletionOutcome::Deleted | CandidateDeletionOutcome::Disappeared => {}
+                CandidateDeletionOutcome::Deleted | CandidateDeletionOutcome::Disappeared => {
+                    deleted += 1;
+                }
                 CandidateDeletionOutcome::Preserved(reason) => {
                     let _ = reason;
                 }
             }
         }
     }
-    Ok(())
+    Ok(CleanupSummary {
+        classified,
+        deleted,
+        preserved: classified - deleted,
+    })
 }
 
+fn print_cleanup_summary(summary: CleanupSummary) {
+    if summary.classified > 0 {
+        println!(
+            "Config backup cleanup: {} classified, {} deleted, {} preserved",
+            summary.classified, summary.deleted, summary.preserved
+        );
+    }
+}
 fn is_canonical_quickstart_route(route: &RouteRule) -> bool {
     route.event == "*"
         && route.filter.is_empty()
@@ -5282,7 +5311,7 @@ name = "general"
                 "custom.name.toml.bak-label-20260708T072000Z",
                 "custom.name.toml"
             )
-            .is_some()
+            .is_none()
         );
         assert!(
             parse_duplicated_legacy_backup_name(
@@ -5294,6 +5323,7 @@ name = "general"
 
         for name in [
             "config.toml.bak-label_with_underscore-20260708T072000Z",
+            "config.toml.bak-label-20260708T072000Z",
             "config.toml.bak-label-20260708T072000",
             "config.toml.bak-20260708T07200Z",
             "config.toml.bak-20260708-extra",
@@ -5384,24 +5414,24 @@ name = "general"
         let parent = dir.path();
         let now = OffsetDateTime::from_unix_timestamp(1_800_000_000).unwrap();
         let exact_cutoff = format!(
-            "config.toml.bak-exact-cutoff-{}",
+            "config.toml.bak-gajae-runtime-rename-{}",
             utc_backup_timestamp(now - TimeDuration::days(30)).unwrap()
         );
         let just_newer = format!(
-            "config.toml.bak-just-newer-{}",
+            "config.toml.bak-gajae-runtime-rename-{}",
             utc_backup_timestamp(now - TimeDuration::days(30) + TimeDuration::seconds(1)).unwrap()
         );
         fs::write(parent.join(&exact_cutoff), "cutoff").unwrap();
         fs::write(parent.join(&just_newer), "recent").unwrap();
         for index in 0..10 {
             let name = format!(
-                "config.toml.bak-later-{index}-{}",
+                "config.toml.bak-gajae-runtime-rename-{}",
                 utc_backup_timestamp(now - TimeDuration::days(20 - index)).unwrap()
             );
             fs::write(parent.join(name), "later").unwrap();
         }
         let mut before_delete = |_: &BackupCandidate| Ok(());
-        cleanup_config_backups_with(
+        let summary = cleanup_config_backups_with_hooks(
             parent,
             None,
             "config.toml",
@@ -5409,8 +5439,18 @@ name = "general"
             &[],
             now,
             &mut before_delete,
+            &mut |_: &BackupCandidate| Ok(()),
+            &mut |_: &BackupCandidate| Ok(()),
         )
         .unwrap();
+        assert_eq!(
+            summary,
+            CleanupSummary {
+                classified: 12,
+                deleted: 1,
+                preserved: 11,
+            }
+        );
         assert!(!parent.join(exact_cutoff).exists());
         assert!(parent.join(just_newer).exists());
     }
@@ -6748,7 +6788,7 @@ name = "general"
         assert_eq!(managed_entries.len(), 1);
         assert_eq!(fs::read(managed_entries[0].path()).unwrap(), original_bytes);
         match result {
-            Ok(()) => {
+            Ok(_) => {
                 assert!(fs::read_to_string(&path).unwrap().contains("alerts"));
             }
             Err(error) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3504,17 +3504,11 @@ fn parse_compact_backup_date(value: &str) -> Option<OffsetDateTime> {
         .map(|date| date.midnight().assume_utc())
 }
 
-/// Root backup labels are prune-eligible only when provenance is evidenced by
-/// historical clawhip backup producers (commits 25ba837 and 1e17b35).
+/// Root backup labels are preserved because no historical clawhip producer proves
+/// their provenance. An owner-approved compatibility boundary is required before
+/// labeled root backups become prune-eligible.
 fn valid_legacy_backup_label_prefix(prefix: &str) -> bool {
-    if prefix.is_empty() {
-        return true;
-    }
-
-    matches!(
-        prefix.strip_suffix('-'),
-        Some("gajae-runtime-rename" | "release-radar" | "gp-mention")
-    )
+    prefix.is_empty()
 }
 
 fn parse_root_legacy_backup_name(name: &str, filename: &str) -> Option<OffsetDateTime> {
@@ -3896,12 +3890,10 @@ where
                 after_preflight,
                 after_delete_check,
             )? {
-                CandidateDeletionOutcome::Deleted | CandidateDeletionOutcome::Disappeared => {
+                CandidateDeletionOutcome::Deleted => {
                     deleted += 1;
                 }
-                CandidateDeletionOutcome::Preserved(reason) => {
-                    let _ = reason;
-                }
+                CandidateDeletionOutcome::Disappeared | CandidateDeletionOutcome::Preserved(_) => {}
             }
         }
     }
@@ -5279,29 +5271,11 @@ name = "general"
     }
 
     #[test]
-    fn backup_filename_parsers_accept_evidenced_families_and_reject_near_misses() {
+    fn backup_filename_parsers_accept_unlabeled_root_families_and_preserve_labels() {
         let expected = parse_compact_backup_timestamp_seconds("20260708T072000Z").unwrap();
         assert_eq!(
-            parse_root_legacy_backup_name(
-                "config.toml.bak-gajae-runtime-rename-20260708T072000Z",
-                "config.toml"
-            ),
+            parse_root_legacy_backup_name("config.toml.bak-20260708T072000Z", "config.toml"),
             Some(expected)
-        );
-        assert!(
-            parse_root_legacy_backup_name(
-                "config.toml.bak-release-radar-20260708T0720Z",
-                "config.toml"
-            )
-            .is_some()
-        );
-        assert!(
-            parse_root_legacy_backup_name("config.toml.bak-gp-mention-20260708", "config.toml")
-                .is_some()
-        );
-        assert!(
-            parse_root_legacy_backup_name("config.toml.bak-20260708T072000Z", "config.toml")
-                .is_some()
         );
         assert!(
             parse_duplicated_legacy_backup_name(
@@ -5309,13 +5283,6 @@ name = "general"
                 "config.toml"
             )
             .is_some()
-        );
-        assert!(
-            parse_root_legacy_backup_name(
-                "custom.name.toml.bak-label-20260708T072000Z",
-                "custom.name.toml"
-            )
-            .is_none()
         );
         assert!(
             parse_duplicated_legacy_backup_name(
@@ -5326,6 +5293,9 @@ name = "general"
         );
 
         for name in [
+            "config.toml.bak-gajae-runtime-rename-20260708T072000Z",
+            "config.toml.bak-release-radar-20260708T0720Z",
+            "config.toml.bak-gp-mention-20260708",
             "config.toml.bak-label_with_underscore-20260708T072000Z",
             "config.toml.bak-label-20260708T072000Z",
             "config.toml.bak-label-20260708T072000",
@@ -5418,18 +5388,18 @@ name = "general"
         let parent = dir.path();
         let now = OffsetDateTime::from_unix_timestamp(1_800_000_000).unwrap();
         let exact_cutoff = format!(
-            "config.toml.bak-gajae-runtime-rename-{}",
+            "config.toml.bak-{}",
             utc_backup_timestamp(now - TimeDuration::days(30)).unwrap()
         );
         let just_newer = format!(
-            "config.toml.bak-gajae-runtime-rename-{}",
+            "config.toml.bak-{}",
             utc_backup_timestamp(now - TimeDuration::days(30) + TimeDuration::seconds(1)).unwrap()
         );
         fs::write(parent.join(&exact_cutoff), "cutoff").unwrap();
         fs::write(parent.join(&just_newer), "recent").unwrap();
         for index in 0..10 {
             let name = format!(
-                "config.toml.bak-gajae-runtime-rename-{}",
+                "config.toml.bak-{}",
                 utc_backup_timestamp(now - TimeDuration::days(20 - index)).unwrap()
             );
             fs::write(parent.join(name), "later").unwrap();
@@ -5500,7 +5470,7 @@ name = "general"
 
     #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
     #[test]
-    fn backup_cleanup_preserves_selected_candidate_without_supported_descriptor_proof() {
+    fn backup_cleanup_counts_candidates_without_supported_descriptor_proof() {
         let dir = tempfile::tempdir().unwrap();
         let parent = dir.path();
         for day in 1..=11 {
@@ -5512,8 +5482,7 @@ name = "general"
         }
         let oldest = parent.join("config.toml.bak-20000101");
         let mut before_delete = |_: &BackupCandidate| Ok(());
-
-        cleanup_config_backups_with(
+        let summary = cleanup_config_backups_with_hooks(
             parent,
             None,
             "config.toml",
@@ -5521,9 +5490,19 @@ name = "general"
             &[],
             OffsetDateTime::now_utc(),
             &mut before_delete,
+            &mut |_: &BackupCandidate| Ok(()),
+            &mut |_: &BackupCandidate| Ok(()),
         )
         .unwrap();
 
+        assert_eq!(
+            summary,
+            CleanupSummary {
+                classified: 11,
+                deleted: 0,
+                preserved: 11,
+            }
+        );
         assert_eq!(fs::read_to_string(oldest).unwrap(), "candidate");
     }
     #[cfg(unix)]
@@ -6517,6 +6496,53 @@ name = "general"
         assert!(replaced);
         assert_eq!(fs::read_to_string(target).unwrap(), "replacement");
         assert_eq!(fs::read_to_string(moved).unwrap(), "original");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn backup_cleanup_does_not_report_concurrently_disappeared_candidate_as_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path();
+        for day in 1..=11 {
+            fs::write(
+                parent.join(format!("config.toml.bak-200001{day:02}")),
+                "original",
+            )
+            .unwrap();
+        }
+        let target = parent.join("config.toml.bak-20000101");
+        let mut before_delete = |_: &BackupCandidate| Ok(());
+        let mut removed = false;
+        let mut remove_candidate = |candidate: &BackupCandidate| -> Result<()> {
+            if candidate.path == target && !removed {
+                fs::remove_file(&target)?;
+                removed = true;
+            }
+            Ok(())
+        };
+        let summary = cleanup_config_backups_with_hooks(
+            parent,
+            None,
+            "config.toml",
+            None,
+            &[],
+            OffsetDateTime::now_utc(),
+            &mut before_delete,
+            &mut remove_candidate,
+            &mut |_: &BackupCandidate| Ok(()),
+        )
+        .unwrap();
+
+        assert!(removed);
+        assert_eq!(
+            summary,
+            CleanupSummary {
+                classified: 11,
+                deleted: 0,
+                preserved: 11,
+            }
+        );
+        assert!(!target.exists());
     }
 
     #[cfg(unix)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3556,7 +3556,14 @@ fn safe_cleanup_file_identity(metadata: &Metadata) -> Option<FileIdentity> {
     if metadata.nlink() != 1 {
         return None;
     }
-    metadata_identity(metadata)
+    #[cfg(unix)]
+    {
+        metadata_identity(metadata)
+    }
+    #[cfg(not(unix))]
+    {
+        Some(FileIdentity {})
+    }
 }
 
 fn collect_cleanup_candidates(
@@ -3859,9 +3866,6 @@ where
             parent.display()
         )
         .into());
-    }
-    if parent_dir.identity.is_none() {
-        return Ok(CleanupSummary::default());
     }
     let cutoff = now - TimeDuration::days(30);
     let mut candidates =

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Read, Write};
+#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
+
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -1757,10 +1759,11 @@ fn write_receipt_tempfile(input: &[u8]) -> Result<TempReceiptFile> {
         "clawhip-gajae-receipt-{}.json",
         uuid::Uuid::new_v4()
     ));
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options
         .open(&path)
         .context("failed to create temporary receipt file")?;
     file.write_all(input)

--- a/src/main.rs
+++ b/src/main.rs
@@ -956,8 +956,14 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
         }
     }
 
-    editable.save_with_backup(config_path)?;
+    let cleanup = editable.save_with_backup_reporting(config_path)?;
     println!("Saved {}", config_path.display());
+    if cleanup.classified > 0 {
+        println!(
+            "Config backup cleanup: {} classified, {} deleted, {} preserved",
+            cleanup.classified, cleanup.deleted, cleanup.preserved
+        );
+    }
     Ok(())
 }
 

--- a/src/tmux_wrapper.rs
+++ b/src/tmux_wrapper.rs
@@ -1527,6 +1527,7 @@ fn default_keyword_window_secs() -> u64 {
     30
 }
 
+#[cfg(unix)]
 fn current_parent_process_info() -> Option<ParentProcessInfo> {
     let pid = std::os::unix::process::parent_id();
     if pid == 0 {
@@ -1539,6 +1540,11 @@ fn current_parent_process_info() -> Option<ParentProcessInfo> {
         .filter(|value| !value.is_empty());
 
     Some(ParentProcessInfo { pid, name })
+}
+
+#[cfg(not(unix))]
+fn current_parent_process_info() -> Option<ParentProcessInfo> {
+    None
 }
 
 fn format_watch_audit_log(registration: &RegisteredTmuxSession) -> String {

--- a/tests/config_backup_cleanup.rs
+++ b/tests/config_backup_cleanup.rs
@@ -5,7 +5,9 @@ use std::io::Read;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::os::unix::process::CommandExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::path::PathBuf;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::process::Stdio;
 use std::process::{Command, Output};
@@ -288,21 +290,37 @@ fn config_backup_cleanup_preserves_mode_000_candidate_on_changed_and_noop_setup(
 
 #[cfg(not(unix))]
 #[test]
-fn config_backup_cleanup_preserves_candidates_without_identity_proof() {
+fn config_backup_cleanup_counts_and_preserves_root_candidates_without_identity_proof() {
     let temp = TempDir::new().expect("tempdir");
     let config_path = temp.path().join("config.toml");
     let initial = run_setup(&config_path, "initial");
     assert!(initial.status.success());
-    let legacy = temp.path().join("config.toml.bak-20200101");
-    fs::write(&legacy, "legacy").expect("write legacy backup");
 
-    let changed = run_setup(&config_path, "changed");
+    for day in 1..=11 {
+        fs::write(
+            temp.path().join(format!("config.toml.bak-202001{day:02}")),
+            format!("legacy-{day}"),
+        )
+        .expect("write legacy backup");
+    }
+
+    let observed = run_setup(&config_path, "initial");
     assert!(
-        changed.status.success(),
-        "changed setup failed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&changed.stdout),
-        String::from_utf8_lossy(&changed.stderr)
+        observed.status.success(),
+        "no-op setup failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&observed.stdout),
+        String::from_utf8_lossy(&observed.stderr)
     );
-    assert!(legacy.exists());
-    assert!(fs::read_to_string(config_path).unwrap().contains("changed"));
+    assert!(
+        String::from_utf8_lossy(&observed.stdout)
+            .contains("Config backup cleanup: 11 classified, 0 deleted, 11 preserved")
+    );
+    for day in 1..=11 {
+        assert!(
+            temp.path()
+                .join(format!("config.toml.bak-202001{day:02}"))
+                .exists()
+        );
+    }
+    assert!(fs::read_to_string(config_path).unwrap().contains("initial"));
 }

--- a/tests/config_backup_cleanup.rs
+++ b/tests/config_backup_cleanup.rs
@@ -151,8 +151,9 @@ fn config_backup_cleanup_converges_legacy_snapshots_on_changed_and_noop_saves() 
         "unknown",
     )
     .expect("write unknown backup");
-    let evidenced = temp.path().join("config.toml.bak-release-radar-20190101");
-    fs::write(&evidenced, "evidenced").expect("write evidenced backup");
+    let labeled = temp.path().join("config.toml.bak-release-radar-20190101");
+    fs::write(&labeled, "labeled").expect("write labeled backup");
+
     let lookalike = temp
         .path()
         .join("config.toml.bak-release-radar-copy-20200115");
@@ -186,7 +187,7 @@ fn config_backup_cleanup_converges_legacy_snapshots_on_changed_and_noop_saves() 
     assert!(temp.path().join("config.toml.bak-unknown-format").exists());
     let duplicated = temp.path().join("config.config.toml.bak-2020-01-13-0000");
     assert!(duplicated.exists());
-    assert!(!evidenced.exists());
+    assert!(labeled.exists());
     assert!(lookalike.exists());
     let noop_only = temp.path().join("config.toml.bak-20190101");
     fs::write(&noop_only, "no-op-only stale backup").expect("write no-op-only backup");

--- a/tests/config_backup_cleanup.rs
+++ b/tests/config_backup_cleanup.rs
@@ -149,6 +149,12 @@ fn config_backup_cleanup_converges_legacy_snapshots_on_changed_and_noop_saves() 
         "unknown",
     )
     .expect("write unknown backup");
+    let evidenced = temp.path().join("config.toml.bak-release-radar-20190101");
+    fs::write(&evidenced, "evidenced").expect("write evidenced backup");
+    let lookalike = temp
+        .path()
+        .join("config.toml.bak-release-radar-copy-20200115");
+    fs::write(&lookalike, "lookalike").expect("write lookalike backup");
 
     let changed = run_setup(&config_path, "changed");
     assert!(
@@ -157,6 +163,12 @@ fn config_backup_cleanup_converges_legacy_snapshots_on_changed_and_noop_saves() 
         String::from_utf8_lossy(&changed.stdout),
         String::from_utf8_lossy(&changed.stderr)
     );
+    let changed_stdout = String::from_utf8_lossy(&changed.stdout);
+    assert!(changed_stdout.contains("Config backup cleanup: "));
+    assert!(changed_stdout.contains(" classified, "));
+    assert!(changed_stdout.contains(" deleted, "));
+    assert!(changed_stdout.contains(" preserved"));
+    assert!(!changed_stdout.contains("release-radar"));
     assert!(
         fs::read_to_string(&config_path)
             .unwrap()
@@ -172,6 +184,8 @@ fn config_backup_cleanup_converges_legacy_snapshots_on_changed_and_noop_saves() 
     assert!(temp.path().join("config.toml.bak-unknown-format").exists());
     let duplicated = temp.path().join("config.config.toml.bak-2020-01-13-0000");
     assert!(duplicated.exists());
+    assert!(!evidenced.exists());
+    assert!(lookalike.exists());
     let noop_only = temp.path().join("config.toml.bak-20190101");
     fs::write(&noop_only, "no-op-only stale backup").expect("write no-op-only backup");
     assert!(noop_only.exists());


### PR DESCRIPTION
## Summary
- restrict root backup cleanup to finite evidenced labels
- preserve unknown and lookalike labels while retaining existing recovery policy
- report counts-only cleanup outcomes from setup and interactive saves

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings

Closes #308