### PR TITLE
feat: add signed HTTP event sink

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,8 +16,8 @@ clawhip v0.3.0 ships a daemon-first event pipeline for Discord delivery. This do
               -> [sources]
               -> [mpsc queue]
               -> [dispatcher]
-              -> [router -> renderer -> discord sink]
-              -> [Discord REST delivery]
+              -> [router -> renderer -> Discord / Slack / HTTP sink]
+              -> [Discord REST / Slack webhook / signed HTTP delivery]
 ```
 
 ## Core components
@@ -74,9 +74,13 @@ That keeps message formatting out of the transport layer and makes the dispatch 
 
 ### Sink (`crate::sink`)
 
-Transport is represented by the `Sink` trait. The sink shipped in v0.3.0 is the Discord sink, which delivers either to a Discord channel or a Discord webhook target.
+Transport is represented by the `Sink` trait. Discord delivers to channels, threads, or Discord
+webhooks; Slack delivers to incoming webhooks; the generic HTTP sink delivers signed normalized
+events to a configured controller endpoint; and the local-file sink appends bounded summaries.
 
-The renderer/sink split is important even with a single shipped sink because it removes transport concerns from routing and event modeling.
+The renderer/sink split keeps transport concerns out of routing and event modeling. Multiple
+matching routes are attempted independently, so one event can fan out to HTTP and Discord and a
+failure at one target does not suppress the remaining deliveries.
 
 ## Configuration model
 
@@ -101,6 +105,26 @@ channel = "1480171113253175356"
 mention = "<@1465264645320474637>"
 format = "compact"
 ```
+
+For direct Clawhip → Hermes delivery, configure one provider endpoint and reference the HMAC
+secret by environment-variable name rather than storing the secret in TOML:
+
+```toml
+[providers.http]
+endpoint = "http://127.0.0.1:8644/webhooks/clawhip-controller"
+hmac_secret_env = "HERMES_CLAWHIP_HMAC_SECRET"
+
+[[routes]]
+event = "*"
+sink = "http"
+```
+
+The HTTP sink serializes a bounded public-safe `clawhip.http-event.v1` body, signs the exact body
+bytes with HMAC-SHA256 in `X-Hub-Signature-256`, and uses the event correlation identity for a
+stable `X-Request-ID`. Plain HTTP is restricted to loopback hosts, HTTPS is allowed for remote
+hosts, and redirects are disabled. Telemetry and provenance retain only a host plus stable
+redacted endpoint fingerprint; secret values, raw response bodies, local paths, and webhook URL
+paths are not emitted. Discord credentials are not required for HTTP-only routing.
 
 ## Delivery semantics
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "futures-util",
  "libc",
  "reqwest",
