### PR TITLE
fix(tmux): reconcile only ownerless stale registrations

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -479,10 +479,20 @@ fn health_payload(
     port: u16,
     registered_tmux_sessions: usize,
     native_hooks: Value,
-    tmux: Value,
+    mut tmux: Value,
     subscriptions: &[SubscriptionSnapshot],
     git_monitors: GitMonitorLifecycleCounts,
 ) -> Value {
+    if let Some(diagnostics) = tmux.as_object_mut() {
+        diagnostics.insert(
+            "configured_monitor_count".to_string(),
+            json!(config.monitors.tmux.sessions.len()),
+        );
+        diagnostics.insert(
+            "registry_registration_count".to_string(),
+            json!(registered_tmux_sessions),
+        );
+    }
     let subscription_degraded = subscriptions.iter().any(|subscription| {
         subscription.enabled
             && subscription.desired_running
@@ -1355,7 +1365,11 @@ async fn expire_terminal_tmux_registration(state: &AppState, event: &IncomingEve
             .filter_map(|session| {
                 snapshot
                     .get(session)
-                    .filter(|registration| registration.lane.is_none())
+                    .filter(|registration| {
+                        registration.lane.is_none()
+                            && registration.parent_process.is_none()
+                            && !registration.active_wrapper_monitor
+                    })
                     .map(|registration| AbsentRegistrationCandidate {
                         session: session.clone(),
                         registration_generation: registration.registration_generation,
@@ -2364,6 +2378,13 @@ mod tests {
         }
     }
 
+    fn ownerless_tmux_registration(session: &str) -> RegisteredTmuxSession {
+        let mut registration = tmux_registration(session);
+        registration.parent_process = None;
+        registration.active_wrapper_monitor = false;
+        registration
+    }
+
     fn gajae_test_event() -> IncomingEvent {
         IncomingEvent {
             kind: "github.pr.opened".into(),
@@ -2636,7 +2657,7 @@ mod tests {
         registry
             .write()
             .await
-            .insert("issue-221".into(), tmux_registration("issue-221"));
+            .insert("issue-221".into(), ownerless_tmux_registration("issue-221"));
         registry
             .write()
             .await
@@ -2832,6 +2853,11 @@ mod tests {
         assert_eq!(payload["configured_tmux_monitors"], Value::from(1));
         assert_eq!(payload["configured_workspace_monitors"], Value::from(1));
         assert_eq!(payload["registered_tmux_sessions"], Value::from(3));
+        assert_eq!(payload["tmux"]["configured_monitor_count"], Value::from(1));
+        assert_eq!(
+            payload["tmux"]["registry_registration_count"],
+            Value::from(3)
+        );
         assert!(payload["native_hooks"]["totals"]["received"].is_number());
         assert_eq!(payload["token_precedence_warning"], Value::Null);
     }
@@ -4022,10 +4048,10 @@ mod tests {
                 lane: None,
             },
         );
-        registry
-            .write()
-            .await
-            .insert("stale-wrapper".into(), tmux_registration("stale-wrapper"));
+        registry.write().await.insert(
+            "stale-wrapper".into(),
+            ownerless_tmux_registration("stale-wrapper"),
+        );
 
         let state = AppState {
             config: Arc::new(AppConfig::default()),

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -1177,6 +1177,10 @@ pub struct AbsentRegistrationCandidate {
     pub registration_generation: u64,
 }
 
+fn registration_is_ownerless(registration: &RegisteredTmuxSession) -> bool {
+    !registration.active_wrapper_monitor && registration.parent_process.is_none()
+}
+
 /// Prune daemon-owned dynamic registrations and explicitly retired/quiesced
 /// lane registrations whose tmux session has been observed absent. Active and
 /// handoff lane evidence is preserved regardless of liveness to avoid
@@ -1206,6 +1210,7 @@ pub async fn prune_absent_dynamic_registrations(
                     .lane
                     .as_ref()
                     .is_none_or(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced)
+                && (registration.lane.is_some() || registration_is_ownerless(registration))
         });
 
         if removable && next.remove(&candidate.session).is_some() {
@@ -1832,6 +1837,7 @@ pub async fn list_active_tmux_registrations(
                     !available_sessions.contains(*session)
                         && registration.registration_source != RegistrationSource::ConfigMonitor
                         && registration.lane.is_none()
+                        && registration_is_ownerless(registration)
                 })
                 .map(|(session, registration)| AbsentRegistrationCandidate {
                     session: session.clone(),
@@ -1925,7 +1931,8 @@ async fn poll_tmux(
                     .as_ref()
                     .is_some_and(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced);
                 if registration.registration_source != RegistrationSource::ConfigMonitor
-                    && (registration.lane.is_none() || retired_lane)
+                    && ((registration.lane.is_none() && registration_is_ownerless(registration))
+                        || retired_lane)
                 {
                     dynamic_prune_candidates.push(AbsentRegistrationCandidate {
                         session: session_name.clone(),
@@ -4418,7 +4425,7 @@ error: failed";
     }
 
     #[tokio::test]
-    async fn prune_absent_dynamic_removes_dead_cliwatch_no_lane() {
+    async fn prune_absent_dynamic_preserves_live_owner_then_removes_ownerless_registration() {
         let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
         let path = std::env::temp_dir().join(format!(
             "clawhip-test-prune-cliwatch-{}.json",
@@ -4436,7 +4443,10 @@ error: failed";
             format: None,
             registered_at: "2026-07-29T00:00:00Z".into(),
             registration_source: RegistrationSource::CliWatch,
-            parent_process: None,
+            parent_process: Some(ParentProcessInfo {
+                pid: 42,
+                name: Some("clawhip-wrapper".into()),
+            }),
             registration_generation: 0,
             active_wrapper_monitor: true,
 
@@ -4450,6 +4460,27 @@ error: failed";
             session: "dead-watch".into(),
             registration_generation: 0,
         }];
+        let removed = prune_absent_dynamic_registrations(&registry, &path, &candidates)
+            .await
+            .unwrap();
+        assert_eq!(removed, 0);
+        assert!(registry.read().await.contains_key("dead-watch"));
+        registry
+            .write()
+            .await
+            .get_mut("dead-watch")
+            .unwrap()
+            .active_wrapper_monitor = false;
+        let removed = prune_absent_dynamic_registrations(&registry, &path, &candidates)
+            .await
+            .unwrap();
+        assert_eq!(removed, 0);
+        registry
+            .write()
+            .await
+            .get_mut("dead-watch")
+            .unwrap()
+            .parent_process = None;
         let removed = prune_absent_dynamic_registrations(&registry, &path, &candidates)
             .await
             .unwrap();

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -1149,10 +1149,12 @@ pub async fn remove_tmux_registrations(
     let mut removed = 0;
     for session in sessions {
         let removable = next.get(session).is_none_or(|registration| {
-            registration
-                .lane
-                .as_ref()
-                .is_none_or(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced)
+            registration.registration_source == RegistrationSource::ConfigMonitor
+                || registration
+                    .lane
+                    .as_ref()
+                    .is_some_and(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced)
+                || (registration.lane.is_none() && registration_is_ownerless(registration))
         });
 
         if removable && next.remove(session).is_some() {
@@ -4678,6 +4680,29 @@ error: failed";
             1
         );
         assert!(!registry.read().await.contains_key("retained-lane"));
+    }
+
+    #[tokio::test]
+    async fn remove_tmux_registrations_preserves_owned_dynamic_registration() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let mut owned = registration(Vec::new());
+        owned.session = "owned-runtime".into();
+        owned.registration_source = RegistrationSource::CliWatch;
+        owned.parent_process = Some(ParentProcessInfo {
+            pid: 42,
+            name: Some("clawhip-wrapper".into()),
+        });
+        registry.write().await.insert(owned.session.clone(), owned);
+
+        assert_eq!(
+            remove_tmux_registrations(&registry, &path, &["owned-runtime".into()])
+                .await
+                .unwrap(),
+            0
+        );
+        assert!(registry.read().await.contains_key("owned-runtime"));
     }
 
     #[tokio::test]

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -1060,7 +1060,7 @@ fn restart_reconciles_stale_terminal_watch_registry_without_duplicate_live_watch
                 "registration_source": "cli-watch",
                 "parent_process": null,
                 "registration_generation": 7,
-                "active_wrapper_monitor": true
+                "active_wrapper_monitor": false
             },
             "live-watch": {
                 "session": "live-watch",
@@ -1101,6 +1101,11 @@ fn restart_reconciles_stale_terminal_watch_registry_without_duplicate_live_watch
     let reconciled = registry(&config_path);
     assert!(reconciled.get("stale-watch").is_none());
     assert!(reconciled.get("live-watch").is_some());
+    let health = http_json_value(port, "GET", "/health", json!({}));
+    assert_eq!(health["configured_tmux_monitors"], 0);
+    assert_eq!(health["registered_tmux_sessions"], 1);
+    assert_eq!(health["tmux"]["configured_monitor_count"], 0);
+    assert_eq!(health["tmux"]["registry_registration_count"], 1);
 
     let listed = lane_command(&config_path, &home, &tmux, &discord, &["tmux", "list"]);
     successful(&listed);


### PR DESCRIPTION
## Summary
- expose configured monitor and registry registration counts distinctly in health/status diagnostics
- prune absent dynamic registrations only when ownerless, while retaining active wrapper and parent-process ownership
- preserve explicit retired, quiesced lane cleanup and generation fencing

## Verification
- `cargo test` (848 passed)
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test --test lane_thread_verification restart_reconciles_stale_terminal_watch_registry_without_duplicate_live_watch`

Closes #310