+ "ring",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio-tungstenite = { version = "0.26", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 futures-util = "0.3"
+ring = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -385,6 +385,48 @@ webhook = "https://hooks.slack.com/services/T.../B.../yyy"
 format = "alert"
 ```
 
+## Signed HTTP webhook setup
+
+The generic `http` sink delivers a normalized, bounded, public-safe JSON event directly to a
+local controller such as Hermes. Discord is optional when every event you intend to deliver is
+covered by HTTP, Slack, local-file, or Discord-webhook routes.
+
+Keep the HMAC secret outside the TOML file and reference its environment-variable name:
+
+```bash
+export HERMES_CLAWHIP_HMAC_SECRET="replace-with-a-random-shared-secret"
+```
+
+```toml
+[providers.http]
+endpoint = "http://127.0.0.1:8644/webhooks/clawhip-controller"
+hmac_secret_env = "HERMES_CLAWHIP_HMAC_SECRET"
+
+[[routes]]
+event = "*"
+sink = "http"
+```
+
+The sink signs the exact transmitted bytes with HMAC-SHA256 and sends the result as
+`X-Hub-Signature-256: sha256=<hex>`. `X-Request-ID` is stable for the normalized event and is
+also present in the body. Plain HTTP is accepted only for loopback endpoints (`127.0.0.0/8`,
+`::1`, or `localhost`); non-loopback endpoints must use HTTPS. Redirects are disabled, response
+bodies and endpoint paths are not copied into errors or telemetry, and raw event payloads,
+credentials, local paths, and webhook URLs are excluded or redacted from the outbound body.
+
+HTTP and Discord can fan out from the same event by adding a second matching route:
+
+```toml
+[[routes]]
+event = "github.*"
+sink = "http"
+
+[[routes]]
+event = "github.*"
+sink = "discord"
+channel = "PROJECT_CHANNEL_ID"
+```
+
 ## System model
 
 ```text
@@ -392,8 +434,8 @@ format = "alert"
               -> [sources]
               -> [mpsc queue]
               -> [dispatcher]
-              -> [router -> renderer -> Discord/Slack sink]
-              -> [Discord REST / Slack webhook delivery]
+              -> [router -> renderer -> Discord/Slack/HTTP sink]
+              -> [Discord REST / Slack webhook / signed HTTP delivery]
 ```
 
 Input sources in v0.3.0:
@@ -796,7 +838,7 @@ non-zero when any destination is missing or not explicitly allowed.
 
 Output is public-safe by design: text and JSON reports include counts, clawhip
 source labels, and channel IDs only. They do not dump gateway tokens, webhook
-URLs, raw config payloads, or unrelated gateway fields. Webhooks, Slack routes,
+URLs, raw config payloads, or unrelated gateway fields. Discord/Slack webhooks, HTTP routes,
 localfile routes, and thread-only targets are outside this allowlist check.
 
 ## Dynamic token contract

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::env;
 use std::ffi::CString;
 use std::fs::{self, File, Metadata, OpenOptions};
 use std::io::{self, Read, Write};
+use std::net::IpAddr;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(unix)]
@@ -316,6 +317,8 @@ pub struct ProvidersConfig {
     pub discord: DiscordConfig,
     #[serde(default)]
     pub slack: SlackConfig,
+    #[serde(default, skip_serializing_if = "HttpConfig::is_empty")]
+    pub http: HttpConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -328,6 +331,14 @@ pub struct DiscordConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SlackConfig {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HttpConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(default, alias = "secret_env", skip_serializing_if = "Option::is_none")]
+    pub hmac_secret_env: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonConfig {
@@ -347,7 +358,7 @@ impl DiscordConfig {
 
 impl ProvidersConfig {
     fn is_empty(&self) -> bool {
-        self.discord.is_empty() && self.slack.is_empty()
+        self.discord.is_empty() && self.slack.is_empty() && self.http.is_empty()
     }
 }
 
@@ -476,6 +487,20 @@ impl SlackConfig {
     }
 }
 
+impl HttpConfig {
+    pub fn endpoint(&self) -> Option<&str> {
+        non_empty_trimmed(self.endpoint.as_deref())
+    }
+
+    pub fn hmac_secret_env(&self) -> Option<&str> {
+        non_empty_trimmed(self.hmac_secret_env.as_deref())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.endpoint().is_none() && self.hmac_secret_env().is_none()
+    }
+}
+
 impl RouteRule {
     pub fn effective_sink(&self) -> &str {
         let sink = self.sink.trim();
@@ -513,7 +538,9 @@ impl RouteRule {
     }
 
     fn has_any_webhook_target(&self) -> bool {
-        self.discord_webhook_target().is_some() || self.slack_webhook_target().is_some()
+        self.discord_webhook_target().is_some()
+            || self.slack_webhook_target().is_some()
+            || self.effective_sink() == "http"
     }
 }
 
@@ -1051,6 +1078,47 @@ fn non_empty_trimmed(value: Option<&str>) -> Option<&str> {
     })
 }
 
+pub(crate) fn validate_http_endpoint(endpoint: &str) -> Result<()> {
+    let url = reqwest::Url::parse(endpoint)
+        .map_err(|_| "providers.http.endpoint must be an absolute http:// or https:// URL")?;
+
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("providers.http.endpoint must not contain credentials".into());
+    }
+    if url.fragment().is_some() {
+        return Err("providers.http.endpoint must not contain a fragment".into());
+    }
+    if url.host_str().is_none() {
+        return Err("providers.http.endpoint must include a host".into());
+    }
+
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" if url_host_is_loopback(&url) => Ok(()),
+        "http" => Err("plain HTTP providers.http.endpoint must use a loopback host".into()),
+        _ => Err("providers.http.endpoint must use http:// or https://".into()),
+    }
+}
+
+fn url_host_is_loopback(url: &reqwest::Url) -> bool {
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    if host.eq_ignore_ascii_case("localhost") || host.eq_ignore_ascii_case("localhost.") {
+        return true;
+    }
+
+    host.trim_matches(['[', ']'])
+        .parse::<IpAddr>()
+        .is_ok_and(|address| address.is_loopback())
+}
+
+fn valid_env_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some('_' | 'A'..='Z' | 'a'..='z'))
+        && chars.all(|ch| matches!(ch, '_' | 'A'..='Z' | 'a'..='z' | '0'..='9'))
+}
+
 fn discord_token_from_env_with<F>(mut get_env: F) -> Option<String>
 where
     F: FnMut(&str) -> Option<String>,
@@ -1376,6 +1444,12 @@ impl AppConfig {
         self.webhook_route_count() > 0
     }
 
+    pub fn has_http_routes(&self) -> bool {
+        self.routes
+            .iter()
+            .any(|route| route.effective_sink() == "http")
+    }
+
     fn has_localfile_routes(&self) -> bool {
         self.routes.iter().any(|route| {
             route.effective_sink() == "localfile" && route.local_file_target().is_some()
@@ -1557,12 +1631,34 @@ impl AppConfig {
             }
         }
 
+        if self.has_http_routes() || !self.providers.http.is_empty() {
+            let endpoint = self.providers.http.endpoint().ok_or_else(|| {
+                "providers.http.endpoint is required when the HTTP sink is configured".to_string()
+            })?;
+            validate_http_endpoint(endpoint)?;
+
+            let secret_env = self.providers.http.hmac_secret_env().ok_or_else(|| {
+                "providers.http.hmac_secret_env is required when the HTTP sink is configured"
+                    .to_string()
+            })?;
+            if !valid_env_var_name(secret_env) {
+                return Err(
+                    "providers.http.hmac_secret_env must be a valid environment variable name"
+                        .into(),
+                );
+            }
+        }
+
         for (index, route) in self.routes.iter().enumerate() {
             let sink = route.effective_sink();
             let has_channel = normalize_secret(route.channel.clone()).is_some();
+            let has_thread_field = normalize_secret(route.thread.clone()).is_some();
             let has_thread = route.discord_thread_target().is_some();
             let has_discord_webhook = route.discord_webhook_target().is_some();
             let has_slack_webhook = route.slack_webhook_target().is_some();
+            let has_webhook_field = normalize_secret(route.webhook.clone()).is_some();
+            let has_slack_webhook_field = normalize_secret(route.slack_webhook.clone()).is_some();
+            let has_local_path = normalize_secret(route.local_path.clone()).is_some();
             if let Some(gajae) = &route.gajae {
                 let subcommand = gajae.subcommand.trim();
                 if subcommand.is_empty() {
@@ -1579,7 +1675,7 @@ impl AppConfig {
                     format!("route #{} ({}) must set a sink", index + 1, route.event).into(),
                 );
             }
-            if !matches!(sink, "discord" | "slack" | "localfile") {
+            if !matches!(sink, "discord" | "slack" | "http" | "localfile") {
                 return Err(format!(
                     "route #{} ({}) uses unsupported sink '{}'",
                     index + 1,
@@ -1649,6 +1745,21 @@ impl AppConfig {
                         .into());
                     }
                 }
+                "http" => {
+                    if has_channel
+                        || has_thread_field
+                        || has_webhook_field
+                        || has_slack_webhook_field
+                        || has_local_path
+                    {
+                        return Err(format!(
+                            "route #{} ({}) cannot set channel/thread/webhook/local_path fields when sink = \"http\"",
+                            index + 1,
+                            route.event
+                        )
+                        .into());
+                    }
+                }
                 _ => unreachable!(),
             }
         }
@@ -1669,7 +1780,7 @@ impl AppConfig {
                 && !self.has_webhook_routes()
             {
                 return Err(format!(
-                    "workspace monitor #{} has no channel and no default Discord destination",
+                    "workspace monitor #{} has no route or default destination",
                     index + 1
                 )
                 .into());
@@ -1718,7 +1829,7 @@ impl AppConfig {
                 && !self.discord_watch.enabled
             {
                 return Err(
-                    "missing Discord delivery config: configure [providers.discord].token (or legacy [discord].token), at least one route webhook, or a localfile route"
+                    "missing delivery config: configure [providers.discord].token (or legacy [discord].token), at least one Discord/Slack/HTTP webhook route, or a localfile route"
                         .into(),
                 );
             }
@@ -2253,6 +2364,14 @@ impl AppConfig {
             self.defaults.channel.as_deref().unwrap_or("<unset>")
         );
         println!("  Webhook routes: {}", self.routes_with_webhooks());
+        println!(
+            "  HTTP sink: {}",
+            if self.providers.http.is_empty() {
+                "<unset>"
+            } else {
+                "configured"
+            }
+        );
         println!("  Default format: {}", self.defaults.format.as_str());
         println!("  Routes: {}", self.routes.len());
         println!("  Git monitors: {}", self.monitors.git.repos.len());
@@ -2264,10 +2383,10 @@ impl AppConfig {
     fn print_template_hint(&self) {
         println!("Advanced routes and monitors are still edited manually in the config file.");
         println!(
-            "Sections: [providers.discord], [dispatch], [daemon], [ledger], [cron], [[cron.jobs]], [[routes]], [[monitors.git.repos]], [[monitors.tmux.sessions]], [[monitors.workspace]]"
+            "Sections: [providers.discord], [providers.http], [dispatch], [daemon], [ledger], [cron], [[cron.jobs]], [[routes]], [[monitors.git.repos]], [[monitors.tmux.sessions]], [[monitors.workspace]]"
         );
         println!(
-            "Routes may set either channel = \"...\" or webhook = \"https://discord.com/api/webhooks/...\"."
+            "Routes may target Discord/Slack webhooks, sink = \"http\" with [providers.http], or sink = \"localfile\"."
         );
         println!(
             r#"Webhook example: [[routes]] event = "tmux.keyword" webhook = "https://discord.com/api/webhooks/...""#
@@ -2282,6 +2401,9 @@ impl AppConfig {
             normalize_secret(self.providers.discord.bot_token.clone());
         self.providers.discord.legacy_default_channel =
             normalize_text(self.providers.discord.legacy_default_channel.clone());
+        self.providers.http.endpoint = normalize_text(self.providers.http.endpoint.clone());
+        self.providers.http.hmac_secret_env =
+            normalize_text(self.providers.http.hmac_secret_env.clone());
         self.defaults.channel = normalize_text(self.defaults.channel.clone());
         self.monitors.github_token = normalize_secret(self.monitors.github_token.clone());
 
@@ -2291,6 +2413,7 @@ impl AppConfig {
             route.channel_name = normalize_text(route.channel_name.clone());
             route.webhook = normalize_text(route.webhook.clone());
             route.slack_webhook = normalize_text(route.slack_webhook.clone());
+            route.local_path = normalize_text(route.local_path.clone());
             route.mention = normalize_text(route.mention.clone());
             route.template = normalize_text(route.template.clone());
             if let Some(gajae) = &mut route.gajae {
@@ -4176,6 +4299,30 @@ mod tests {
     }
 
     #[test]
+    fn config_without_http_provider_remains_backward_compatible() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"
+[providers.discord]
+token = "bot-token"
+
+[[routes]]
+event = "git.commit"
+channel = "ops"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_default(&path).unwrap();
+
+        assert!(config.providers.http.is_empty());
+        assert!(config.validate().is_ok());
+        assert!(!config.to_pretty_toml().unwrap().contains("providers.http"));
+    }
+
+    #[test]
     fn load_or_default_rejects_conflicting_legacy_and_provider_discord() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
@@ -4402,6 +4549,169 @@ thread = "123456789012345678"
     }
 
     #[test]
+    fn http_only_route_satisfies_delivery_validation_without_discord() {
+        let config = AppConfig {
+            providers: ProvidersConfig {
+                http: HttpConfig {
+                    endpoint: Some("http://127.0.0.1:8644/webhooks/clawhip-controller".into()),
+                    hmac_secret_env: Some("HERMES_CLAWHIP_HMAC_SECRET".into()),
+                },
+                ..ProvidersConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "*".into(),
+                sink: "http".into(),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        assert!(config.validate().is_ok(), "{:?}", config.validate().err());
+        assert!(config.has_http_routes());
+        assert_eq!(config.webhook_route_count(), 1);
+    }
+
+    #[test]
+    fn load_or_default_parses_http_provider_and_secret_env_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"
+[providers.http]
+endpoint = "http://127.0.0.1:8644/webhooks/clawhip-controller"
+secret_env = "HERMES_CLAWHIP_HMAC_SECRET"
+
+[[routes]]
+event = "*"
+sink = "http"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_default(&path).unwrap();
+
+        assert_eq!(
+            config.providers.http.endpoint(),
+            Some("http://127.0.0.1:8644/webhooks/clawhip-controller")
+        );
+        assert_eq!(
+            config.providers.http.hmac_secret_env(),
+            Some("HERMES_CLAWHIP_HMAC_SECRET")
+        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn http_endpoint_policy_allows_loopback_http_and_https() {
+        for endpoint in [
+            "http://127.0.0.1:8644/webhooks/clawhip-controller",
+            "http://[::1]:8644/webhooks/clawhip-controller",
+            "http://localhost:8644/webhooks/clawhip-controller",
+            "https://controller.example/webhooks/clawhip-controller",
+        ] {
+            assert!(
+                validate_http_endpoint(endpoint).is_ok(),
+                "endpoint should be allowed: {endpoint}"
+            );
+        }
+    }
+
+    #[test]
+    fn http_endpoint_policy_rejects_non_loopback_plain_http_and_credentials() {
+        let non_loopback = validate_http_endpoint(
+            "http://controller.example/webhooks/clawhip-controller?token=secret",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(non_loopback.contains("loopback"));
+        assert!(!non_loopback.contains("controller.example"));
+        assert!(!non_loopback.contains("secret"));
+
+        let credentials = validate_http_endpoint(
+            "https://user:password@controller.example/webhooks/clawhip-controller",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(credentials.contains("must not contain credentials"));
+        assert!(!credentials.contains("password"));
+        assert!(!credentials.contains("controller.example"));
+    }
+
+    #[test]
+    fn http_route_requires_complete_provider_config() {
+        let missing_endpoint = AppConfig {
+            providers: ProvidersConfig {
+                http: HttpConfig {
+                    endpoint: None,
+                    hmac_secret_env: Some("HERMES_CLAWHIP_HMAC_SECRET".into()),
+                },
+                ..ProvidersConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "*".into(),
+                sink: "http".into(),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        assert!(
+            missing_endpoint
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("providers.http.endpoint is required")
+        );
+
+        let invalid_env = AppConfig {
+            providers: ProvidersConfig {
+                http: HttpConfig {
+                    endpoint: Some("https://controller.example/webhook".into()),
+                    hmac_secret_env: Some("NOT VALID".into()),
+                },
+                ..ProvidersConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "*".into(),
+                sink: "http".into(),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        assert!(
+            invalid_env
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("valid environment variable name")
+        );
+    }
+
+    #[test]
+    fn http_route_rejects_transport_specific_target_fields() {
+        let config = AppConfig {
+            providers: ProvidersConfig {
+                http: HttpConfig {
+                    endpoint: Some("https://controller.example/webhook".into()),
+                    hmac_secret_env: Some("HERMES_CLAWHIP_HMAC_SECRET".into()),
+                },
+                ..ProvidersConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "*".into(),
+                sink: "http".into(),
+                webhook: Some("https://must-not-be-used.example/secret".into()),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("cannot set channel/thread/webhook/local_path"));
+        assert!(!error.contains("must-not-be-used"));
+    }
+
+    #[test]
     fn localfile_route_does_not_bypass_missing_token_for_discord_channel_route() {
         let config = AppConfig {
             routes: vec![
@@ -4457,6 +4767,7 @@ thread = "123456789012345678"
                     legacy_default_channel: None,
                 },
                 slack: SlackConfig::default(),
+                http: HttpConfig::default(),
             },
             routes: vec![RouteRule {
                 event: "tmux.keyword".into(),
@@ -4532,6 +4843,7 @@ thread = "123456789012345678"
                     legacy_default_channel: None,
                 },
                 slack: SlackConfig::default(),
+                http: HttpConfig::default(),
             },
             daemon: DaemonConfig {
                 base_url: "http://127.0.0.1:25294".into(),
@@ -4890,6 +5202,7 @@ message = " ping "
                     legacy_default_channel: None,
                 },
                 slack: SlackConfig::default(),
+                http: HttpConfig::default(),
             },
             cron: CronConfig {
                 poll_interval_secs: 30,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -25,7 +25,7 @@ use crate::native_observability::{
 use crate::render::{DefaultRenderer, Renderer};
 use crate::router::Router;
 
-use crate::sink::{DiscordSink, LocalFileSink, Sink, SlackSink};
+use crate::sink::{DiscordSink, HttpSink, LocalFileSink, Sink, SlackSink};
 use crate::source::tmux::{
     AbsentRegistrationCandidate, prune_absent_dynamic_registrations, session_exists,
 };
@@ -36,7 +36,6 @@ use crate::source::tmux::{
     record_lane_delivery, record_lane_verification, register_lane_registration,
     retire_lane_if_absent, update_lane_evidence, update_lane_workflow,
 };
-
 use crate::source::{
     GitHubSource, GitHubStatusSource, GitMonitorLifecycleCounts, GitSource, RegisteredTmuxSession,
     SharedGitMonitorDiagnostics, SharedTmuxRegistry, Source, SubscriptionSnapshot,
@@ -133,7 +132,11 @@ pub async fn run(
     println!("clawhip v{VERSION} starting (token_source: {token_source})");
     telemetry::emit(daemon_record(
         telemetry::reason::DAEMON_STARTUP,
-        json!({"version": VERSION, "token_source": token_source}),
+        json!({
+            "version": VERSION,
+            "token_source": token_source,
+            "http_routes_configured": config.has_http_routes(),
+        }),
     ));
     if let Some(env_var) = config.discord_token_env_shadow() {
         let warning = discord_token_shadow_warning(env_var);
@@ -151,6 +154,12 @@ pub async fn run(
     );
     sinks.insert("slack".into(), Box::new(SlackSink::default()));
     sinks.insert("localfile".into(), Box::new(LocalFileSink));
+    if config.has_http_routes() {
+        sinks.insert(
+            "http".into(),
+            Box::new(HttpSink::from_config(&config.providers.http)?),
+        );
+    }
     let renderer: Box<dyn Renderer> = Box::new(DefaultRenderer);
     let router = Router::new(config.clone());
     let tmux_registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
@@ -505,6 +514,7 @@ fn health_payload(
         "token_source": config.discord_token_source(),
         "token_precedence_warning": config.discord_token_env_shadow().map(discord_token_shadow_warning),
         "webhook_routes_configured": config.has_webhook_routes(),
+        "http_routes_configured": config.has_http_routes(),
         "port": port,
         "configured_git_monitors": config.monitors.git.repos.len(),
         "git_monitors": git_monitors,
@@ -2860,6 +2870,33 @@ mod tests {
         );
         assert!(payload["native_hooks"]["totals"]["received"].is_number());
         assert_eq!(payload["token_precedence_warning"], Value::Null);
+        assert_eq!(payload["http_routes_configured"], Value::Bool(false));
+    }
+
+    #[test]
+    fn health_payload_reports_http_routes_without_exposing_endpoint() {
+        let mut config = AppConfig::default();
+        config.providers.http.endpoint =
+            Some("https://controller.example/webhooks/clawhip-controller?token=secret".into());
+        config.providers.http.hmac_secret_env = Some("HERMES_CLAWHIP_HMAC_SECRET".into());
+        config.routes.push(RouteRule {
+            event: "*".into(),
+            sink: "http".into(),
+            ..RouteRule::default()
+        });
+
+        let payload = health_payload(
+            &config,
+            25294,
+            0,
+            snapshot_shared(&new_shared_native_hook_observability()),
+        );
+        let rendered = serde_json::to_string(&payload).unwrap();
+
+        assert_eq!(payload["http_routes_configured"], Value::Bool(true));
+        assert!(!rendered.contains("controller.example"));
+        assert!(!rendered.contains("clawhip-controller"));
+        assert!(!rendered.contains("secret"));
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2890,6 +2890,9 @@ mod tests {
             25294,
             0,
             snapshot_shared(&new_shared_native_hook_observability()),
+            json!({}),
+            &[],
+            GitMonitorLifecycleCounts::default(),
         );
         let rendered = serde_json::to_string(&payload).unwrap();
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -251,6 +251,9 @@ impl DiscordClient {
                 SinkTarget::SlackWebhook(_) => {
                     return Err("cannot send Slack webhook via Discord client".into());
                 }
+                SinkTarget::HttpEndpoint(_) => {
+                    return Err("cannot send HTTP target via Discord client".into());
+                }
                 SinkTarget::LocalFile(_) => {
                     return Err("cannot send localfile target via Discord client".into());
                 }
@@ -981,6 +984,7 @@ fn target_rate_limit_key(target: &SinkTarget) -> String {
         SinkTarget::DiscordThread(thread_id) => format!("discord:thread:{thread_id}"),
         SinkTarget::DiscordWebhook(webhook_url) => format!("discord:webhook:{webhook_url}"),
         SinkTarget::SlackWebhook(webhook_url) => format!("slack:webhook:{webhook_url}"),
+        SinkTarget::HttpEndpoint(endpoint) => format!("http:endpoint:{endpoint}"),
         SinkTarget::LocalFile(path) => format!("localfile:{path}"),
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1139,6 +1139,7 @@ fn sink_target_key(target: &SinkTarget) -> String {
         SinkTarget::DiscordThread(thread) => format!("discord-thread:{thread}"),
         SinkTarget::DiscordWebhook(webhook) => format!("discord-webhook:{webhook}"),
         SinkTarget::SlackWebhook(webhook) => format!("slack-webhook:{webhook}"),
+        SinkTarget::HttpEndpoint(endpoint) => format!("http-endpoint:{endpoint}"),
         SinkTarget::LocalFile(path) => format!("localfile:{path}"),
     }
 }
@@ -1156,10 +1157,10 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::config::{AppConfig, RouteRule};
+    use crate::config::{AppConfig, HttpConfig, ProvidersConfig, RouteRule};
     use crate::native_observability::new_shared_native_hook_observability;
     use crate::render::DefaultRenderer;
-    use crate::sink::{DiscordSink, SlackSink};
+    use crate::sink::{DiscordSink, HttpSink, SlackSink};
     use tempfile::tempdir;
 
     fn dummy_queued_delivery() -> QueuedRoutineDelivery {
@@ -1507,6 +1508,88 @@ mod tests {
             request.contains("\"text\":\"🚨 tmux session issue-28 hit keyword 'error': boom\"")
         );
         assert!(request.contains("\"blocks\""));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_fans_out_to_signed_http_and_discord() {
+        use tokio::time::{Duration, timeout};
+
+        let (http_endpoint, mut http_requests, http_server) = spawn_webhook_collector(1).await;
+        let (discord_webhook, mut discord_requests, discord_server) =
+            spawn_webhook_collector(1).await;
+        let config = AppConfig {
+            providers: ProvidersConfig {
+                http: HttpConfig {
+                    endpoint: Some(http_endpoint),
+                    hmac_secret_env: Some("HERMES_CLAWHIP_HMAC_SECRET".into()),
+                },
+                ..ProvidersConfig::default()
+            },
+            routes: vec![
+                RouteRule {
+                    event: "tmux.keyword".into(),
+                    sink: "http".into(),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "tmux.keyword".into(),
+                    sink: "discord".into(),
+                    webhook: Some(discord_webhook),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+        let (tx, rx) = mpsc::channel(1);
+        let router = Router::new(Arc::new(config));
+        let mut sinks: HashMap<String, Box<dyn Sink>> = HashMap::new();
+        sinks.insert(
+            "http".into(),
+            Box::new(HttpSink::new(b"shared-secret").unwrap()),
+        );
+        sinks.insert(
+            "discord".into(),
+            Box::new(DiscordSink::from_config(Arc::new(AppConfig::default())).unwrap()),
+        );
+        let mut dispatcher = Dispatcher::new(
+            rx,
+            router,
+            Box::new(DefaultRenderer),
+            sinks,
+            Duration::from_secs(30),
+            None,
+            new_shared_native_hook_observability(),
+        );
+        let task = tokio::spawn(async move { dispatcher.run().await.unwrap() });
+
+        tx.send(IncomingEvent::tmux_keyword(
+            "issue-301".into(),
+            "error".into(),
+            "boom".into(),
+            None,
+        ))
+        .await
+        .unwrap();
+        drop(tx);
+        task.await.unwrap();
+
+        let http_request = timeout(Duration::from_secs(2), http_requests.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let discord_request = timeout(Duration::from_secs(2), discord_requests.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        http_server.await.unwrap();
+        discord_server.await.unwrap();
+
+        let lower_http = http_request.to_ascii_lowercase();
+        assert!(lower_http.contains("x-hub-signature-256: sha256="));
+        assert!(lower_http.contains("x-request-id:"));
+        assert!(http_request.contains("\"schema\":\"clawhip.http-event.v1\""));
+        assert!(http_request.contains("\"type\":\"tmux.keyword\""));
+        assert!(discord_request.contains("\"content\":\"tmux:issue-301 matched 'error' => boom\""));
     }
 
     #[tokio::test]

--- a/src/gateway_allowlist.rs
+++ b/src/gateway_allowlist.rs
@@ -422,6 +422,11 @@ mod tests {
                     ..RouteRule::default()
                 },
                 RouteRule {
+                    event: "http".into(),
+                    sink: "http".into(),
+                    ..RouteRule::default()
+                },
+                RouteRule {
                     event: "thread".into(),
                     thread: Some("999".into()),
                     ..RouteRule::default()

--- a/src/router.rs
+++ b/src/router.rs
@@ -247,6 +247,7 @@ impl Router {
             SinkTarget::DiscordThread(_)
             | SinkTarget::DiscordWebhook(_)
             | SinkTarget::SlackWebhook(_)
+            | SinkTarget::HttpEndpoint(_)
             | SinkTarget::LocalFile(_) => Err("matched route uses a non-channel target".into()),
         }
     }
@@ -412,6 +413,19 @@ impl Router {
                     )
                     .into()
                 }),
+            "http" => self
+                .config
+                .providers
+                .http
+                .endpoint()
+                .map(|endpoint| SinkTarget::HttpEndpoint(endpoint.to_string()))
+                .ok_or_else(|| {
+                    format!(
+                        "no HTTP endpoint configured for event {}",
+                        event.canonical_kind()
+                    )
+                    .into()
+                }),
             "localfile" => route
                 .and_then(RouteRule::local_file_target)
                 .map(|path| SinkTarget::LocalFile(path.to_string()))
@@ -502,10 +516,11 @@ fn delivery_explanation(
         SinkTarget::DiscordChannel(name) => {
             (format!("DiscordChannel({name:?})"), Some(name.clone()))
         }
-        SinkTarget::DiscordThread(_) => (telemetry::safe_target_id(&delivery.target), None),
-        SinkTarget::DiscordWebhook(url) => (format!("DiscordWebhook({url})"), None),
-        SinkTarget::SlackWebhook(url) => (format!("SlackWebhook({url})"), None),
-        SinkTarget::LocalFile(path) => (format!("LocalFile({path})"), None),
+        SinkTarget::DiscordThread(_)
+        | SinkTarget::DiscordWebhook(_)
+        | SinkTarget::SlackWebhook(_)
+        | SinkTarget::HttpEndpoint(_)
+        | SinkTarget::LocalFile(_) => (telemetry::safe_target_id(&delivery.target), None),
     };
 
     DeliveryExplanation {
@@ -720,7 +735,7 @@ pub(crate) fn cap_to_discord_limit(content: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{DefaultsConfig, RouteRule};
+    use crate::config::{DefaultsConfig, HttpConfig, ProvidersConfig, RouteRule};
     use crate::events::{RoutingMetadata, normalize_event};
     use crate::render::DefaultRenderer;
     use crate::sink::{DiscordSink, SlackSink};
@@ -824,6 +839,42 @@ mod tests {
             SinkTarget::LocalFile("/tmp/clawhip/events.jsonl".into())
         );
         assert_eq!(delivery.trace.result, RouteTraceResult::Matched);
+    }
+
+    #[tokio::test]
+    async fn resolve_http_route_uses_provider_endpoint_and_redacted_trace() {
+        let endpoint = "https://controller.example/webhooks/clawhip-controller?token=secret";
+        let config = AppConfig {
+            providers: ProvidersConfig {
+                http: HttpConfig {
+                    endpoint: Some(endpoint.into()),
+                    hmac_secret_env: Some("HERMES_CLAWHIP_HMAC_SECRET".into()),
+                },
+                ..ProvidersConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "tmux.keyword".into(),
+                sink: "http".into(),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+        let event =
+            IncomingEvent::tmux_keyword("issue-301".into(), "error".into(), "boom".into(), None);
+
+        let delivery = router.preview_delivery(&event).await.unwrap();
+
+        assert_eq!(delivery.sink, "http");
+        assert_eq!(delivery.target, SinkTarget::HttpEndpoint(endpoint.into()));
+        assert!(
+            delivery
+                .trace
+                .target
+                .starts_with("http:endpoint:controller.example/redacted/")
+        );
+        assert!(!delivery.trace.target.contains("clawhip-controller"));
+        assert!(!delivery.trace.target.contains("secret"));
     }
 
     #[tokio::test]
@@ -3079,5 +3130,25 @@ mod tests {
             "Discord channel delivery must be capped"
         );
         assert!(content.ends_with('…'));
+        let router = Router::new(Arc::new(config));
+        let event = IncomingEvent {
+            kind: "session.finished".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({"session_id":"sess-1"}),
+        };
+
+        let provenance = router.explain(&event);
+        let text = provenance.to_string();
+        let serialized = serde_json::to_string(&provenance).unwrap();
+
+        for rendered in [text, serialized] {
+            assert!(rendered.contains("http:endpoint:controller.example/redacted/"));
+            assert!(!rendered.contains("clawhip-controller"));
+            assert!(!rendered.contains("secret"));
+            assert!(!rendered.contains(endpoint));
+        }
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -3130,6 +3130,26 @@ mod tests {
             "Discord channel delivery must be capped"
         );
         assert!(content.ends_with('…'));
+    }
+
+    #[test]
+    fn explain_redacts_http_endpoint_in_text_and_json() {
+        let endpoint = "https://controller.example/webhooks/clawhip-controller?token=secret";
+        let config = AppConfig {
+            providers: ProvidersConfig {
+                http: HttpConfig {
+                    endpoint: Some(endpoint.into()),
+                    hmac_secret_env: Some("HERMES_CLAWHIP_HMAC_SECRET".into()),
+                },
+                ..ProvidersConfig::default()
+            },
+            routes: vec![RouteRule {
+                event: "session.*".into(),
+                sink: "http".into(),
+                ..RouteRule::default()
+            }],
+            ..AppConfig::default()
+        };
         let router = Router::new(Arc::new(config));
         let event = IncomingEvent {
             kind: "session.finished".into(),

--- a/src/sink/http.rs
+++ b/src/sink/http.rs
@@ -1,0 +1,1035 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::redirect::Policy;
+use ring::{digest, hmac};
+use serde_json::{Map, Value, json};
+use time::{OffsetDateTime, UtcOffset, format_description::well_known::Rfc3339};
+
+use crate::Result;
+use crate::config::{HttpConfig, validate_http_endpoint};
+use crate::telemetry;
+
+use super::{Sink, SinkMessage, SinkTarget};
+
+const EVENT_SCHEMA: &str = "clawhip.http-event.v1";
+const MAX_EVENT_BODY_BYTES: usize = 16 * 1024;
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_SUMMARY_CHARS: usize = 1_024;
+const MAX_PUBLIC_STRING_CHARS: usize = 512;
+const MAX_EVENT_TIMESTAMP_BYTES: usize = 35;
+const MAX_PUBLIC_FIELDS: usize = 48;
+const MAX_PUBLIC_ARRAY_ITEMS: usize = 16;
+const MAX_PUBLIC_DEPTH: usize = 3;
+const FALLBACK_EVENT_TIMESTAMP: &str = "1970-01-01T00:00:00Z";
+
+#[derive(Clone)]
+pub struct HttpSink {
+    client: reqwest::Client,
+    secret: Arc<[u8]>,
+}
+
+impl HttpSink {
+    pub fn new(secret: impl AsRef<[u8]>) -> Result<Self> {
+        Self::with_request_timeout(secret, HTTP_REQUEST_TIMEOUT)
+    }
+
+    fn with_request_timeout(secret: impl AsRef<[u8]>, timeout: Duration) -> Result<Self> {
+        let secret = secret.as_ref();
+        if secret.is_empty() {
+            return Err("HTTP sink HMAC secret must not be empty".into());
+        }
+
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .redirect(Policy::none())
+                .timeout(timeout)
+                .build()?,
+            secret: Arc::from(secret),
+        })
+    }
+
+    pub fn from_config(config: &HttpConfig) -> Result<Self> {
+        let endpoint = config
+            .endpoint()
+            .ok_or_else(|| "providers.http.endpoint is required for the HTTP sink".to_string())?;
+        validate_http_endpoint(endpoint)?;
+
+        let secret_env = config.hmac_secret_env().ok_or_else(|| {
+            "providers.http.hmac_secret_env is required for the HTTP sink".to_string()
+        })?;
+        let secret = std::env::var(secret_env).map_err(|_| {
+            format!(
+                "HTTP sink HMAC secret environment variable {secret_env} is not set or is not valid UTF-8"
+            )
+        })?;
+        if secret.is_empty() {
+            return Err(format!(
+                "HTTP sink HMAC secret environment variable {secret_env} is empty"
+            )
+            .into());
+        }
+
+        Self::new(secret.as_bytes())
+    }
+}
+
+#[async_trait]
+impl Sink for HttpSink {
+    async fn send(&self, target: &SinkTarget, message: &SinkMessage) -> Result<()> {
+        let SinkTarget::HttpEndpoint(endpoint) = target else {
+            return Err("HTTP sink received a non-HTTP target".into());
+        };
+        validate_http_endpoint(endpoint)?;
+
+        let request_id = request_id_for_message(message);
+        let body = event_body(message, target, &request_id)?;
+        let body_bytes = body.len();
+        let signature = hmac_signature(&self.secret, &body);
+        emit_http_telemetry(
+            telemetry::event_name::HTTP_SEND_ATTEMPT,
+            telemetry::reason::HTTP_PRE_SEND,
+            message,
+            target,
+            &request_id,
+            body_bytes,
+            None,
+        );
+
+        let response = match self
+            .client
+            .post(endpoint)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header("X-Hub-Signature-256", signature)
+            .header("X-Request-ID", &request_id)
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(_) => {
+                emit_http_telemetry(
+                    telemetry::event_name::HTTP_SEND_FAILURE,
+                    telemetry::reason::HTTP_TRANSPORT_ERROR,
+                    message,
+                    target,
+                    &request_id,
+                    body_bytes,
+                    None,
+                );
+                return Err("HTTP sink request failed before receiving a response".into());
+            }
+        };
+
+        let status = response.status();
+        if status.is_success() {
+            emit_http_telemetry(
+                telemetry::event_name::HTTP_SEND_SUCCESS,
+                telemetry::reason::HTTP_SUCCESS,
+                message,
+                target,
+                &request_id,
+                body_bytes,
+                Some(status.as_u16()),
+            );
+            return Ok(());
+        }
+
+        emit_http_telemetry(
+            telemetry::event_name::HTTP_SEND_FAILURE,
+            telemetry::reason::HTTP_STATUS_ERROR,
+            message,
+            target,
+            &request_id,
+            body_bytes,
+            Some(status.as_u16()),
+        );
+        Err(format!("HTTP sink request failed with status {}", status.as_u16()).into())
+    }
+}
+
+fn event_body(message: &SinkMessage, target: &SinkTarget, request_id: &str) -> Result<Vec<u8>> {
+    let mut state = NormalizationState::default();
+    let timestamp = event_timestamp(&message.payload);
+    let payload = normalize_payload(&message.payload, &mut state);
+    let summary = public_text(&message.content, MAX_SUMMARY_CHARS, &mut state);
+    let source = message
+        .event_kind
+        .split('.')
+        .next()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("custom");
+    let provenance = message.telemetry.as_ref().map(|context| {
+        json!({
+            "route_result": context.route_result,
+            "route_index": context.route_index,
+            "target": telemetry::safe_target_id(target),
+            "batch_count": context.batch_count,
+        })
+    });
+
+    let mut value = json!({
+        "schema": EVENT_SCHEMA,
+        "request_id": request_id,
+        "timestamp": timestamp,
+        "type": bounded_identifier(&message.event_kind, 160),
+        "source": bounded_identifier(source, 80),
+        "format": message.format.as_str(),
+        "summary": summary,
+        "payload": payload,
+        "provenance": provenance,
+        "target": telemetry::safe_target_id(target),
+        "public_safe": true,
+        "redacted": state.redacted,
+        "truncated": state.truncated,
+    });
+
+    let mut body = serde_json::to_vec(&value)?;
+    if body.len() > MAX_EVENT_BODY_BYTES {
+        value["summary"] = json!(truncate_chars(
+            value["summary"].as_str().unwrap_or_default(),
+            256
+        ));
+        value["payload"] = json!({"truncated": true});
+        value["truncated"] = json!(true);
+        body = serde_json::to_vec(&value)?;
+    }
+    if body.len() > MAX_EVENT_BODY_BYTES {
+        return Err("normalized HTTP event body exceeds the public-safe size limit".into());
+    }
+
+    Ok(body)
+}
+
+fn event_timestamp(payload: &Value) -> String {
+    ["event_timestamp", "timestamp", "first_seen_at"]
+        .into_iter()
+        .filter_map(|key| payload.get(key))
+        .find_map(canonical_timestamp)
+        .unwrap_or_else(|| FALLBACK_EVENT_TIMESTAMP.to_string())
+}
+
+fn canonical_timestamp(value: &Value) -> Option<String> {
+    let parsed = match value {
+        Value::String(value) => parse_timestamp(value),
+        Value::Number(value) => value.as_i64().and_then(timestamp_from_unix_integer),
+        _ => None,
+    }?;
+    let formatted = parsed.to_offset(UtcOffset::UTC).format(&Rfc3339).ok()?;
+
+    (formatted.len() <= MAX_EVENT_TIMESTAMP_BYTES).then_some(formatted)
+}
+
+fn parse_timestamp(value: &str) -> Option<OffsetDateTime> {
+    let value = value.trim();
+    OffsetDateTime::parse(value, &Rfc3339).ok().or_else(|| {
+        value
+            .parse::<i64>()
+            .ok()
+            .and_then(timestamp_from_unix_integer)
+    })
+}
+
+fn timestamp_from_unix_integer(value: i64) -> Option<OffsetDateTime> {
+    let seconds = if value.unsigned_abs() >= 10_000_000_000 {
+        value / 1_000
+    } else {
+        value
+    };
+    OffsetDateTime::from_unix_timestamp(seconds).ok()
+}
+
+#[derive(Default)]
+struct NormalizationState {
+    redacted: bool,
+    truncated: bool,
+}
+
+fn normalize_payload(payload: &Value, state: &mut NormalizationState) -> Value {
+    normalize_public_value(None, payload, 0, state).unwrap_or_else(|| json!({}))
+}
+
+fn normalize_public_value(
+    key: Option<&str>,
+    value: &Value,
+    depth: usize,
+    state: &mut NormalizationState,
+) -> Option<Value> {
+    if depth > MAX_PUBLIC_DEPTH {
+        state.truncated = true;
+        return None;
+    }
+
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) => {
+            let key = key?;
+            if is_public_scalar_field(key) {
+                Some(value.clone())
+            } else {
+                state.redacted = true;
+                None
+            }
+        }
+        Value::String(value) => {
+            let key = key?;
+            if is_url_field(key) {
+                Some(json!(public_url(value, state)))
+            } else if is_public_text_field(key) {
+                Some(json!(public_text(value, MAX_PUBLIC_STRING_CHARS, state)))
+            } else {
+                state.redacted = true;
+                None
+            }
+        }
+        Value::Array(values) => {
+            let key = key?;
+            if !is_public_array_field(key) {
+                state.redacted = true;
+                return None;
+            }
+
+            if values.len() > MAX_PUBLIC_ARRAY_ITEMS {
+                state.truncated = true;
+            }
+            let values = values
+                .iter()
+                .take(MAX_PUBLIC_ARRAY_ITEMS)
+                .filter_map(|value| match value {
+                    Value::String(value) => {
+                        Some(json!(public_text(value, MAX_PUBLIC_STRING_CHARS, state)))
+                    }
+                    _ => normalize_public_value(None, value, depth + 1, state),
+                })
+                .collect();
+            Some(Value::Array(values))
+        }
+        Value::Object(object) => {
+            if key.is_some() {
+                state.redacted = true;
+                return None;
+            }
+            let mut safe = Map::new();
+            if object.len() > MAX_PUBLIC_FIELDS {
+                state.truncated = true;
+            }
+            for (key, value) in object {
+                if safe.len() >= MAX_PUBLIC_FIELDS {
+                    state.truncated = true;
+                    break;
+                }
+                if is_sensitive_field(key) {
+                    state.redacted = true;
+                    continue;
+                }
+                if let Some(value) = normalize_public_value(Some(key), value, depth + 1, state) {
+                    safe.insert(key.clone(), value);
+                } else if matches!(value, Value::Object(_) | Value::Array(_)) {
+                    state.redacted = true;
+                }
+            }
+            Some(Value::Object(safe))
+        }
+    }
+}
+
+fn is_public_text_field(key: &str) -> bool {
+    matches!(
+        key,
+        "action"
+            | "actor"
+            | "agent_name"
+            | "branch"
+            | "commit"
+            | "conclusion"
+            | "contract"
+            | "contract_event"
+            | "correlation_id"
+            | "event"
+            | "event_id"
+            | "event_kind"
+            | "event_name"
+            | "error_message"
+            | "error_summary"
+            | "first_seen_at"
+            | "hook_event_name"
+            | "id"
+            | "keyword"
+            | "line"
+            | "last_line"
+            | "message"
+            | "name"
+            | "new_branch"
+            | "new_status"
+            | "normalized_event"
+            | "observation_confidence"
+            | "observation_source"
+            | "old_branch"
+            | "old_status"
+            | "project"
+            | "provider"
+            | "question_summary"
+            | "repo"
+            | "repo_name"
+            | "route_key"
+            | "session"
+            | "session_id"
+            | "session_name"
+            | "sha"
+            | "short_commit"
+            | "source"
+            | "state_family"
+            | "status"
+            | "summary"
+            | "summary_text"
+            | "tag"
+            | "title"
+            | "tool_name"
+            | "workflow"
+    )
+}
+
+fn is_url_field(key: &str) -> bool {
+    matches!(key, "url" | "pr_url")
+}
+
+fn is_public_scalar_field(key: &str) -> bool {
+    matches!(
+        key,
+        "active_sessions_needing_action"
+            | "approval_hold"
+            | "batch_count"
+            | "comments"
+            | "commit_count"
+            | "count"
+            | "elapsed_secs"
+            | "fallback_evidence"
+            | "hit_count"
+            | "is_prerelease"
+            | "issue_number"
+            | "local_only"
+            | "minutes"
+            | "number"
+            | "open_issues"
+            | "open_prs"
+            | "pr_number"
+            | "release_hold"
+            | "run_job_count"
+            | "zero_backlog"
+    )
+}
+
+fn is_public_array_field(key: &str) -> bool {
+    matches!(key, "commits" | "event_kinds" | "hits" | "reasons")
+}
+
+fn is_sensitive_field(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+        || key.contains("passwd")
+        || key.contains("authorization")
+        || key.contains("credential")
+        || key.contains("cookie")
+        || key.contains("webhook")
+        || key.ends_with("_path")
+        || matches!(
+            key.as_str(),
+            "command"
+                | "cwd"
+                | "directory"
+                | "event_payload"
+                | "payload"
+                | "raw"
+                | "tool_input"
+                | "tool_response"
+                | "transcript_path"
+                | "worktree_path"
+        )
+}
+
+fn public_text(value: &str, max_chars: usize, state: &mut NormalizationState) -> String {
+    let mut collapsed = String::with_capacity(value.len().min(max_chars));
+    let mut previous_space = false;
+    let mut output_chars = 0;
+    let max_scanned_chars = max_chars.saturating_mul(4).max(max_chars);
+    for (index, ch) in value.chars().enumerate() {
+        if index >= max_scanned_chars || output_chars > max_chars {
+            state.truncated = true;
+            break;
+        }
+        let normalized = if ch.is_control() || ch.is_whitespace() {
+            ' '
+        } else {
+            ch
+        };
+        if normalized == ' ' {
+            if previous_space {
+                continue;
+            }
+            previous_space = true;
+        } else {
+            previous_space = false;
+        }
+        collapsed.push(normalized);
+        output_chars += 1;
+    }
+
+    let redacted_urls = redact_urls_in_text(collapsed.trim(), state);
+    let redacted_secrets = redact_secret_assignments(&redacted_urls, state);
+    if redacted_secrets.chars().count() > max_chars {
+        state.truncated = true;
+    }
+    truncate_chars(&redacted_secrets, max_chars)
+}
+
+fn redact_urls_in_text(value: &str, state: &mut NormalizationState) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut remainder = value;
+
+    loop {
+        let lower = remainder.to_ascii_lowercase();
+        let http = lower.find("http://");
+        let https = lower.find("https://");
+        let Some(start) = (match (http, https) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            (Some(index), None) | (None, Some(index)) => Some(index),
+            (None, None) => None,
+        }) else {
+            output.push_str(remainder);
+            break;
+        };
+
+        output.push_str(&remainder[..start]);
+        let url_and_rest = &remainder[start..];
+        let end = url_and_rest
+            .find(char::is_whitespace)
+            .unwrap_or(url_and_rest.len());
+        let token = &url_and_rest[..end];
+        let trimmed = token.trim_end_matches(['.', ',', ';', ':', ')', ']', '}', '>', '\'', '"']);
+        let suffix = &token[trimmed.len()..];
+        output.push_str(&public_url(trimmed, state));
+        output.push_str(suffix);
+        remainder = &url_and_rest[end..];
+    }
+
+    output
+}
+
+fn redact_secret_assignments(value: &str, state: &mut NormalizationState) -> String {
+    value
+        .split(' ')
+        .map(|word| {
+            let lower = word.to_ascii_lowercase();
+            for marker in [
+                "authorization:",
+                "authorization=",
+                "password=",
+                "passwd=",
+                "secret=",
+                "token=",
+            ] {
+                if let Some(index) = lower.find(marker) {
+                    state.redacted = true;
+                    return format!(
+                        "{}{}[redacted]",
+                        &word[..index],
+                        &word[index..index + marker.len()]
+                    );
+                }
+            }
+            word.to_string()
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn public_url(value: &str, state: &mut NormalizationState) -> String {
+    let Ok(mut url) = reqwest::Url::parse(value) else {
+        state.redacted = true;
+        return "[redacted-url]".to_string();
+    };
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        state.redacted = true;
+        return "[redacted-url]".to_string();
+    }
+
+    let path = url.path().to_ascii_lowercase();
+    let sensitive = !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || path.contains("/webhook")
+        || path.contains("/hooks/")
+        || path.contains("token")
+        || path.contains("secret")
+        || path.contains("signature");
+    if sensitive {
+        state.redacted = true;
+        return format!(
+            "{}://{}",
+            url.scheme(),
+            telemetry::redacted_url_fingerprint(value)
+        );
+    }
+
+    url.set_query(None);
+    url.set_fragment(None);
+    truncate_chars(url.as_str(), MAX_PUBLIC_STRING_CHARS)
+}
+
+fn request_id_for_message(message: &SinkMessage) -> String {
+    let candidate = message
+        .telemetry
+        .as_ref()
+        .map(|context| context.correlation_id.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| {
+            telemetry::correlation_id_for_message(&message.event_kind, &message.payload)
+        });
+
+    if candidate.len() <= 128
+        && !candidate.is_empty()
+        && candidate.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':' | b'/')
+        })
+    {
+        return candidate;
+    }
+
+    let digest = digest::digest(&digest::SHA256, candidate.as_bytes());
+    format!("clawhip-{}", hex(digest.as_ref()))
+}
+
+fn bounded_identifier(value: &str, max_chars: usize) -> String {
+    let normalized = value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':'))
+        .collect::<String>();
+    truncate_chars(&normalized, max_chars)
+}
+
+fn hmac_signature(secret: &[u8], body: &[u8]) -> String {
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+    let signature = hmac::sign(&key, body);
+    format!("sha256={}", hex(signature.as_ref()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+
+    let mut truncated = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    truncated.push('…');
+    truncated
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_http_telemetry(
+    event_name: &str,
+    reason_code: &str,
+    message: &SinkMessage,
+    target: &SinkTarget,
+    request_id: &str,
+    body_bytes: usize,
+    status: Option<u16>,
+) {
+    let correlation_id = message
+        .telemetry
+        .as_ref()
+        .map(|context| context.correlation_id.clone())
+        .unwrap_or_else(|| {
+            telemetry::correlation_id_for_message(&message.event_kind, &message.payload)
+        });
+    let mut record = telemetry::record(event_name, reason_code, correlation_id);
+    record.insert(
+        "target".to_string(),
+        json!(telemetry::safe_target_id(target)),
+    );
+    record.insert("request_id".to_string(), json!(request_id));
+    record.insert("event_kind".to_string(), json!(message.event_kind));
+    record.insert("format".to_string(), json!(message.format.as_str()));
+    record.insert("body_bytes".to_string(), json!(body_bytes));
+    record.insert("status".to_string(), json!(status));
+    if let Some(context) = &message.telemetry {
+        record.insert("route_result".to_string(), json!(context.route_result));
+        record.insert("route_index".to_string(), json!(context.route_index));
+        record.insert("batch_count".to_string(), json!(context.batch_count));
+    }
+    telemetry::emit(record);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::MessageFormat;
+    use crate::sink::SinkTelemetry;
+    use serial_test::serial;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::time::{Duration, timeout};
+
+    fn message() -> SinkMessage {
+        SinkMessage {
+            event_kind: "session.finished".into(),
+            format: MessageFormat::Compact,
+            content: "done https://example.test/public token=hidden".into(),
+            payload: json!({
+                "event_id": "evt-1",
+                "repo_name": "clawhip",
+                "session_id": "sess-1",
+                "summary": "complete",
+                "url": "https://example.test/result?token=private",
+                "repo_path": "/private/repo",
+                "api_token": "must-not-leak",
+                "event_payload": {"raw": "must-not-leak"}
+            }),
+            telemetry: Some(SinkTelemetry {
+                correlation_id: "request-123".into(),
+                route_result: Some("matched".into()),
+                route_index: Some(1),
+                target: "http:example.test/redacted/1234".into(),
+                batch_count: None,
+            }),
+        }
+    }
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) -> (String, Vec<u8>) {
+        let mut bytes = Vec::new();
+        let mut buffer = [0_u8; 2048];
+        let header_end;
+        loop {
+            let count = stream.read(&mut buffer).await.unwrap();
+            assert!(count > 0, "connection closed before request headers");
+            bytes.extend_from_slice(&buffer[..count]);
+            if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                header_end = index + 4;
+                break;
+            }
+        }
+
+        let headers = String::from_utf8_lossy(&bytes[..header_end]).to_string();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().unwrap())
+            })
+            .unwrap_or_default();
+        while bytes.len() < header_end + content_length {
+            let count = stream.read(&mut buffer).await.unwrap();
+            assert!(count > 0, "connection closed before request body");
+            bytes.extend_from_slice(&buffer[..count]);
+        }
+
+        (
+            headers,
+            bytes[header_end..header_end + content_length].to_vec(),
+        )
+    }
+
+    #[test]
+    fn hmac_sha256_matches_known_vector() {
+        assert_eq!(
+            hmac_signature(b"key", b"The quick brown fox jumps over the lazy dog"),
+            "sha256=f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"
+        );
+    }
+
+    #[test]
+    fn request_id_is_stable_and_header_safe() {
+        let message = message();
+        assert_eq!(request_id_for_message(&message), "request-123");
+        assert_eq!(
+            request_id_for_message(&message),
+            request_id_for_message(&message)
+        );
+
+        let mut unsafe_message = message;
+        unsafe_message.telemetry.as_mut().unwrap().correlation_id =
+            "private request\r\nX-Injected: yes".into();
+        let request_id = request_id_for_message(&unsafe_message);
+        assert!(request_id.starts_with("clawhip-"));
+        assert_eq!(request_id.len(), "clawhip-".len() + 64);
+        assert!(
+            request_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        );
+        assert_eq!(request_id, request_id_for_message(&unsafe_message));
+    }
+
+    #[test]
+    fn normalized_body_is_bounded_and_public_safe() {
+        let target = SinkTarget::HttpEndpoint(
+            "https://controller.example/webhooks/clawhip-controller?token=endpoint-secret".into(),
+        );
+        let mut message = message();
+        message.content = format!("{} https://hooks.example/secret/token", "x".repeat(30_000));
+
+        let body = event_body(&message, &target, "request-123").unwrap();
+        let parsed: Value = serde_json::from_slice(&body).unwrap();
+        let rendered = String::from_utf8(body.clone()).unwrap();
+
+        assert!(body.len() <= MAX_EVENT_BODY_BYTES);
+        assert_eq!(parsed["schema"], EVENT_SCHEMA);
+        assert_eq!(parsed["request_id"], "request-123");
+        assert_eq!(parsed["timestamp"], FALLBACK_EVENT_TIMESTAMP);
+        assert_eq!(parsed["type"], "session.finished");
+        assert_eq!(parsed["source"], "session");
+        assert_eq!(parsed["payload"]["repo_name"], "clawhip");
+        assert!(parsed["payload"].get("repo_path").is_none());
+        assert!(parsed["payload"].get("api_token").is_none());
+        assert!(parsed["payload"].get("event_payload").is_none());
+        assert!(parsed["truncated"].as_bool().unwrap());
+        assert!(parsed["redacted"].as_bool().unwrap());
+        for secret in [
+            "/private/repo",
+            "must-not-leak",
+            "endpoint-secret",
+            "https://controller.example/webhooks/clawhip-controller",
+        ] {
+            assert!(!rendered.contains(secret), "body leaked {secret}");
+        }
+    }
+
+    #[test]
+    fn top_level_timestamp_prefers_valid_event_timestamp_then_timestamp() {
+        let target = SinkTarget::HttpEndpoint("https://controller.example/events".into());
+        let mut message = message();
+        message.payload["event_timestamp"] = json!("2026-08-17T12:34:56+09:00");
+        message.payload["timestamp"] = json!("2026-08-17T04:05:06Z");
+
+        let body = event_body(&message, &target, "request-123").unwrap();
+        let parsed: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(parsed["timestamp"], "2026-08-17T03:34:56Z");
+        assert!(parsed["timestamp"].as_str().unwrap().len() <= MAX_EVENT_TIMESTAMP_BYTES);
+
+        message.payload["event_timestamp"] = json!("not-a-timestamp");
+        let body = event_body(&message, &target, "request-123").unwrap();
+        let parsed: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(parsed["timestamp"], "2026-08-17T04:05:06Z");
+    }
+
+    #[test]
+    fn top_level_timestamp_uses_stable_ingress_and_epoch_fallbacks() {
+        let target = SinkTarget::HttpEndpoint("https://controller.example/events".into());
+        let mut message = message();
+        message.payload["event_timestamp"] = json!("invalid");
+        message.payload["timestamp"] = json!({"raw": "invalid"});
+        message.payload["first_seen_at"] = json!("2026-08-17T05:06:07Z");
+
+        let body = event_body(&message, &target, "request-123").unwrap();
+        let parsed: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["timestamp"], "2026-08-17T05:06:07Z");
+
+        message
+            .payload
+            .as_object_mut()
+            .unwrap()
+            .remove("first_seen_at");
+        let first = event_body(&message, &target, "request-123").unwrap();
+        let second = event_body(&message, &target, "request-123").unwrap();
+        let parsed: Value = serde_json::from_slice(&first).unwrap();
+
+        assert_eq!(parsed["timestamp"], FALLBACK_EVENT_TIMESTAMP);
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn sends_exact_signed_body_with_stable_request_id() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let (headers, body) = read_request(&mut stream).await;
+            stream
+                .write_all(
+                    b"HTTP/1.1 204 No Content\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            (headers, body)
+        });
+        let endpoint = format!("http://{addr}/webhooks/clawhip-controller");
+        let target = SinkTarget::HttpEndpoint(endpoint);
+        let sink = HttpSink::new(b"shared-secret").unwrap();
+        let message = message();
+
+        let send = tokio::spawn({
+            let sink = sink.clone();
+            let target = target.clone();
+            let message = message.clone();
+            async move { sink.send(&target, &message).await }
+        });
+        let (headers, body) = timeout(Duration::from_secs(2), server)
+            .await
+            .unwrap()
+            .unwrap();
+
+        send.await.unwrap().unwrap();
+        let expected_body = event_body(&message, &target, "request-123").unwrap();
+        assert_eq!(body, expected_body);
+        assert!(
+            headers
+                .to_ascii_lowercase()
+                .contains("content-type: application/json")
+        );
+        assert!(
+            headers.contains("x-request-id: request-123")
+                || headers.contains("X-Request-ID: request-123")
+        );
+        let signature = hmac_signature(b"shared-secret", &body);
+        assert!(
+            headers.contains(&format!("x-hub-signature-256: {signature}"))
+                || headers.contains(&format!("X-Hub-Signature-256: {signature}"))
+        );
+    }
+
+    #[tokio::test]
+    async fn refuses_redirects_and_does_not_contact_redirect_target() {
+        let redirect_target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_addr = redirect_target.local_addr().unwrap();
+        let redirector = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let redirector_addr = redirector.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = redirector.accept().await.unwrap();
+            let _ = read_request(&mut stream).await;
+            let response = format!(
+                "HTTP/1.1 302 Found\r\nlocation: http://{target_addr}/redirected\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let sink = HttpSink::new(b"secret").unwrap();
+        let endpoint = SinkTarget::HttpEndpoint(format!(
+            "http://{redirector_addr}/webhooks/clawhip-controller"
+        ));
+        let error = sink
+            .send(&endpoint, &message())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("status 302"));
+        server.await.unwrap();
+        assert!(
+            timeout(Duration::from_millis(150), redirect_target.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn status_error_does_not_expose_endpoint_or_response_body() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut stream).await;
+            let body = "private-controller-error secret-token";
+            let response = format!(
+                "HTTP/1.1 500 Internal Server Error\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        let endpoint = format!("http://{addr}/webhooks/private-controller");
+        let sink = HttpSink::new(b"secret").unwrap();
+
+        let error = sink
+            .send(&SinkTarget::HttpEndpoint(endpoint.clone()), &message())
+            .await
+            .unwrap_err()
+            .to_string();
+        server.await.unwrap();
+
+        assert_eq!(error, "HTTP sink request failed with status 500");
+        assert!(!error.contains(&endpoint));
+        assert!(!error.contains("private-controller-error"));
+        assert!(!error.contains("secret-token"));
+    }
+
+    #[tokio::test]
+    async fn request_timeout_is_bounded_and_public_safe() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_request(&mut stream).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+        let endpoint = format!("http://{addr}/webhooks/private-controller");
+        let sink = HttpSink::with_request_timeout(b"secret", Duration::from_millis(50)).unwrap();
+
+        let error = sink
+            .send(&SinkTarget::HttpEndpoint(endpoint.clone()), &message())
+            .await
+            .unwrap_err()
+            .to_string();
+        server.await.unwrap();
+
+        assert_eq!(
+            error,
+            "HTTP sink request failed before receiving a response"
+        );
+        assert!(!error.contains(&endpoint));
+        assert!(!error.contains("private-controller"));
+    }
+
+    #[test]
+    #[serial]
+    fn from_config_loads_secret_from_referenced_environment_variable() {
+        let name = "CLAWHIP_TEST_HTTP_HMAC_SECRET";
+        unsafe { std::env::set_var(name, "env-secret") };
+        let config = HttpConfig {
+            endpoint: Some("http://127.0.0.1:8644/webhooks/clawhip-controller".into()),
+            hmac_secret_env: Some(name.into()),
+        };
+
+        let result = HttpSink::from_config(&config);
+        unsafe { std::env::remove_var(name) };
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn from_config_reports_missing_secret_without_exposing_endpoint() {
+        let name = "CLAWHIP_TEST_MISSING_HTTP_HMAC_SECRET";
+        unsafe { std::env::remove_var(name) };
+        let endpoint = "https://controller.example/webhooks/private?token=endpoint-secret";
+        let config = HttpConfig {
+            endpoint: Some(endpoint.into()),
+            hmac_secret_env: Some(name.into()),
+        };
+
+        let error = match HttpSink::from_config(&config) {
+            Ok(_) => panic!("missing secret must fail"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error.contains(name));
+        assert!(!error.contains(endpoint));
+        assert!(!error.contains("controller.example"));
+        assert!(!error.contains("endpoint-secret"));
+    }
+}

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -1,4 +1,5 @@
 pub mod discord;
+pub mod http;
 pub mod local_file;
 pub mod slack;
 
@@ -9,6 +10,7 @@ use crate::events::MessageFormat;
 use serde_json::Value;
 
 pub use discord::DiscordSink;
+pub use http::HttpSink;
 pub use local_file::LocalFileSink;
 pub use slack::SlackSink;
 
@@ -18,6 +20,7 @@ pub enum SinkTarget {
     DiscordThread(String),
     DiscordWebhook(String),
     SlackWebhook(String),
+    HttpEndpoint(String),
     LocalFile(String),
 }
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -24,6 +24,7 @@ impl SlackClient {
             | SinkTarget::DiscordWebhook(_) => {
                 Err("cannot send Discord target via Slack client".into())
             }
+            SinkTarget::HttpEndpoint(_) => Err("cannot send HTTP target via Slack client".into()),
             SinkTarget::LocalFile(_) => Err("cannot send localfile target via Slack client".into()),
         }
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -17,6 +17,9 @@ pub mod event_name {
     pub const DISCORD_SEND_ATTEMPT: &str = "discord_send_attempt";
     pub const DISCORD_SEND_FAILURE: &str = "discord_send_failure";
     pub const DISCORD_SEND_SUCCESS: &str = "discord_send_success";
+    pub const HTTP_SEND_ATTEMPT: &str = "http_send_attempt";
+    pub const HTTP_SEND_FAILURE: &str = "http_send_failure";
+    pub const HTTP_SEND_SUCCESS: &str = "http_send_success";
     pub const CIRCUIT_TRANSITION: &str = "circuit_transition";
     pub const DLQ_BURY: &str = "dlq_bury";
     pub const SOURCE_DEGRADED: &str = "source_degraded";
@@ -43,6 +46,10 @@ pub mod reason {
     pub const DISCORD_RETRY: &str = "discord_retry";
     pub const DISCORD_EXHAUSTED: &str = "discord_exhausted";
     pub const DISCORD_SUCCESS: &str = "discord_success";
+    pub const HTTP_PRE_SEND: &str = "http_pre_send";
+    pub const HTTP_TRANSPORT_ERROR: &str = "http_transport_error";
+    pub const HTTP_STATUS_ERROR: &str = "http_status_error";
+    pub const HTTP_SUCCESS: &str = "http_success";
     pub const CIRCUIT_OPEN: &str = "circuit_open";
     pub const CIRCUIT_TRANSITION: &str = "circuit_transition";
     pub const DLQ_WRITE: &str = "dlq_write";
@@ -114,22 +121,29 @@ pub fn safe_target_id(target: &SinkTarget) -> String {
         SinkTarget::SlackWebhook(webhook_url) => {
             format!("slack:webhook:{}", redacted_url_fingerprint(webhook_url))
         }
+        SinkTarget::HttpEndpoint(endpoint) => {
+            format!("http:endpoint:{}", redacted_url_fingerprint(endpoint))
+        }
         SinkTarget::LocalFile(path) => format!("localfile:{:016x}", fingerprint(path)),
     }
 }
 
 pub fn redacted_url_fingerprint(url: &str) -> String {
-    let host = url
-        .split_once("://")
-        .map(|(_, rest)| rest)
-        .unwrap_or(url)
-        .split('/')
-        .next()
-        .unwrap_or("unknown-host")
-        .trim()
-        .split('@')
-        .next_back()
-        .unwrap_or("unknown-host");
+    let host = reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| {
+            let host = parsed.host_str()?;
+            let host = if host.contains(':') {
+                format!("[{host}]")
+            } else {
+                host.to_string()
+            };
+            Some(match parsed.port() {
+                Some(port) => format!("{host}:{port}"),
+                None => host,
+            })
+        })
+        .unwrap_or_else(|| "unknown-host".to_string());
     format!("{host}/redacted/{:016x}", fingerprint(url))
 }
 
@@ -217,6 +231,28 @@ mod tests {
 
         assert!(safe.starts_with("localfile:"));
         assert!(!safe.contains("/tmp/clawhip/events.jsonl"));
+    }
+
+    #[test]
+    fn http_target_id_redacts_endpoint_path_and_query() {
+        let endpoint = "https://controller.example/webhooks/clawhip?token=secret";
+        let safe = safe_target_id(&SinkTarget::HttpEndpoint(endpoint.into()));
+
+        assert!(safe.starts_with("http:endpoint:controller.example/redacted/"));
+        assert!(!safe.contains("clawhip"));
+        assert!(!safe.contains("secret"));
+        assert!(!safe.contains(endpoint));
+    }
+
+    #[test]
+    fn http_target_id_does_not_treat_query_as_host() {
+        let endpoint = "https://controller.example?token=secret";
+        let safe = safe_target_id(&SinkTarget::HttpEndpoint(endpoint.into()));
+
+        assert!(safe.starts_with("http:endpoint:controller.example/redacted/"));
+        assert!(!safe.contains("token"));
+        assert!(!safe.contains("secret"));
+        assert!(!safe.contains(endpoint));
     }
 
     #[test]


### PR DESCRIPTION
Adds a generic signed HTTP sink for direct Clawhip → local controller delivery, with Discord remaining optional.\n\nKey points:\n- normalized, bounded public-safe JSON event envelope\n- exact-body HMAC-SHA256 via X-Hub-Signature-256\n- stable X-Request-ID for receiver idempotency\n- loopback-only plaintext HTTP; HTTPS for remote endpoints\n- redirects disabled and secrets/endpoints redacted from diagnostics\n- HTTP + Discord multi-delivery fanout\n- docs for local Hermes endpoint\n\nVerified locally:\n- git diff --check\n- cargo fmt --check\n- cargo check\n- cargo clippy --all-targets -- -D warnings\n- cargo test