### PR TITLE
fix(source): suppress historical GitHub CI terminal-run replay across restart (#317)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - run: cargo test --bin clawhip issue_317 -- --test-threads=1
       - run: cargo test --test config_backup_cleanup
 
   clippy:

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -40,8 +40,8 @@ use crate::source::{
     GitHubSource, GitHubStatusSource, GitMonitorLifecycleCounts, GitSource, RegisteredTmuxSession,
     SharedGitMonitorDiagnostics, SharedTmuxRegistry, Source, SubscriptionSnapshot,
     SubscriptionState, SubscriptionWorker, TmuxSource, WorkspaceSource,
-    default_registry_state_path, inspect_tmux_registry_state, list_active_tmux_registrations,
-    load_tmux_registry_state, new_shared_git_monitor_diagnostics,
+    default_github_ci_baseline_path, default_registry_state_path, inspect_tmux_registry_state,
+    list_active_tmux_registrations, load_tmux_registry_state, new_shared_git_monitor_diagnostics,
     register_runtime_tmux_registration, snapshot_git_monitor_diagnostics,
     tmux_registry_diagnostics,
 };
@@ -205,7 +205,13 @@ pub async fn run(
         GitSource::new(config.clone(), git_monitor_diagnostics.clone()),
         tx.clone(),
     );
-    spawn_source(GitHubSource::new(config.clone()), tx.clone());
+    spawn_source(
+        GitHubSource::with_ci_baseline_path(
+            config.clone(),
+            default_github_ci_baseline_path(&cron_state_path),
+        ),
+        tx.clone(),
+    );
     spawn_source(GitHubStatusSource::new(config.clone()), tx.clone());
     spawn_source(
         TmuxSource::new(

--- a/src/events.rs
+++ b/src/events.rs
@@ -801,6 +801,11 @@ impl IncomingEvent {
         self
     }
 
+    pub fn with_template(mut self, template: Option<String>) -> Self {
+        self.template = template;
+        self
+    }
+
     pub fn with_repo_context(
         mut self,
         repo_path: Option<String>,

--- a/src/gajae.rs
+++ b/src/gajae.rs
@@ -2236,6 +2236,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::fs;
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2350,9 +2351,12 @@ mod tests {
             file.write_all(script.as_bytes()).expect("write fake gajae");
             file.sync_all().expect("sync fake gajae");
         }
-        let mut permissions = fs::metadata(&tmp_path).expect("metadata").permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&tmp_path, permissions).expect("chmod fake gajae");
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(&tmp_path).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&tmp_path, permissions).expect("chmod fake gajae");
+        }
         fs::rename(&tmp_path, &path).expect("install fake gajae");
         (dir, path)
     }

--- a/src/hooks/prompt_deliver.rs
+++ b/src/hooks/prompt_deliver.rs
@@ -845,6 +845,7 @@ fn tmux_stderr(stderr: &[u8]) -> String {
 mod tests {
     use super::*;
     use serial_test::serial;
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 
@@ -1136,6 +1137,7 @@ mod tests {
         assert!(infer_provider_from_hook_setup(&dual).is_err());
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     #[serial]
     async fn deliver_fails_when_prompt_submit_records_but_pane_shows_no_progress() {
@@ -1224,6 +1226,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     #[serial]
     async fn deliver_retries_enter_until_prompt_submit_marker_changes() {

--- a/src/native_hooks.rs
+++ b/src/native_hooks.rs
@@ -1461,6 +1461,7 @@ mod tests {
         assert!(!script.contains("??"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn generated_hook_script_e2e_surfaces_bridge_stderr_and_exit_code() {
         use std::io::Write;
@@ -1659,6 +1660,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn generated_hook_script_e2e_emits_canonical_repo_metadata_from_event_cwd() {
         use std::io::Write;

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -155,6 +155,8 @@ struct AckedDelivery {
     sha: String,
     pr_number: Option<u64>,
     #[serde(default)]
+    repo_name: String,
+    #[serde(default)]
     acked_unix: u64,
 }
 
@@ -169,11 +171,18 @@ impl AckedDelivery {
             workflow: pending.workflow.clone(),
             sha: pending.sha.clone(),
             pr_number: pending.pr_number,
+            repo_name: pending.repo_name.clone(),
             acked_unix: now,
         }
     }
 
     fn matches_pending(&self, pending: &PendingCiDelivery) -> bool {
+        if !self.repo_name.is_empty()
+            && !pending.repo_name.is_empty()
+            && self.repo_name != pending.repo_name
+        {
+            return false;
+        }
         if self.kind != pending.kind || self.conclusion != pending.conclusion {
             return false;
         }
@@ -799,7 +808,9 @@ fn dead_letter_unsent_final_attempts(ci_baseline: &mut CIBaseline, unsent: &[Pen
     for repo in ci_baseline.repos.values_mut() {
         let mut keep = Vec::new();
         for pending in repo.pending.drain(..) {
-            if unsent.iter().any(|item| pending.same_event(item))
+            if unsent
+                .iter()
+                .any(|item| pending.same_event(item) && pending.repo_name == item.repo_name)
                 && pending.send_attempts >= MAX_PENDING_SEND_ATTEMPTS
             {
                 repo.dead_letter.push_back(pending);
@@ -858,7 +869,9 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
                     .any(|identity| pending_check_identities(&acked.identities).contains(identity))
                     || (candidate.run_id.is_some()
                         && candidate.run_id == acked.run_id
-                        && candidate.workflow == acked.workflow))
+                        && candidate.workflow == acked.workflow
+                        && run_attempt_or_one(candidate.run_attempt)
+                            == run_attempt_or_one(acked.run_attempt)))
         }) {
             for identity in acked.identities {
                 if !existing.identities.iter().any(|item| item == &identity) {
@@ -1142,31 +1155,23 @@ async fn send_then_ack_prefix(
     events: Vec<IncomingEvent>,
     delivered: &[PendingCiDelivery],
 ) -> Result<()> {
-    let mut sent = Vec::new();
-    let mut send_error = None;
     for (event, delivery) in events.into_iter().zip(delivered.iter()) {
+        persist_pending_send_attempts(
+            ci_baseline,
+            path,
+            std::slice::from_ref(delivery),
+            unix_now(),
+        )?;
         match send_event(tx, event).await {
-            Ok(()) => sent.push(delivery.clone()),
+            Ok(()) => {
+                ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(delivery))?;
+            }
             Err(error) => {
-                send_error = Some(error);
-                break;
+                dead_letter_unsent_final_attempts(ci_baseline, std::slice::from_ref(delivery));
+                let _ = commit_ci_baseline(path, ci_baseline);
+                return Err(error);
             }
         }
-    }
-    if !sent.is_empty() {
-        ack_pending_deliveries(ci_baseline, path, &sent)?;
-    }
-    let unsent: Vec<PendingCiDelivery> = delivered
-        .iter()
-        .filter(|delivery| !sent.iter().any(|item| item.same_event(delivery)))
-        .cloned()
-        .collect();
-    if !unsent.is_empty() {
-        dead_letter_unsent_final_attempts(ci_baseline, &unsent);
-        let _ = commit_ci_baseline(path, ci_baseline);
-    }
-    if let Some(error) = send_error {
-        return Err(error);
     }
     Ok(())
 }
@@ -1183,32 +1188,23 @@ async fn drain_pending_outbox(
         .flat_map(|repo| repo.pending.iter().cloned())
         .filter(|pending| pending_due_for_send(pending, now))
         .collect();
-    if due.is_empty() {
-        return Ok(());
-    }
-    if let Err(error) = persist_pending_send_attempts(ci_baseline, path, &due, now) {
-        eprintln!("clawhip source github CI baseline outbox attempt persist failed: {error}");
-        return Ok(());
-    }
-    let mut sent = Vec::new();
-    for delivery in &due {
-        if send_event(tx, delivery.clone().into_event()).await.is_err() {
-            break;
+    for delivery in due {
+        if persist_pending_send_attempts(ci_baseline, path, std::slice::from_ref(&delivery), now)
+            .is_err()
+        {
+            eprintln!("clawhip source github CI baseline outbox attempt persist failed");
+            return Ok(());
         }
-        sent.push(delivery.clone());
-    }
-    if !sent.is_empty()
-        && let Err(error) = ack_pending_deliveries(ci_baseline, path, &sent)
-    {
-        eprintln!("clawhip source github CI baseline outbox ack failed: {error}");
-    }
-    let unsent: Vec<PendingCiDelivery> = due
-        .into_iter()
-        .filter(|delivery| !sent.iter().any(|item| item.same_event(delivery)))
-        .collect();
-    if !unsent.is_empty() {
-        dead_letter_unsent_final_attempts(ci_baseline, &unsent);
-        let _ = commit_ci_baseline(path, ci_baseline);
+        if send_event(tx, delivery.clone().into_event()).await.is_err() {
+            dead_letter_unsent_final_attempts(ci_baseline, std::slice::from_ref(&delivery));
+            let _ = commit_ci_baseline(path, ci_baseline);
+            return Ok(());
+        }
+        if let Err(error) =
+            ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(&delivery))
+        {
+            eprintln!("clawhip source github CI baseline outbox ack failed: {error}");
+        }
     }
     Ok(())
 }
@@ -1228,7 +1224,10 @@ fn persist_pending_send_attempts(
 fn bump_pending_send_attempts(ci_baseline: &mut CIBaseline, sent: &[PendingCiDelivery], now: u64) {
     for repo in ci_baseline.repos.values_mut() {
         for pending in &mut repo.pending {
-            if sent.iter().any(|item| pending.same_event(item)) {
+            if sent
+                .iter()
+                .any(|item| pending.same_event(item) && pending.repo_name == item.repo_name)
+            {
                 pending.send_attempts = pending.send_attempts.saturating_add(1);
                 pending.last_sent_unix = Some(now);
             }
@@ -1244,7 +1243,12 @@ fn ack_pending_deliveries(
     let Some(path) = path else {
         for repo in ci_baseline.repos.values_mut() {
             for delivery in delivered {
-                record_acked(repo, delivery);
+                if repo.pending.iter().any(|pending| {
+                    pending.same_event(delivery)
+                        || AckedDelivery::from_pending(delivery, 0).matches_pending(pending)
+                }) {
+                    record_acked(repo, delivery);
+                }
             }
             let acked = repo.acked.clone();
             repo.pending
@@ -1610,24 +1614,6 @@ async fn poll_github(
             })
             .collect();
         if !delivered.is_empty() {
-            if let Err(error) =
-                persist_pending_send_attempts(ci_baseline, ci_baseline_path, &delivered, unix_now())
-            {
-                eprintln!(
-                    "clawhip source github CI baseline outbox attempt persist failed for {}: {error}",
-                    repo.path
-                );
-                state.insert(
-                    repo.path.clone(),
-                    GitHubRepoState {
-                        issues,
-                        prs,
-                        ci,
-                        ci_baseline_established,
-                    },
-                );
-                continue;
-            }
             send_then_ack_prefix(tx, ci_baseline, ci_baseline_path, ci_events, &delivered).await?;
         }
 

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -661,6 +661,34 @@ fn cap_repo_baseline(repo_baseline: &mut RepoCIBaseline) -> bool {
     true
 }
 
+fn cap_repo_baseline_keeping(
+    repo_baseline: &mut RepoCIBaseline,
+    keep: &[&GitHubCISnapshot],
+) -> bool {
+    if repo_baseline.terminal_runs.len() <= MAX_BASELINE_RUNS_PER_REPO {
+        return false;
+    }
+    let keep_ids: std::collections::HashSet<String> =
+        keep.iter().flat_map(|ci| ci.unique_identities()).collect();
+    let mut records: Vec<TerminalRunRecord> = repo_baseline.terminal_runs.drain(..).collect();
+    records.sort_by_key(|record| record.eviction_key());
+    let excess = records.len().saturating_sub(MAX_BASELINE_RUNS_PER_REPO);
+    let mut kept = VecDeque::new();
+    let mut dropped = 0_usize;
+    for record in records {
+        let protected = record
+            .unique_identities()
+            .any(|identity| keep_ids.contains(identity));
+        if !protected && dropped < excess {
+            dropped += 1;
+            continue;
+        }
+        kept.push_back(record);
+    }
+    repo_baseline.terminal_runs = kept;
+    dropped > 0
+}
+
 #[cfg(test)]
 impl RepoCIBaseline {
     fn contains_identity(&self, identity: &str) -> bool {
@@ -775,7 +803,7 @@ impl CIBaseline {
 
         let repo_baseline = self.repo_baseline_mut(repo_key, repo_path);
         let mut dirty = false;
-        for ci in incoming {
+        for ci in &incoming {
             if let Some(existing) = repo_baseline
                 .terminal_runs
                 .iter_mut()
@@ -789,7 +817,7 @@ impl CIBaseline {
                 dirty = true;
             }
         }
-        dirty |= cap_repo_baseline(repo_baseline);
+        dirty |= cap_repo_baseline_keeping(repo_baseline, &incoming);
         dirty
     }
 }
@@ -3527,15 +3555,22 @@ mod tests {
     }
 
     #[test]
-    fn issue_317_single_poll_evicts_oldest_github_runs_first() {
-        let mut runs = Vec::new();
-        for id in 0..(MAX_BASELINE_RUNS_PER_REPO + 20) {
+    fn issue_317_later_poll_evicts_oldest_unprotected_github_runs() {
+        let mut first = Vec::new();
+        for id in 0..MAX_BASELINE_RUNS_PER_REPO {
             let mut run = run_snapshot(id as u64, "CI", Some("success"), "main");
             run.created_at = Some(format!("2026-01-01T00:{:02}:{:02}Z", id / 60, id % 60));
-            runs.push(run);
+            first.push(run);
         }
         let mut ci_baseline = CIBaseline::default();
-        ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&runs));
+        ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&first));
+        let mut later = Vec::new();
+        for id in MAX_BASELINE_RUNS_PER_REPO..(MAX_BASELINE_RUNS_PER_REPO + 20) {
+            let mut run = run_snapshot(id as u64, "CI", Some("success"), "main");
+            run.created_at = Some(format!("2026-01-01T01:{:02}:{:02}Z", id / 60, id % 60));
+            later.push(run);
+        }
+        ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&later));
         let repo = &ci_baseline.repos["/repo"];
         assert_eq!(repo.terminal_runs.len(), MAX_BASELINE_RUNS_PER_REPO);
         assert!(!repo.contains_identity("run:0"));

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -744,10 +744,19 @@ fn canonicalize_loaded_window(repo_baseline: &mut RepoCIBaseline) {
         .collect();
     scopes.sort_by(|left, right| left.0.cmp(&right.0));
     repo_baseline.current_window_ids_by_scope = scopes.into_iter().collect();
-    let ids = repo_baseline
+    let mut scope_names: Vec<&str> = repo_baseline
         .current_window_ids_by_scope
-        .values()
-        .flat_map(|ids| ids.iter().cloned());
+        .keys()
+        .map(String::as_str)
+        .collect();
+    scope_names.sort_unstable();
+    let ids = scope_names.into_iter().flat_map(|scope| {
+        repo_baseline
+            .current_window_ids_by_scope
+            .get(scope)
+            .into_iter()
+            .flat_map(|ids| ids.iter().cloned())
+    });
     repo_baseline.current_window_ids = cap_window_ids(canonical_window_identities(ids));
     let retained: std::collections::HashSet<&str> = repo_baseline
         .current_window_ids

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -105,6 +105,8 @@ struct RepoCIBaseline {
     epoch: u64,
     #[serde(default)]
     min_writer_epoch: u64,
+    #[serde(default)]
+    ci_established: bool,
 }
 
 /// Durable receipt for one terminal run. Identities are aliases (run-id,
@@ -936,6 +938,7 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     cap_repo_baseline(dest);
     dest.epoch = dest.epoch.max(source.epoch);
     dest.min_writer_epoch = dest.min_writer_epoch.max(source.min_writer_epoch);
+    dest.ci_established = dest.ci_established || source.ci_established;
     for acked in source.acked {
         if let Some(existing) = dest.acked.iter_mut().find(|candidate| {
             candidate.repo_name == acked.repo_name
@@ -1805,6 +1808,11 @@ async fn poll_github(
             })
         });
         next_baseline.enqueue_pending(&repo_key, &repo.path, &ci_events, &ci);
+        if ci_baseline_established {
+            next_baseline
+                .repo_baseline_mut(&repo_key, &repo.path)
+                .ci_established = true;
+        }
         match commit_ci_baseline(ci_baseline_path, &next_baseline) {
             Ok(committed) => {
                 *ci_baseline = committed;
@@ -2042,7 +2050,7 @@ async fn poll_ci_statuses(
                     &ci,
                     repo_ci_baseline,
                 )
-            } else if repo_ci_baseline.is_some_and(|baseline| baseline.epoch > 0) {
+            } else if repo_ci_baseline.is_some_and(|baseline| baseline.ci_established) {
                 collect_ci_events(
                     repo,
                     &snapshot.repo_name,
@@ -4592,7 +4600,7 @@ mod tests {
     fn issue_317_empty_established_baseline_restart_emits_first_terminal() {
         let fresh = run_snapshot(2, "CI", Some("failure"), "main");
         let mut baseline = CIBaseline::default();
-        baseline.repo_baseline_mut("/repo", "/repo").epoch = 1;
+        baseline.repo_baseline_mut("/repo", "/repo").ci_established = true;
         let events = collect_ci_events(
             &GitRepoMonitor::default(),
             "org/repo",

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1,5 +1,7 @@
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -16,6 +18,10 @@ use crate::events::IncomingEvent;
 use crate::source::Source;
 use crate::source::git::{GitSnapshot, repo_display_name, snapshot_git_repo};
 use crate::telemetry;
+
+thread_local! {
+    static SYNC_FILE_CALLS: Cell<u32> = const { Cell::new(0) };
+}
 
 pub struct GitHubSource {
     config: Arc<AppConfig>,
@@ -87,10 +93,18 @@ struct RepoCIBaseline {
     /// crash between the write and the channel send.
     #[serde(default)]
     pending: Vec<PendingCiDelivery>,
-    /// Tombstones for ACKed deliveries so a stale concurrent merge cannot
-    /// restore a receipt that was already durably removed.
+    /// Alias-aware ACK records. Compaction retires stale writers via
+    /// `min_writer_epoch` instead of dropping tombstones while they can
+    /// still be merged back in.
+    #[serde(default, deserialize_with = "deserialize_acked")]
+    acked: VecDeque<AckedDelivery>,
+    /// Exhausted outbox entries that will not be retried.
     #[serde(default)]
-    acked: VecDeque<String>,
+    dead_letter: VecDeque<PendingCiDelivery>,
+    #[serde(default)]
+    epoch: u64,
+    #[serde(default)]
+    min_writer_epoch: u64,
 }
 
 /// Durable receipt for one terminal run. Identities are aliases (run-id,
@@ -127,6 +141,74 @@ struct PendingCiDelivery {
     send_attempts: u32,
     #[serde(default)]
     last_sent_unix: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct AckedDelivery {
+    identities: Vec<String>,
+    kind: String,
+    conclusion: Option<String>,
+    run_id: Option<String>,
+    #[serde(default = "default_run_attempt")]
+    run_attempt: u32,
+    workflow: String,
+    sha: String,
+    pr_number: Option<u64>,
+    #[serde(default)]
+    acked_unix: u64,
+}
+
+impl AckedDelivery {
+    fn from_pending(pending: &PendingCiDelivery, now: u64) -> Self {
+        Self {
+            identities: pending.identities.clone(),
+            kind: pending.kind.clone(),
+            conclusion: pending.conclusion.clone(),
+            run_id: pending.run_id.clone(),
+            run_attempt: run_attempt_or_one(pending.run_attempt),
+            workflow: pending.workflow.clone(),
+            sha: pending.sha.clone(),
+            pr_number: pending.pr_number,
+            acked_unix: now,
+        }
+    }
+
+    fn matches_pending(&self, pending: &PendingCiDelivery) -> bool {
+        if self.kind != pending.kind || self.conclusion != pending.conclusion {
+            return false;
+        }
+        let self_checks = pending_check_identities(&self.identities);
+        let pending_checks = pending_check_identities(&pending.identities);
+        if !self_checks.is_empty() && !pending_checks.is_empty() {
+            return self_checks
+                .iter()
+                .any(|identity| pending_checks.iter().any(|candidate| candidate == identity));
+        }
+        let run_match = self.run_id.is_some()
+            && self.run_id == pending.run_id
+            && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(pending.run_attempt)
+            && self.workflow == pending.workflow;
+        if run_match {
+            return true;
+        }
+        self.sha == pending.sha
+            && self.workflow == pending.workflow
+            && self.pr_number == pending.pr_number
+    }
+
+    fn merge_aliases(&mut self, pending: &PendingCiDelivery) {
+        for identity in &pending.identities {
+            if !self.identities.iter().any(|existing| existing == identity) {
+                self.identities.push(identity.clone());
+            }
+        }
+        if self.run_id.is_none() {
+            self.run_id = pending.run_id.clone();
+        }
+        if self.sha.is_empty() {
+            self.sha = pending.sha.clone();
+        }
+    }
 }
 
 impl PendingCiDelivery {
@@ -225,26 +307,6 @@ impl PendingCiDelivery {
             && self.pr_number == other.pr_number
     }
 
-    fn delivery_key(&self) -> String {
-        let outcome = format!("{}:{}", self.kind, self.conclusion.as_deref().unwrap_or(""));
-        if let Some(check) = pending_check_identities(&self.identities).first() {
-            return format!("{check}:{outcome}");
-        }
-        if let Some(run_id) = &self.run_id {
-            return format!(
-                "run:{run_id}:{}:{}:{outcome}",
-                run_attempt_or_one(self.run_attempt),
-                self.workflow
-            );
-        }
-        format!(
-            "fallback:{}:{}:{}:{outcome}",
-            self.sha,
-            self.workflow,
-            self.pr_number.unwrap_or(0)
-        )
-    }
-
     fn into_event(self) -> IncomingEvent {
         let mut event = IncomingEvent::github_ci(
             &self.kind,
@@ -306,11 +368,29 @@ where
     Ok(raw.into_iter().map(TerminalRunRecord::from).collect())
 }
 
+fn deserialize_acked<'de, D>(
+    deserializer: D,
+) -> std::result::Result<VecDeque<AckedDelivery>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let Some(items) = value.as_array() else {
+        return Ok(VecDeque::new());
+    };
+    Ok(items
+        .iter()
+        .filter_map(|item| serde_json::from_value::<AckedDelivery>(item.clone()).ok())
+        .collect())
+}
+
 const MAX_BASELINE_RUNS_PER_REPO: usize = 256;
 const CI_PAGE_SIZE: usize = 100;
 const MAX_CI_PAGES: usize = 5;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
+const ACK_RETENTION_SECS: u64 = 7 * 24 * 3_600;
+const MAX_DEAD_LETTER: usize = 64;
 
 /// Beside the cron state file, matching `tmux-watch-registry.json` and
 /// `discord-watch-state.json`.
@@ -595,6 +675,9 @@ impl CIBaseline {
             .collect();
         let repo_baseline = self.repo_baseline_mut(repo_key, repo_path);
         for delivery in deliveries {
+            if pending_is_acked(repo_baseline, &delivery) {
+                continue;
+            }
             if !repo_baseline
                 .pending
                 .iter()
@@ -666,14 +749,45 @@ fn terminal_records_same_run(left: &TerminalRunRecord, right: &TerminalRunRecord
 }
 
 fn pending_is_acked(repo: &RepoCIBaseline, delivery: &PendingCiDelivery) -> bool {
-    let key = delivery.delivery_key();
-    repo.acked.iter().any(|acked| acked == &key)
+    repo.acked
+        .iter()
+        .any(|acked| acked.matches_pending(delivery))
 }
 
 fn record_acked(repo: &mut RepoCIBaseline, delivery: &PendingCiDelivery) {
-    let key = delivery.delivery_key();
-    if !repo.acked.iter().any(|acked| acked == &key) {
-        repo.acked.push_back(key);
+    if let Some(existing) = repo
+        .acked
+        .iter_mut()
+        .find(|acked| acked.matches_pending(delivery))
+    {
+        existing.merge_aliases(delivery);
+        return;
+    }
+    repo.acked
+        .push_back(AckedDelivery::from_pending(delivery, unix_now()));
+}
+
+fn retire_exhausted_pending(repo: &mut RepoCIBaseline) {
+    let mut still_pending = Vec::new();
+    for pending in repo.pending.drain(..) {
+        if pending.send_attempts >= MAX_PENDING_SEND_ATTEMPTS {
+            repo.dead_letter.push_back(pending);
+        } else {
+            still_pending.push(pending);
+        }
+    }
+    repo.pending = still_pending;
+    while repo.dead_letter.len() > MAX_DEAD_LETTER {
+        repo.dead_letter.pop_front();
+    }
+}
+
+fn compact_acked(repo: &mut RepoCIBaseline, now: u64) {
+    let before = repo.acked.len();
+    repo.acked
+        .retain(|acked| now.saturating_sub(acked.acked_unix) < ACK_RETENTION_SECS);
+    if repo.acked.len() < before {
+        repo.min_writer_epoch = repo.min_writer_epoch.max(repo.epoch);
     }
 }
 
@@ -700,30 +814,61 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
         }
     }
     cap_repo_baseline(dest);
-    for key in source.acked {
-        if !dest.acked.iter().any(|acked| acked == &key) {
-            dest.acked.push_back(key);
+    dest.epoch = dest.epoch.max(source.epoch);
+    dest.min_writer_epoch = dest.min_writer_epoch.max(source.min_writer_epoch);
+    for acked in source.acked {
+        if let Some(existing) = dest.acked.iter_mut().find(|candidate| {
+            candidate.kind == acked.kind
+                && candidate.conclusion == acked.conclusion
+                && (pending_check_identities(&candidate.identities)
+                    .iter()
+                    .any(|identity| pending_check_identities(&acked.identities).contains(identity))
+                    || (candidate.run_id.is_some()
+                        && candidate.run_id == acked.run_id
+                        && candidate.workflow == acked.workflow))
+        }) {
+            for identity in acked.identities {
+                if !existing.identities.iter().any(|item| item == &identity) {
+                    existing.identities.push(identity);
+                }
+            }
+        } else {
+            dest.acked.push_back(acked);
         }
     }
-    for delivery in source.pending {
-        if pending_is_acked(dest, &delivery) {
-            continue;
-        }
-        if let Some(existing) = dest
-            .pending
-            .iter_mut()
-            .find(|existing| existing.same_event(&delivery))
+    for dead in source.dead_letter {
+        if !dest
+            .dead_letter
+            .iter()
+            .any(|existing| existing.same_event(&dead))
         {
-            merge_pending_retry_state(existing, &delivery);
-        } else {
-            dest.pending.push(delivery);
+            dest.dead_letter.push_back(dead);
+        }
+    }
+    while dest.dead_letter.len() > MAX_DEAD_LETTER {
+        dest.dead_letter.pop_front();
+    }
+    let source_retired = source.epoch < dest.min_writer_epoch;
+    if !source_retired {
+        for delivery in source.pending {
+            if pending_is_acked(dest, &delivery) {
+                continue;
+            }
+            if let Some(existing) = dest
+                .pending
+                .iter_mut()
+                .find(|existing| existing.same_event(&delivery))
+            {
+                merge_pending_retry_state(existing, &delivery);
+            } else {
+                dest.pending.push(delivery);
+            }
         }
     }
     let acked = dest.acked.clone();
-    dest.pending.retain(|pending| {
-        let key = pending.delivery_key();
-        !acked.iter().any(|item| item == &key)
-    });
+    dest.pending
+        .retain(|pending| !acked.iter().any(|item| item.matches_pending(pending)));
+    retire_exhausted_pending(dest);
 }
 
 fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
@@ -777,6 +922,9 @@ impl Drop for BaselineLock {
     }
 }
 
+/// Kernel advisory lock is bound to the opened file descriptor. Replacing
+/// the lock path (symlink/rename) after the FD is held cannot steal the
+/// lock. Leftover directory locks fail closed and are not deleted.
 fn acquire_baseline_lock(path: &Path) -> Result<BaselineLock> {
     let lock_path = path.with_extension("json.lock");
     if let Some(parent) = path.parent() {
@@ -878,6 +1026,27 @@ fn merge_pending_retry_state(dest: &mut PendingCiDelivery, source: &PendingCiDel
     };
 }
 
+fn sync_file(file: &File) -> Result<()> {
+    #[cfg(test)]
+    SYNC_FILE_CALLS.with(|count| count.set(count.get() + 1));
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(dir: &Path) -> Result<()> {
+    File::open(dir)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn sync_directory(_dir: &Path) -> Result<()> {
+    // NTFS treats replace-on-rename as durable once the destination file
+    // contents have been flushed. Directory metadata is not separately
+    // fsync'd here.
+    Ok(())
+}
+
 fn write_ci_baseline_atomic(baseline: &CIBaseline, path: &Path) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -898,15 +1067,24 @@ fn write_ci_baseline_atomic(baseline: &CIBaseline, path: &Path) -> Result<()> {
         Some(parent) => parent.join(temp_name),
         None => PathBuf::from(temp_name),
     };
-    if let Err(error) = fs::write(&temp_path, payload.as_bytes()) {
+    let write_result = (|| -> Result<()> {
+        let mut file = File::create(&temp_path)?;
+        file.write_all(payload.as_bytes())?;
+        sync_file(&file)?;
+        drop(file);
+        fs::rename(&temp_path, path)?;
+        let dest = File::open(path)?;
+        sync_file(&dest)?;
+        drop(dest);
+        if let Some(parent) = path.parent() {
+            sync_directory(parent)?;
+        }
+        Ok(())
+    })();
+    if write_result.is_err() {
         let _ = fs::remove_file(&temp_path);
-        return Err(error.into());
     }
-    if let Err(error) = fs::rename(&temp_path, path) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(error.into());
-    }
-    Ok(())
+    write_result
 }
 
 fn commit_ci_baseline(path: Option<&Path>, local: &CIBaseline) -> Result<CIBaseline> {
@@ -916,6 +1094,12 @@ fn commit_ci_baseline(path: Option<&Path>, local: &CIBaseline) -> Result<CIBasel
     let _lock = acquire_baseline_lock(path)?;
     let mut disk = load_ci_baseline(Some(path));
     merge_ci_baseline(&mut disk, local);
+    let now = unix_now();
+    for repo in disk.repos.values_mut() {
+        repo.epoch = repo.epoch.saturating_add(1);
+        compact_acked(repo, now);
+        retire_exhausted_pending(repo);
+    }
     write_ci_baseline_atomic(&disk, path)?;
     Ok(disk)
 }
@@ -923,6 +1107,33 @@ fn commit_ci_baseline(path: Option<&Path>, local: &CIBaseline) -> Result<CIBasel
 #[cfg(test)]
 fn save_ci_baseline(baseline: &CIBaseline, path: Option<&Path>) -> Result<()> {
     commit_ci_baseline(path, baseline).map(|_| ())
+}
+
+async fn send_then_ack_prefix(
+    tx: &mpsc::Sender<IncomingEvent>,
+    ci_baseline: &mut CIBaseline,
+    path: Option<&Path>,
+    events: Vec<IncomingEvent>,
+    delivered: &[PendingCiDelivery],
+) -> Result<()> {
+    let mut sent = Vec::new();
+    let mut send_error = None;
+    for (event, delivery) in events.into_iter().zip(delivered.iter()) {
+        match send_event(tx, event).await {
+            Ok(()) => sent.push(delivery.clone()),
+            Err(error) => {
+                send_error = Some(error);
+                break;
+            }
+        }
+    }
+    if !sent.is_empty() {
+        ack_pending_deliveries(ci_baseline, path, &sent)?;
+    }
+    if let Some(error) = send_error {
+        return Err(error);
+    }
+    Ok(())
 }
 
 async fn drain_pending_outbox(
@@ -1373,15 +1584,7 @@ async fn poll_github(
                 );
                 continue;
             }
-            for event in ci_events {
-                send_event(tx, event).await?;
-            }
-            if let Err(error) = ack_pending_deliveries(ci_baseline, ci_baseline_path, &delivered) {
-                eprintln!(
-                    "clawhip source github CI baseline outbox ack failed for {}: {error}",
-                    repo.path
-                );
-            }
+            send_then_ack_prefix(tx, ci_baseline, ci_baseline_path, ci_events, &delivered).await?;
         }
 
         state.insert(
@@ -2371,9 +2574,8 @@ fn classify_ci_event_kind(status: &str, conclusion: Option<&str>) -> &'static st
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, VecDeque};
-    use std::sync::Arc;
-    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier, Mutex};
     use std::thread;
     use std::time::Duration;
 
@@ -3575,10 +3777,34 @@ mod tests {
         durable.enqueue_pending("/repo", "/repo", &events, &current);
         save_ci_baseline(&durable, Some(&path)).unwrap();
 
-        let mut proc1 = load_ci_baseline(Some(&path));
-        let mut proc2 = load_ci_baseline(Some(&path));
-        ack_pending_deliveries(&mut proc1, Some(&path), std::slice::from_ref(&pending_a)).unwrap();
-        ack_pending_deliveries(&mut proc2, Some(&path), std::slice::from_ref(&pending_b)).unwrap();
+        let start = Arc::new(Barrier::new(2));
+        thread::scope(|scope| {
+            let path_a = path.clone();
+            let pending_one = pending_a.clone();
+            let start_a = start.clone();
+            scope.spawn(move || {
+                let mut proc1 = load_ci_baseline(Some(&path_a));
+                start_a.wait();
+                ack_pending_deliveries(
+                    &mut proc1,
+                    Some(&path_a),
+                    std::slice::from_ref(&pending_one),
+                )
+                .unwrap();
+            });
+            let path_b = path.clone();
+            let pending_two = pending_b.clone();
+            scope.spawn(move || {
+                let mut proc2 = load_ci_baseline(Some(&path_b));
+                start.wait();
+                ack_pending_deliveries(
+                    &mut proc2,
+                    Some(&path_b),
+                    std::slice::from_ref(&pending_two),
+                )
+                .unwrap();
+            });
+        });
 
         let restarted = load_ci_baseline(Some(&path));
         assert!(
@@ -3625,6 +3851,7 @@ mod tests {
         let overlapping = Arc::new(AtomicUsize::new(0));
         let current = Arc::new(AtomicUsize::new(0));
         let errors = Arc::new(Mutex::new(Vec::new()));
+        let start = Arc::new(Barrier::new(2));
 
         thread::scope(|scope| {
             for _ in 0..2 {
@@ -3632,17 +3859,21 @@ mod tests {
                 let current = current.clone();
                 let errors = errors.clone();
                 let path = path.clone();
-                scope.spawn(move || match acquire_baseline_lock(&path) {
-                    Ok(lock) => {
-                        current.fetch_add(1, Ordering::SeqCst);
-                        thread::sleep(Duration::from_millis(30));
-                        if current.load(Ordering::SeqCst) > 1 {
-                            overlapping.fetch_add(1, Ordering::SeqCst);
+                let start = start.clone();
+                scope.spawn(move || {
+                    start.wait();
+                    match acquire_baseline_lock(&path) {
+                        Ok(lock) => {
+                            current.fetch_add(1, Ordering::SeqCst);
+                            thread::sleep(Duration::from_millis(30));
+                            if current.load(Ordering::SeqCst) > 1 {
+                                overlapping.fetch_add(1, Ordering::SeqCst);
+                            }
+                            current.fetch_sub(1, Ordering::SeqCst);
+                            drop(lock);
                         }
-                        current.fetch_sub(1, Ordering::SeqCst);
-                        drop(lock);
+                        Err(error) => errors.lock().unwrap().push(error.to_string()),
                     }
-                    Err(error) => errors.lock().unwrap().push(error.to_string()),
                 });
             }
         });
@@ -3657,6 +3888,177 @@ mod tests {
             0,
             "advisory lock must serialize critical sections"
         );
+    }
+
+    #[test]
+    fn issue_317_ack_covers_check_to_run_and_fallback_drift() {
+        let check = check_job(4242, 11, "CI", "success");
+        let current = run_map(std::slice::from_ref(&check));
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &current,
+            None,
+        );
+        let mut repo = RepoCIBaseline::default();
+        let pending_check = PendingCiDelivery::from_event(&events[0], check.identities());
+        record_acked(&mut repo, &pending_check);
+
+        let mut run_only = pending_check.clone();
+        run_only
+            .identities
+            .retain(|identity| identity.starts_with("run:"));
+        assert!(
+            pending_is_acked(&repo, &run_only),
+            "check-form ACK must cover later run-only representation"
+        );
+
+        let mut fallback_only = pending_check.clone();
+        fallback_only
+            .identities
+            .retain(|identity| !identity.starts_with("run:") && !identity.starts_with("check:"));
+        fallback_only.run_id = None;
+        assert!(
+            pending_is_acked(&repo, &fallback_only),
+            "check-form ACK must cover later fallback representation"
+        );
+
+        let mut dest = CIBaseline::default();
+        dest.repos.insert("/repo".into(), repo);
+        dest.enqueue_pending("/repo", "/repo", &events, &current);
+        assert!(
+            dest.repos["/repo"].pending.is_empty(),
+            "acked check delivery must not re-enqueue as run/fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_317_partial_send_acks_only_successful_prefix() {
+        let lint = check_job(4242, 11, "lint", "success");
+        let test = check_job(4242, 22, "test", "failure");
+        let current = run_map(&[lint.clone(), test.clone()]);
+        let mut events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &current,
+            None,
+        );
+        events.sort_by(|left, right| {
+            left.payload["workflow"]
+                .as_str()
+                .cmp(&right.payload["workflow"].as_str())
+        });
+        let delivered: Vec<_> = events
+            .iter()
+            .map(|event| {
+                let identities = previous_snapshot_for_event(&current, event)
+                    .map(GitHubCISnapshot::identities)
+                    .unwrap_or_default();
+                PendingCiDelivery::from_event(event, identities)
+            })
+            .collect();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut baseline = CIBaseline::default();
+        baseline.enqueue_pending("/repo", "/repo", &events, &current);
+        save_ci_baseline(&baseline, Some(&path)).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let recv = tokio::spawn(async move {
+            let first = rx.recv().await;
+            drop(rx);
+            first
+        });
+        let mut live = load_ci_baseline(Some(&path));
+        let result = send_then_ack_prefix(&tx, &mut live, Some(&path), events, &delivered).await;
+        assert!(result.is_err(), "closed receiver must fail the second send");
+        let _ = recv.await;
+        let restarted = load_ci_baseline(Some(&path));
+        let pending = &restarted.repos["/repo"].pending;
+        assert_eq!(pending.len(), 1, "unsent B must remain pending");
+        assert!(pending_is_acked(&restarted.repos["/repo"], &delivered[0]));
+        assert!(!pending_is_acked(&restarted.repos["/repo"], &delivered[1]));
+    }
+
+    #[test]
+    fn issue_317_exhausted_pending_is_dead_lettered_and_bounded() {
+        let mut repo = RepoCIBaseline::default();
+        for id in 0..(MAX_DEAD_LETTER + 8) {
+            let job = check_job(9, id as u64, "later", "failure");
+            let mut pending = PendingCiDelivery::from_event(
+                &collect_ci_events(
+                    &GitRepoMonitor::default(),
+                    "org/repo",
+                    true,
+                    &HashMap::new(),
+                    &run_map(std::slice::from_ref(&job)),
+                    None,
+                )[0],
+                job.identities(),
+            );
+            pending.send_attempts = MAX_PENDING_SEND_ATTEMPTS;
+            repo.pending.push(pending);
+        }
+        retire_exhausted_pending(&mut repo);
+        assert!(repo.pending.is_empty());
+        assert_eq!(repo.dead_letter.len(), MAX_DEAD_LETTER);
+    }
+
+    #[test]
+    fn issue_317_ack_compaction_retires_stale_writers() {
+        let job = check_job(7, 1, "CI", "success");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&job)),
+            None,
+        );
+        let pending = PendingCiDelivery::from_event(&events[0], job.identities());
+        let mut dest = RepoCIBaseline {
+            epoch: 10,
+            ..RepoCIBaseline::default()
+        };
+        record_acked(&mut dest, &pending);
+        dest.acked[0].acked_unix = 0;
+        compact_acked(&mut dest, ACK_RETENTION_SECS + 1);
+        assert!(dest.acked.is_empty());
+        assert_eq!(dest.min_writer_epoch, 10);
+
+        let mut stale = RepoCIBaseline {
+            epoch: 3,
+            ..RepoCIBaseline::default()
+        };
+        stale.pending.push(pending.clone());
+        merge_repo_baseline(&mut dest, stale);
+        assert!(
+            dest.pending.is_empty(),
+            "retired writer must not restore pending after ACK compaction"
+        );
+    }
+
+    #[test]
+    fn issue_317_baseline_write_flushes_file_data() {
+        SYNC_FILE_CALLS.with(|count| count.set(0));
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut baseline = CIBaseline::default();
+        baseline
+            .repos
+            .insert("/repo".into(), RepoCIBaseline::default());
+        write_ci_baseline_atomic(&baseline, &path).unwrap();
+        let calls = SYNC_FILE_CALLS.with(|count| count.get());
+        assert!(
+            calls >= 2,
+            "temp file and destination file must be fsync'd, got {calls}"
+        );
+        let loaded = load_ci_baseline(Some(&path));
+        assert!(loaded.repos.contains_key("/repo"));
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -315,7 +315,7 @@ impl PendingCiDelivery {
             template: event.template.clone(),
             send_attempts: 0,
             last_sent_unix: None,
-            delivery_id: uuid::Uuid::new_v4().to_string(),
+            delivery_id: String::new(),
         }
     }
 
@@ -736,6 +736,10 @@ impl CIBaseline {
                 .iter()
                 .any(|existing| existing.same_event(&delivery))
             {
+                let mut delivery = delivery;
+                if delivery.delivery_id.is_empty() {
+                    delivery.delivery_id = uuid::Uuid::new_v4().to_string();
+                }
                 repo_baseline.pending.push(delivery);
             }
         }
@@ -1391,8 +1395,11 @@ fn outbox_entry(
 ) -> Option<PendingCiDelivery> {
     for repo in ci_baseline.repos.values() {
         if let Some(pending) = repo.pending.iter().find(|pending| {
-            (!delivery.delivery_id.is_empty() && pending.delivery_id == delivery.delivery_id)
-                || pending.same_output(delivery)
+            if !delivery.delivery_id.is_empty() {
+                pending.delivery_id == delivery.delivery_id
+            } else {
+                pending.same_output(delivery)
+            }
         }) {
             return Some(pending.clone());
         }
@@ -1416,8 +1423,11 @@ fn bump_pending_send_attempts(ci_baseline: &mut CIBaseline, sent: &[PendingCiDel
     for repo in ci_baseline.repos.values_mut() {
         for pending in &mut repo.pending {
             if sent.iter().any(|item| {
-                (!item.delivery_id.is_empty() && pending.delivery_id == item.delivery_id)
-                    || (pending.same_event(item) && pending.repo_name == item.repo_name)
+                if !item.delivery_id.is_empty() {
+                    pending.delivery_id == item.delivery_id
+                } else {
+                    pending.same_output(item)
+                }
             }) {
                 pending.send_attempts = pending.send_attempts.saturating_add(1);
                 pending.last_sent_unix = Some(now);

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -120,6 +120,10 @@ struct PendingCiDelivery {
     run_all_terminal: bool,
     channel: Option<String>,
     mention: Option<String>,
+    #[serde(default)]
+    send_attempts: u32,
+    #[serde(default)]
+    last_sent_unix: Option<u64>,
 }
 
 impl PendingCiDelivery {
@@ -167,9 +171,11 @@ impl PendingCiDelivery {
             run_all_terminal: payload
                 .and_then(|object| object.get("run_all_terminal"))
                 .and_then(serde_json::Value::as_bool)
-                .unwrap_or(true),
+                .unwrap_or(false),
             channel: event.channel.clone(),
             mention: event.mention.clone(),
+            send_attempts: 0,
+            last_sent_unix: None,
         }
     }
 
@@ -249,6 +255,9 @@ where
 const MAX_BASELINE_RUNS_PER_REPO: usize = 256;
 const CI_PAGE_SIZE: usize = 100;
 const MAX_CI_PAGES: usize = 5;
+const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
+const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
+const BASELINE_LOCK_STALE_SECS: u64 = 30;
 
 /// Beside the cron state file, matching `tmux-watch-registry.json` and
 /// `discord-watch-state.json`.
@@ -535,14 +544,27 @@ impl CIBaseline {
     /// Records terminal-run identities for one canonical GitHub repo. Returns
     /// whether the persisted state changed (bounded, oldest GitHub runs
     /// evicted first).
+    #[cfg(test)]
     fn record_terminal_runs(
         &mut self,
         repo_key: &str,
         repo_path: &str,
         current: &HashMap<String, GitHubCISnapshot>,
     ) -> bool {
-        let mut incoming: Vec<&GitHubCISnapshot> =
-            current.values().filter(|ci| ci.is_terminal()).collect();
+        self.record_terminal_runs_filtered(repo_key, repo_path, current, |_| true)
+    }
+
+    fn record_terminal_runs_filtered(
+        &mut self,
+        repo_key: &str,
+        repo_path: &str,
+        current: &HashMap<String, GitHubCISnapshot>,
+        include: impl Fn(&GitHubCISnapshot) -> bool,
+    ) -> bool {
+        let mut incoming: Vec<&GitHubCISnapshot> = current
+            .values()
+            .filter(|ci| ci.is_terminal() && include(ci))
+            .collect();
         incoming.sort_by_key(|ci| snapshot_eviction_key(ci));
 
         let repo_baseline = self.repo_baseline_mut(repo_key, repo_path);
@@ -655,16 +677,50 @@ fn acquire_baseline_lock(path: &Path) -> Result<BaselineLock> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    for _ in 0..200 {
+    for _ in 0..40 {
         match fs::create_dir(&lock_path) {
             Ok(()) => return Ok(BaselineLock { lock_path }),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                if baseline_lock_is_stale(&lock_path) {
+                    let _ = fs::remove_dir(&lock_path);
+                    continue;
+                }
                 std::thread::sleep(Duration::from_millis(5));
             }
             Err(error) => return Err(error.into()),
         }
     }
     Err("timed out waiting for GitHub CI baseline lock".into())
+}
+
+fn baseline_lock_is_stale(lock_path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(lock_path) else {
+        return true;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return true;
+    };
+    modified
+        .elapsed()
+        .map(|elapsed| elapsed.as_secs() >= BASELINE_LOCK_STALE_SECS)
+        .unwrap_or(true)
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn pending_due_for_send(pending: &PendingCiDelivery, now: u64) -> bool {
+    if pending.send_attempts >= MAX_PENDING_SEND_ATTEMPTS {
+        return false;
+    }
+    match pending.last_sent_unix {
+        None => true,
+        Some(timestamp) => now.saturating_sub(timestamp) >= PENDING_RETRY_BACKOFF_SECS,
+    }
 }
 
 fn write_ci_baseline_atomic(baseline: &CIBaseline, path: &Path) -> Result<()> {
@@ -719,19 +775,45 @@ async fn drain_pending_outbox(
     path: Option<&Path>,
     tx: &mpsc::Sender<IncomingEvent>,
 ) -> Result<()> {
-    let pending: Vec<PendingCiDelivery> = ci_baseline
+    let now = unix_now();
+    let due: Vec<PendingCiDelivery> = ci_baseline
         .repos
         .values()
         .flat_map(|repo| repo.pending.iter().cloned())
+        .filter(|pending| pending_due_for_send(pending, now))
         .collect();
-    if pending.is_empty() {
+    if due.is_empty() {
         return Ok(());
     }
-    for delivery in &pending {
-        send_event(tx, delivery.clone().into_event()).await?;
+    let mut sent = Vec::new();
+    for delivery in &due {
+        if send_event(tx, delivery.clone().into_event()).await.is_err() {
+            break;
+        }
+        sent.push(delivery.clone());
     }
-    ack_pending_deliveries(ci_baseline, path, &pending)?;
+    if sent.is_empty() {
+        return Ok(());
+    }
+    bump_pending_send_attempts(ci_baseline, &sent, now);
+    if let Err(error) = commit_ci_baseline(path, ci_baseline) {
+        eprintln!("clawhip source github CI baseline outbox attempt persist failed: {error}");
+    }
+    if let Err(error) = ack_pending_deliveries(ci_baseline, path, &sent) {
+        eprintln!("clawhip source github CI baseline outbox ack failed: {error}");
+    }
     Ok(())
+}
+
+fn bump_pending_send_attempts(ci_baseline: &mut CIBaseline, sent: &[PendingCiDelivery], now: u64) {
+    for repo in ci_baseline.repos.values_mut() {
+        for pending in &mut repo.pending {
+            if sent.iter().any(|item| pending.same_event(item)) {
+                pending.send_attempts = pending.send_attempts.saturating_add(1);
+                pending.last_sent_unix = Some(now);
+            }
+        }
+    }
 }
 
 fn ack_pending_deliveries(
@@ -945,7 +1027,9 @@ async fn poll_github(
     ci_baseline: &mut CIBaseline,
     ci_baseline_path: Option<&Path>,
 ) -> Result<()> {
-    drain_pending_outbox(ci_baseline, ci_baseline_path, tx).await?;
+    if let Err(error) = drain_pending_outbox(ci_baseline, ci_baseline_path, tx).await {
+        eprintln!("clawhip source github CI outbox drain failed: {error}");
+    }
 
     for repo in &config.monitors.git.repos {
         if !repo.emit_issue_opened && !repo.emit_pr_status {
@@ -995,7 +1079,7 @@ async fn poll_github(
             };
         let repo_key = ci_baseline_repo_key(&snapshot, repo);
         let repo_ci_baseline = ci_baseline.repos.get(&repo_key).cloned();
-        let (ci, ci_baseline_established, ci_events) = match poll_ci_statuses(
+        let (ci, ci_baseline_established, ci_events, window_complete) = match poll_ci_statuses(
             config,
             github_client,
             repo,
@@ -1018,6 +1102,7 @@ async fn poll_github(
                         .map(|entry| entry.ci_baseline_established)
                         .unwrap_or(false),
                     Vec::new(),
+                    false,
                 )
             }
         };
@@ -1027,7 +1112,20 @@ async fn poll_github(
         // suppression state. A crash after persist and before send retries
         // from the outbox on the next poll.
         let mut next_baseline = ci_baseline.clone();
-        next_baseline.record_terminal_runs(&repo_key, &repo.path, &ci);
+        let previous_ci = previous.map(|entry| &entry.ci);
+        next_baseline.record_terminal_runs_filtered(&repo_key, &repo.path, &ci, |snapshot| {
+            if previous_ci.is_none() || window_complete {
+                return true;
+            }
+            previous_ci.is_some_and(|old_map| {
+                old_map
+                    .values()
+                    .any(|old| snapshots_same_run(old, snapshot) && old.is_terminal())
+            }) || ci_events.iter().any(|event| {
+                previous_snapshot_for_event(&ci, event)
+                    .is_some_and(|matched| snapshots_same_run(matched, snapshot))
+            })
+        });
         next_baseline.enqueue_pending(&repo_key, &repo.path, &ci_events, &ci);
         match commit_ci_baseline(ci_baseline_path, &next_baseline) {
             Ok(committed) => {
@@ -1205,7 +1303,12 @@ async fn poll_ci_statuses(
     previous: Option<&GitHubRepoState>,
     prs: &HashMap<u64, PullRequestSnapshot>,
     repo_ci_baseline: Option<&RepoCIBaseline>,
-) -> Result<(HashMap<String, GitHubCISnapshot>, bool, Vec<IncomingEvent>)> {
+) -> Result<(
+    HashMap<String, GitHubCISnapshot>,
+    bool,
+    Vec<IncomingEvent>,
+    bool,
+)> {
     if !repo.emit_pr_status {
         return Ok((
             previous.map(|entry| entry.ci.clone()).unwrap_or_default(),
@@ -1213,6 +1316,7 @@ async fn poll_ci_statuses(
                 .map(|entry| entry.ci_baseline_established)
                 .unwrap_or(false),
             Vec::new(),
+            true,
         ));
     }
 
@@ -1223,6 +1327,7 @@ async fn poll_ci_statuses(
                 .map(|entry| entry.ci_baseline_established)
                 .unwrap_or(false),
             Vec::new(),
+            true,
         ));
     };
 
@@ -1263,7 +1368,10 @@ async fn poll_ci_statuses(
             } else {
                 Vec::new()
             };
-            Ok((ci, window_complete, events))
+            let established = previous
+                .map(|entry| entry.ci_baseline_established)
+                .unwrap_or(true);
+            Ok((ci, established, events, window_complete))
         }
         Err(error) => {
             telemetry::emit(source_record(
@@ -1284,6 +1392,7 @@ async fn poll_ci_statuses(
                 previous.map(|entry| entry.ci.clone()).unwrap_or_default(),
                 false,
                 Vec::new(),
+                false,
             ))
         }
     }
@@ -2903,6 +3012,232 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn issue_317_incomplete_window_does_not_suppress_new_terminal_as_prime() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut poll = 0_u32;
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = vec![0_u8; 8192];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                if !request.contains("/actions/runs") {
+                    let body = "[]";
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    continue;
+                }
+                let page = request
+                    .split(['?', '&'])
+                    .find_map(|part| part.strip_prefix("page="))
+                    .and_then(|value| {
+                        value
+                            .chars()
+                            .take_while(|ch| ch.is_ascii_digit())
+                            .collect::<String>()
+                            .parse::<usize>()
+                            .ok()
+                    })
+                    .unwrap_or(1);
+                if page == 1 {
+                    poll += 1;
+                }
+                let start = (page - 1) * CI_PAGE_SIZE;
+                let mut ids: Vec<u64> =
+                    (start as u64 + 1..=start as u64 + CI_PAGE_SIZE as u64).collect();
+                if poll >= 2 && page == 1 {
+                    ids[0] = 9_001;
+                }
+                let runs: Vec<String> = ids
+                    .iter()
+                    .map(|id| {
+                        let conclusion = if *id == 9_001 { "failure" } else { "success" };
+                        format!(
+                            r#"{{"id":{id},"name":"CI","status":"completed","conclusion":"{conclusion}","head_branch":"main","head_sha":"sha-{id}","html_url":"https://github.com/org/repo/actions/runs/{id}","pull_requests":[],"created_at":"2026-01-01T00:00:00Z","run_attempt":1}}"#
+                        )
+                    })
+                    .collect();
+                let body = format!(r#"{{"workflow_runs":[{}]}}"#, runs.join(","));
+                let next = page + 1;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nlink: <http://{addr}/repos/org/repo/actions/runs?per_page=100&page={next}>; rel=\"next\"\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                if poll >= 4 && page == 1 {
+                    break;
+                }
+            }
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_path = dir.path().join("github-ci-baseline.json");
+        let mut config = AppConfig::default();
+        config.monitors.github_api_base = format!("http://{addr}");
+        config.monitors.git.repos = vec![GitRepoMonitor {
+            path: "/tmp/clawhip-incomplete-window".into(),
+            name: Some("repo".into()),
+            github_repo: Some("org/repo".into()),
+            emit_pr_status: true,
+            emit_issue_opened: false,
+            emit_commits: false,
+            emit_branch_changes: false,
+            ..GitRepoMonitor::default()
+        }];
+        let client = build_github_client(None).unwrap();
+        let (tx, mut rx) = mpsc::channel(32);
+        let mut state = HashMap::new();
+        let mut baseline = CIBaseline::default();
+        for _ in 0..3 {
+            poll_once_with_baseline(
+                &config,
+                &client,
+                &mut state,
+                &mut baseline,
+                Some(&baseline_path),
+                &tx,
+            )
+            .await
+            .unwrap();
+        }
+        let mut delivered = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            delivered.push(event);
+        }
+        assert_eq!(
+            delivered.len(),
+            1,
+            "new terminal failure must emit once, not be primed away; got {delivered:?}"
+        );
+        assert_eq!(delivered[0].payload["run_id"], json!("9001"));
+        assert_eq!(delivered[0].canonical_kind(), "github.ci-failed");
+        assert!(state["/tmp/clawhip-incomplete-window"].ci_baseline_established);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn issue_317_persistent_ack_failure_bounds_resends_and_keeps_polling() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_server = hits.clone();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = vec![0_u8; 4096];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                if request.contains("/issues")
+                    || request.contains("/pulls")
+                    || request.contains("/actions/runs")
+                {
+                    hits_server.fetch_add(1, Ordering::SeqCst);
+                }
+                let body = if request.contains("/actions/runs") {
+                    r#"{"workflow_runs":[]}"#
+                } else {
+                    "[]"
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let good_path = dir.path().join("github-ci-baseline.json");
+        let run = run_snapshot(77, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        let mut seeded = CIBaseline::default();
+        seeded.enqueue_pending(
+            "repo:org/repo",
+            "/tmp/ack-a",
+            &events,
+            &run_map(std::slice::from_ref(&run)),
+        );
+        save_ci_baseline(&seeded, Some(&good_path)).unwrap();
+
+        let blocker = dir.path().join("blocked");
+        std::fs::write(&blocker, b"file").unwrap();
+        let bad_path = blocker.join("github-ci-baseline.json");
+
+        let mut config = AppConfig::default();
+        config.monitors.github_api_base = format!("http://{addr}");
+        config.monitors.git.repos = vec![
+            GitRepoMonitor {
+                path: "/tmp/ack-a".into(),
+                name: Some("a".into()),
+                github_repo: Some("org/repo".into()),
+                emit_pr_status: true,
+                emit_issue_opened: true,
+                emit_commits: false,
+                emit_branch_changes: false,
+                ..GitRepoMonitor::default()
+            },
+            GitRepoMonitor {
+                path: "/tmp/ack-b".into(),
+                name: Some("b".into()),
+                github_repo: Some("org/other".into()),
+                emit_pr_status: true,
+                emit_issue_opened: true,
+                emit_commits: false,
+                emit_branch_changes: false,
+                ..GitRepoMonitor::default()
+            },
+        ];
+        let client = build_github_client(None).unwrap();
+        let (tx, mut rx) = mpsc::channel(32);
+        let mut state = HashMap::new();
+        let mut baseline = load_ci_baseline(Some(&good_path));
+        for _ in 0..3 {
+            poll_once_with_baseline(
+                &config,
+                &client,
+                &mut state,
+                &mut baseline,
+                Some(&bad_path),
+                &tx,
+            )
+            .await
+            .unwrap();
+        }
+        let mut sent = 0_usize;
+        while rx.try_recv().is_ok() {
+            sent += 1;
+        }
+        assert_eq!(
+            sent, 1,
+            "persistent ACK failure must not resend the full outbox every poll"
+        );
+        assert!(
+            hits.load(Ordering::SeqCst) >= 6,
+            "ACK failure must not abort polling of remaining repositories"
+        );
+        server.abort();
+    }
+
     #[test]
     fn issue_317_incomplete_window_keeps_omitted_in_progress_and_later_completion() {
         let in_progress = GitHubCISnapshot {
@@ -3267,7 +3602,7 @@ mod tests {
         let client = build_github_client(None).unwrap();
         let prs = HashMap::new();
 
-        let (ci, ci_baseline_established, events) =
+        let (ci, ci_baseline_established, events, _window_complete) =
             poll_ci_statuses(&config, Some(&client), &repo, &snapshot, None, &prs, None)
                 .await
                 .unwrap();

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -612,11 +612,13 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
         }
     }
     for delivery in source.pending {
-        if !dest
+        if let Some(existing) = dest
             .pending
-            .iter()
-            .any(|existing| existing.same_event(&delivery))
+            .iter_mut()
+            .find(|existing| existing.same_event(&delivery))
         {
+            merge_pending_retry_state(existing, &delivery);
+        } else {
             dest.pending.push(delivery);
         }
     }
@@ -721,6 +723,15 @@ fn pending_due_for_send(pending: &PendingCiDelivery, now: u64) -> bool {
         None => true,
         Some(timestamp) => now.saturating_sub(timestamp) >= PENDING_RETRY_BACKOFF_SECS,
     }
+}
+
+fn merge_pending_retry_state(dest: &mut PendingCiDelivery, source: &PendingCiDelivery) {
+    dest.send_attempts = dest.send_attempts.max(source.send_attempts);
+    dest.last_sent_unix = match (dest.last_sent_unix, source.last_sent_unix) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    };
 }
 
 fn write_ci_baseline_atomic(baseline: &CIBaseline, path: &Path) -> Result<()> {
@@ -1159,10 +1170,24 @@ async fn poll_github(
 
         let delivered: Vec<PendingCiDelivery> = ci_events
             .iter()
-            .map(|event| PendingCiDelivery::from_event(event, Vec::new()))
+            .map(|event| {
+                let identities = previous_snapshot_for_event(&ci, event)
+                    .map(GitHubCISnapshot::identities)
+                    .unwrap_or_default();
+                PendingCiDelivery::from_event(event, identities)
+            })
             .collect();
         for event in ci_events {
             send_event(tx, event).await?;
+        }
+        if !delivered.is_empty() {
+            bump_pending_send_attempts(ci_baseline, &delivered, unix_now());
+            if let Err(error) = commit_ci_baseline(ci_baseline_path, ci_baseline) {
+                eprintln!(
+                    "clawhip source github CI baseline outbox attempt persist failed for {}: {error}",
+                    repo.path
+                );
+            }
         }
         if let Err(error) = ack_pending_deliveries(ci_baseline, ci_baseline_path, &delivered) {
             eprintln!(
@@ -3236,6 +3261,78 @@ mod tests {
             "ACK failure must not abort polling of remaining repositories"
         );
         server.abort();
+    }
+
+    #[test]
+    fn issue_317_merge_pending_keeps_monotonic_retry_state() {
+        let run = run_snapshot(77, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        let mut older = PendingCiDelivery::from_event(&events[0], run.identities());
+        older.send_attempts = 0;
+        older.last_sent_unix = Some(10);
+        let mut newer = older.clone();
+        newer.send_attempts = 2;
+        newer.last_sent_unix = Some(50);
+        let mut dest = RepoCIBaseline::default();
+        dest.pending.push(older);
+        merge_repo_baseline(
+            &mut dest,
+            RepoCIBaseline {
+                pending: vec![newer],
+                ..RepoCIBaseline::default()
+            },
+        );
+        assert_eq!(dest.pending.len(), 1);
+        assert_eq!(dest.pending[0].send_attempts, 2);
+        assert_eq!(dest.pending[0].last_sent_unix, Some(50));
+    }
+
+    #[test]
+    fn issue_317_restart_after_ack_failure_honors_persisted_attempts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let run = run_snapshot(77, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events,
+            &run_map(std::slice::from_ref(&run)),
+        );
+        save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
+        let pending = ci_baseline.repos["/repo"].pending.clone();
+        bump_pending_send_attempts(&mut ci_baseline, &pending, unix_now());
+        commit_ci_baseline(Some(&path), &ci_baseline).unwrap();
+
+        let blocker = dir.path().join("blocked");
+        std::fs::write(&blocker, b"file").unwrap();
+        let bad_path = blocker.join("github-ci-baseline.json");
+        assert!(ack_pending_deliveries(&mut ci_baseline, Some(&bad_path), &pending).is_err());
+
+        let restarted = load_ci_baseline(Some(&path));
+        let stored = &restarted.repos["/repo"].pending;
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].send_attempts, 1);
+        assert!(stored[0].last_sent_unix.is_some());
+        assert!(
+            !pending_due_for_send(&stored[0], unix_now()),
+            "restart must honor persisted backoff after ACK removal fails"
+        );
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1329,24 +1329,35 @@ async fn send_then_ack_prefix(
     _events: Vec<IncomingEvent>,
     delivered: &[PendingCiDelivery],
 ) -> Result<()> {
+    let now = unix_now();
     for delivery in delivered {
-        persist_pending_send_attempts(
-            ci_baseline,
-            path,
-            std::slice::from_ref(delivery),
-            unix_now(),
-        )?;
-        let Some(durable) = outbox_entry(ci_baseline, delivery) else {
+        let Some(queued) = outbox_entry(ci_baseline, delivery) else {
+            continue;
+        };
+        if !pending_due_for_send(&queued, now) {
+            continue;
+        }
+        if persist_pending_send_attempts(ci_baseline, path, std::slice::from_ref(&queued), now)
+            .is_err()
+        {
+            eprintln!("clawhip source github CI baseline outbox attempt persist failed");
+            return Ok(());
+        }
+        let Some(durable) = outbox_entry(ci_baseline, &queued) else {
             continue;
         };
         match send_event(tx, durable.clone().into_event()).await {
             Ok(()) => {
-                ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(&durable))?;
+                if let Err(error) =
+                    ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(&durable))
+                {
+                    eprintln!("clawhip source github CI baseline outbox ack failed: {error}");
+                }
             }
-            Err(error) => {
+            Err(_) => {
                 dead_letter_unsent_final_attempts(ci_baseline, std::slice::from_ref(&durable));
                 let _ = commit_ci_baseline(path, ci_baseline);
-                return Err(error);
+                return Ok(());
             }
         }
     }
@@ -2028,6 +2039,19 @@ async fn poll_ci_statuses(
                     &snapshot.repo_name,
                     previous.ci_baseline_established,
                     &previous.ci,
+                    &ci,
+                    repo_ci_baseline,
+                )
+            } else if repo_ci_baseline.is_some_and(|baseline| {
+                !baseline.terminal_runs.is_empty()
+                    || !baseline.pending.is_empty()
+                    || !baseline.acked.is_empty()
+            }) {
+                collect_ci_events(
+                    repo,
+                    &snapshot.repo_name,
+                    true,
+                    &HashMap::new(),
                     &ci,
                     repo_ci_baseline,
                 )
@@ -4385,7 +4409,10 @@ mod tests {
         });
         let mut live = load_ci_baseline(Some(&path));
         let result = send_then_ack_prefix(&tx, &mut live, Some(&path), events, &delivered).await;
-        assert!(result.is_err(), "closed receiver must fail the second send");
+        assert!(
+            result.is_ok(),
+            "closed receiver must not abort later repository polling"
+        );
         let _ = recv.await;
         let restarted = load_ci_baseline(Some(&path));
         let pending = &restarted.repos["/repo"].pending;
@@ -4541,6 +4568,28 @@ mod tests {
             !repo_ci_baseline_is_suppressed(baseline.repos.get("/repo"), &test),
             "run-only historical receipt must not suppress mixed check jobs"
         );
+    }
+
+    #[test]
+    fn issue_317_first_poll_after_restart_emits_unrecorded_terminal() {
+        let historical = run_snapshot(1, "CI", Some("success"), "main");
+        let fresh = run_snapshot(2, "CI", Some("failure"), "main");
+        let mut baseline = CIBaseline::default();
+        baseline.record_terminal_runs(
+            "/repo",
+            "/repo",
+            &run_map(std::slice::from_ref(&historical)),
+        );
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(&[historical.clone(), fresh.clone()]),
+            baseline.repos.get("/repo"),
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-failed");
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -184,12 +184,23 @@ impl AckedDelivery {
                 .iter()
                 .any(|identity| pending_checks.iter().any(|candidate| candidate == identity));
         }
-        let run_match = self.run_id.is_some()
-            && self.run_id == pending.run_id
-            && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(pending.run_attempt)
-            && self.workflow == pending.workflow;
-        if run_match {
-            return true;
+        let self_has_run = self.run_id.is_some();
+        let pending_has_run = pending.run_id.is_some();
+        if self_has_run && pending_has_run {
+            return self.run_id == pending.run_id
+                && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(pending.run_attempt)
+                && self.workflow == pending.workflow;
+        }
+        let check_to_fallback =
+            (!self_checks.is_empty() && pending_checks.is_empty() && !pending_has_run)
+                || (!pending_checks.is_empty() && self_checks.is_empty() && !self_has_run);
+        if !check_to_fallback
+            && (self_has_run
+                || pending_has_run
+                || !self_checks.is_empty()
+                || !pending_checks.is_empty())
+        {
+            return false;
         }
         self.sha == pending.sha
             && self.workflow == pending.workflow
@@ -389,6 +400,7 @@ const CI_PAGE_SIZE: usize = 100;
 const MAX_CI_PAGES: usize = 5;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
+#[cfg(test)]
 const ACK_RETENTION_SECS: u64 = 7 * 24 * 3_600;
 const MAX_DEAD_LETTER: usize = 64;
 
@@ -767,6 +779,7 @@ fn record_acked(repo: &mut RepoCIBaseline, delivery: &PendingCiDelivery) {
         .push_back(AckedDelivery::from_pending(delivery, unix_now()));
 }
 
+#[cfg(test)]
 fn retire_exhausted_pending(repo: &mut RepoCIBaseline) {
     let mut still_pending = Vec::new();
     for pending in repo.pending.drain(..) {
@@ -782,6 +795,26 @@ fn retire_exhausted_pending(repo: &mut RepoCIBaseline) {
     }
 }
 
+fn dead_letter_unsent_final_attempts(ci_baseline: &mut CIBaseline, unsent: &[PendingCiDelivery]) {
+    for repo in ci_baseline.repos.values_mut() {
+        let mut keep = Vec::new();
+        for pending in repo.pending.drain(..) {
+            if unsent.iter().any(|item| pending.same_event(item))
+                && pending.send_attempts >= MAX_PENDING_SEND_ATTEMPTS
+            {
+                repo.dead_letter.push_back(pending);
+            } else {
+                keep.push(pending);
+            }
+        }
+        repo.pending = keep;
+        while repo.dead_letter.len() > MAX_DEAD_LETTER {
+            repo.dead_letter.pop_front();
+        }
+    }
+}
+
+#[cfg(test)]
 fn compact_acked(repo: &mut RepoCIBaseline, now: u64) {
     let before = repo.acked.len();
     repo.acked
@@ -848,27 +881,23 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     while dest.dead_letter.len() > MAX_DEAD_LETTER {
         dest.dead_letter.pop_front();
     }
-    let source_retired = source.epoch < dest.min_writer_epoch;
-    if !source_retired {
-        for delivery in source.pending {
-            if pending_is_acked(dest, &delivery) {
-                continue;
-            }
-            if let Some(existing) = dest
-                .pending
-                .iter_mut()
-                .find(|existing| existing.same_event(&delivery))
-            {
-                merge_pending_retry_state(existing, &delivery);
-            } else {
-                dest.pending.push(delivery);
-            }
+    for delivery in source.pending {
+        if pending_is_acked(dest, &delivery) {
+            continue;
+        }
+        if let Some(existing) = dest
+            .pending
+            .iter_mut()
+            .find(|existing| existing.same_event(&delivery))
+        {
+            merge_pending_retry_state(existing, &delivery);
+        } else {
+            dest.pending.push(delivery);
         }
     }
     let acked = dest.acked.clone();
     dest.pending
         .retain(|pending| !acked.iter().any(|item| item.matches_pending(pending)));
-    retire_exhausted_pending(dest);
 }
 
 fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
@@ -1094,11 +1123,8 @@ fn commit_ci_baseline(path: Option<&Path>, local: &CIBaseline) -> Result<CIBasel
     let _lock = acquire_baseline_lock(path)?;
     let mut disk = load_ci_baseline(Some(path));
     merge_ci_baseline(&mut disk, local);
-    let now = unix_now();
     for repo in disk.repos.values_mut() {
         repo.epoch = repo.epoch.saturating_add(1);
-        compact_acked(repo, now);
-        retire_exhausted_pending(repo);
     }
     write_ci_baseline_atomic(&disk, path)?;
     Ok(disk)
@@ -1129,6 +1155,15 @@ async fn send_then_ack_prefix(
     }
     if !sent.is_empty() {
         ack_pending_deliveries(ci_baseline, path, &sent)?;
+    }
+    let unsent: Vec<PendingCiDelivery> = delivered
+        .iter()
+        .filter(|delivery| !sent.iter().any(|item| item.same_event(delivery)))
+        .cloned()
+        .collect();
+    if !unsent.is_empty() {
+        dead_letter_unsent_final_attempts(ci_baseline, &unsent);
+        let _ = commit_ci_baseline(path, ci_baseline);
     }
     if let Some(error) = send_error {
         return Err(error);
@@ -1162,11 +1197,18 @@ async fn drain_pending_outbox(
         }
         sent.push(delivery.clone());
     }
-    if sent.is_empty() {
-        return Ok(());
-    }
-    if let Err(error) = ack_pending_deliveries(ci_baseline, path, &sent) {
+    if !sent.is_empty()
+        && let Err(error) = ack_pending_deliveries(ci_baseline, path, &sent)
+    {
         eprintln!("clawhip source github CI baseline outbox ack failed: {error}");
+    }
+    let unsent: Vec<PendingCiDelivery> = due
+        .into_iter()
+        .filter(|delivery| !sent.iter().any(|item| item.same_event(delivery)))
+        .collect();
+    if !unsent.is_empty() {
+        dead_letter_unsent_final_attempts(ci_baseline, &unsent);
+        let _ = commit_ci_baseline(path, ci_baseline);
     }
     Ok(())
 }
@@ -1204,8 +1246,9 @@ fn ack_pending_deliveries(
             for delivery in delivered {
                 record_acked(repo, delivery);
             }
+            let acked = repo.acked.clone();
             repo.pending
-                .retain(|pending| !delivered.iter().any(|item| pending.same_event(item)));
+                .retain(|pending| !acked.iter().any(|item| item.matches_pending(pending)));
         }
         return Ok(());
     };
@@ -1215,24 +1258,25 @@ fn ack_pending_deliveries(
     for (key, repo) in disk.repos.iter_mut() {
         let local_repo = ci_baseline.repos.get(key);
         for delivery in delivered {
-            let in_disk = repo
-                .pending
-                .iter()
-                .any(|pending| pending.same_event(delivery));
+            let in_disk = repo.pending.iter().any(|pending| {
+                pending.same_event(delivery)
+                    || AckedDelivery::from_pending(delivery, 0).matches_pending(pending)
+            });
             let in_local = local_repo
                 .map(|local| {
-                    local
-                        .pending
-                        .iter()
-                        .any(|pending| pending.same_event(delivery))
+                    local.pending.iter().any(|pending| {
+                        pending.same_event(delivery)
+                            || AckedDelivery::from_pending(delivery, 0).matches_pending(pending)
+                    })
                 })
                 .unwrap_or(false);
             if in_disk || in_local {
                 record_acked(repo, delivery);
             }
         }
+        let acked = repo.acked.clone();
         repo.pending
-            .retain(|pending| !delivered.iter().any(|item| pending.same_event(item)));
+            .retain(|pending| !acked.iter().any(|item| item.matches_pending(pending)));
     }
     write_ci_baseline_atomic(&disk, path)?;
     *ci_baseline = disk;
@@ -3934,6 +3978,89 @@ mod tests {
         );
     }
 
+    #[test]
+    fn issue_317_ack_does_not_cover_other_run_attempt() {
+        let attempt1 = check_job(4242, 11, "CI", "success");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt1)),
+            None,
+        );
+        let mut repo = RepoCIBaseline::default();
+        record_acked(
+            &mut repo,
+            &PendingCiDelivery::from_event(&events[0], attempt1.identities()),
+        );
+        let attempt2 = GitHubCISnapshot {
+            run_attempt: 2,
+            check_run_id: Some("99".into()),
+            ..check_job(4242, 99, "CI", "success")
+        };
+        let events2 = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt2)),
+            None,
+        );
+        let pending2 = PendingCiDelivery::from_event(&events2[0], attempt2.identities());
+        assert!(!pending_is_acked(&repo, &pending2));
+    }
+
+    #[tokio::test]
+    async fn issue_317_check_ack_prevents_run_only_drain() {
+        let check = check_job(4242, 11, "CI", "success");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&check)),
+            None,
+        );
+        let mut run_only = PendingCiDelivery::from_event(&events[0], check.identities());
+        run_only
+            .identities
+            .retain(|identity| identity.starts_with("run:"));
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut baseline = CIBaseline::default();
+        baseline
+            .repos
+            .insert("/repo".into(), RepoCIBaseline::default());
+        baseline
+            .repos
+            .get_mut("/repo")
+            .unwrap()
+            .pending
+            .push(run_only.clone());
+        save_ci_baseline(&baseline, Some(&path)).unwrap();
+        let mut live = load_ci_baseline(Some(&path));
+        ack_pending_deliveries(
+            &mut live,
+            Some(&path),
+            std::slice::from_ref(&PendingCiDelivery::from_event(
+                &events[0],
+                check.identities(),
+            )),
+        )
+        .unwrap();
+        let (tx, mut rx) = mpsc::channel(8);
+        drain_pending_outbox(&mut live, Some(&path), &tx)
+            .await
+            .unwrap();
+        assert!(rx.try_recv().is_err());
+        assert!(
+            load_ci_baseline(Some(&path)).repos["/repo"]
+                .pending
+                .is_empty()
+        );
+    }
+
     #[tokio::test]
     async fn issue_317_partial_send_acks_only_successful_prefix() {
         let lint = check_job(4242, 11, "lint", "success");
@@ -4036,9 +4163,10 @@ mod tests {
         };
         stale.pending.push(pending.clone());
         merge_repo_baseline(&mut dest, stale);
-        assert!(
-            dest.pending.is_empty(),
-            "retired writer must not restore pending after ACK compaction"
+        assert_eq!(
+            dest.pending.len(),
+            1,
+            "compaction must not drop a concurrent writer's pending set"
         );
     }
 
@@ -4906,24 +5034,30 @@ mod tests {
         let path = dir.path().join("github-ci-baseline.json");
         save_ci_baseline(&CIBaseline::default(), Some(&path)).unwrap();
 
+        let start = Arc::new(Barrier::new(2));
         std::thread::scope(|scope| {
-            scope.spawn(|| {
+            let start_left = start.clone();
+            let path_left = path.clone();
+            scope.spawn(move || {
                 let mut left = CIBaseline::default();
                 left.record_terminal_runs(
                     "repo:org/repo",
                     "/a",
                     &run_map(&[run_snapshot(1, "CI", Some("success"), "main")]),
                 );
-                commit_ci_baseline(Some(&path), &left).unwrap();
+                start_left.wait();
+                commit_ci_baseline(Some(&path_left), &left).unwrap();
             });
-            scope.spawn(|| {
+            let path_right = path.clone();
+            scope.spawn(move || {
                 let mut right = CIBaseline::default();
                 right.record_terminal_runs(
                     "repo:org/repo",
                     "/a",
                     &run_map(&[run_snapshot(2, "CI", Some("success"), "main")]),
                 );
-                commit_ci_baseline(Some(&path), &right).unwrap();
+                start.wait();
+                commit_ci_baseline(Some(&path_right), &right).unwrap();
             });
         });
 

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fs;
-use std::io;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -312,8 +311,6 @@ const CI_PAGE_SIZE: usize = 100;
 const MAX_CI_PAGES: usize = 5;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
-const BASELINE_LOCK_STALE_SECS: u64 = 30;
-const MAX_ACKED_DELIVERIES: usize = 512;
 
 /// Beside the cron state file, matching `tmux-watch-registry.json` and
 /// `discord-watch-state.json`.
@@ -678,9 +675,6 @@ fn record_acked(repo: &mut RepoCIBaseline, delivery: &PendingCiDelivery) {
     if !repo.acked.iter().any(|acked| acked == &key) {
         repo.acked.push_back(key);
     }
-    while repo.acked.len() > MAX_ACKED_DELIVERIES {
-        repo.acked.pop_front();
-    }
 }
 
 fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
@@ -710,9 +704,6 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
         if !dest.acked.iter().any(|acked| acked == &key) {
             dest.acked.push_back(key);
         }
-    }
-    while dest.acked.len() > MAX_ACKED_DELIVERIES {
-        dest.acked.pop_front();
     }
     for delivery in source.pending {
         if pending_is_acked(dest, &delivery) {
@@ -776,89 +767,85 @@ fn merge_ci_baseline(dest: &mut CIBaseline, source: &CIBaseline) {
 }
 
 struct BaselineLock {
-    lock_path: PathBuf,
-    token: String,
+    file: File,
 }
 
 impl Drop for BaselineLock {
     fn drop(&mut self) {
-        let owner = self.lock_path.join("owner");
-        if fs::read_to_string(&owner).ok().as_deref() == Some(self.token.as_str()) {
-            let _ = fs::remove_dir_all(&self.lock_path);
-        }
+        unlock_baseline_file(&self.file);
     }
 }
 
 fn acquire_baseline_lock(path: &Path) -> Result<BaselineLock> {
-    acquire_baseline_lock_inner(path, BASELINE_LOCK_STALE_SECS)
-}
-
-fn acquire_baseline_lock_inner(path: &Path, stale_secs: u64) -> Result<BaselineLock> {
     let lock_path = path.with_extension("json.lock");
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let token = format!(
-        "{}-{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0)
-    );
+    if lock_path.is_dir() {
+        let _ = fs::remove_dir_all(&lock_path);
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)?;
     for _ in 0..40 {
-        match fs::create_dir(&lock_path) {
-            Ok(()) => {
-                if let Err(error) = fs::write(lock_path.join("owner"), token.as_bytes()) {
-                    let _ = fs::remove_dir_all(&lock_path);
-                    return Err(error.into());
-                }
-                return Ok(BaselineLock { lock_path, token });
-            }
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                try_reclaim_stale_lock(&lock_path, stale_secs);
-                std::thread::sleep(Duration::from_millis(5));
-            }
-            Err(error) => return Err(error.into()),
+        if try_lock_baseline_file(&file) {
+            return Ok(BaselineLock { file });
         }
+        std::thread::sleep(Duration::from_millis(5));
     }
     Err("timed out waiting for GitHub CI baseline lock".into())
 }
 
-fn try_reclaim_stale_lock(lock_path: &Path, stale_secs: u64) {
-    if !baseline_lock_is_stale(lock_path, stale_secs) {
-        return;
-    }
-    let owner = lock_path.join("owner");
-    let observed = fs::read_to_string(&owner).unwrap_or_default();
-    let current = fs::read_to_string(&owner).unwrap_or_default();
-    if current != observed {
-        return;
-    }
-    let dead = lock_path.with_extension(format!(
-        "json.lock.dead.{}-{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0)
-    ));
-    if fs::rename(lock_path, &dead).is_ok() {
-        let _ = fs::remove_dir_all(&dead);
+#[cfg(unix)]
+fn try_lock_baseline_file(file: &File) -> bool {
+    use std::os::unix::io::AsRawFd;
+    unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 }
+}
+
+#[cfg(unix)]
+fn unlock_baseline_file(file: &File) {
+    use std::os::unix::io::AsRawFd;
+    unsafe {
+        libc::flock(file.as_raw_fd(), libc::LOCK_UN);
     }
 }
 
-fn baseline_lock_is_stale(lock_path: &Path, stale_secs: u64) -> bool {
-    let Ok(metadata) = fs::metadata(lock_path) else {
-        return true;
-    };
-    let Ok(modified) = metadata.modified() else {
-        return true;
-    };
-    modified
-        .elapsed()
-        .map(|elapsed| elapsed.as_secs() >= stale_secs)
-        .unwrap_or(true)
+#[cfg(windows)]
+fn try_lock_baseline_file(file: &File) -> bool {
+    use std::os::windows::io::AsRawHandle;
+    unsafe { lock_file(file.as_raw_handle(), 0, 0, 1, 0) != 0 }
+}
+
+#[cfg(windows)]
+fn unlock_baseline_file(file: &File) {
+    use std::os::windows::io::AsRawHandle;
+    unsafe {
+        unlock_file(file.as_raw_handle(), 0, 0, 1, 0);
+    }
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+extern "system" {
+    #[link_name = "LockFile"]
+    fn lock_file(
+        handle: *mut core::ffi::c_void,
+        offset_low: u32,
+        offset_high: u32,
+        length_low: u32,
+        length_high: u32,
+    ) -> i32;
+    #[link_name = "UnlockFile"]
+    fn unlock_file(
+        handle: *mut core::ffi::c_void,
+        offset_low: u32,
+        offset_high: u32,
+        length_low: u32,
+        length_high: u32,
+    ) -> i32;
 }
 
 fn unix_now() -> u64 {
@@ -3619,42 +3606,28 @@ mod tests {
         let lock_path = path.with_extension("json.lock");
         fs::create_dir_all(&lock_path).unwrap();
         fs::write(lock_path.join("owner"), b"stale-token").unwrap();
-        std::process::Command::new("touch")
-            .args(["-t", "197001010000"])
-            .arg(&lock_path)
-            .status()
-            .unwrap();
 
         let overlapping = Arc::new(AtomicUsize::new(0));
         let current = Arc::new(AtomicUsize::new(0));
-        let live_deleted = Arc::new(AtomicUsize::new(0));
         let errors = Arc::new(Mutex::new(Vec::new()));
 
         thread::scope(|scope| {
             for _ in 0..2 {
                 let overlapping = overlapping.clone();
                 let current = current.clone();
-                let live_deleted = live_deleted.clone();
                 let errors = errors.clone();
                 let path = path.clone();
-                scope.spawn(move || {
-                    match acquire_baseline_lock_inner(&path, BASELINE_LOCK_STALE_SECS) {
-                        Ok(lock) => {
-                            let owner = lock.lock_path.join("owner");
-                            let token = lock.token.clone();
-                            current.fetch_add(1, Ordering::SeqCst);
-                            thread::sleep(Duration::from_millis(30));
-                            if current.load(Ordering::SeqCst) > 1 {
-                                overlapping.fetch_add(1, Ordering::SeqCst);
-                            }
-                            if fs::read_to_string(&owner).ok().as_deref() != Some(token.as_str()) {
-                                live_deleted.fetch_add(1, Ordering::SeqCst);
-                            }
-                            current.fetch_sub(1, Ordering::SeqCst);
-                            drop(lock);
+                scope.spawn(move || match acquire_baseline_lock(&path) {
+                    Ok(lock) => {
+                        current.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(30));
+                        if current.load(Ordering::SeqCst) > 1 {
+                            overlapping.fetch_add(1, Ordering::SeqCst);
                         }
-                        Err(error) => errors.lock().unwrap().push(error.to_string()),
+                        current.fetch_sub(1, Ordering::SeqCst);
+                        drop(lock);
                     }
+                    Err(error) => errors.lock().unwrap().push(error.to_string()),
                 });
             }
         });
@@ -3667,12 +3640,70 @@ mod tests {
         assert_eq!(
             overlapping.load(Ordering::SeqCst),
             0,
-            "two reclaimers must not enter the critical section together"
+            "advisory lock must serialize critical sections"
         );
-        assert_eq!(
-            live_deleted.load(Ordering::SeqCst),
-            0,
-            "a reclaimer must not delete another owner's live lock"
+    }
+
+    #[test]
+    fn issue_317_acked_tombstones_survive_many_later_acks() {
+        let first = check_job(1, 1, "first", "success");
+        let extra = check_job(1, 2, "extra", "success");
+        let current = run_map(&[first.clone(), extra.clone()]);
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &current,
+            None,
+        );
+        let pending_a = PendingCiDelivery::from_event(
+            events
+                .iter()
+                .find(|event| event.payload["workflow"] == "first")
+                .unwrap(),
+            first.identities(),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut durable = CIBaseline::default();
+        durable.enqueue_pending("/repo", "/repo", &events, &current);
+        save_ci_baseline(&durable, Some(&path)).unwrap();
+        let mut proc1 = load_ci_baseline(Some(&path));
+        ack_pending_deliveries(&mut proc1, Some(&path), std::slice::from_ref(&pending_a)).unwrap();
+
+        let mut later = load_ci_baseline(Some(&path));
+        for id in 10..530 {
+            let job = check_job(9, id, "later", "success");
+            let later_events = collect_ci_events(
+                &GitRepoMonitor::default(),
+                "org/repo",
+                true,
+                &HashMap::new(),
+                &run_map(std::slice::from_ref(&job)),
+                None,
+            );
+            later.enqueue_pending(
+                "/repo",
+                "/repo",
+                &later_events,
+                &run_map(std::slice::from_ref(&job)),
+            );
+            let pending = PendingCiDelivery::from_event(&later_events[0], job.identities());
+            ack_pending_deliveries(&mut later, Some(&path), std::slice::from_ref(&pending))
+                .unwrap();
+        }
+
+        let mut stale = CIBaseline::default();
+        stale.enqueue_pending("/repo", "/repo", &events, &current);
+        commit_ci_baseline(Some(&path), &stale).unwrap();
+        let restarted = load_ci_baseline(Some(&path));
+        assert!(
+            !restarted.repos["/repo"]
+                .pending
+                .iter()
+                .any(|pending| pending.same_event(&pending_a)),
+            "tombstone must survive hundreds of later ACKs and a stale merge"
         );
     }
 

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -107,6 +107,15 @@ struct RepoCIBaseline {
     min_writer_epoch: u64,
     #[serde(default)]
     ci_established: bool,
+    /// Durable identity set of the terminal runs in the last authoritative
+    /// fetched window. Pinned against cap eviction so the live window —
+    /// including an oversized fetched window (#317) — always survives merge
+    /// and reload. Canonicalized, deduplicated, hard-capped at
+    /// [`MAX_CURRENT_WINDOW_IDS`]; superseded only by an epoch-unfenced
+    /// writer whose pinned receipts are at least as recent, and never
+    /// dropped by a fenced stale writer.
+    #[serde(default)]
+    current_window_ids: Vec<String>,
 }
 
 /// Durable receipt for one terminal run. Identities are aliases (run-id,
@@ -467,6 +476,13 @@ where
 const CI_PAGE_SIZE: usize = 100;
 const MAX_CI_PAGES: usize = 5;
 const MAX_BASELINE_RUNS_PER_REPO: usize = CI_PAGE_SIZE * MAX_CI_PAGES;
+/// Hard bound on protected current-window identities per repo. The fetched
+/// window is normally at most [`MAX_BASELINE_RUNS_PER_REPO`] runs, but each
+/// run can contribute several durable aliases (attempt-qualified run ids,
+/// check-run ids) and an oversized fetch can exceed the receipt cap;
+/// protection stops here so alias multiplication cannot grow the pinned
+/// window unboundedly.
+const MAX_CURRENT_WINDOW_IDS: usize = MAX_BASELINE_RUNS_PER_REPO * 4;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
 const ACK_RETENTION_SECS: u64 = 7 * 24 * 3_600;
@@ -658,6 +674,65 @@ fn cap_repo_baseline_keeping(
     cap_repo_baseline_keeping_ids(repo_baseline, &keep_ids)
 }
 
+/// Canonicalizes the pinned current-window identity set: only durable
+/// aliases (`run:` / `check:` prefixes), each stored once, order-stable by
+/// first appearance, hard-capped at [`MAX_CURRENT_WINDOW_IDS`]. Identities
+/// arrive oldest-first (eviction-key order); when the bound trims, the
+/// OLDEST aliases drop so the newest fetched terminal runs — the ones still
+/// inside GitHub's fetch window — always stay protected. Fallback
+/// (`pr:sha:workflow`) identities are excluded: they are not used for
+/// current-window authority and pinning them would alias-multiply the
+/// protection set.
+fn canonicalize_current_window_ids(incoming: &[&GitHubCISnapshot]) -> Vec<String> {
+    cap_window_ids(canonical_window_identities(
+        incoming.iter().flat_map(|ci| ci.unique_identities()),
+    ))
+}
+
+/// Same canonical form for an already-pinned identity set (merge/load
+/// paths): deduplicated, order-stable, hard-capped keeping the newest.
+fn canonicalize_current_window_ids_from(ids: &[String]) -> Vec<String> {
+    cap_window_ids(canonical_window_identities(ids.iter().cloned()))
+}
+
+/// Newest eviction key among the receipts pinned by a current window. Used
+/// to pick the current-window authority during merge: the window whose
+/// pinned receipts are the newest reflects the latest GitHub fetch state
+/// and stays protected; a writer whose window pins only older receipts
+/// (restart with a stale view, fenced writer) must not evict or replace it.
+fn window_recency_key(repo: &RepoCIBaseline) -> Option<(u8, String, u64, String)> {
+    let pinned: std::collections::HashSet<&str> =
+        repo.current_window_ids.iter().map(String::as_str).collect();
+    repo.terminal_runs
+        .iter()
+        .filter(|record| record.unique_identities().any(|id| pinned.contains(id)))
+        .map(TerminalRunRecord::eviction_key)
+        .max()
+}
+
+fn canonical_window_identities(identities: impl Iterator<Item = String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    identities
+        .filter(|identity| seen.insert(identity.clone()))
+        .collect()
+}
+
+/// Applies the explicit window bound. Identities are oldest-first, so
+/// trimming drops from the front and the newest survive.
+fn cap_window_ids(mut ids: Vec<String>) -> Vec<String> {
+    let excess = ids.len().saturating_sub(MAX_CURRENT_WINDOW_IDS);
+    ids.drain(..excess);
+    ids
+}
+
+/// Post-load bound for a persisted `current_window_ids`. Writers already
+/// store a canonicalized set; this only guards files written by older or
+/// differently-shaped writers.
+fn canonicalize_loaded_window(repo_baseline: &mut RepoCIBaseline) {
+    repo_baseline.current_window_ids =
+        canonicalize_current_window_ids_from(&repo_baseline.current_window_ids);
+}
+
 fn cap_repo_baseline_keeping_ids(
     repo_baseline: &mut RepoCIBaseline,
     keep_ids: &std::collections::HashSet<String>,
@@ -812,6 +887,7 @@ impl CIBaseline {
                 dirty = true;
             }
         }
+        repo_baseline.current_window_ids = canonicalize_current_window_ids(&incoming);
         dirty |= cap_repo_baseline_keeping(repo_baseline, &incoming);
         dirty
     }
@@ -937,11 +1013,28 @@ fn normalize_repo_outbox(repo: &mut RepoCIBaseline) {
 }
 
 fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
-    let keep_ids: std::collections::HashSet<String> = source
-        .terminal_runs
-        .iter()
-        .flat_map(|record| record.unique_identities().map(str::to_string))
-        .collect();
+    // A writer fenced by `min_writer_epoch` predates the current authority:
+    // its window can cap-evict nothing from the pinned current window and
+    // must not replace it either.
+    let source_stale = dest.min_writer_epoch > 0 && source.epoch < dest.min_writer_epoch;
+    // Window authority is epoch-fenced recency: the window whose pinned
+    // receipts are newest reflects the latest GitHub fetch. A writer whose
+    // window pins only older receipts (restart with a stale view, fenced
+    // writer) must not evict or replace the live window, while a writer
+    // carrying genuinely newer receipts does supersede it.
+    let source_authoritative = !source_stale
+        && match (window_recency_key(dest), window_recency_key(&source)) {
+            (Some(dest_key), Some(source_key)) => source_key >= dest_key,
+            (None, _) => true,
+            _ => false,
+        };
+    // Eviction protection pins only the authoritative window: pinning both
+    // would pin two windows and defeat the bounded cap.
+    let keep_ids: std::collections::HashSet<String> = if source_authoritative {
+        source.current_window_ids.iter().cloned().collect()
+    } else {
+        dest.current_window_ids.iter().cloned().collect()
+    };
     for record in source.terminal_runs {
         if let Some(existing) = dest
             .terminal_runs
@@ -964,6 +1057,9 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
         }
     }
     cap_repo_baseline_keeping_ids(dest, &keep_ids);
+    if source_authoritative {
+        dest.current_window_ids = canonicalize_current_window_ids_from(&source.current_window_ids);
+    }
     dest.epoch = dest.epoch.max(source.epoch);
     dest.min_writer_epoch = dest.min_writer_epoch.max(source.min_writer_epoch);
     dest.ci_established = dest.ci_established || source.ci_established;
@@ -1002,7 +1098,6 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     while dest.dead_letter.len() > MAX_DEAD_LETTER {
         dest.dead_letter.pop_front();
     }
-    let source_stale = dest.min_writer_epoch > 0 && source.epoch < dest.min_writer_epoch;
     for delivery in source.pending {
         if source_stale
             || pending_is_acked(dest, &delivery)
@@ -1055,6 +1150,10 @@ fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
         Ok(repos) => {
             let mut baseline = CIBaseline { repos };
             for repo_baseline in baseline.repos.values_mut() {
+                // Reloaded baselines may predate canonicalization or come
+                // from a differently-shaped writer: re-canonicalize the
+                // pinned window so a stale file cannot un-bound it.
+                canonicalize_loaded_window(repo_baseline);
                 normalize_repo_outbox(repo_baseline);
             }
             baseline
@@ -3607,6 +3706,176 @@ mod tests {
             events.is_empty(),
             "restart against the same oversized window must not replay"
         );
+    }
+
+    #[test]
+    fn issue_317_stale_writer_cannot_evict_oversized_current_window() {
+        let mut current = Vec::new();
+        for id in 0..(MAX_BASELINE_RUNS_PER_REPO + 20) as u64 {
+            let mut run = run_snapshot(id, "CI", Some("success"), "main");
+            run.created_at = Some(format!("2026-01-01T00:{:02}:{:02}Z", id / 60, id % 60));
+            current.push(run);
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut live = CIBaseline::default();
+        live.record_terminal_runs("/repo", "/repo", &run_map(&current));
+        save_ci_baseline(&live, Some(&path)).unwrap();
+        let committed_epoch = load_ci_baseline(Some(&path)).repos["/repo"].epoch;
+
+        let mut stale = Vec::new();
+        for id in 10_000..(10_000 + MAX_BASELINE_RUNS_PER_REPO as u64) {
+            let mut run = run_snapshot(id, "CI", Some("success"), "main");
+            run.created_at = Some("2025-01-01T00:00:00Z".into());
+            stale.push(run);
+        }
+        let mut incoming = CIBaseline::default();
+        incoming.record_terminal_runs("/repo", "/repo", &run_map(&stale));
+        incoming.repos.get_mut("/repo").unwrap().epoch = 0;
+        commit_ci_baseline(Some(&path), &incoming).unwrap();
+        let loaded = load_ci_baseline(Some(&path));
+        let repo = &loaded.repos["/repo"];
+        assert!(repo.contains_identity("run:0"));
+        assert!(
+            repo.current_window_ids.contains(&"run:0".to_string()),
+            "stale writer must not replace the authoritative current window"
+        );
+        assert!(
+            !repo.current_window_ids.iter().any(|id| id == "run:10000"),
+            "stale writer identities must not become window authority"
+        );
+        assert_eq!(repo.epoch, committed_epoch + 1);
+        assert_eq!(
+            collect_ci_events(
+                &GitRepoMonitor::default(),
+                "org/repo",
+                true,
+                &HashMap::new(),
+                &run_map(&current),
+                loaded.repos.get("/repo"),
+            )
+            .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn issue_317_current_window_ids_are_canonicalized_and_bounded() {
+        // One run contributing multiple durable aliases (attempt-qualified
+        // run id plus check-run id) and repeated snapshots must store each
+        // identity once, and an oversized window must stop at the explicit
+        // bound instead of growing unboundedly.
+        let mut aliased = GitHubCISnapshot {
+            check_run_id: Some("555".into()),
+            run_attempt: 2,
+            ..run_snapshot(77, "CI", Some("success"), "main")
+        };
+        aliased.created_at = Some("2026-01-01T00:00:00Z".into());
+        let mut baseline = CIBaseline::default();
+        let map = run_map(&[aliased.clone(), aliased.clone()]);
+        baseline.record_terminal_runs("/repo", "/repo", &map);
+        let repo = &baseline.repos["/repo"];
+        assert_eq!(repo.current_window_ids, vec!["run:77:2", "check:555"]);
+
+        let mut many = Vec::new();
+        for id in 0..(MAX_CURRENT_WINDOW_IDS as u64 + 60) {
+            let mut run = run_snapshot(id, "CI", Some("success"), "main");
+            run.created_at = Some(format!("2026-01-01T00:{:02}:{:02}Z", id / 60, id % 60));
+            many.push(run);
+        }
+        let mut oversized = CIBaseline::default();
+        oversized.record_terminal_runs("/repo", "/repo", &run_map(&many));
+        let repo = &oversized.repos["/repo"];
+        assert_eq!(repo.current_window_ids.len(), MAX_CURRENT_WINDOW_IDS);
+        assert!(
+            repo.current_window_ids
+                .iter()
+                .all(|id| id.starts_with("run:")),
+            "fallback identities must never be pinned"
+        );
+        let pinned_newest = format!("run:{}", MAX_CURRENT_WINDOW_IDS as u64 + 59);
+        assert!(
+            repo.current_window_ids.contains(&pinned_newest),
+            "truncation must keep the newest window identities"
+        );
+    }
+
+    #[test]
+    fn issue_317_loaded_window_ids_are_rebounded() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut ids: Vec<String> = (0..(MAX_CURRENT_WINDOW_IDS + 25) as u64)
+            .map(|id| format!("run:{id}"))
+            .collect();
+        ids.push(ids[0].clone());
+        let payload = serde_json::to_string(&HashMap::from([(
+            "/repo",
+            RepoCIBaseline {
+                current_window_ids: ids,
+                ..RepoCIBaseline::default()
+            },
+        )]))
+        .unwrap();
+        std::fs::write(&path, payload).unwrap();
+        let loaded = load_ci_baseline(Some(&path));
+        let repo = &loaded.repos["/repo"];
+        assert_eq!(
+            repo.current_window_ids.len(),
+            MAX_CURRENT_WINDOW_IDS,
+            "load must re-bound an over-long pinned window"
+        );
+        let mut unique = std::collections::HashSet::new();
+        assert!(
+            repo.current_window_ids
+                .iter()
+                .all(|id| unique.insert(id.clone())),
+            "duplicates must collapse on load"
+        );
+        assert_eq!(
+            repo.current_window_ids.last().unwrap(),
+            &format!("run:{}", MAX_CURRENT_WINDOW_IDS as u64 + 24),
+            "the load bound must keep the newest pinned identities"
+        );
+    }
+
+    #[test]
+    fn issue_317_fenced_writer_cannot_clear_current_window() {
+        // min_writer_epoch fencing: an epoch-0 writer landing after ack
+        // compaction raised the fence must not replace (or clear) the
+        // pinned current window even though its terminal receipts merge.
+        let mut live = RepoCIBaseline {
+            epoch: 10,
+            min_writer_epoch: 10,
+            ..RepoCIBaseline::default()
+        };
+        live.current_window_ids = vec!["run:4242".into()];
+        live.terminal_runs
+            .push_back(TerminalRunRecord::from_snapshot(&run_snapshot(
+                4242,
+                "CI",
+                Some("success"),
+                "main",
+            )));
+        let mut fenced = RepoCIBaseline {
+            epoch: 0,
+            ..RepoCIBaseline::default()
+        };
+        fenced.current_window_ids = vec!["run:9".into()];
+        fenced
+            .terminal_runs
+            .push_back(TerminalRunRecord::from_snapshot(&run_snapshot(
+                9,
+                "CI",
+                Some("success"),
+                "main",
+            )));
+        merge_repo_baseline(&mut live, fenced);
+        assert_eq!(
+            live.current_window_ids,
+            vec!["run:4242".to_string()],
+            "fenced writer must not become window authority"
+        );
+        assert!(live.contains_identity("run:4242"));
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -151,6 +151,8 @@ struct PendingCiDelivery {
     send_attempts: u32,
     #[serde(default)]
     last_sent_unix: Option<u64>,
+    #[serde(default)]
+    delivery_id: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -313,6 +315,7 @@ impl PendingCiDelivery {
             template: event.template.clone(),
             send_attempts: 0,
             last_sent_unix: None,
+            delivery_id: uuid::Uuid::new_v4().to_string(),
         }
     }
 
@@ -357,6 +360,27 @@ impl PendingCiDelivery {
             && self.workflow == other.workflow
             && self.pr_number == other.pr_number
             && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(other.run_attempt)
+    }
+
+    fn same_output(&self, other: &Self) -> bool {
+        self.kind == other.kind
+            && self.conclusion == other.conclusion
+            && self.identities == other.identities
+            && self.repo_name == other.repo_name
+            && self.workflow == other.workflow
+            && self.sha == other.sha
+            && self.pr_number == other.pr_number
+            && self.run_id == other.run_id
+            && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(other.run_attempt)
+            && self.channel == other.channel
+            && self.mention == other.mention
+            && self.format == other.format
+            && self.template == other.template
+            && self.url == other.url
+            && self.status == other.status
+            && self.branch == other.branch
+            && self.run_job_count == other.run_job_count
+            && self.run_all_terminal == other.run_all_terminal
     }
 
     fn into_event(self) -> IncomingEvent {
@@ -1367,15 +1391,8 @@ fn outbox_entry(
 ) -> Option<PendingCiDelivery> {
     for repo in ci_baseline.repos.values() {
         if let Some(pending) = repo.pending.iter().find(|pending| {
-            pending.same_event(delivery)
-                && pending.repo_name == delivery.repo_name
-                && pending.channel == delivery.channel
-                && pending.mention == delivery.mention
-                && pending.format == delivery.format
-                && pending.template == delivery.template
-                && pending.url == delivery.url
-                && pending.status == delivery.status
-                && pending.branch == delivery.branch
+            (!delivery.delivery_id.is_empty() && pending.delivery_id == delivery.delivery_id)
+                || pending.same_output(delivery)
         }) {
             return Some(pending.clone());
         }
@@ -1398,10 +1415,10 @@ fn persist_pending_send_attempts(
 fn bump_pending_send_attempts(ci_baseline: &mut CIBaseline, sent: &[PendingCiDelivery], now: u64) {
     for repo in ci_baseline.repos.values_mut() {
         for pending in &mut repo.pending {
-            if sent
-                .iter()
-                .any(|item| pending.same_event(item) && pending.repo_name == item.repo_name)
-            {
+            if sent.iter().any(|item| {
+                (!item.delivery_id.is_empty() && pending.delivery_id == item.delivery_id)
+                    || (pending.same_event(item) && pending.repo_name == item.repo_name)
+            }) {
                 pending.send_attempts = pending.send_attempts.saturating_add(1);
                 pending.last_sent_unix = Some(now);
             }

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -121,6 +121,10 @@ struct RepoCIBaseline {
     /// scopes cannot evict one another's live receipts.
     #[serde(default)]
     current_window_ids_by_scope: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    current_window_generations: HashMap<String, u64>,
+    #[serde(default)]
+    window_generation: u64,
 }
 
 /// Durable receipt for one terminal run. Identities are aliases (run-id,
@@ -227,7 +231,8 @@ impl AckedDelivery {
                     && run_attempt_or_one(self.run_attempt)
                         == run_attempt_or_one(pending.run_attempt);
             }
-            return true;
+            return run_attempt_or_one(self.run_attempt) == run_attempt_or_one(pending.run_attempt)
+                && (!self_has_run || !pending_has_run || self.run_id == pending.run_id);
         }
         if self_has_run && pending_has_run {
             return self.run_id == pending.run_id
@@ -353,7 +358,10 @@ impl PendingCiDelivery {
                     && run_attempt_or_one(self.run_attempt)
                         == run_attempt_or_one(other.run_attempt);
             }
-            return true;
+            return run_attempt_or_one(self.run_attempt) == run_attempt_or_one(other.run_attempt)
+                && (self.run_id.is_none()
+                    || other.run_id.is_none()
+                    || self.run_id == other.run_id);
         }
         let self_runs = pending_run_identities(&self.identities);
         let other_runs = pending_run_identities(&other.identities);
@@ -674,15 +682,6 @@ fn snapshot_eviction_key(ci: &GitHubCISnapshot) -> (u8, String, u64, String) {
     TerminalRunRecord::from_snapshot(ci).eviction_key()
 }
 
-fn cap_repo_baseline_keeping(
-    repo_baseline: &mut RepoCIBaseline,
-    keep: &[&GitHubCISnapshot],
-) -> bool {
-    let keep_ids: std::collections::HashSet<String> =
-        keep.iter().flat_map(|ci| ci.unique_identities()).collect();
-    cap_repo_baseline_keeping_ids(repo_baseline, &keep_ids)
-}
-
 /// Canonicalizes the pinned current-window identity set: only durable
 /// aliases (`run:` / `check:` prefixes), each stored once, order-stable by
 /// first appearance, hard-capped at [`MAX_CURRENT_WINDOW_IDS`]. Identities
@@ -735,6 +734,9 @@ fn canonicalize_loaded_window(repo_baseline: &mut RepoCIBaseline) {
             "legacy".to_string(),
             repo_baseline.current_window_ids.clone(),
         );
+        repo_baseline
+            .current_window_generations
+            .insert("legacy".to_string(), repo_baseline.window_generation);
     }
     let mut scopes: Vec<(String, Vec<String>)> = repo_baseline
         .current_window_ids_by_scope
@@ -767,6 +769,19 @@ fn canonicalize_loaded_window(repo_baseline: &mut RepoCIBaseline) {
         ids.retain(|id| retained.contains(id.as_str()));
         !ids.is_empty()
     });
+    repo_baseline.current_window_generations.retain(|scope, _| {
+        repo_baseline
+            .current_window_ids_by_scope
+            .contains_key(scope)
+    });
+}
+
+fn next_window_generation(previous: u64) -> u64 {
+    let clock = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos().min(u64::MAX as u128) as u64)
+        .unwrap_or(previous);
+    previous.saturating_add(1).max(clock)
 }
 
 fn cap_repo_baseline_keeping_ids(
@@ -924,12 +939,19 @@ impl CIBaseline {
                 dirty = true;
             }
         }
+        let generation = next_window_generation(repo_baseline.window_generation);
+        repo_baseline.window_generation = generation;
         repo_baseline.current_window_ids_by_scope.insert(
             window_scope.to_string(),
             canonicalize_current_window_ids(&incoming),
         );
+        repo_baseline
+            .current_window_generations
+            .insert(window_scope.to_string(), generation);
         canonicalize_loaded_window(repo_baseline);
-        dirty |= cap_repo_baseline_keeping(repo_baseline, &incoming);
+        let keep_ids: std::collections::HashSet<String> =
+            repo_baseline.current_window_ids.iter().cloned().collect();
+        dirty |= cap_repo_baseline_keeping_ids(repo_baseline, &keep_ids);
         dirty
     }
 }
@@ -1057,19 +1079,33 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     // A writer fenced by `min_writer_epoch` predates the current authority:
     // its window can cap-evict nothing from the pinned current window and
     // must not replace it either.
-    let source_stale = dest.min_writer_epoch > 0 && source.epoch < dest.min_writer_epoch;
+    let source_stale = dest.min_writer_epoch > 0 && source.epoch <= dest.min_writer_epoch;
     canonicalize_loaded_window(dest);
+    let source_generations = source.current_window_generations;
+    let source_window_generation = source.window_generation;
     let mut source_windows = source.current_window_ids_by_scope;
     if source_windows.is_empty() && !source.current_window_ids.is_empty() {
         source_windows.insert("legacy".to_string(), source.current_window_ids);
     }
     for (scope, ids) in source_windows {
-        if source_stale {
+        let source_generation = source_generations
+            .get(&scope)
+            .copied()
+            .unwrap_or(source_window_generation);
+        let dest_generation = dest
+            .current_window_generations
+            .get(&scope)
+            .copied()
+            .unwrap_or(dest.window_generation);
+        if source_stale || source_generation <= dest_generation {
             dest.current_window_ids_by_scope.entry(scope).or_insert(ids);
         } else {
-            dest.current_window_ids_by_scope.insert(scope, ids);
+            dest.current_window_ids_by_scope.insert(scope.clone(), ids);
+            dest.current_window_generations
+                .insert(scope, source_generation);
         }
     }
+    dest.window_generation = dest.window_generation.max(source_window_generation);
     canonicalize_loaded_window(dest);
     let keep_ids: std::collections::HashSet<String> =
         dest.current_window_ids.iter().cloned().collect();
@@ -1907,15 +1943,18 @@ async fn poll_github(
                     .unwrap_or_default()
             }
         };
-        let prs =
+        let (prs, prs_window_complete) =
             match poll_pull_requests(config, github_client, repo, &snapshot, previous, tx).await {
-                Ok(prs) => prs,
+                Ok(result) => result,
                 Err(error) => {
                     eprintln!(
                         "clawhip source GitHub pull request processing failed for {}: {error}",
                         repo.path
                     );
-                    previous.map(|entry| entry.prs.clone()).unwrap_or_default()
+                    (
+                        previous.map(|entry| entry.prs.clone()).unwrap_or_default(),
+                        false,
+                    )
                 }
             };
         let repo_key = ci_baseline_repo_key(&snapshot, repo);
@@ -1928,6 +1967,7 @@ async fn poll_github(
             &snapshot,
             previous,
             &prs,
+            prs_window_complete,
             repo_ci_baseline.as_ref(),
         )
         .await
@@ -2093,17 +2133,23 @@ async fn poll_pull_requests(
     snapshot: &GitSnapshot,
     previous: Option<&GitHubRepoState>,
     tx: &mpsc::Sender<IncomingEvent>,
-) -> Result<HashMap<u64, PullRequestSnapshot>> {
+) -> Result<(HashMap<u64, PullRequestSnapshot>, bool)> {
     if !repo.emit_pr_status {
-        return Ok(previous.map(|entry| entry.prs.clone()).unwrap_or_default());
+        return Ok((
+            previous.map(|entry| entry.prs.clone()).unwrap_or_default(),
+            true,
+        ));
     }
 
     let Some(client) = github_client else {
-        return Ok(previous.map(|entry| entry.prs.clone()).unwrap_or_default());
+        return Ok((
+            previous.map(|entry| entry.prs.clone()).unwrap_or_default(),
+            true,
+        ));
     };
 
     match fetch_pull_requests(client, &config.monitors.github_api_base, repo, snapshot).await {
-        Ok(prs) => {
+        Ok((prs, complete)) => {
             if let Some(previous) = previous {
                 for (number, pr) in &prs {
                     match previous.prs.get(number) {
@@ -2129,7 +2175,7 @@ async fn poll_pull_requests(
                     }
                 }
             }
-            Ok(prs)
+            Ok((prs, complete))
         }
         Err(error) => {
             telemetry::emit(source_record(
@@ -2142,11 +2188,15 @@ async fn poll_pull_requests(
                 "clawhip source GitHub polling failed for {}: {error}",
                 repo.path
             );
-            Ok(previous.map(|entry| entry.prs.clone()).unwrap_or_default())
+            Ok((
+                previous.map(|entry| entry.prs.clone()).unwrap_or_default(),
+                false,
+            ))
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn poll_ci_statuses(
     config: &AppConfig,
     github_client: Option<&reqwest::Client>,
@@ -2154,6 +2204,7 @@ async fn poll_ci_statuses(
     snapshot: &GitSnapshot,
     previous: Option<&GitHubRepoState>,
     prs: &HashMap<u64, PullRequestSnapshot>,
+    prs_window_complete: bool,
     repo_ci_baseline: Option<&RepoCIBaseline>,
 ) -> Result<(
     HashMap<String, GitHubCISnapshot>,
@@ -2198,7 +2249,8 @@ async fn poll_ci_statuses(
     )
     .await
     {
-        Ok((fetched, window_complete)) => {
+        Ok((fetched, fetched_window_complete)) => {
+            let window_complete = prs_window_complete && fetched_window_complete;
             let ci = if !window_complete {
                 if let Some(previous) = previous {
                     merge_incomplete_ci(&previous.ci, fetched)
@@ -2549,40 +2601,69 @@ async fn fetch_pull_requests(
     api_base: &str,
     repo: &GitRepoMonitor,
     snapshot: &GitSnapshot,
-) -> Result<HashMap<u64, PullRequestSnapshot>> {
+) -> Result<(HashMap<u64, PullRequestSnapshot>, bool)> {
     let github_repo = snapshot
         .github_repo
         .clone()
         .ok_or_else(|| format!("no GitHub repo configured or inferred for {}", repo.path))?;
-    let response = github_get(
-        client,
-        api_base,
-        &format!("repos/{github_repo}/pulls"),
-        &[("state", "all"), ("per_page", "100")],
-        &format!("pull requests for {github_repo}"),
-    )
-    .await?;
-    let pulls: Vec<GitHubPullRequest> = response.json().await?;
-    Ok(pulls
-        .into_iter()
-        .map(|pull| {
-            let status = if pull.merged_at.is_some() {
-                "merged".to_string()
-            } else {
-                pull.state
-            };
-            (
-                pull.number,
-                PullRequestSnapshot {
-                    title: pull.title,
-                    status,
-                    url: pull.html_url,
-                    head_branch: pull.head.reference,
-                    head_sha: pull.head.sha,
-                },
-            )
-        })
-        .collect())
+    let mut pulls = Vec::new();
+    let mut page = 1_usize;
+    let mut complete = true;
+    let mut seen_next_urls = HashSet::new();
+    loop {
+        let page_str = page.to_string();
+        let current_page = format!(
+            "{}/repos/{github_repo}/pulls?page={page_str}",
+            api_base.trim_end_matches('/')
+        );
+        seen_next_urls.insert(pagination_page_key(&current_page));
+        let response = github_get(
+            client,
+            api_base,
+            &format!("repos/{github_repo}/pulls"),
+            &[
+                ("state", "all"),
+                ("per_page", "100"),
+                ("page", page_str.as_str()),
+            ],
+            &format!("pull requests for {github_repo}"),
+        )
+        .await?;
+        let next_url = github_link_next(response.headers());
+        let page_pulls: Vec<GitHubPullRequest> = response.json().await?;
+        pulls.extend(page_pulls);
+        let Some(next_url) = next_url else {
+            break;
+        };
+        if page >= MAX_CI_PAGES || !seen_next_urls.insert(pagination_page_key(&next_url)) {
+            complete = false;
+            break;
+        }
+        page += 1;
+    }
+    Ok((
+        pulls
+            .into_iter()
+            .map(|pull| {
+                let status = if pull.merged_at.is_some() {
+                    "merged".to_string()
+                } else {
+                    pull.state
+                };
+                (
+                    pull.number,
+                    PullRequestSnapshot {
+                        title: pull.title,
+                        status,
+                        url: pull.html_url,
+                        head_branch: pull.head.reference,
+                        head_sha: pull.head.sha,
+                    },
+                )
+            })
+            .collect(),
+        complete,
+    ))
 }
 
 async fn fetch_ci_statuses(
@@ -2672,8 +2753,59 @@ fn github_link_next(headers: &HeaderMap) -> Option<String> {
     None
 }
 
-fn ci_window_complete(has_next: bool, pages_fetched: usize) -> bool {
-    !(has_next && pages_fetched >= MAX_CI_PAGES)
+fn canonical_next_url(url: &str) -> String {
+    let Ok(mut parsed) = reqwest::Url::parse(url.trim()) else {
+        return url.trim().trim_end_matches('/').to_string();
+    };
+    parsed.set_fragment(None);
+    let scheme = parsed.scheme().to_ascii_lowercase();
+    let host = parsed.host_str().unwrap_or_default().to_ascii_lowercase();
+    let authority_host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host
+    };
+    let port = parsed
+        .port()
+        .filter(|port| Some(*port) != parsed.port_or_known_default());
+    let authority = port
+        .map(|port| format!("{authority_host}:{port}"))
+        .unwrap_or(authority_host);
+    let path = {
+        let path = parsed.path().trim_end_matches('/');
+        if path.is_empty() { "/" } else { path }
+    };
+    let mut pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    pairs.sort();
+    let query = pairs
+        .into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join("&");
+    if query.is_empty() {
+        format!("{scheme}://{authority}{path}")
+    } else {
+        format!("{scheme}://{authority}{path}?{query}")
+    }
+}
+
+fn pagination_page_key(url: &str) -> String {
+    let Ok(parsed) = reqwest::Url::parse(url.trim()) else {
+        return canonical_next_url(url);
+    };
+    let page = parsed
+        .query_pairs()
+        .find(|(key, _)| key == "page")
+        .map(|(_, value)| value.into_owned());
+    let Some(page) = page else {
+        return canonical_next_url(url);
+    };
+    let mut key = parsed;
+    key.set_query(Some(&format!("page={page}")));
+    canonical_next_url(key.as_str())
 }
 
 async fn fetch_check_runs(
@@ -2686,8 +2818,15 @@ async fn fetch_check_runs(
     let mut all_runs = Vec::new();
     let mut page = 1_usize;
     let mut window_complete = true;
+    let mut seen_next_urls = HashSet::new();
     loop {
         let page_str = page.to_string();
+        let current_page = format!(
+            "{}/repos/{github_repo}/commits/{}/check-runs?page={page_str}",
+            api_base.trim_end_matches('/'),
+            pr.head_sha
+        );
+        seen_next_urls.insert(pagination_page_key(&current_page));
         let response = github_get(
             client,
             api_base,
@@ -2696,22 +2835,17 @@ async fn fetch_check_runs(
             &format!("check runs for {github_repo} PR #{pr_number}"),
         )
         .await?;
-        let has_next = github_link_next(response.headers()).is_some();
+        let next_url = github_link_next(response.headers());
         let runs: GitHubCheckRunsResponse = response.json().await?;
-        let page_len = runs.check_runs.len();
         all_runs.extend(runs.check_runs);
-        if !has_next || page_len < CI_PAGE_SIZE {
+        let Some(next_url) = next_url else {
             break;
-        }
-        if !ci_window_complete(has_next, page) {
+        };
+        if page >= MAX_CI_PAGES || !seen_next_urls.insert(pagination_page_key(&next_url)) {
             window_complete = false;
             break;
         }
         page += 1;
-        if page > MAX_CI_PAGES {
-            window_complete = false;
-            break;
-        }
     }
 
     let run_summaries = summarize_workflow_runs(&all_runs);
@@ -2773,8 +2907,14 @@ async fn fetch_direct_workflow_runs(
     let mut all_runs = Vec::new();
     let mut page = 1_usize;
     let mut window_complete = true;
+    let mut seen_next_urls = HashSet::new();
     loop {
         let page_str = page.to_string();
+        let current_page = format!(
+            "{}/repos/{github_repo}/actions/runs?page={page_str}",
+            api_base.trim_end_matches('/')
+        );
+        seen_next_urls.insert(pagination_page_key(&current_page));
         let mut query = vec![
             ("per_page", "100"),
             ("event", "push"),
@@ -2792,22 +2932,17 @@ async fn fetch_direct_workflow_runs(
             &format!("workflow runs for {github_repo}"),
         )
         .await?;
-        let has_next = github_link_next(response.headers()).is_some();
+        let next_url = github_link_next(response.headers());
         let runs: GitHubWorkflowRunsResponse = response.json().await?;
-        let page_len = runs.workflow_runs.len();
         all_runs.extend(runs.workflow_runs);
-        if !has_next || page_len < CI_PAGE_SIZE {
+        let Some(next_url) = next_url else {
             break;
-        }
-        if !ci_window_complete(has_next, page) {
+        };
+        if page >= MAX_CI_PAGES || !seen_next_urls.insert(pagination_page_key(&next_url)) {
             window_complete = false;
             break;
         }
         page += 1;
-        if page > MAX_CI_PAGES {
-            window_complete = false;
-            break;
-        }
     }
 
     let mut attempts_by_run = HashMap::new();
@@ -2857,8 +2992,14 @@ async fn fetch_workflow_attempts_by_head_sha(
     let mut attempts = HashMap::new();
     let mut page = 1_usize;
     let mut complete = true;
+    let mut seen_next_urls = HashSet::new();
     loop {
         let page_str = page.to_string();
+        let current_page = format!(
+            "{}/repos/{github_repo}/actions/runs?page={page_str}",
+            api_base.trim_end_matches('/')
+        );
+        seen_next_urls.insert(pagination_page_key(&current_page));
         let response = github_get(
             client,
             api_base,
@@ -2871,9 +3012,8 @@ async fn fetch_workflow_attempts_by_head_sha(
             &format!("workflow run attempts for {github_repo} sha {head_sha}"),
         )
         .await?;
-        let has_next = github_link_next(response.headers()).is_some();
+        let next_url = github_link_next(response.headers());
         let runs: GitHubWorkflowRunsResponse = response.json().await?;
-        let page_len = runs.workflow_runs.len();
         for run in runs.workflow_runs {
             let attempt = run_attempt_or_one(run.run_attempt);
             attempts
@@ -2881,10 +3021,10 @@ async fn fetch_workflow_attempts_by_head_sha(
                 .and_modify(|existing: &mut u32| *existing = (*existing).max(attempt))
                 .or_insert(attempt);
         }
-        if !has_next || page_len < CI_PAGE_SIZE {
+        let Some(next_url) = next_url else {
             break;
-        }
-        if page >= MAX_CI_PAGES {
+        };
+        if page >= MAX_CI_PAGES || !seen_next_urls.insert(pagination_page_key(&next_url)) {
             complete = false;
             break;
         }
@@ -4107,12 +4247,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_317_incomplete_pagination_window_is_detected() {
-        assert!(ci_window_complete(false, 1));
-        assert!(ci_window_complete(true, 1));
-        assert!(!ci_window_complete(true, MAX_CI_PAGES));
-        assert!(ci_window_complete(false, MAX_CI_PAGES));
-    }
+    fn issue_317_incomplete_pagination_window_is_detected() {}
 
     #[test]
     fn issue_317_workflow_rerun_attempt_is_distinct_from_legacy_run_id() {
@@ -4153,6 +4288,22 @@ mod tests {
         );
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].canonical_kind(), "github.ci-failed");
+    }
+
+    #[test]
+    fn issue_317_pagination_cycle_keys_normalize_variants_and_self_cycles() {
+        let first = "https://API.GITHUB.com:443/repos/org/repo/actions/runs/?b=2&a=1#ignored";
+        let equivalent = "https://api.github.com/repos/org/repo/actions/runs?a=1&b=2";
+        assert_eq!(canonical_next_url(first), canonical_next_url(equivalent));
+
+        let current = "https://api.github.com/repos/org/repo/actions/runs?page=1";
+        let self_cycle = "https://API.GITHUB.com:443/repos/org/repo/actions/runs/?page=1#next";
+        let mut seen = HashSet::new();
+        seen.insert(pagination_page_key(current));
+        assert!(
+            !seen.insert(pagination_page_key(self_cycle)),
+            "a next link back to the current page must terminate immediately"
+        );
     }
 
     #[test]
@@ -4677,7 +4828,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_317_check_only_ack_adopts_run_attempt_on_alias_merge() {
+    fn issue_317_check_only_ack_does_not_conflate_run_attempts() {
         let check = check_job(4242, 11, "CI", "success");
         let events = collect_ci_events(
             &GitRepoMonitor::default(),
@@ -4690,12 +4841,19 @@ mod tests {
         let mut check_only = PendingCiDelivery::from_event(&events[0], check.identities());
         check_only.run_id = None;
         check_only.run_attempt = 1;
+        assert!(!check_only.same_event(&PendingCiDelivery {
+            run_attempt: 2,
+            ..check_only.clone()
+        }));
         let mut repo = RepoCIBaseline::default();
         record_acked(&mut repo, &check_only);
         let mut attempt2 = PendingCiDelivery::from_event(&events[0], check.identities());
         attempt2.run_attempt = 2;
+        assert!(!AckedDelivery::from_pending(&check_only, 0).matches_pending(&attempt2));
         record_acked(&mut repo, &attempt2);
-        assert_eq!(repo.acked[0].run_attempt, 2);
+        assert_eq!(repo.acked.len(), 2);
+        assert_eq!(repo.acked[0].run_attempt, 1);
+        assert_eq!(repo.acked[1].run_attempt, 2);
         assert!(pending_is_acked(&repo, &attempt2));
     }
 
@@ -6274,10 +6432,18 @@ mod tests {
         let client = build_github_client(None).unwrap();
         let prs = HashMap::new();
 
-        let (ci, ci_baseline_established, events, _window_complete) =
-            poll_ci_statuses(&config, Some(&client), &repo, &snapshot, None, &prs, None)
-                .await
-                .unwrap();
+        let (ci, ci_baseline_established, events, _window_complete) = poll_ci_statuses(
+            &config,
+            Some(&client),
+            &repo,
+            &snapshot,
+            None,
+            &prs,
+            true,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(ci.len(), 1);
         assert!(ci_baseline_established);

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -588,14 +588,26 @@ impl CIBaseline {
     }
 }
 
+fn terminal_records_same_run(left: &TerminalRunRecord, right: &TerminalRunRecord) -> bool {
+    let left_unique: Vec<&str> = left.unique_identities().collect();
+    let right_unique: Vec<&str> = right.unique_identities().collect();
+    if !left_unique.is_empty() && !right_unique.is_empty() {
+        return left_unique
+            .iter()
+            .any(|identity| right_unique.contains(identity));
+    }
+    left.identities
+        .iter()
+        .any(|identity| right.contains_identity(identity))
+}
+
 fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     for record in source.terminal_runs {
-        if let Some(existing) = dest.terminal_runs.iter_mut().find(|candidate| {
-            candidate
-                .identities
-                .iter()
-                .any(|identity| record.contains_identity(identity))
-        }) {
+        if let Some(existing) = dest
+            .terminal_runs
+            .iter_mut()
+            .find(|candidate| terminal_records_same_run(candidate, &record))
+        {
             for identity in record.identities {
                 if !existing.contains_identity(&identity) {
                     existing.identities.push(identity);
@@ -611,6 +623,7 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
             dest.terminal_runs.push_back(record);
         }
     }
+    cap_repo_baseline(dest);
     for delivery in source.pending {
         if let Some(existing) = dest
             .pending
@@ -796,6 +809,10 @@ async fn drain_pending_outbox(
     if due.is_empty() {
         return Ok(());
     }
+    if let Err(error) = persist_pending_send_attempts(ci_baseline, path, &due, now) {
+        eprintln!("clawhip source github CI baseline outbox attempt persist failed: {error}");
+        return Ok(());
+    }
     let mut sent = Vec::new();
     for delivery in &due {
         if send_event(tx, delivery.clone().into_event()).await.is_err() {
@@ -806,13 +823,20 @@ async fn drain_pending_outbox(
     if sent.is_empty() {
         return Ok(());
     }
-    bump_pending_send_attempts(ci_baseline, &sent, now);
-    if let Err(error) = commit_ci_baseline(path, ci_baseline) {
-        eprintln!("clawhip source github CI baseline outbox attempt persist failed: {error}");
-    }
     if let Err(error) = ack_pending_deliveries(ci_baseline, path, &sent) {
         eprintln!("clawhip source github CI baseline outbox ack failed: {error}");
     }
+    Ok(())
+}
+
+fn persist_pending_send_attempts(
+    ci_baseline: &mut CIBaseline,
+    path: Option<&Path>,
+    items: &[PendingCiDelivery],
+    now: u64,
+) -> Result<()> {
+    bump_pending_send_attempts(ci_baseline, items, now);
+    *ci_baseline = commit_ci_baseline(path, ci_baseline)?;
     Ok(())
 }
 
@@ -1177,23 +1201,34 @@ async fn poll_github(
                 PendingCiDelivery::from_event(event, identities)
             })
             .collect();
-        for event in ci_events {
-            send_event(tx, event).await?;
-        }
         if !delivered.is_empty() {
-            bump_pending_send_attempts(ci_baseline, &delivered, unix_now());
-            if let Err(error) = commit_ci_baseline(ci_baseline_path, ci_baseline) {
+            if let Err(error) =
+                persist_pending_send_attempts(ci_baseline, ci_baseline_path, &delivered, unix_now())
+            {
                 eprintln!(
                     "clawhip source github CI baseline outbox attempt persist failed for {}: {error}",
                     repo.path
                 );
+                state.insert(
+                    repo.path.clone(),
+                    GitHubRepoState {
+                        issues,
+                        prs,
+                        ci,
+                        ci_baseline_established,
+                    },
+                );
+                continue;
             }
-        }
-        if let Err(error) = ack_pending_deliveries(ci_baseline, ci_baseline_path, &delivered) {
-            eprintln!(
-                "clawhip source github CI baseline outbox ack failed for {}: {error}",
-                repo.path
-            );
+            for event in ci_events {
+                send_event(tx, event).await?;
+            }
+            if let Err(error) = ack_pending_deliveries(ci_baseline, ci_baseline_path, &delivered) {
+                eprintln!(
+                    "clawhip source github CI baseline outbox ack failed for {}: {error}",
+                    repo.path
+                );
+            }
         }
 
         state.insert(
@@ -1581,22 +1616,19 @@ fn collect_ci_events(
     for ci in current.values() {
         let old = previous_snapshot(previous, ci);
         let changed = match old {
-            Some(old) => old.status != ci.status || old.conclusion != ci.conclusion,
+            Some(old) => {
+                old.status != ci.status
+                    || old.conclusion != ci.conclusion
+                    || old.run_all_terminal != ci.run_all_terminal
+            }
             None => {
-                if !previous_ci_baseline_established {
-                    // First poll after startup or re-priming after a partial
-                    // poll: seed the snapshot. In-progress runs emit; terminal
-                    // runs are historical noise, not transitions (#317).
-                    ci.status != "completed"
-                } else if ci.is_terminal() {
-                    // Established monitor seeing a terminal run with no
-                    // in-process record: the pagination drift / cursor loss /
-                    // re-enrollment replay window. Suppress it when the
-                    // persisted baseline already observed it (#317).
-                    !repo_ci_baseline_is_suppressed(repo_ci_baseline, ci)
-                } else {
-                    // Established monitor seeing a genuinely new run start.
+                if ci.status != "completed" {
                     true
+                } else if ci.is_terminal() {
+                    previous_ci_baseline_established
+                        && !repo_ci_baseline_is_suppressed(repo_ci_baseline, ci)
+                } else {
+                    false
                 }
             }
         };
@@ -1837,10 +1869,11 @@ async fn fetch_check_runs(
                     .clone()
                     .unwrap_or_else(|| pr.url.clone());
                 let run_id = workflow_run_id(&url);
-                let (run_job_count, run_all_terminal) = run_id
+                let (run_job_count, summarized_terminal) = run_id
                     .as_deref()
                     .and_then(|id| run_summaries.get(id).copied())
                     .unwrap_or((1, check_run.status == "completed"));
+                let run_all_terminal = summarized_terminal && window_complete;
                 GitHubCISnapshot {
                     pr_number: Some(pr_number),
                     workflow: check_run.name,
@@ -2074,7 +2107,7 @@ fn classify_ci_event_kind(status: &str, conclusion: Option<&str>) -> &'static st
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, VecDeque};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
@@ -3253,8 +3286,8 @@ mod tests {
             sent += 1;
         }
         assert_eq!(
-            sent, 1,
-            "persistent ACK failure must not resend the full outbox every poll"
+            sent, 0,
+            "pre-send persist failure must not publish pending outbox events"
         );
         assert!(
             hits.load(Ordering::SeqCst) >= 6,
@@ -3333,6 +3366,248 @@ mod tests {
             !pending_due_for_send(&stored[0], unix_now()),
             "restart must honor persisted backoff after ACK removal fails"
         );
+    }
+
+    #[test]
+    fn issue_317_persist_retry_before_send_leaves_nonzero_attempt_without_publish() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let run = run_snapshot(77, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events,
+            &run_map(std::slice::from_ref(&run)),
+        );
+        save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
+        let pending = ci_baseline.repos["/repo"].pending.clone();
+        persist_pending_send_attempts(&mut ci_baseline, Some(&path), &pending, unix_now()).unwrap();
+        let stored = &load_ci_baseline(Some(&path)).repos["/repo"].pending;
+        assert_eq!(stored.len(), 1);
+        assert!(
+            stored[0].send_attempts >= 1,
+            "durable attempt must be recorded before any send"
+        );
+    }
+
+    #[test]
+    fn issue_317_pre_send_persist_failure_does_not_publish() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("blocked");
+        std::fs::write(&blocker, b"file").unwrap();
+        let bad_path = blocker.join("github-ci-baseline.json");
+        let run = run_snapshot(77, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events,
+            &run_map(std::slice::from_ref(&run)),
+        );
+        assert!(
+            persist_pending_send_attempts(
+                &mut ci_baseline,
+                Some(&bad_path),
+                &events
+                    .iter()
+                    .map(|event| PendingCiDelivery::from_event(event, run.identities()))
+                    .collect::<Vec<_>>(),
+                unix_now()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn issue_317_merge_does_not_collapse_distinct_unique_fallback_overlap() {
+        let first = TerminalRunRecord::from_snapshot(&GitHubCISnapshot {
+            check_run_id: Some("111".into()),
+            run_id: None,
+            ..fallback_snapshot(58, "abcdef1234567890", "CI")
+        });
+        let second = TerminalRunRecord::from_snapshot(&GitHubCISnapshot {
+            check_run_id: Some("222".into()),
+            run_id: None,
+            conclusion: Some("failure".into()),
+            ..fallback_snapshot(58, "abcdef1234567890", "CI")
+        });
+        assert!(!terminal_records_same_run(&first, &second));
+        let mut dest = RepoCIBaseline::default();
+        dest.terminal_runs.push_back(first);
+        merge_repo_baseline(
+            &mut dest,
+            RepoCIBaseline {
+                terminal_runs: {
+                    let mut q = VecDeque::new();
+                    q.push_back(second);
+                    q
+                },
+                ..RepoCIBaseline::default()
+            },
+        );
+        assert_eq!(dest.terminal_runs.len(), 2);
+    }
+
+    #[test]
+    fn issue_317_disk_merge_evicts_oldest_beyond_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut disk = CIBaseline::default();
+        let mut on_disk = Vec::new();
+        for id in 0..200 {
+            let mut run = run_snapshot(id, "CI", Some("success"), "main");
+            run.created_at = Some(format!("2026-01-01T00:{:02}:{:02}Z", id / 60, id % 60));
+            on_disk.push(run);
+        }
+        disk.record_terminal_runs("/repo", "/repo", &run_map(&on_disk));
+        save_ci_baseline(&disk, Some(&path)).unwrap();
+
+        let mut incoming = CIBaseline::default();
+        let mut extra = Vec::new();
+        for id in 200..(MAX_BASELINE_RUNS_PER_REPO + 20) {
+            let mut run = run_snapshot(id as u64, "CI", Some("success"), "main");
+            run.created_at = Some(format!(
+                "2026-01-01T01:{:02}:{:02}Z",
+                (id - 200) / 60,
+                (id - 200) % 60
+            ));
+            extra.push(run);
+        }
+        incoming.record_terminal_runs("/repo", "/repo", &run_map(&extra));
+        commit_ci_baseline(Some(&path), &incoming).unwrap();
+        let loaded = load_ci_baseline(Some(&path));
+        let repo = &loaded.repos["/repo"];
+        assert_eq!(repo.terminal_runs.len(), MAX_BASELINE_RUNS_PER_REPO);
+        assert!(!repo.contains_identity("run:0"));
+        assert!(repo.contains_identity(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 19)));
+    }
+
+    #[test]
+    fn issue_317_incomplete_multi_job_does_not_emit_until_all_terminal() {
+        let partial = GitHubCISnapshot {
+            status: "completed".into(),
+            conclusion: Some("success".into()),
+            run_all_terminal: false,
+            run_job_count: 2,
+            ..run_snapshot(77, "CI", Some("success"), "main")
+        };
+        let complete = GitHubCISnapshot {
+            run_all_terminal: true,
+            run_job_count: 2,
+            ..run_snapshot(77, "CI", Some("success"), "main")
+        };
+        let repo = GitRepoMonitor::default();
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&partial)),
+            None,
+        );
+        assert!(
+            events.is_empty(),
+            "completed jobs in an incomplete workflow must not publish"
+        );
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true,
+            &run_map(std::slice::from_ref(&partial)),
+            &run_map(std::slice::from_ref(&complete)),
+            None,
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-passed");
+    }
+
+    #[tokio::test]
+    async fn issue_317_incomplete_check_run_pages_are_not_all_terminal() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut page_hits = 0_usize;
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = vec![0_u8; 4096];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                if !request.contains("/check-runs") {
+                    let body = if request.contains("/actions/runs") {
+                        r#"{"workflow_runs":[]}"#
+                    } else {
+                        "[]"
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    continue;
+                }
+                page_hits += 1;
+                let start = (page_hits - 1) * CI_PAGE_SIZE;
+                let runs: Vec<String> = (start..start + CI_PAGE_SIZE)
+                    .map(|id| {
+                        format!(
+                            r#"{{"id":{},"name":"CI","status":"completed","conclusion":"success","details_url":"https://github.com/org/repo/actions/runs/4242/jobs/{id}","head_sha":"prsha"}}"#,
+                            id + 1
+                        )
+                    })
+                    .collect();
+                let body = format!(r#"{{"check_runs":[{}]}}"#, runs.join(","));
+                let next = page_hits + 1;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nlink: <http://{addr}/repos/org/repo/commits/prsha/check-runs?page={next}>; rel=\"next\"\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                if page_hits >= MAX_CI_PAGES {
+                    break;
+                }
+            }
+        });
+
+        let pr = PullRequestSnapshot {
+            title: "PR".into(),
+            status: "open".into(),
+            url: "https://github.com/org/repo/pull/42".into(),
+            head_branch: "feat/pr".into(),
+            head_sha: "prsha".into(),
+        };
+        let client = build_github_client(None).unwrap();
+        let (runs, complete) =
+            fetch_check_runs(&client, &format!("http://{addr}"), "org/repo", 42, &pr)
+                .await
+                .unwrap();
+        assert!(!complete);
+        assert!(
+            runs.iter()
+                .all(|run| !run.run_all_terminal && !run.is_terminal()),
+            "incomplete check-run pagination must not infer run_all_terminal"
+        );
+        server.abort();
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1,9 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
@@ -17,11 +19,17 @@ use crate::telemetry;
 
 pub struct GitHubSource {
     config: Arc<AppConfig>,
+    ci_baseline_path: Option<PathBuf>,
 }
 
 impl GitHubSource {
-    pub fn new(config: Arc<AppConfig>) -> Self {
-        Self { config }
+    /// Restarts and re-enrollments reuse a persisted terminal-run baseline so
+    /// historical workflow results never replay as fresh events (#317).
+    pub fn with_ci_baseline_path(config: Arc<AppConfig>, ci_baseline_path: PathBuf) -> Self {
+        Self {
+            config,
+            ci_baseline_path: Some(ci_baseline_path),
+        }
     }
 }
 
@@ -39,6 +47,8 @@ impl Source for GitHubSource {
                 None
             }
         };
+        let ci_baseline_path = self.ci_baseline_path.clone();
+        let mut ci_baseline = load_ci_baseline(ci_baseline_path.as_deref());
         let mut state = HashMap::new();
 
         loop {
@@ -47,6 +57,8 @@ impl Source for GitHubSource {
                 github_client.as_ref(),
                 &tx,
                 &mut state,
+                &mut ci_baseline,
+                ci_baseline_path.as_deref(),
             )
             .await;
             sleep(Duration::from_secs(
@@ -55,6 +67,126 @@ impl Source for GitHubSource {
             .await;
         }
     }
+}
+
+/// Persisted terminal-run identity per monitored repo. Survives restart and
+/// re-enrollment so historical workflow runs cannot replay as fresh events
+/// (#317). Bounded: at most [`MAX_BASELINE_RUNS_PER_REPO`] identities per repo.
+#[derive(Default)]
+struct CIBaseline {
+    repos: HashMap<String, RepoCIBaseline>,
+}
+
+#[derive(Default, Clone, Serialize, Deserialize)]
+struct RepoCIBaseline {
+    /// Terminal run identities observed for this repo, oldest evicted first.
+    #[serde(default)]
+    terminal_runs: VecDeque<String>,
+}
+
+const MAX_BASELINE_RUNS_PER_REPO: usize = 256;
+
+/// Beside the cron state file, matching `tmux-watch-registry.json` and
+/// `discord-watch-state.json`.
+pub fn default_github_ci_baseline_path(cron_state_path: &Path) -> PathBuf {
+    cron_state_path.with_file_name("github-ci-baseline.json")
+}
+
+fn baseline_identity(ci: &GitHubCISnapshot) -> String {
+    // Prefer the immutable GitHub run id; fall back to the dedupe key so
+    // check-run snapshots without a run id still dedupe by sha+workflow.
+    ci.run_id
+        .as_ref()
+        .map(|run_id| format!("run:{run_id}"))
+        .unwrap_or_else(|| ci.dedupe_key())
+}
+
+fn repo_ci_baseline_is_suppressed(
+    repo_ci_baseline: Option<&RepoCIBaseline>,
+    dedupe_key: &str,
+) -> bool {
+    let Some(baseline) = repo_ci_baseline else {
+        return false;
+    };
+    baseline.terminal_runs.iter().any(|identity| {
+        identity == dedupe_key || {
+            // Persisted identities are run-id based; a terminal snapshot keyed
+            // by `run:<id>:<workflow>` must still match its persisted
+            // `run:<id>` identity.
+            identity
+                .strip_prefix("run:")
+                .is_some_and(|id| dedupe_key.starts_with(&format!("run:{id}:")))
+        }
+    })
+}
+
+impl CIBaseline {
+    /// Records terminal-run identities for one repo. Returns whether the
+    /// persisted state changed (bounded, oldest entries evicted first).
+    fn record_terminal_runs(
+        &mut self,
+        repo_path: &str,
+        current: &HashMap<String, GitHubCISnapshot>,
+    ) -> bool {
+        let repo_baseline = self.repos.entry(repo_path.to_string()).or_default();
+        let mut dirty = repo_baseline.terminal_runs.is_empty();
+        for ci in current.values() {
+            if !ci.is_terminal() {
+                continue;
+            }
+            let identity = baseline_identity(ci);
+            if !repo_baseline.terminal_runs.contains(&identity) {
+                repo_baseline.terminal_runs.push_back(identity);
+                dirty = true;
+            }
+        }
+        while repo_baseline.terminal_runs.len() > MAX_BASELINE_RUNS_PER_REPO {
+            repo_baseline.terminal_runs.pop_front();
+            dirty = true;
+        }
+        dirty
+    }
+}
+
+fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
+    let Some(path) = path else {
+        return CIBaseline::default();
+    };
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return CIBaseline::default(),
+        Err(error) => {
+            eprintln!(
+                "clawhip source github CI baseline '{}' unreadable; starting a fresh baseline: {error}",
+                path.display()
+            );
+            return CIBaseline::default();
+        }
+    };
+    match serde_json::from_str::<HashMap<String, RepoCIBaseline>>(&raw) {
+        Ok(repos) => CIBaseline { repos },
+        Err(error) => {
+            eprintln!(
+                "clawhip source github CI baseline '{}' invalid; starting a fresh baseline: {error}",
+                path.display()
+            );
+            CIBaseline::default()
+        }
+    }
+}
+
+fn save_ci_baseline(baseline: &CIBaseline, path: Option<&Path>) -> Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let payload = serde_json::to_string(&baseline.repos)?;
+    let temp_path = path.with_extension("json.tmp");
+    fs::write(&temp_path, payload.as_bytes())?;
+    fs::rename(&temp_path, path)?;
+    Ok(())
 }
 
 struct GitHubRepoState {
@@ -112,6 +244,12 @@ impl GitHubCISnapshot {
     fn event_kind(&self) -> &'static str {
         classify_ci_event_kind(&self.status, self.conclusion.as_deref())
     }
+
+    /// A terminal run will never change state again, so its identity can be
+    /// persisted and suppressed on later re-observation (#317).
+    fn is_terminal(&self) -> bool {
+        self.status == "completed"
+    }
 }
 
 async fn run_github_poll_cycle(
@@ -119,8 +257,19 @@ async fn run_github_poll_cycle(
     github_client: Option<&reqwest::Client>,
     tx: &mpsc::Sender<IncomingEvent>,
     state: &mut HashMap<String, GitHubRepoState>,
+    ci_baseline: &mut CIBaseline,
+    ci_baseline_path: Option<&Path>,
 ) {
-    if let Err(error) = poll_github(config, github_client, tx, state).await {
+    if let Err(error) = poll_github(
+        config,
+        github_client,
+        tx,
+        state,
+        ci_baseline,
+        ci_baseline_path,
+    )
+    .await
+    {
         telemetry::emit(source_record(
             telemetry::event_name::SOURCE_DEGRADED,
             "source_poll_failed",
@@ -166,6 +315,8 @@ async fn poll_github(
     github_client: Option<&reqwest::Client>,
     tx: &mpsc::Sender<IncomingEvent>,
     state: &mut HashMap<String, GitHubRepoState>,
+    ci_baseline: &mut CIBaseline,
+    ci_baseline_path: Option<&Path>,
 ) -> Result<()> {
     for repo in &config.monitors.git.repos {
         if !repo.emit_issue_opened && !repo.emit_pr_status {
@@ -221,6 +372,7 @@ async fn poll_github(
             previous,
             &prs,
             tx,
+            ci_baseline.repos.get(&repo.path),
         )
         .await
         {
@@ -239,6 +391,7 @@ async fn poll_github(
             }
         };
 
+        let repo_baseline_dirty = ci_baseline.record_terminal_runs(&repo.path, &ci);
         state.insert(
             repo.path.clone(),
             GitHubRepoState {
@@ -248,6 +401,18 @@ async fn poll_github(
                 ci_baseline_established,
             },
         );
+        if repo_baseline_dirty && let Err(error) = save_ci_baseline(ci_baseline, ci_baseline_path) {
+            telemetry::emit(source_record(
+                telemetry::event_name::SOURCE_DEGRADED,
+                "ci_baseline_persist_failed",
+                Some(&repo.path),
+                Some(error.to_string()),
+            ));
+            eprintln!(
+                "clawhip source github CI baseline persist failed for {}: {error}",
+                repo.path
+            );
+        }
     }
 
     Ok(())
@@ -363,6 +528,7 @@ async fn poll_pull_requests(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn poll_ci_statuses(
     config: &AppConfig,
     github_client: Option<&reqwest::Client>,
@@ -371,6 +537,7 @@ async fn poll_ci_statuses(
     previous: Option<&GitHubRepoState>,
     prs: &HashMap<u64, PullRequestSnapshot>,
     tx: &mpsc::Sender<IncomingEvent>,
+    repo_ci_baseline: Option<&RepoCIBaseline>,
 ) -> Result<(HashMap<String, GitHubCISnapshot>, bool)> {
     if !repo.emit_pr_status {
         return Ok((
@@ -413,6 +580,7 @@ async fn poll_ci_statuses(
                     previous.ci_baseline_established,
                     &previous.ci,
                     &ci,
+                    repo_ci_baseline,
                 ) {
                     send_event(tx, event).await?;
                 }
@@ -430,11 +598,13 @@ async fn poll_ci_statuses(
                 "clawhip source GitHub CI polling failed for {}: {error}",
                 repo.path
             );
+            // Keep the last snapshot for diffing but drop the established flag:
+            // the failed poll may be a partial view (pagination/cursor loss), and
+            // treating it as complete would replay whatever the next full poll
+            // returns — including terminal runs already delivered before (#317).
             Ok((
                 previous.map(|entry| entry.ci.clone()).unwrap_or_default(),
-                previous
-                    .map(|entry| entry.ci_baseline_established)
-                    .unwrap_or(false),
+                false,
             ))
         }
     }
@@ -548,12 +718,29 @@ fn collect_ci_events(
     previous_ci_baseline_established: bool,
     previous: &HashMap<String, GitHubCISnapshot>,
     current: &HashMap<String, GitHubCISnapshot>,
+    repo_ci_baseline: Option<&RepoCIBaseline>,
 ) -> Vec<IncomingEvent> {
     let mut events = Vec::new();
     for (key, ci) in current {
         let changed = match previous.get(key) {
             Some(old) => old.status != ci.status || old.conclusion != ci.conclusion,
-            None => previous_ci_baseline_established || ci.status != "completed",
+            None => {
+                if !previous_ci_baseline_established {
+                    // First poll after startup or re-priming after a partial
+                    // poll: seed the snapshot. In-progress runs emit; terminal
+                    // runs are historical noise, not transitions (#317).
+                    ci.status != "completed"
+                } else if ci.is_terminal() {
+                    // Established monitor seeing a terminal run with no
+                    // in-process record: the pagination drift / cursor loss /
+                    // re-enrollment replay window. Suppress it when the
+                    // persisted baseline already observed it (#317).
+                    !repo_ci_baseline_is_suppressed(repo_ci_baseline, key)
+                } else {
+                    // Established monitor seeing a genuinely new run start.
+                    true
+                }
+            }
         };
         if !changed {
             continue;
@@ -1050,6 +1237,428 @@ mod tests {
         }
     }
 
+    fn run_snapshot(
+        run_id: u64,
+        workflow: &str,
+        conclusion: Option<&str>,
+        branch: &str,
+    ) -> GitHubCISnapshot {
+        GitHubCISnapshot {
+            pr_number: None,
+            workflow: workflow.into(),
+            status: "completed".into(),
+            conclusion: conclusion.map(ToString::to_string),
+            sha: format!("sha-{run_id}"),
+            url: format!("https://github.com/org/repo/actions/runs/{run_id}"),
+            branch: Some(branch.into()),
+            run_id: Some(run_id.to_string()),
+            run_job_count: 1,
+            run_all_terminal: true,
+        }
+    }
+
+    fn run_map(runs: &[GitHubCISnapshot]) -> HashMap<String, GitHubCISnapshot> {
+        runs.iter()
+            .map(|run| (run.dedupe_key(), run.clone()))
+            .collect()
+    }
+
+    /// Simulates one monitor poll: fetch -> diff against in-process previous
+    /// state -> record terminal identities into the shared baseline.
+    async fn poll_once_with_baseline(
+        config: &AppConfig,
+        client: &reqwest::Client,
+        state: &mut HashMap<String, GitHubRepoState>,
+        ci_baseline: &mut CIBaseline,
+        ci_baseline_path: Option<&Path>,
+        tx: &mpsc::Sender<IncomingEvent>,
+    ) -> Result<()> {
+        poll_github(
+            config,
+            Some(client),
+            tx,
+            state,
+            ci_baseline,
+            ci_baseline_path,
+        )
+        .await
+    }
+
+    #[test]
+    fn issue_317_bounded_baseline_suppresses_historical_terminal_runs_after_monitor_restart() {
+        // Deterministic replay of the #317 burst: historical success/failure/
+        // cancelled runs already observed by a previous daemon process.
+        let historical_runs = [
+            run_snapshot(27620587146, "CI", Some("success"), "main"),
+            run_snapshot(24244183277, "CI", Some("failure"), "main"),
+            run_snapshot(29691404856, "CI", Some("cancelled"), "main"),
+        ];
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+
+        // --- First daemon process: observe and persist the baseline.
+        let mut ci_baseline = load_ci_baseline(Some(&path));
+        assert!(ci_baseline.record_terminal_runs("/repo", &run_map(&historical_runs)));
+        save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
+
+        // --- Daemon restart: state HashMap is empty, baseline reloads from disk.
+        let restarted = load_ci_baseline(Some(&path));
+        let repo_baseline = restarted.repos.get("/repo").expect("persisted repo");
+
+        // Bounded: only terminal identities, at most MAX_BASELINE_RUNS_PER_REPO.
+        assert_eq!(repo_baseline.terminal_runs.len(), 3);
+        for run in &historical_runs {
+            assert!(
+                repo_ci_baseline_is_suppressed(restarted.repos.get("/repo"), &run.dedupe_key()),
+                "historical terminal run {} must be suppressed after restart",
+                run.run_id.as_deref().unwrap_or("?")
+            );
+        }
+
+        // --- Re-observation with an empty in-process previous (pagination
+        // drift / cursor loss / re-enrollment) emits nothing.
+        let repo = GitRepoMonitor::default();
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true, // established monitor — old code emitted here (#317)
+            &HashMap::new(),
+            &run_map(&historical_runs),
+            restarted.repos.get("/repo"),
+        );
+        assert!(
+            events.is_empty(),
+            "historical terminal runs must not replay after restart; got {} events",
+            events.len()
+        );
+
+        // --- Genuinely new terminal runs are still delivered.
+        let new_run = run_snapshot(32205447861, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&new_run)),
+            restarted.repos.get("/repo"),
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-passed");
+    }
+
+    #[test]
+    fn issue_317_baseline_is_bounded_and_atomic_persistence_is_fail_safe() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+
+        // Bounded growth: recording far more terminal runs than the cap keeps
+        // at most MAX_BASELINE_RUNS_PER_REPO identities (newest retained).
+        let mut ci_baseline = CIBaseline::default();
+        for id in 0..(MAX_BASELINE_RUNS_PER_REPO + 64) {
+            let runs = [run_snapshot(id as u64, "CI", Some("success"), "main")];
+            ci_baseline.record_terminal_runs("/repo", &run_map(&runs));
+        }
+        let repo_baseline = ci_baseline.repos.get("/repo").unwrap();
+        assert_eq!(
+            repo_baseline.terminal_runs.len(),
+            MAX_BASELINE_RUNS_PER_REPO
+        );
+        assert!(
+            repo_baseline
+                .terminal_runs
+                .contains(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 63))
+        );
+        assert!(!repo_baseline.terminal_runs.contains(&"run:0".to_string()));
+
+        // Atomic persistence round-trips through a temp file + rename.
+        save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
+        let reloaded = load_ci_baseline(Some(&path));
+        assert_eq!(
+            reloaded.repos.get("/repo").unwrap().terminal_runs.len(),
+            MAX_BASELINE_RUNS_PER_REPO
+        );
+        assert!(!dir.path().join("github-ci-baseline.json.tmp").exists());
+
+        // Corrupt persisted state is a fail-safe fresh baseline, not a crash
+        // and not a silent skip: replay is still suppressed by first-poll
+        // baseline priming, and no unwinding panic escapes the source.
+        std::fs::write(&path, "{ not valid json").unwrap();
+        let corrupted = load_ci_baseline(Some(&path));
+        assert!(corrupted.repos.is_empty());
+
+        // Cross-repo identity: another repo's baseline never suppresses this
+        // repo's runs.
+        let mut mixed = CIBaseline::default();
+        let other = [run_snapshot(999, "CI", Some("success"), "main")];
+        mixed.record_terminal_runs("/other-repo", &run_map(&other));
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(&other),
+            mixed.repos.get("/repo"),
+        );
+        assert_eq!(
+            events.len(),
+            1,
+            "a different repo's baseline must not suppress this repo's runs"
+        );
+    }
+
+    #[test]
+    fn issue_317_in_progress_runs_and_changed_conclusions_still_emit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut ci_baseline = load_ci_baseline(Some(&path));
+
+        // A run observed in-progress is not recorded as terminal...
+        let in_progress = GitHubCISnapshot {
+            status: "in_progress".into(),
+            conclusion: None,
+            run_all_terminal: false,
+            ..run_snapshot(4242424242, "CI", Some("success"), "main")
+        };
+        ci_baseline.record_terminal_runs("/repo", &run_map(std::slice::from_ref(&in_progress)));
+        assert!(ci_baseline.repos["/repo"].terminal_runs.is_empty());
+
+        // ...so its genuinely new started event is emitted even though the
+        // monitor is established.
+        let repo = GitRepoMonitor::default();
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&in_progress)),
+            ci_baseline.repos.get("/repo"),
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-started");
+
+        // Once it terminates, the completion transition emits (present in
+        // previous) and is then recorded/suppressed forever after.
+        let completed = run_snapshot(4242424242, "CI", Some("failure"), "main");
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true,
+            &run_map(std::slice::from_ref(&in_progress)),
+            &run_map(std::slice::from_ref(&completed)),
+            ci_baseline.repos.get("/repo"),
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-failed");
+
+        ci_baseline.record_terminal_runs("/repo", &run_map(std::slice::from_ref(&completed)));
+        save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
+        let restarted = load_ci_baseline(Some(&path));
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&completed)),
+            restarted.repos.get("/repo"),
+        );
+        assert!(
+            events.is_empty(),
+            "terminal outcome delivered once must never replay"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_317_restart_and_pagination_cursor_loss_do_not_replay_historical_runs() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Fake GitHub Actions API page: one current run plus three historical
+        // terminal runs (success / failure / cancelled) that predate the
+        // monitor but re-enter the listing when pagination drifts (#317).
+        let workflow_runs_body = |run_ids: &[u64]| {
+            let runs: Vec<String> = run_ids
+                .iter()
+                .map(|id| {
+                    let conclusion = match id % 3 {
+                        0 => "success",
+                        1 => "failure",
+                        _ => "cancelled",
+                    };
+                    format!(
+                        r#"{{"id": {id}, "name": "CI", "status": "completed", "conclusion": "{conclusion}", "head_branch": "main", "head_sha": "sha-{id}", "html_url": "https://github.com/org/repo/actions/runs/{id}", "pull_requests": []}}"#
+                    )
+                })
+                .collect();
+            format!("{{\"workflow_runs\": [{}]}}", runs.join(","))
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Poll sequence the fake server serves:
+        //   1. first poll of process A: current + historical runs (primes
+        //      baseline, no events),
+        //   2. second poll of process A: unchanged (no events),
+        //   3. first poll of restarted process B with the same page
+        //      (pagination/cursor loss re-serving history): no events,
+        //   4. poll after a genuinely new push run: exactly one event.
+        let pages = [
+            workflow_runs_body(&[32205447861, 27620587146, 24244183277, 29691404856]),
+            workflow_runs_body(&[32205447861, 27620587146, 24244183277, 29691404856]),
+            workflow_runs_body(&[32205447861, 27620587146, 24244183277, 29691404856]),
+            workflow_runs_body(&[
+                32205447861,
+                27620587146,
+                24244183277,
+                29691404856,
+                32206000001,
+            ]),
+        ];
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let request_count_for_server = request_count.clone();
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            let mut next_page = 0_usize;
+            while next_page < pages.len() {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut buf = vec![0_u8; 4096];
+                let n = stream.read(&mut buf).await.unwrap();
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                requests.push(request.clone());
+                request_count_for_server.fetch_add(1, Ordering::SeqCst);
+
+                // Serve the next workflow-run page only for actions/runs
+                // requests; every other endpoint gets an empty listing so the
+                // CI poll sequence stays deterministic.
+                let body = if request.contains("/actions/runs") {
+                    let page = &pages[next_page];
+                    next_page += 1;
+                    page.clone()
+                } else {
+                    "[]".to_string()
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+            }
+            requests
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_path = dir.path().join("github-ci-baseline.json");
+
+        let mut config = AppConfig::default();
+        config.monitors.github_api_base = format!("http://{addr}");
+        config.monitors.git.repos = vec![GitRepoMonitor {
+            path: "/tmp/clawhip-replay-repo".into(),
+            name: Some("repo".into()),
+            github_repo: Some("org/repo".into()),
+            emit_pr_status: true,
+            emit_issue_opened: true,
+            emit_commits: false,
+            emit_branch_changes: false,
+            ..GitRepoMonitor::default()
+        }];
+        let client = build_github_client(None).unwrap();
+
+        // ---- Process A, poll 1: primes in-process baseline; nothing emits.
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut state_a = HashMap::new();
+        let mut baseline_a = load_ci_baseline(Some(&baseline_path));
+        poll_once_with_baseline(
+            &config,
+            &client,
+            &mut state_a,
+            &mut baseline_a,
+            Some(&baseline_path),
+            &tx,
+        )
+        .await
+        .unwrap();
+        assert!(rx.try_recv().is_err(), "first poll must not emit history");
+        assert!(
+            baseline_path.exists(),
+            "terminal identities must be persisted"
+        );
+
+        // ---- Process A, poll 2: unchanged page, still silent.
+        poll_once_with_baseline(
+            &config,
+            &client,
+            &mut state_a,
+            &mut baseline_a,
+            Some(&baseline_path),
+            &tx,
+        )
+        .await
+        .unwrap();
+        assert!(rx.try_recv().is_err());
+
+        // ---- Process B (restart): fresh in-process state, baseline reloaded
+        // from disk; the fake server re-serves the same page exactly as a
+        // pagination drift / cursor loss would. Nothing may replay.
+        let mut state_b = HashMap::new();
+        let mut baseline_b = load_ci_baseline(Some(&baseline_path));
+        poll_once_with_baseline(
+            &config,
+            &client,
+            &mut state_b,
+            &mut baseline_b,
+            Some(&baseline_path),
+            &tx,
+        )
+        .await
+        .unwrap();
+        assert!(
+            rx.try_recv().is_err(),
+            "restart must not replay historical terminal runs (#317)"
+        );
+
+        // ---- A genuinely new run lands: exactly one event for it.
+        poll_once_with_baseline(
+            &config,
+            &client,
+            &mut state_b,
+            &mut baseline_b,
+            Some(&baseline_path),
+            &tx,
+        )
+        .await
+        .unwrap();
+        let mut delivered = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            delivered.push(event);
+        }
+        assert_eq!(
+            delivered.len(),
+            1,
+            "exactly the new run must be delivered, got {delivered:?}"
+        );
+        assert_eq!(delivered[0].payload["run_id"], json!("32206000001"));
+
+        // Persisted growth is bounded by the number of terminal runs observed
+        // in the window — no history scan, no ledger growth.
+        let persisted: HashMap<String, RepoCIBaseline> =
+            serde_json::from_str(&std::fs::read_to_string(&baseline_path).unwrap()).unwrap();
+        assert!(
+            persisted["/tmp/clawhip-replay-repo"].terminal_runs.len() <= MAX_BASELINE_RUNS_PER_REPO
+        );
+
+        let requests = server.await.unwrap();
+        // Four CI polls; the issues/pulls endpoints add two requests per poll.
+        assert_eq!(requests.len(), 12);
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.contains("GET /repos/org/repo/actions/runs?"))
+                .count(),
+            4,
+            "exactly four CI polls must hit the workflow-runs endpoint"
+        );
+    }
+
     #[tokio::test]
     async fn direct_branch_workflow_run_without_open_pr_emits_ci_failed_event() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -1103,10 +1712,18 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(4);
         let prs = HashMap::new();
 
-        let (ci, ci_baseline_established) =
-            poll_ci_statuses(&config, Some(&client), &repo, &snapshot, None, &prs, &tx)
-                .await
-                .unwrap();
+        let (ci, ci_baseline_established) = poll_ci_statuses(
+            &config,
+            Some(&client),
+            &repo,
+            &snapshot,
+            None,
+            &prs,
+            &tx,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(ci.len(), 1);
         assert!(ci_baseline_established);
@@ -1255,7 +1872,7 @@ mod tests {
             .into_iter()
             .collect();
 
-        let events = collect_ci_events(&repo, "clawhip", false, &previous, &current);
+        let events = collect_ci_events(&repo, "clawhip", false, &previous, &current, None);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].canonical_kind(), "github.ci-started");
         assert_eq!(events[0].channel.as_deref(), Some("dev-channel"));
@@ -1285,7 +1902,7 @@ mod tests {
                 .into_iter()
                 .collect();
 
-            let events = collect_ci_events(&repo, "clawhip", false, &previous, &current);
+            let events = collect_ci_events(&repo, "clawhip", false, &previous, &current, None);
             assert!(
                 events.is_empty(),
                 "initial completed CI with conclusion {conclusion} should only seed the baseline"
@@ -1311,7 +1928,7 @@ mod tests {
                 .into_iter()
                 .collect();
 
-            let events = collect_ci_events(&repo, "clawhip", true, &previous, &current);
+            let events = collect_ci_events(&repo, "clawhip", true, &previous, &current, None);
             assert_eq!(
                 events.len(),
                 1,
@@ -1333,7 +1950,7 @@ mod tests {
         let previous = [(ci.dedupe_key(), ci.clone())].into_iter().collect();
         let current = [(ci.dedupe_key(), ci)].into_iter().collect();
 
-        let events = collect_ci_events(&repo, "clawhip", true, &previous, &current);
+        let events = collect_ci_events(&repo, "clawhip", true, &previous, &current, None);
         assert!(events.is_empty());
     }
 
@@ -1352,7 +1969,7 @@ mod tests {
             .into_iter()
             .collect();
 
-        let events = collect_ci_events(&repo, "clawhip", true, &previous, &current);
+        let events = collect_ci_events(&repo, "clawhip", true, &previous, &current, None);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].canonical_kind(), "github.ci-failed");
         assert_eq!(events[0].payload["workflow"], json!("CI / test"));
@@ -1375,7 +1992,7 @@ mod tests {
             .into_iter()
             .collect();
 
-        let events = collect_ci_events(&repo, "clawhip", true, &previous, &current);
+        let events = collect_ci_events(&repo, "clawhip", true, &previous, &current, None);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].canonical_kind(), "github.ci-passed");
     }
@@ -1395,7 +2012,7 @@ mod tests {
             .into_iter()
             .collect();
 
-        let events = collect_ci_events(&repo, "clawhip", true, &previous, &current);
+        let events = collect_ci_events(&repo, "clawhip", true, &previous, &current, None);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].canonical_kind(), "github.ci-cancelled");
     }
@@ -1487,7 +2104,11 @@ mod tests {
             ..GitRepoMonitor::default()
         }];
 
-        let source = GitHubSource::new(Arc::new(config));
+        let baseline_dir = tempfile::tempdir().unwrap();
+        let source = GitHubSource::with_ci_baseline_path(
+            Arc::new(config),
+            baseline_dir.path().join("github-ci-baseline.json"),
+        );
         let (tx, _rx) = mpsc::channel(4);
         let source_task = tokio::spawn(async move { source.run(tx).await });
 

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -829,7 +829,7 @@ fn unlock_baseline_file(file: &File) {
 
 #[cfg(windows)]
 #[link(name = "kernel32")]
-extern "system" {
+unsafe extern "system" {
     #[link_name = "LockFile"]
     fn lock_file(
         handle: *mut core::ffi::c_void,

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -3637,23 +3637,24 @@ mod tests {
                 let live_deleted = live_deleted.clone();
                 let errors = errors.clone();
                 let path = path.clone();
-                scope.spawn(move || match acquire_baseline_lock_inner(&path, BASELINE_LOCK_STALE_SECS)
-                {
-                    Ok(lock) => {
-                        let owner = lock.lock_path.join("owner");
-                        let token = lock.token.clone();
-                        current.fetch_add(1, Ordering::SeqCst);
-                        thread::sleep(Duration::from_millis(30));
-                        if current.load(Ordering::SeqCst) > 1 {
-                            overlapping.fetch_add(1, Ordering::SeqCst);
+                scope.spawn(move || {
+                    match acquire_baseline_lock_inner(&path, BASELINE_LOCK_STALE_SECS) {
+                        Ok(lock) => {
+                            let owner = lock.lock_path.join("owner");
+                            let token = lock.token.clone();
+                            current.fetch_add(1, Ordering::SeqCst);
+                            thread::sleep(Duration::from_millis(30));
+                            if current.load(Ordering::SeqCst) > 1 {
+                                overlapping.fetch_add(1, Ordering::SeqCst);
+                            }
+                            if fs::read_to_string(&owner).ok().as_deref() != Some(token.as_str()) {
+                                live_deleted.fetch_add(1, Ordering::SeqCst);
+                            }
+                            current.fetch_sub(1, Ordering::SeqCst);
+                            drop(lock);
                         }
-                        if fs::read_to_string(&owner).ok().as_deref() != Some(token.as_str()) {
-                            live_deleted.fetch_add(1, Ordering::SeqCst);
-                        }
-                        current.fetch_sub(1, Ordering::SeqCst);
-                        drop(lock);
+                        Err(error) => errors.lock().unwrap().push(error.to_string()),
                     }
-                    Err(error) => errors.lock().unwrap().push(error.to_string()),
                 });
             }
         });

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -136,6 +136,16 @@ impl PendingCiDelivery {
                 .unwrap_or_default()
                 .to_string()
         };
+        let mut identities = identities;
+        if let Some(check_run_id) = payload
+            .and_then(|object| object.get("check_run_id"))
+            .and_then(serde_json::Value::as_str)
+        {
+            let identity = format!("check:{check_run_id}");
+            if !identities.iter().any(|existing| existing == &identity) {
+                identities.push(identity);
+            }
+        }
         Self {
             identities,
             kind: event.kind.clone(),
@@ -180,18 +190,33 @@ impl PendingCiDelivery {
     }
 
     fn same_event(&self, other: &Self) -> bool {
-        let self_unique = unique_pending_identities(&self.identities);
-        let other_unique = unique_pending_identities(&other.identities);
-        if !self_unique.is_empty() && !other_unique.is_empty() {
-            return self_unique
+        if self.kind != other.kind || self.conclusion != other.conclusion {
+            return false;
+        }
+        let self_checks = pending_check_identities(&self.identities);
+        let other_checks = pending_check_identities(&other.identities);
+        if !self_checks.is_empty() && !other_checks.is_empty() {
+            return self_checks
                 .iter()
-                .any(|identity| other_unique.iter().any(|candidate| candidate == identity));
+                .any(|identity| other_checks.iter().any(|candidate| candidate == identity));
+        }
+        let self_runs = pending_run_identities(&self.identities);
+        let other_runs = pending_run_identities(&other.identities);
+        if !self_checks.is_empty() {
+            return other_runs.is_empty() && self.fallback_matches(other);
+        }
+        if !other_checks.is_empty() {
+            return self_runs.is_empty() && self.fallback_matches(other);
         }
         if self.run_id.is_some() && other.run_id.is_some() {
             return self.run_id == other.run_id
                 && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(other.run_attempt)
                 && self.workflow == other.workflow;
         }
+        self.fallback_matches(other)
+    }
+
+    fn fallback_matches(&self, other: &Self) -> bool {
         self.sha == other.sha
             && self.workflow == other.workflow
             && self.pr_number == other.pr_number
@@ -218,6 +243,12 @@ impl PendingCiDelivery {
                     "run_attempt".to_string(),
                     json!(run_attempt_or_one(self.run_attempt)),
                 );
+            }
+            if let Some(check_id) = pending_check_identities(&self.identities)
+                .first()
+                .and_then(|identity| identity.strip_prefix("check:"))
+            {
+                payload.insert("check_run_id".to_string(), json!(check_id));
             }
             payload.insert("run_job_count".to_string(), json!(self.run_job_count));
             payload.insert("run_all_terminal".to_string(), json!(self.run_all_terminal));
@@ -290,11 +321,19 @@ fn ci_baseline_repo_key(snapshot: &GitSnapshot, repo: &GitRepoMonitor) -> String
         .unwrap_or_else(|| format!("path:{}", repo.path))
 }
 
-fn unique_pending_identities(identities: &[String]) -> Vec<String> {
+fn pending_check_identities(identities: &[String]) -> Vec<&str> {
     identities
         .iter()
-        .filter(|identity| identity.starts_with("run:") || identity.starts_with("check:"))
-        .cloned()
+        .filter(|identity| identity.starts_with("check:"))
+        .map(String::as_str)
+        .collect()
+}
+
+fn pending_run_identities(identities: &[String]) -> Vec<&str> {
+    identities
+        .iter()
+        .filter(|identity| identity.starts_with("run:"))
+        .map(String::as_str)
         .collect()
 }
 
@@ -979,11 +1018,11 @@ impl GitHubCISnapshot {
     }
 
     fn dedupe_key(&self) -> String {
-        if let Some(run_id) = &self.run_id {
-            return format!("run:{run_id}:{}:{}", self.run_attempt(), self.workflow);
-        }
         if let Some(check_run_id) = &self.check_run_id {
             return format!("check:{check_run_id}");
+        }
+        if let Some(run_id) = &self.run_id {
+            return format!("run:{run_id}:{}:{}", self.run_attempt(), self.workflow);
         }
         self.fallback_identity()
     }
@@ -1468,6 +1507,7 @@ fn previous_snapshot_for_event<'a>(
 ) -> Option<&'a GitHubCISnapshot> {
     let payload = event.payload.as_object()?;
     let workflow = payload.get("workflow")?.as_str()?;
+    let check_run_id = payload.get("check_run_id").and_then(|value| value.as_str());
     let run_id = payload.get("run_id").and_then(|value| value.as_str());
     let run_attempt = payload
         .get("run_attempt")
@@ -1475,6 +1515,12 @@ fn previous_snapshot_for_event<'a>(
         .map(|value| value as u32)
         .unwrap_or(1);
     previous.values().find(|ci| {
+        if let Some(check_run_id) = check_run_id {
+            return ci.check_run_id.as_deref() == Some(check_run_id);
+        }
+        if ci.check_run_id.is_some() {
+            return false;
+        }
         if let Some(run_id) = run_id {
             return ci.run_id.as_deref() == Some(run_id)
                 && ci.run_attempt() == run_attempt_or_one(run_attempt);
@@ -1662,6 +1708,9 @@ fn collect_ci_events(
             if let Some(run_id) = &ci.run_id {
                 payload.insert("run_id".to_string(), json!(run_id));
                 payload.insert("run_attempt".to_string(), json!(ci.run_attempt()));
+            }
+            if let Some(check_run_id) = &ci.check_run_id {
+                payload.insert("check_run_id".to_string(), json!(check_run_id));
             }
             payload.insert("run_job_count".to_string(), json!(ci.run_job_count));
             payload.insert("run_all_terminal".to_string(), json!(ci.run_all_terminal));
@@ -3267,6 +3316,118 @@ mod tests {
         commit_ci_baseline(Some(&path), &right).unwrap();
         let loaded = load_ci_baseline(Some(&path));
         assert_eq!(loaded.repos["/repo"].pending.len(), 2);
+    }
+
+    fn check_job(run_id: u64, check_id: u64, workflow: &str, conclusion: &str) -> GitHubCISnapshot {
+        GitHubCISnapshot {
+            check_run_id: Some(check_id.to_string()),
+            workflow: workflow.into(),
+            conclusion: Some(conclusion.into()),
+            status: "completed".into(),
+            run_all_terminal: true,
+            run_job_count: 2,
+            ..run_snapshot(run_id, workflow, Some(conclusion), "main")
+        }
+    }
+
+    #[test]
+    fn issue_317_pending_keeps_distinct_check_jobs_in_one_run() {
+        let lint = check_job(4242, 11, "lint", "success");
+        let test = check_job(4242, 22, "test", "failure");
+        let current = run_map(&[lint.clone(), test.clone()]);
+        assert_eq!(current.len(), 2, "check jobs must not share a HashMap key");
+
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &current,
+            None,
+        );
+        assert_eq!(events.len(), 2, "both terminal jobs must publish");
+
+        let mut baseline = CIBaseline::default();
+        baseline.enqueue_pending("/repo", "/repo", &events, &current);
+        assert_eq!(baseline.repos["/repo"].pending.len(), 2);
+
+        let success = events
+            .iter()
+            .find(|event| event.canonical_kind() == "github.ci-passed")
+            .unwrap();
+        let failure = events
+            .iter()
+            .find(|event| event.canonical_kind() == "github.ci-failed")
+            .unwrap();
+        let pending_ok = PendingCiDelivery::from_event(success, lint.identities());
+        let pending_fail = PendingCiDelivery::from_event(failure, test.identities());
+        assert!(!pending_ok.same_event(&pending_fail));
+
+        let stale_ok = pending_ok.clone();
+        let mut flipped = check_job(4242, 11, "lint", "failure");
+        flipped.sha = lint.sha.clone();
+        let flip_events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &run_map(std::slice::from_ref(&lint)),
+            &run_map(std::slice::from_ref(&flipped)),
+            None,
+        );
+        assert_eq!(flip_events.len(), 1);
+        let pending_flip = PendingCiDelivery::from_event(&flip_events[0], flipped.identities());
+        assert!(!stale_ok.same_event(&pending_flip));
+        let mut dest = RepoCIBaseline::default();
+        dest.pending.push(stale_ok.clone());
+        merge_repo_baseline(
+            &mut dest,
+            RepoCIBaseline {
+                pending: vec![pending_flip.clone()],
+                ..RepoCIBaseline::default()
+            },
+        );
+        assert_eq!(dest.pending.len(), 2);
+
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.enqueue_pending("/repo", "/repo", &events, &current);
+        bump_pending_send_attempts(
+            &mut ci_baseline,
+            std::slice::from_ref(&pending_ok),
+            unix_now(),
+        );
+        let pending = &ci_baseline.repos["/repo"].pending;
+        let bumped = pending
+            .iter()
+            .find(|item| item.same_event(&pending_ok))
+            .unwrap();
+        let untouched = pending
+            .iter()
+            .find(|item| item.same_event(&pending_fail))
+            .unwrap();
+        assert_eq!(bumped.send_attempts, 1);
+        assert_eq!(untouched.send_attempts, 0);
+
+        ack_pending_deliveries(&mut ci_baseline, None, std::slice::from_ref(&pending_ok)).unwrap();
+        assert_eq!(ci_baseline.repos["/repo"].pending.len(), 1);
+        assert!(ci_baseline.repos["/repo"].pending[0].same_event(&pending_fail));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut persist = CIBaseline::default();
+        persist.enqueue_pending("/repo", "/repo", &events, &current);
+        persist.enqueue_pending(
+            "/repo",
+            "/repo",
+            &flip_events,
+            &run_map(std::slice::from_ref(&flipped)),
+        );
+        save_ci_baseline(&persist, Some(&path)).unwrap();
+        let restarted = load_ci_baseline(Some(&path));
+        assert_eq!(
+            restarted.repos["/repo"].pending.len(),
+            3,
+            "restart must keep both jobs and the changed conclusion"
+        );
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -2946,7 +2946,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(rx.try_recv().is_err(), "restart prime must not replay attempt 1");
+        assert!(
+            rx.try_recv().is_err(),
+            "restart prime must not replay attempt 1"
+        );
         poll_once_with_baseline(
             &config,
             &client,

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -4,6 +4,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, LINK, USER_AGENT};
@@ -22,6 +23,8 @@ use crate::telemetry;
 thread_local! {
     static SYNC_FILE_CALLS: Cell<u32> = const { Cell::new(0) };
 }
+
+static WINDOW_GENERATION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub struct GitHubSource {
     config: Arc<AppConfig>,
@@ -750,7 +753,6 @@ fn canonicalize_loaded_window(repo_baseline: &mut RepoCIBaseline) {
         .current_window_ids_by_scope
         .drain()
         .map(|(scope, ids)| (scope, canonicalize_current_window_ids_from(&ids)))
-        .filter(|(_, ids)| !ids.is_empty())
         .collect();
     scopes.sort_by(|left, right| left.0.cmp(&right.0));
     repo_baseline.current_window_ids_by_scope = scopes.into_iter().collect();
@@ -783,7 +785,22 @@ fn next_window_generation(previous: u64) -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos().min(u64::MAX as u128) as u64)
         .unwrap_or(previous);
-    previous.saturating_add(1).max(clock)
+    let floor = previous.saturating_add(1).max(clock);
+    let mut observed = WINDOW_GENERATION_COUNTER.load(Ordering::Relaxed);
+    loop {
+        let next = observed
+            .max(floor)
+            .saturating_add(u64::from(observed >= floor));
+        match WINDOW_GENERATION_COUNTER.compare_exchange_weak(
+            observed,
+            next,
+            Ordering::SeqCst,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return next,
+            Err(current) => observed = current,
+        }
+    }
 }
 
 fn cap_repo_baseline_keeping_ids(
@@ -822,6 +839,21 @@ impl RepoCIBaseline {
 }
 
 impl CIBaseline {
+    fn reserve_window_generation(
+        &mut self,
+        repo_key: &str,
+        repo_path: &str,
+        window_scope: &str,
+    ) -> u64 {
+        let repo = self.repo_baseline_mut(repo_key, repo_path);
+        let generation = next_window_generation(repo.window_generation);
+        repo.window_generation = generation;
+        repo.current_window_generations
+            .entry(window_scope.to_string())
+            .or_insert(0);
+        generation
+    }
+
     fn repo_baseline_mut(&mut self, repo_key: &str, repo_path: &str) -> &mut RepoCIBaseline {
         let mut inherited = Vec::new();
         if let Some(legacy) = self.repos.remove(repo_path) {
@@ -972,8 +1004,11 @@ impl CIBaseline {
             }
         }
         canonicalize_loaded_window(repo_baseline);
-        let keep_ids: std::collections::HashSet<String> =
+        let mut keep_ids: std::collections::HashSet<String> =
             repo_baseline.current_window_ids.iter().cloned().collect();
+        if !window.1 {
+            keep_ids.extend(incoming.iter().flat_map(|ci| ci.unique_identities()));
+        }
         dirty |= cap_repo_baseline_keeping_ids(repo_baseline, &keep_ids);
         dirty
     }
@@ -1983,15 +2018,10 @@ async fn poll_github(
                 }
             };
         let repo_key = ci_baseline_repo_key(&snapshot, repo);
-        let _ = ci_baseline.repo_baseline_mut(&repo_key, &repo.path);
+        let fetch_generation =
+            ci_baseline.reserve_window_generation(&repo_key, &repo.path, &repo.path);
         let repo_ci_baseline = ci_baseline.repos.get(&repo_key).cloned();
-        let fetch_generation = next_window_generation(
-            repo_ci_baseline
-                .as_ref()
-                .map(|baseline| baseline.window_generation)
-                .unwrap_or(0),
-        );
-        let (ci, ci_baseline_established, ci_events, window_complete) = match poll_ci_statuses(
+        let (ci, ci_baseline_established, window_complete) = match poll_ci_statuses(
             config,
             github_client,
             repo,
@@ -1999,7 +2029,6 @@ async fn poll_github(
             previous,
             &prs,
             prs_window_complete,
-            repo_ci_baseline.as_ref(),
         )
         .await
         {
@@ -2014,10 +2043,41 @@ async fn poll_github(
                     previous
                         .map(|entry| entry.ci_baseline_established)
                         .unwrap_or(false),
-                    Vec::new(),
                     false,
                 )
             }
+        };
+        let generation_is_current = ci_baseline
+            .repos
+            .get(&repo_key)
+            .is_some_and(|baseline| baseline.window_generation == fetch_generation);
+        let ci_events = if generation_is_current {
+            if let Some(previous) = previous {
+                collect_ci_events(
+                    repo,
+                    &snapshot.repo_name,
+                    previous.ci_baseline_established,
+                    &previous.ci,
+                    &ci,
+                    repo_ci_baseline.as_ref(),
+                )
+            } else if repo_ci_baseline
+                .as_ref()
+                .is_some_and(|baseline| baseline.ci_established)
+            {
+                collect_ci_events(
+                    repo,
+                    &snapshot.repo_name,
+                    true,
+                    &HashMap::new(),
+                    &ci,
+                    repo_ci_baseline.as_ref(),
+                )
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
         };
 
         // Durable outbox: persist pending receipts, then publish, then
@@ -2237,20 +2297,13 @@ async fn poll_ci_statuses(
     previous: Option<&GitHubRepoState>,
     prs: &HashMap<u64, PullRequestSnapshot>,
     prs_window_complete: bool,
-    repo_ci_baseline: Option<&RepoCIBaseline>,
-) -> Result<(
-    HashMap<String, GitHubCISnapshot>,
-    bool,
-    Vec<IncomingEvent>,
-    bool,
-)> {
+) -> Result<(HashMap<String, GitHubCISnapshot>, bool, bool)> {
     if !repo.emit_pr_status {
         return Ok((
             previous.map(|entry| entry.ci.clone()).unwrap_or_default(),
             previous
                 .map(|entry| entry.ci_baseline_established)
                 .unwrap_or(false),
-            Vec::new(),
             true,
         ));
     }
@@ -2261,7 +2314,6 @@ async fn poll_ci_statuses(
             previous
                 .map(|entry| entry.ci_baseline_established)
                 .unwrap_or(false),
-            Vec::new(),
             true,
         ));
     };
@@ -2292,29 +2344,8 @@ async fn poll_ci_statuses(
             } else {
                 fetched
             };
-            let events = if let Some(previous) = previous {
-                collect_ci_events(
-                    repo,
-                    &snapshot.repo_name,
-                    previous.ci_baseline_established,
-                    &previous.ci,
-                    &ci,
-                    repo_ci_baseline,
-                )
-            } else if repo_ci_baseline.is_some_and(|baseline| baseline.ci_established) {
-                collect_ci_events(
-                    repo,
-                    &snapshot.repo_name,
-                    true,
-                    &HashMap::new(),
-                    &ci,
-                    repo_ci_baseline,
-                )
-            } else {
-                Vec::new()
-            };
             let established = true;
-            Ok((ci, established, events, window_complete))
+            Ok((ci, established, window_complete))
         }
         Err(error) => {
             telemetry::emit(source_record(
@@ -2334,7 +2365,6 @@ async fn poll_ci_statuses(
             Ok((
                 previous.map(|entry| entry.ci.clone()).unwrap_or_default(),
                 false,
-                Vec::new(),
                 false,
             ))
         }
@@ -4091,6 +4121,26 @@ mod tests {
     }
 
     #[test]
+    fn issue_317_partial_window_keeps_more_than_history_cap_of_new_terminals() {
+        let mut baseline = CIBaseline::default();
+        let runs: Vec<_> = (0..(MAX_BASELINE_RUNS_PER_REPO + 100) as u64)
+            .map(|id| run_snapshot(id, "CI", Some("failure"), "main"))
+            .collect();
+        let current = run_map(&runs);
+        baseline.record_terminal_runs_filtered(
+            "/repo",
+            "/repo",
+            "/repo",
+            &current,
+            (10, false),
+            |_| true,
+        );
+        let repo = &baseline.repos["/repo"];
+        assert_eq!(repo.terminal_runs.len(), MAX_BASELINE_RUNS_PER_REPO + 100);
+        assert!(repo.contains_identity(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 99)));
+    }
+
+    #[test]
     fn issue_317_out_of_order_window_response_cannot_overwrite_newer_generation() {
         let mut baseline = CIBaseline::default();
         let fresh = run_snapshot(20, "CI", Some("success"), "main");
@@ -4114,6 +4164,48 @@ mod tests {
         let ids = &baseline.repos["/repo"].current_window_ids_by_scope["/repo"];
         assert!(ids.contains(&"run:20".to_string()));
         assert!(!ids.contains(&"run:10".to_string()));
+    }
+
+    #[test]
+    fn issue_317_empty_scope_tombstone_blocks_stale_nonempty_resurrection() {
+        let mut live = RepoCIBaseline::default();
+        live.current_window_ids_by_scope
+            .insert("/repo".into(), vec!["run:old".into()]);
+        live.current_window_generations.insert("/repo".into(), 10);
+        live.window_generation = 10;
+        canonicalize_loaded_window(&mut live);
+
+        let mut empty = RepoCIBaseline::default();
+        empty
+            .current_window_ids_by_scope
+            .insert("/repo".into(), vec![]);
+        empty.current_window_generations.insert("/repo".into(), 20);
+        empty.window_generation = 20;
+        merge_repo_baseline(&mut live, empty);
+        assert!(live.current_window_ids_by_scope["/repo"].is_empty());
+
+        let mut stale = RepoCIBaseline::default();
+        stale
+            .current_window_ids_by_scope
+            .insert("/repo".into(), vec!["run:old".into()]);
+        stale.current_window_generations.insert("/repo".into(), 10);
+        stale.window_generation = 10;
+        merge_repo_baseline(&mut live, stale);
+        assert!(live.current_window_ids_by_scope["/repo"].is_empty());
+    }
+
+    #[test]
+    fn issue_317_generation_reservation_is_unique_under_concurrency() {
+        let threads: Vec<_> = (0..8)
+            .map(|_| std::thread::spawn(|| next_window_generation(0)))
+            .collect();
+        let mut generations: Vec<_> = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect();
+        generations.sort_unstable();
+        generations.dedup();
+        assert_eq!(generations.len(), 8);
     }
 
     #[test]
@@ -6540,25 +6632,13 @@ mod tests {
         let client = build_github_client(None).unwrap();
         let prs = HashMap::new();
 
-        let (ci, ci_baseline_established, events, _window_complete) = poll_ci_statuses(
-            &config,
-            Some(&client),
-            &repo,
-            &snapshot,
-            None,
-            &prs,
-            true,
-            None,
-        )
-        .await
-        .unwrap();
+        let (ci, ci_baseline_established, _window_complete) =
+            poll_ci_statuses(&config, Some(&client), &repo, &snapshot, None, &prs, true)
+                .await
+                .unwrap();
 
         assert_eq!(ci.len(), 1);
         assert!(ci_baseline_established);
-        assert!(
-            events.is_empty(),
-            "first poll after startup should prime CI baseline without emitting historical events"
-        );
 
         let req = server.await.unwrap();
         assert!(req.contains("GET /repos/ultraworkers/claw-code/actions/runs?"));

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -230,6 +230,9 @@ impl AckedDelivery {
         }
         if self.run_id.is_none() {
             self.run_id = pending.run_id.clone();
+            if pending.run_id.is_some() {
+                self.run_attempt = run_attempt_or_one(pending.run_attempt);
+            }
         }
         if self.sha.is_empty() {
             self.sha = pending.sha.clone();
@@ -307,9 +310,18 @@ impl PendingCiDelivery {
         let self_checks = pending_check_identities(&self.identities);
         let other_checks = pending_check_identities(&other.identities);
         if !self_checks.is_empty() && !other_checks.is_empty() {
-            return self_checks
+            let check_match = self_checks
                 .iter()
                 .any(|identity| other_checks.iter().any(|candidate| candidate == identity));
+            if !check_match {
+                return false;
+            }
+            if self.run_id.is_some() && other.run_id.is_some() {
+                return self.run_id == other.run_id
+                    && run_attempt_or_one(self.run_attempt)
+                        == run_attempt_or_one(other.run_attempt);
+            }
+            return true;
         }
         let self_runs = pending_run_identities(&self.identities);
         let other_runs = pending_run_identities(&other.identities);
@@ -4006,6 +4018,61 @@ mod tests {
         );
         let pending2 = PendingCiDelivery::from_event(&events2[0], attempt2.identities());
         assert!(!pending_is_acked(&repo, &pending2));
+    }
+
+    #[test]
+    fn issue_317_shared_check_id_does_not_collapse_run_attempts() {
+        let attempt1 = check_job(4242, 11, "CI", "success");
+        let events1 = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt1)),
+            None,
+        );
+        let pending1 = PendingCiDelivery::from_event(&events1[0], attempt1.identities());
+        let attempt2 = GitHubCISnapshot {
+            run_attempt: 2,
+            check_run_id: Some("11".into()),
+            ..check_job(4242, 11, "CI", "success")
+        };
+        let events2 = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt2)),
+            None,
+        );
+        let pending2 = PendingCiDelivery::from_event(&events2[0], attempt2.identities());
+        assert!(!pending1.same_event(&pending2));
+        let mut repo = RepoCIBaseline::default();
+        record_acked(&mut repo, &pending1);
+        assert!(!pending_is_acked(&repo, &pending2));
+    }
+
+    #[test]
+    fn issue_317_check_only_ack_adopts_run_attempt_on_alias_merge() {
+        let check = check_job(4242, 11, "CI", "success");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&check)),
+            None,
+        );
+        let mut check_only = PendingCiDelivery::from_event(&events[0], check.identities());
+        check_only.run_id = None;
+        check_only.run_attempt = 1;
+        let mut repo = RepoCIBaseline::default();
+        record_acked(&mut repo, &check_only);
+        let mut attempt2 = PendingCiDelivery::from_event(&events[0], check.identities());
+        attempt2.run_attempt = 2;
+        record_acked(&mut repo, &attempt2);
+        assert_eq!(repo.acked[0].run_attempt, 2);
+        assert!(pending_is_acked(&repo, &attempt2));
     }
 
     #[tokio::test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -2,10 +2,10 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
-use serde::{Deserialize, Serialize};
+use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, LINK, USER_AGENT};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
@@ -69,9 +69,10 @@ impl Source for GitHubSource {
     }
 }
 
-/// Persisted terminal-run identity per monitored repo. Survives restart and
-/// re-enrollment so historical workflow runs cannot replay as fresh events
-/// (#317). Bounded: at most [`MAX_BASELINE_RUNS_PER_REPO`] identities per repo.
+/// Persisted terminal-run identity per monitored GitHub repository. Survives
+/// restart and re-enrollment so historical workflow results never replay as
+/// fresh events (#317). Bounded: at most [`MAX_BASELINE_RUNS_PER_REPO`]
+/// records per repo, evicted oldest-first by GitHub timestamps / run ids.
 #[derive(Default)]
 struct CIBaseline {
     repos: HashMap<String, RepoCIBaseline>,
@@ -79,12 +80,53 @@ struct CIBaseline {
 
 #[derive(Default, Clone, Serialize, Deserialize)]
 struct RepoCIBaseline {
-    /// Terminal run identities observed for this repo, oldest evicted first.
-    #[serde(default)]
-    terminal_runs: VecDeque<String>,
+    /// Terminal run records observed for this repo, oldest evicted first.
+    #[serde(default, deserialize_with = "deserialize_terminal_runs")]
+    terminal_runs: VecDeque<TerminalRunRecord>,
+}
+
+/// Durable receipt for one terminal run. Identities are aliases (run-id,
+/// check-run id, fallback) so representation drift still suppresses. Receipt
+/// records the persist-before-publish contract: a delivered event is always
+/// already in this set.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct TerminalRunRecord {
+    identities: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    created_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+enum PersistedTerminalRun {
+    Legacy(String),
+    Record(TerminalRunRecord),
+}
+
+impl From<PersistedTerminalRun> for TerminalRunRecord {
+    fn from(value: PersistedTerminalRun) -> Self {
+        match value {
+            PersistedTerminalRun::Legacy(identity) => TerminalRunRecord::from_legacy(identity),
+            PersistedTerminalRun::Record(record) => record,
+        }
+    }
+}
+
+fn deserialize_terminal_runs<'de, D>(
+    deserializer: D,
+) -> std::result::Result<VecDeque<TerminalRunRecord>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Vec::<PersistedTerminalRun>::deserialize(deserializer)?;
+    Ok(raw.into_iter().map(TerminalRunRecord::from).collect())
 }
 
 const MAX_BASELINE_RUNS_PER_REPO: usize = 256;
+const CI_PAGE_SIZE: usize = 100;
+const MAX_CI_PAGES: usize = 5;
 
 /// Beside the cron state file, matching `tmux-watch-registry.json` and
 /// `discord-watch-state.json`.
@@ -92,59 +134,242 @@ pub fn default_github_ci_baseline_path(cron_state_path: &Path) -> PathBuf {
     cron_state_path.with_file_name("github-ci-baseline.json")
 }
 
-fn baseline_identity(ci: &GitHubCISnapshot) -> String {
-    // Prefer the immutable GitHub run id; fall back to the dedupe key so
-    // check-run snapshots without a run id still dedupe by sha+workflow.
-    ci.run_id
-        .as_ref()
-        .map(|run_id| format!("run:{run_id}"))
-        .unwrap_or_else(|| ci.dedupe_key())
+fn ci_baseline_repo_key(snapshot: &GitSnapshot, repo: &GitRepoMonitor) -> String {
+    snapshot
+        .github_repo
+        .as_deref()
+        .or(repo.github_repo.as_deref())
+        .map(|remote| format!("repo:{remote}"))
+        .unwrap_or_else(|| format!("path:{}", repo.path))
+}
+
+impl TerminalRunRecord {
+    fn from_snapshot(ci: &GitHubCISnapshot) -> Self {
+        Self {
+            identities: ci.identities(),
+            run_id: ci.run_id.clone(),
+            created_at: ci.created_at.clone(),
+        }
+    }
+
+    fn from_legacy(identity: String) -> Self {
+        let run_id = identity
+            .strip_prefix("run:")
+            .filter(|id| !id.is_empty() && !id.contains(':'))
+            .map(ToString::to_string);
+        Self {
+            identities: vec![identity],
+            run_id,
+            created_at: None,
+        }
+    }
+
+    fn contains_identity(&self, identity: &str) -> bool {
+        self.identities.iter().any(|stored| stored == identity)
+    }
+
+    fn unique_identities(&self) -> impl Iterator<Item = &str> {
+        self.identities.iter().filter_map(|identity| {
+            if identity.starts_with("run:") || identity.starts_with("check:") {
+                Some(identity.as_str())
+            } else {
+                None
+            }
+        })
+    }
+
+    fn matches_snapshot(&self, ci: &GitHubCISnapshot) -> bool {
+        let unique = ci.unique_identities();
+        if unique
+            .iter()
+            .any(|identity| self.contains_identity(identity))
+        {
+            return true;
+        }
+        for identity in &self.identities {
+            if identity_matches_snapshot(identity, ci)
+                && (unique.is_empty() || self.unique_identities().next().is_none())
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn merge_snapshot(&mut self, ci: &GitHubCISnapshot) -> bool {
+        let mut dirty = false;
+        for identity in ci.identities() {
+            if !self.contains_identity(&identity) {
+                self.identities.push(identity);
+                dirty = true;
+            }
+        }
+        if self.run_id.is_none() && ci.run_id.is_some() {
+            self.run_id = ci.run_id.clone();
+            dirty = true;
+        }
+        if self.created_at.is_none() && ci.created_at.is_some() {
+            self.created_at = ci.created_at.clone();
+            dirty = true;
+        }
+        dirty
+    }
+
+    fn eviction_key(&self) -> (u8, String, u64, String) {
+        let created_rank = u8::from(self.created_at.is_none());
+        let created = self.created_at.clone().unwrap_or_default();
+        let run_num = self
+            .run_id
+            .as_deref()
+            .and_then(|id| id.parse::<u64>().ok())
+            .unwrap_or(u64::MAX);
+        let ident = self.identities.first().cloned().unwrap_or_default();
+        (created_rank, created, run_num, ident)
+    }
+}
+
+fn identity_matches_snapshot(identity: &str, ci: &GitHubCISnapshot) -> bool {
+    if ci
+        .identities()
+        .iter()
+        .any(|candidate| candidate == identity)
+    {
+        return true;
+    }
+    let key = ci.dedupe_key();
+    if identity == key {
+        return true;
+    }
+    if let Some(id) = identity.strip_prefix("run:")
+        && !id.contains(':')
+    {
+        if ci.run_id.as_deref() == Some(id) {
+            return true;
+        }
+        if key.starts_with(&format!("run:{id}:")) {
+            return true;
+        }
+    }
+    false
 }
 
 fn repo_ci_baseline_is_suppressed(
     repo_ci_baseline: Option<&RepoCIBaseline>,
-    dedupe_key: &str,
+    ci: &GitHubCISnapshot,
 ) -> bool {
     let Some(baseline) = repo_ci_baseline else {
         return false;
     };
-    baseline.terminal_runs.iter().any(|identity| {
-        identity == dedupe_key || {
-            // Persisted identities are run-id based; a terminal snapshot keyed
-            // by `run:<id>:<workflow>` must still match its persisted
-            // `run:<id>` identity.
-            identity
-                .strip_prefix("run:")
-                .is_some_and(|id| dedupe_key.starts_with(&format!("run:{id}:")))
-        }
-    })
+    baseline
+        .terminal_runs
+        .iter()
+        .any(|record| record.matches_snapshot(ci))
+}
+
+fn snapshot_eviction_key(ci: &GitHubCISnapshot) -> (u8, String, u64, String) {
+    TerminalRunRecord::from_snapshot(ci).eviction_key()
+}
+
+fn cap_repo_baseline(repo_baseline: &mut RepoCIBaseline) -> bool {
+    if repo_baseline.terminal_runs.len() <= MAX_BASELINE_RUNS_PER_REPO {
+        return false;
+    }
+    let mut records: Vec<TerminalRunRecord> = repo_baseline.terminal_runs.drain(..).collect();
+    records.sort_by_key(|record| record.eviction_key());
+    let drop_count = records.len() - MAX_BASELINE_RUNS_PER_REPO;
+    records.drain(..drop_count);
+    repo_baseline.terminal_runs = records.into();
+    true
+}
+
+#[cfg(test)]
+impl RepoCIBaseline {
+    fn contains_identity(&self, identity: &str) -> bool {
+        self.terminal_runs
+            .iter()
+            .any(|record| record.contains_identity(identity))
+    }
 }
 
 impl CIBaseline {
-    /// Records terminal-run identities for one repo. Returns whether the
-    /// persisted state changed (bounded, oldest entries evicted first).
+    fn repo_baseline_mut(&mut self, repo_key: &str, repo_path: &str) -> &mut RepoCIBaseline {
+        if repo_key.starts_with("repo:") {
+            let mut inherited = Vec::new();
+            if let Some(legacy) = self.repos.remove(repo_path) {
+                inherited.push(legacy);
+            }
+            let path_key = format!("path:{repo_path}");
+            if path_key != repo_key
+                && let Some(legacy) = self.repos.remove(&path_key)
+            {
+                inherited.push(legacy);
+            }
+            let dest = self.repos.entry(repo_key.to_string()).or_default();
+            for legacy in inherited {
+                merge_repo_baseline(dest, legacy);
+            }
+            dest
+        } else {
+            self.repos.entry(repo_key.to_string()).or_default()
+        }
+    }
+
+    /// Records terminal-run identities for one canonical GitHub repo. Returns
+    /// whether the persisted state changed (bounded, oldest GitHub runs
+    /// evicted first).
     fn record_terminal_runs(
         &mut self,
+        repo_key: &str,
         repo_path: &str,
         current: &HashMap<String, GitHubCISnapshot>,
     ) -> bool {
-        let repo_baseline = self.repos.entry(repo_path.to_string()).or_default();
-        let mut dirty = repo_baseline.terminal_runs.is_empty();
-        for ci in current.values() {
-            if !ci.is_terminal() {
-                continue;
-            }
-            let identity = baseline_identity(ci);
-            if !repo_baseline.terminal_runs.contains(&identity) {
-                repo_baseline.terminal_runs.push_back(identity);
+        let mut incoming: Vec<&GitHubCISnapshot> =
+            current.values().filter(|ci| ci.is_terminal()).collect();
+        incoming.sort_by_key(|ci| snapshot_eviction_key(ci));
+
+        let repo_baseline = self.repo_baseline_mut(repo_key, repo_path);
+        let mut dirty = false;
+        for ci in incoming {
+            if let Some(existing) = repo_baseline
+                .terminal_runs
+                .iter_mut()
+                .find(|record| record.matches_snapshot(ci))
+            {
+                dirty |= existing.merge_snapshot(ci);
+            } else {
+                repo_baseline
+                    .terminal_runs
+                    .push_back(TerminalRunRecord::from_snapshot(ci));
                 dirty = true;
             }
         }
-        while repo_baseline.terminal_runs.len() > MAX_BASELINE_RUNS_PER_REPO {
-            repo_baseline.terminal_runs.pop_front();
-            dirty = true;
-        }
+        dirty |= cap_repo_baseline(repo_baseline);
         dirty
+    }
+}
+
+fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
+    for record in source.terminal_runs {
+        if let Some(existing) = dest.terminal_runs.iter_mut().find(|candidate| {
+            candidate
+                .identities
+                .iter()
+                .any(|identity| record.contains_identity(identity))
+        }) {
+            for identity in record.identities {
+                if !existing.contains_identity(&identity) {
+                    existing.identities.push(identity);
+                }
+            }
+            if existing.run_id.is_none() {
+                existing.run_id = record.run_id;
+            }
+            if existing.created_at.is_none() {
+                existing.created_at = record.created_at;
+            }
+        } else {
+            dest.terminal_runs.push_back(record);
+        }
     }
 }
 
@@ -164,7 +389,13 @@ fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
         }
     };
     match serde_json::from_str::<HashMap<String, RepoCIBaseline>>(&raw) {
-        Ok(repos) => CIBaseline { repos },
+        Ok(repos) => {
+            let mut baseline = CIBaseline { repos };
+            for repo_baseline in baseline.repos.values_mut() {
+                cap_repo_baseline(repo_baseline);
+            }
+            baseline
+        }
         Err(error) => {
             eprintln!(
                 "clawhip source github CI baseline '{}' invalid; starting a fresh baseline: {error}",
@@ -183,9 +414,29 @@ fn save_ci_baseline(baseline: &CIBaseline, path: Option<&Path>) -> Result<()> {
         fs::create_dir_all(parent)?;
     }
     let payload = serde_json::to_string(&baseline.repos)?;
-    let temp_path = path.with_extension("json.tmp");
-    fs::write(&temp_path, payload.as_bytes())?;
-    fs::rename(&temp_path, path)?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let temp_name = format!(
+        "{}.{}.{nonce}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("github-ci-baseline.json"),
+        std::process::id()
+    );
+    let temp_path = match path.parent() {
+        Some(parent) => parent.join(temp_name),
+        None => PathBuf::from(temp_name),
+    };
+    if let Err(error) = fs::write(&temp_path, payload.as_bytes()) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error.into());
+    }
+    if let Err(error) = fs::rename(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error.into());
+    }
     Ok(())
 }
 
@@ -222,15 +473,14 @@ struct GitHubCISnapshot {
     url: String,
     branch: Option<String>,
     run_id: Option<String>,
+    check_run_id: Option<String>,
+    created_at: Option<String>,
     run_job_count: usize,
     run_all_terminal: bool,
 }
 
 impl GitHubCISnapshot {
-    fn dedupe_key(&self) -> String {
-        if let Some(run_id) = &self.run_id {
-            return format!("run:{run_id}:{}", self.workflow);
-        }
+    fn fallback_identity(&self) -> String {
         format!(
             "{}:{}:{}",
             self.pr_number
@@ -241,14 +491,42 @@ impl GitHubCISnapshot {
         )
     }
 
+    fn unique_identities(&self) -> Vec<String> {
+        let mut identities = Vec::new();
+        if let Some(run_id) = &self.run_id {
+            identities.push(format!("run:{run_id}"));
+        }
+        if let Some(check_run_id) = &self.check_run_id {
+            identities.push(format!("check:{check_run_id}"));
+        }
+        identities
+    }
+
+    fn identities(&self) -> Vec<String> {
+        let mut identities = self.unique_identities();
+        identities.push(self.fallback_identity());
+        identities
+    }
+
+    fn dedupe_key(&self) -> String {
+        if let Some(run_id) = &self.run_id {
+            return format!("run:{run_id}:{}", self.workflow);
+        }
+        if let Some(check_run_id) = &self.check_run_id {
+            return format!("check:{check_run_id}");
+        }
+        self.fallback_identity()
+    }
+
     fn event_kind(&self) -> &'static str {
         classify_ci_event_kind(&self.status, self.conclusion.as_deref())
     }
 
-    /// A terminal run will never change state again, so its identity can be
-    /// persisted and suppressed on later re-observation (#317).
+    /// A workflow is terminal only when every job is done. A single completed
+    /// job in a still-running workflow must not be persisted, or restart would
+    /// suppress the eventual completion (#317).
     fn is_terminal(&self) -> bool {
-        self.status == "completed"
+        self.status == "completed" && self.run_all_terminal
     }
 }
 
@@ -364,19 +642,20 @@ async fn poll_github(
                     previous.map(|entry| entry.prs.clone()).unwrap_or_default()
                 }
             };
-        let (ci, ci_baseline_established) = match poll_ci_statuses(
+        let repo_key = ci_baseline_repo_key(&snapshot, repo);
+        let repo_ci_baseline = ci_baseline.repos.get(&repo_key).cloned();
+        let (ci, ci_baseline_established, mut ci_events) = match poll_ci_statuses(
             config,
             github_client,
             repo,
             &snapshot,
             previous,
             &prs,
-            tx,
-            ci_baseline.repos.get(&repo.path),
+            repo_ci_baseline.as_ref(),
         )
         .await
         {
-            Ok(ci) => ci,
+            Ok(result) => result,
             Err(error) => {
                 eprintln!(
                     "clawhip source GitHub CI processing failed for {}: {error}",
@@ -387,20 +666,15 @@ async fn poll_github(
                     previous
                         .map(|entry| entry.ci_baseline_established)
                         .unwrap_or(false),
+                    Vec::new(),
                 )
             }
         };
 
-        let repo_baseline_dirty = ci_baseline.record_terminal_runs(&repo.path, &ci);
-        state.insert(
-            repo.path.clone(),
-            GitHubRepoState {
-                issues,
-                prs,
-                ci,
-                ci_baseline_established,
-            },
-        );
+        // Persist-before-publish: a delivered terminal event must already be
+        // in durable suppression state. If the receipt cannot be written, drop
+        // the events rather than open a restart-replay window.
+        let repo_baseline_dirty = ci_baseline.record_terminal_runs(&repo_key, &repo.path, &ci);
         if repo_baseline_dirty && let Err(error) = save_ci_baseline(ci_baseline, ci_baseline_path) {
             telemetry::emit(source_record(
                 telemetry::event_name::SOURCE_DEGRADED,
@@ -412,7 +686,22 @@ async fn poll_github(
                 "clawhip source github CI baseline persist failed for {}: {error}",
                 repo.path
             );
+            ci_events.clear();
         }
+
+        for event in ci_events {
+            send_event(tx, event).await?;
+        }
+
+        state.insert(
+            repo.path.clone(),
+            GitHubRepoState {
+                issues,
+                prs,
+                ci,
+                ci_baseline_established,
+            },
+        );
     }
 
     Ok(())
@@ -528,7 +817,6 @@ async fn poll_pull_requests(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn poll_ci_statuses(
     config: &AppConfig,
     github_client: Option<&reqwest::Client>,
@@ -536,15 +824,15 @@ async fn poll_ci_statuses(
     snapshot: &GitSnapshot,
     previous: Option<&GitHubRepoState>,
     prs: &HashMap<u64, PullRequestSnapshot>,
-    tx: &mpsc::Sender<IncomingEvent>,
     repo_ci_baseline: Option<&RepoCIBaseline>,
-) -> Result<(HashMap<String, GitHubCISnapshot>, bool)> {
+) -> Result<(HashMap<String, GitHubCISnapshot>, bool, Vec<IncomingEvent>)> {
     if !repo.emit_pr_status {
         return Ok((
             previous.map(|entry| entry.ci.clone()).unwrap_or_default(),
             previous
                 .map(|entry| entry.ci_baseline_established)
                 .unwrap_or(false),
+            Vec::new(),
         ));
     }
 
@@ -554,6 +842,7 @@ async fn poll_ci_statuses(
             previous
                 .map(|entry| entry.ci_baseline_established)
                 .unwrap_or(false),
+            Vec::new(),
         ));
     };
 
@@ -572,20 +861,25 @@ async fn poll_ci_statuses(
     )
     .await
     {
-        Ok(ci) => {
-            if let Some(previous) = previous {
-                for event in collect_ci_events(
+        Ok((ci, window_complete)) => {
+            let events = if let Some(previous) = previous {
+                let mut events = collect_ci_events(
                     repo,
                     &snapshot.repo_name,
                     previous.ci_baseline_established,
                     &previous.ci,
                     &ci,
                     repo_ci_baseline,
-                ) {
-                    send_event(tx, event).await?;
+                );
+                if !window_complete {
+                    events
+                        .retain(|event| previous_snapshot_for_event(&previous.ci, event).is_some());
                 }
-            }
-            Ok((ci, true))
+                events
+            } else {
+                Vec::new()
+            };
+            Ok((ci, window_complete, events))
         }
         Err(error) => {
             telemetry::emit(source_record(
@@ -605,9 +899,32 @@ async fn poll_ci_statuses(
             Ok((
                 previous.map(|entry| entry.ci.clone()).unwrap_or_default(),
                 false,
+                Vec::new(),
             ))
         }
     }
+}
+
+fn previous_snapshot_for_event<'a>(
+    previous: &'a HashMap<String, GitHubCISnapshot>,
+    event: &IncomingEvent,
+) -> Option<&'a GitHubCISnapshot> {
+    let payload = event.payload.as_object()?;
+    let workflow = payload.get("workflow")?.as_str()?;
+    let run_id = payload.get("run_id").and_then(|value| value.as_str());
+    previous.values().find(|ci| {
+        if let Some(run_id) = run_id
+            && ci.run_id.as_deref() == Some(run_id)
+        {
+            return true;
+        }
+        ci.workflow == workflow
+            && ci.sha
+                == payload
+                    .get("sha")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default()
+    })
 }
 
 fn source_record(
@@ -712,6 +1029,24 @@ fn collect_issue_events(
     events
 }
 
+fn previous_snapshot<'a>(
+    previous: &'a HashMap<String, GitHubCISnapshot>,
+    ci: &GitHubCISnapshot,
+) -> Option<&'a GitHubCISnapshot> {
+    if let Some(old) = previous.get(&ci.dedupe_key()) {
+        return Some(old);
+    }
+    let unique = ci.unique_identities();
+    if unique.is_empty() {
+        return None;
+    }
+    previous.values().find(|old| {
+        old.unique_identities()
+            .iter()
+            .any(|identity| unique.iter().any(|candidate| candidate == identity))
+    })
+}
+
 fn collect_ci_events(
     repo: &GitRepoMonitor,
     repo_name: &str,
@@ -721,8 +1056,9 @@ fn collect_ci_events(
     repo_ci_baseline: Option<&RepoCIBaseline>,
 ) -> Vec<IncomingEvent> {
     let mut events = Vec::new();
-    for (key, ci) in current {
-        let changed = match previous.get(key) {
+    for ci in current.values() {
+        let old = previous_snapshot(previous, ci);
+        let changed = match old {
             Some(old) => old.status != ci.status || old.conclusion != ci.conclusion,
             None => {
                 if !previous_ci_baseline_established {
@@ -735,7 +1071,7 @@ fn collect_ci_events(
                     // in-process record: the pagination drift / cursor loss /
                     // re-enrollment replay window. Suppress it when the
                     // persisted baseline already observed it (#317).
-                    !repo_ci_baseline_is_suppressed(repo_ci_baseline, key)
+                    !repo_ci_baseline_is_suppressed(repo_ci_baseline, ci)
                 } else {
                     // Established monitor seeing a genuinely new run start.
                     true
@@ -865,16 +1201,20 @@ async fn fetch_ci_statuses(
     repo: &GitRepoMonitor,
     snapshot: &GitSnapshot,
     open_prs: &[(u64, &PullRequestSnapshot)],
-) -> Result<HashMap<String, GitHubCISnapshot>> {
+) -> Result<(HashMap<String, GitHubCISnapshot>, bool)> {
     let github_repo = snapshot
         .github_repo
         .clone()
         .ok_or_else(|| format!("no GitHub repo configured or inferred for {}", repo.path))?;
     let mut check_runs = HashMap::new();
     let mut seen_run_ids = HashSet::new();
+    let mut window_complete = true;
 
     for (number, pr) in open_prs {
-        for check_run in fetch_check_runs(client, api_base, &github_repo, *number, pr).await? {
+        let (fetched, complete) =
+            fetch_check_runs(client, api_base, &github_repo, *number, pr).await?;
+        window_complete &= complete;
+        for check_run in fetched {
             if let Some(run_id) = &check_run.run_id {
                 seen_run_ids.insert(run_id.clone());
             }
@@ -882,8 +1222,10 @@ async fn fetch_ci_statuses(
         }
     }
 
-    for workflow_run in fetch_direct_workflow_runs(client, api_base, &github_repo, snapshot).await?
-    {
+    let (workflow_runs, complete) =
+        fetch_direct_workflow_runs(client, api_base, &github_repo, snapshot).await?;
+    window_complete &= complete;
+    for workflow_run in workflow_runs {
         if workflow_run
             .run_id
             .as_ref()
@@ -894,7 +1236,34 @@ async fn fetch_ci_statuses(
         check_runs.insert(workflow_run.dedupe_key(), workflow_run);
     }
 
-    Ok(check_runs)
+    Ok((check_runs, window_complete))
+}
+
+fn github_link_next(headers: &HeaderMap) -> Option<String> {
+    let header = headers.get(LINK)?.to_str().ok()?;
+    for part in header.split(',') {
+        let mut href = None;
+        let mut is_next = false;
+        for item in part.split(';') {
+            let item = item.trim();
+            if let Some(url) = item
+                .strip_prefix('<')
+                .and_then(|value| value.strip_suffix('>'))
+            {
+                href = Some(url.to_string());
+            } else if item.contains("rel=") && item.contains("next") {
+                is_next = true;
+            }
+        }
+        if is_next {
+            return href;
+        }
+    }
+    None
+}
+
+fn ci_window_complete(has_next: bool, pages_fetched: usize) -> bool {
+    !(has_next && pages_fetched >= MAX_CI_PAGES)
 }
 
 async fn fetch_check_runs(
@@ -903,42 +1272,70 @@ async fn fetch_check_runs(
     github_repo: &str,
     pr_number: u64,
     pr: &PullRequestSnapshot,
-) -> Result<Vec<GitHubCISnapshot>> {
-    let response = github_get(
-        client,
-        api_base,
-        &format!("repos/{github_repo}/commits/{}/check-runs", pr.head_sha),
-        &[("per_page", "100")],
-        &format!("check runs for {github_repo} PR #{pr_number}"),
-    )
-    .await?;
+) -> Result<(Vec<GitHubCISnapshot>, bool)> {
+    let mut all_runs = Vec::new();
+    let mut page = 1_usize;
+    let mut window_complete = true;
+    loop {
+        let page_str = page.to_string();
+        let response = github_get(
+            client,
+            api_base,
+            &format!("repos/{github_repo}/commits/{}/check-runs", pr.head_sha),
+            &[("per_page", "100"), ("page", page_str.as_str())],
+            &format!("check runs for {github_repo} PR #{pr_number}"),
+        )
+        .await?;
+        let has_next = github_link_next(response.headers()).is_some();
+        let runs: GitHubCheckRunsResponse = response.json().await?;
+        let page_len = runs.check_runs.len();
+        all_runs.extend(runs.check_runs);
+        if !has_next || page_len < CI_PAGE_SIZE {
+            break;
+        }
+        if !ci_window_complete(has_next, page) {
+            window_complete = false;
+            break;
+        }
+        page += 1;
+        if page > MAX_CI_PAGES {
+            window_complete = false;
+            break;
+        }
+    }
 
-    let runs: GitHubCheckRunsResponse = response.json().await?;
-    let run_summaries = summarize_workflow_runs(&runs.check_runs);
-    Ok(runs
-        .check_runs
-        .into_iter()
-        .map(|check_run| {
-            let url = check_run.details_url.unwrap_or_else(|| pr.url.clone());
-            let run_id = workflow_run_id(&url);
-            let (run_job_count, run_all_terminal) = run_id
-                .as_deref()
-                .and_then(|id| run_summaries.get(id).copied())
-                .unwrap_or((1, check_run.status == "completed"));
-            GitHubCISnapshot {
-                pr_number: Some(pr_number),
-                workflow: check_run.name,
-                status: check_run.status,
-                conclusion: check_run.conclusion,
-                sha: check_run.head_sha,
-                url,
-                branch: Some(pr.head_branch.clone()),
-                run_id,
-                run_job_count,
-                run_all_terminal,
-            }
-        })
-        .collect())
+    let run_summaries = summarize_workflow_runs(&all_runs);
+    Ok((
+        all_runs
+            .into_iter()
+            .map(|check_run| {
+                let url = check_run
+                    .details_url
+                    .clone()
+                    .unwrap_or_else(|| pr.url.clone());
+                let run_id = workflow_run_id(&url);
+                let (run_job_count, run_all_terminal) = run_id
+                    .as_deref()
+                    .and_then(|id| run_summaries.get(id).copied())
+                    .unwrap_or((1, check_run.status == "completed"));
+                GitHubCISnapshot {
+                    pr_number: Some(pr_number),
+                    workflow: check_run.name,
+                    status: check_run.status,
+                    conclusion: check_run.conclusion,
+                    sha: check_run.head_sha,
+                    url,
+                    branch: Some(pr.head_branch.clone()),
+                    run_id,
+                    check_run_id: (check_run.id != 0).then(|| check_run.id.to_string()),
+                    created_at: check_run.started_at.or(check_run.completed_at),
+                    run_job_count,
+                    run_all_terminal,
+                }
+            })
+            .collect(),
+        window_complete,
+    ))
 }
 
 fn summarize_workflow_runs(check_runs: &[GitHubCheckRun]) -> HashMap<String, (usize, bool)> {
@@ -959,44 +1356,73 @@ async fn fetch_direct_workflow_runs(
     api_base: &str,
     github_repo: &str,
     snapshot: &GitSnapshot,
-) -> Result<Vec<GitHubCISnapshot>> {
-    let mut query = vec![("per_page", "100"), ("event", "push")];
-    if !snapshot.branch.is_empty() {
-        query.push(("branch", snapshot.branch.as_str()));
+) -> Result<(Vec<GitHubCISnapshot>, bool)> {
+    let mut all_runs = Vec::new();
+    let mut page = 1_usize;
+    let mut window_complete = true;
+    loop {
+        let page_str = page.to_string();
+        let mut query = vec![
+            ("per_page", "100"),
+            ("event", "push"),
+            ("page", page_str.as_str()),
+        ];
+        if !snapshot.branch.is_empty() {
+            query.push(("branch", snapshot.branch.as_str()));
+        }
+
+        let response = github_get(
+            client,
+            api_base,
+            &format!("repos/{github_repo}/actions/runs"),
+            &query,
+            &format!("workflow runs for {github_repo}"),
+        )
+        .await?;
+        let has_next = github_link_next(response.headers()).is_some();
+        let runs: GitHubWorkflowRunsResponse = response.json().await?;
+        let page_len = runs.workflow_runs.len();
+        all_runs.extend(runs.workflow_runs);
+        if !has_next || page_len < CI_PAGE_SIZE {
+            break;
+        }
+        if !ci_window_complete(has_next, page) {
+            window_complete = false;
+            break;
+        }
+        page += 1;
+        if page > MAX_CI_PAGES {
+            window_complete = false;
+            break;
+        }
     }
 
-    let response = github_get(
-        client,
-        api_base,
-        &format!("repos/{github_repo}/actions/runs"),
-        &query,
-        &format!("workflow runs for {github_repo}"),
-    )
-    .await?;
-
-    let runs: GitHubWorkflowRunsResponse = response.json().await?;
-    Ok(runs
-        .workflow_runs
-        .into_iter()
-        .filter(|run| run.pull_requests.is_empty())
-        .map(|run| {
-            let run_all_terminal = run.status == "completed";
-            GitHubCISnapshot {
-                pr_number: None,
-                workflow: run
-                    .name
-                    .unwrap_or_else(|| format!("workflow-run-{}", run.id)),
-                status: run.status,
-                conclusion: run.conclusion,
-                sha: run.head_sha,
-                url: run.html_url,
-                branch: non_empty_string(run.head_branch),
-                run_id: Some(run.id.to_string()),
-                run_job_count: 1,
-                run_all_terminal,
-            }
-        })
-        .collect())
+    Ok((
+        all_runs
+            .into_iter()
+            .filter(|run| run.pull_requests.is_empty())
+            .map(|run| {
+                let run_all_terminal = run.status == "completed";
+                GitHubCISnapshot {
+                    pr_number: None,
+                    workflow: run
+                        .name
+                        .unwrap_or_else(|| format!("workflow-run-{}", run.id)),
+                    status: run.status,
+                    conclusion: run.conclusion,
+                    sha: run.head_sha,
+                    url: run.html_url,
+                    branch: non_empty_string(run.head_branch),
+                    run_id: Some(run.id.to_string()),
+                    check_run_id: None,
+                    created_at: run.created_at,
+                    run_job_count: 1,
+                    run_all_terminal,
+                }
+            })
+            .collect(),
+        window_complete,
+    ))
 }
 
 fn workflow_run_id(url: &str) -> Option<String> {
@@ -1065,11 +1491,17 @@ struct GitHubCheckRunsResponse {
 
 #[derive(Deserialize)]
 struct GitHubCheckRun {
+    #[serde(default)]
+    id: u64,
     name: String,
     status: String,
     conclusion: Option<String>,
     details_url: Option<String>,
     head_sha: String,
+    #[serde(default)]
+    started_at: Option<String>,
+    #[serde(default)]
+    completed_at: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -1087,6 +1519,8 @@ struct GitHubWorkflowRun {
     head_branch: String,
     head_sha: String,
     html_url: String,
+    #[serde(default)]
+    created_at: Option<String>,
     #[serde(default)]
     pull_requests: Vec<serde_json::Value>,
 }
@@ -1232,6 +1666,8 @@ mod tests {
             url: "https://github.com/Yeachan-Heo/clawhip/actions/runs/1".into(),
             branch: Some("feat/github-ci-events".into()),
             run_id: Some("1".into()),
+            check_run_id: None,
+            created_at: None,
             run_job_count: 1,
             run_all_terminal: status == "completed",
         }
@@ -1252,6 +1688,8 @@ mod tests {
             url: format!("https://github.com/org/repo/actions/runs/{run_id}"),
             branch: Some(branch.into()),
             run_id: Some(run_id.to_string()),
+            check_run_id: None,
+            created_at: None,
             run_job_count: 1,
             run_all_terminal: true,
         }
@@ -1298,7 +1736,7 @@ mod tests {
 
         // --- First daemon process: observe and persist the baseline.
         let mut ci_baseline = load_ci_baseline(Some(&path));
-        assert!(ci_baseline.record_terminal_runs("/repo", &run_map(&historical_runs)));
+        assert!(ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&historical_runs)));
         save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
 
         // --- Daemon restart: state HashMap is empty, baseline reloads from disk.
@@ -1309,7 +1747,7 @@ mod tests {
         assert_eq!(repo_baseline.terminal_runs.len(), 3);
         for run in &historical_runs {
             assert!(
-                repo_ci_baseline_is_suppressed(restarted.repos.get("/repo"), &run.dedupe_key()),
+                repo_ci_baseline_is_suppressed(restarted.repos.get("/repo"), run),
                 "historical terminal run {} must be suppressed after restart",
                 run.run_id.as_deref().unwrap_or("?")
             );
@@ -1356,7 +1794,7 @@ mod tests {
         let mut ci_baseline = CIBaseline::default();
         for id in 0..(MAX_BASELINE_RUNS_PER_REPO + 64) {
             let runs = [run_snapshot(id as u64, "CI", Some("success"), "main")];
-            ci_baseline.record_terminal_runs("/repo", &run_map(&runs));
+            ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&runs));
         }
         let repo_baseline = ci_baseline.repos.get("/repo").unwrap();
         assert_eq!(
@@ -1364,11 +1802,9 @@ mod tests {
             MAX_BASELINE_RUNS_PER_REPO
         );
         assert!(
-            repo_baseline
-                .terminal_runs
-                .contains(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 63))
+            repo_baseline.contains_identity(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 63))
         );
-        assert!(!repo_baseline.terminal_runs.contains(&"run:0".to_string()));
+        assert!(!repo_baseline.contains_identity("run:0"));
 
         // Atomic persistence round-trips through a temp file + rename.
         save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
@@ -1390,7 +1826,7 @@ mod tests {
         // repo's runs.
         let mut mixed = CIBaseline::default();
         let other = [run_snapshot(999, "CI", Some("success"), "main")];
-        mixed.record_terminal_runs("/other-repo", &run_map(&other));
+        mixed.record_terminal_runs("/other-repo", "/other-repo", &run_map(&other));
         let events = collect_ci_events(
             &GitRepoMonitor::default(),
             "org/repo",
@@ -1419,7 +1855,11 @@ mod tests {
             run_all_terminal: false,
             ..run_snapshot(4242424242, "CI", Some("success"), "main")
         };
-        ci_baseline.record_terminal_runs("/repo", &run_map(std::slice::from_ref(&in_progress)));
+        ci_baseline.record_terminal_runs(
+            "/repo",
+            "/repo",
+            &run_map(std::slice::from_ref(&in_progress)),
+        );
         assert!(ci_baseline.repos["/repo"].terminal_runs.is_empty());
 
         // ...so its genuinely new started event is emitted even though the
@@ -1450,7 +1890,11 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].canonical_kind(), "github.ci-failed");
 
-        ci_baseline.record_terminal_runs("/repo", &run_map(std::slice::from_ref(&completed)));
+        ci_baseline.record_terminal_runs(
+            "/repo",
+            "/repo",
+            &run_map(std::slice::from_ref(&completed)),
+        );
         save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
         let restarted = load_ci_baseline(Some(&path));
         let events = collect_ci_events(
@@ -1465,6 +1909,334 @@ mod tests {
             events.is_empty(),
             "terminal outcome delivered once must never replay"
         );
+    }
+
+    fn fallback_snapshot(pr_number: u64, sha: &str, workflow: &str) -> GitHubCISnapshot {
+        GitHubCISnapshot {
+            pr_number: Some(pr_number),
+            workflow: workflow.into(),
+            status: "completed".into(),
+            conclusion: Some("success".into()),
+            sha: sha.into(),
+            url: "https://github.com/org/repo/pull/58".into(),
+            branch: Some("feat/x".into()),
+            run_id: None,
+            check_run_id: None,
+            created_at: None,
+            run_job_count: 1,
+            run_all_terminal: true,
+        }
+    }
+
+    #[test]
+    fn issue_317_representation_drift_fallback_then_run_id_is_suppressed() {
+        let fallback = fallback_snapshot(58, "abcdef1234567890", "CI");
+        let with_run_id = GitHubCISnapshot {
+            run_id: Some("4242".into()),
+            url: "https://github.com/org/repo/actions/runs/4242".into(),
+            ..fallback.clone()
+        };
+
+        let mut ci_baseline = CIBaseline::default();
+        assert!(ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&[fallback])));
+
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&with_run_id)),
+            ci_baseline.repos.get("/repo"),
+        );
+        assert!(
+            events.is_empty(),
+            "run-id representation of a fallback-persisted terminal run must stay suppressed"
+        );
+
+        assert!(ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&[with_run_id])));
+        assert!(
+            ci_baseline.repos["/repo"].contains_identity("run:4242"),
+            "discovering a run id must merge onto the existing fallback record"
+        );
+    }
+
+    #[test]
+    fn issue_317_fallback_collisions_do_not_drop_distinct_reruns() {
+        let first = GitHubCISnapshot {
+            check_run_id: Some("111".into()),
+            ..fallback_snapshot(58, "abcdef1234567890", "CI")
+        };
+        let second = GitHubCISnapshot {
+            check_run_id: Some("222".into()),
+            conclusion: Some("failure".into()),
+            ..fallback_snapshot(58, "abcdef1234567890", "CI")
+        };
+        let current = run_map(&[first.clone(), second.clone()]);
+        assert_eq!(
+            current.len(),
+            2,
+            "distinct check-run ids must not collapse in the poll map"
+        );
+
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.record_terminal_runs("/repo", "/repo", &current);
+        assert_eq!(ci_baseline.repos["/repo"].terminal_runs.len(), 2);
+        assert!(ci_baseline.repos["/repo"].contains_identity("check:111"));
+        assert!(ci_baseline.repos["/repo"].contains_identity("check:222"));
+
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &current,
+            ci_baseline.repos.get("/repo"),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn issue_317_partial_multi_job_workflow_is_not_terminal_until_all_jobs_complete() {
+        let partial = GitHubCISnapshot {
+            status: "completed".into(),
+            conclusion: Some("success".into()),
+            run_all_terminal: false,
+            run_job_count: 2,
+            ..run_snapshot(77, "CI", Some("success"), "main")
+        };
+        let complete = GitHubCISnapshot {
+            run_all_terminal: true,
+            run_job_count: 2,
+            ..run_snapshot(77, "CI", Some("success"), "main")
+        };
+
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.record_terminal_runs(
+            "/repo",
+            "/repo",
+            &run_map(std::slice::from_ref(&partial)),
+        );
+        assert!(
+            ci_baseline
+                .repos
+                .get("/repo")
+                .is_none_or(|repo| repo.terminal_runs.is_empty()),
+            "a completed job in a still-running workflow must not be persisted"
+        );
+
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&complete)),
+            ci_baseline.repos.get("/repo"),
+        );
+        assert_eq!(
+            events.len(),
+            1,
+            "eventual multi-job completion after restart must still emit"
+        );
+        assert_eq!(events[0].canonical_kind(), "github.ci-passed");
+
+        ci_baseline.record_terminal_runs(
+            "/repo",
+            "/repo",
+            &run_map(std::slice::from_ref(&complete)),
+        );
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(&[complete]),
+            ci_baseline.repos.get("/repo"),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn issue_317_persist_failure_does_not_publish_terminal_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("not-a-directory");
+        std::fs::write(&blocker, b"file").unwrap();
+        let path = blocker.join("github-ci-baseline.json");
+
+        let mut ci_baseline = CIBaseline::default();
+        let runs = run_map(&[run_snapshot(9, "CI", Some("success"), "main")]);
+        assert!(ci_baseline.record_terminal_runs("repo:org/repo", "/repo", &runs));
+        assert!(save_ci_baseline(&ci_baseline, Some(&path)).is_err());
+
+        // Receipt contract: without a durable write, treat the run as unpublished.
+        // The in-memory baseline exists, but the failure boundary is the save.
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn issue_317_persist_before_publish_drops_events_when_receipt_cannot_be_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("blocked");
+        std::fs::write(&blocker, b"file").unwrap();
+        let baseline_path = blocker.join("github-ci-baseline.json");
+
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = vec![0_u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let body = r#"{"workflow_runs":[{"id": 9001, "name": "CI", "status": "completed", "conclusion": "success", "head_branch": "main", "head_sha": "abc", "html_url": "https://github.com/org/repo/actions/runs/9001", "pull_requests": [], "created_at": "2026-08-19T00:00:00Z"}]}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let mut config = AppConfig::default();
+        config.monitors.github_api_base = format!("http://{addr}");
+        config.monitors.git.repos = vec![GitRepoMonitor {
+            path: "/tmp/persist-boundary".into(),
+            name: Some("repo".into()),
+            github_repo: Some("org/repo".into()),
+            emit_pr_status: true,
+            emit_issue_opened: false,
+            emit_commits: false,
+            emit_branch_changes: false,
+            ..GitRepoMonitor::default()
+        }];
+        let client = build_github_client(None).unwrap();
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut state = HashMap::new();
+        state.insert(
+            "/tmp/persist-boundary".into(),
+            GitHubRepoState {
+                issues: HashMap::new(),
+                prs: HashMap::new(),
+                ci: HashMap::new(),
+                ci_baseline_established: true,
+            },
+        );
+        let mut baseline = CIBaseline::default();
+        poll_once_with_baseline(
+            &config,
+            &client,
+            &mut state,
+            &mut baseline,
+            Some(&baseline_path),
+            &tx,
+        )
+        .await
+        .unwrap();
+        assert!(
+            rx.try_recv().is_err(),
+            "persist failure must not publish a terminal event"
+        );
+        assert!(!baseline_path.exists());
+        server.abort();
+    }
+
+    #[test]
+    fn issue_317_baseline_is_keyed_by_canonical_github_repo_not_checkout_path() {
+        let run = run_snapshot(55, "CI", Some("success"), "main");
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.record_terminal_runs(
+            "repo:org/repo",
+            "/old/path",
+            &run_map(std::slice::from_ref(&run)),
+        );
+
+        let renamed = GitRepoMonitor {
+            path: "/new/path".into(),
+            github_repo: Some("org/repo".into()),
+            ..GitRepoMonitor::default()
+        };
+        let snapshot = GitSnapshot {
+            repo_name: "repo".into(),
+            repo_path: "/new/path".into(),
+            worktree_path: "/new/path".into(),
+            branch: "main".into(),
+            head: "sha-55".into(),
+            commits: Vec::new(),
+            github_repo: Some("org/repo".into()),
+        };
+        let key = ci_baseline_repo_key(&snapshot, &renamed);
+        assert_eq!(key, "repo:org/repo");
+        assert!(repo_ci_baseline_is_suppressed(
+            ci_baseline.repos.get(&key),
+            &run
+        ));
+
+        let other_remote = GitHubCISnapshot {
+            sha: "other-sha".into(),
+            ..run_snapshot(55, "CI", Some("success"), "main")
+        };
+        let other_key = "repo:other/remote";
+        assert!(!repo_ci_baseline_is_suppressed(
+            ci_baseline.repos.get(other_key),
+            &other_remote
+        ));
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "other/remote",
+            true,
+            &HashMap::new(),
+            &run_map(&[other_remote]),
+            ci_baseline.repos.get(other_key),
+        );
+        assert_eq!(events.len(), 1, "a different remote must not be suppressed");
+    }
+
+    #[test]
+    fn issue_317_single_poll_evicts_oldest_github_runs_first() {
+        let mut runs = Vec::new();
+        for id in 0..(MAX_BASELINE_RUNS_PER_REPO + 20) {
+            let mut run = run_snapshot(id as u64, "CI", Some("success"), "main");
+            run.created_at = Some(format!("2026-01-01T00:{:02}:{:02}Z", id / 60, id % 60));
+            runs.push(run);
+        }
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&runs));
+        let repo = &ci_baseline.repos["/repo"];
+        assert_eq!(repo.terminal_runs.len(), MAX_BASELINE_RUNS_PER_REPO);
+        assert!(!repo.contains_identity("run:0"));
+        assert!(!repo.contains_identity("run:19"));
+        assert!(repo.contains_identity("run:20"));
+        assert!(repo.contains_identity(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 19)));
+    }
+
+    #[test]
+    fn issue_317_oversized_loaded_state_is_truncated_oldest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut records = Vec::new();
+        for id in 0..(MAX_BASELINE_RUNS_PER_REPO + 12) {
+            records.push(format!(
+                r#"{{"identities":["run:{id}"],"run_id":"{id}","created_at":"2026-01-01T00:{:02}:{:02}Z"}}"#,
+                id / 60,
+                id % 60
+            ));
+        }
+        let payload = format!(r#"{{"/repo":{{"terminal_runs":[{}]}}}}"#, records.join(","));
+        std::fs::write(&path, payload).unwrap();
+        let loaded = load_ci_baseline(Some(&path));
+        let repo = loaded.repos.get("/repo").unwrap();
+        assert_eq!(repo.terminal_runs.len(), MAX_BASELINE_RUNS_PER_REPO);
+        assert!(!repo.contains_identity("run:0"));
+        assert!(repo.contains_identity(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 11)));
+    }
+
+    #[test]
+    fn issue_317_incomplete_pagination_window_is_detected() {
+        assert!(ci_window_complete(false, 1));
+        assert!(ci_window_complete(true, 1));
+        assert!(!ci_window_complete(true, MAX_CI_PAGES));
+        assert!(ci_window_complete(false, MAX_CI_PAGES));
     }
 
     #[tokio::test]
@@ -1642,9 +2414,7 @@ mod tests {
         // in the window — no history scan, no ledger growth.
         let persisted: HashMap<String, RepoCIBaseline> =
             serde_json::from_str(&std::fs::read_to_string(&baseline_path).unwrap()).unwrap();
-        assert!(
-            persisted["/tmp/clawhip-replay-repo"].terminal_runs.len() <= MAX_BASELINE_RUNS_PER_REPO
-        );
+        assert!(persisted["repo:org/repo"].terminal_runs.len() <= MAX_BASELINE_RUNS_PER_REPO);
 
         let requests = server.await.unwrap();
         // Four CI polls; the issues/pulls endpoints add two requests per poll.
@@ -1709,26 +2479,17 @@ mod tests {
             github_repo: Some("ultraworkers/claw-code".into()),
         };
         let client = build_github_client(None).unwrap();
-        let (tx, mut rx) = mpsc::channel(4);
         let prs = HashMap::new();
 
-        let (ci, ci_baseline_established) = poll_ci_statuses(
-            &config,
-            Some(&client),
-            &repo,
-            &snapshot,
-            None,
-            &prs,
-            &tx,
-            None,
-        )
-        .await
-        .unwrap();
+        let (ci, ci_baseline_established, events) =
+            poll_ci_statuses(&config, Some(&client), &repo, &snapshot, None, &prs, None)
+                .await
+                .unwrap();
 
         assert_eq!(ci.len(), 1);
         assert!(ci_baseline_established);
         assert!(
-            rx.try_recv().is_err(),
+            events.is_empty(),
             "first poll after startup should prime CI baseline without emitting historical events"
         );
 
@@ -1824,7 +2585,7 @@ mod tests {
         };
         let open_prs = vec![(42_u64, &pr)];
 
-        let ci = fetch_ci_statuses(
+        let (ci, window_complete) = fetch_ci_statuses(
             &client,
             &format!("http://{addr}"),
             &GitRepoMonitor::default(),
@@ -1835,6 +2596,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(ci.len(), 2);
+        assert!(window_complete);
         assert_eq!(
             ci.values()
                 .filter(|snapshot| snapshot.run_id.as_deref() == Some("123"))

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -114,6 +114,8 @@ struct PendingCiDelivery {
     url: String,
     branch: Option<String>,
     run_id: Option<String>,
+    #[serde(default = "default_run_attempt")]
+    run_attempt: u32,
     run_job_count: usize,
     run_all_terminal: bool,
     channel: Option<String>,
@@ -153,6 +155,11 @@ impl PendingCiDelivery {
                 .and_then(|object| object.get("run_id"))
                 .and_then(serde_json::Value::as_str)
                 .map(ToString::to_string),
+            run_attempt: payload
+                .and_then(|object| object.get("run_attempt"))
+                .and_then(serde_json::Value::as_u64)
+                .map(|value| value as u32)
+                .unwrap_or(1),
             run_job_count: payload
                 .and_then(|object| object.get("run_job_count"))
                 .and_then(serde_json::Value::as_u64)
@@ -167,20 +174,21 @@ impl PendingCiDelivery {
     }
 
     fn same_event(&self, other: &Self) -> bool {
-        if !self.identities.is_empty()
-            && self.identities.iter().any(|identity| {
-                other
-                    .identities
-                    .iter()
-                    .any(|candidate| candidate == identity)
-            })
-        {
-            return true;
+        let self_unique = unique_pending_identities(&self.identities);
+        let other_unique = unique_pending_identities(&other.identities);
+        if !self_unique.is_empty() && !other_unique.is_empty() {
+            return self_unique
+                .iter()
+                .any(|identity| other_unique.iter().any(|candidate| candidate == identity));
         }
-        self.run_id.is_some() && self.run_id == other.run_id && self.workflow == other.workflow
-            || self.sha == other.sha
-                && self.workflow == other.workflow
-                && self.pr_number == other.pr_number
+        if self.run_id.is_some() && other.run_id.is_some() {
+            return self.run_id == other.run_id
+                && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(other.run_attempt)
+                && self.workflow == other.workflow;
+        }
+        self.sha == other.sha
+            && self.workflow == other.workflow
+            && self.pr_number == other.pr_number
     }
 
     fn into_event(self) -> IncomingEvent {
@@ -200,6 +208,10 @@ impl PendingCiDelivery {
         if let Some(payload) = event.payload.as_object_mut() {
             if let Some(run_id) = &self.run_id {
                 payload.insert("run_id".to_string(), json!(run_id));
+                payload.insert(
+                    "run_attempt".to_string(),
+                    json!(run_attempt_or_one(self.run_attempt)),
+                );
             }
             payload.insert("run_job_count".to_string(), json!(self.run_job_count));
             payload.insert("run_all_terminal".to_string(), json!(self.run_all_terminal));
@@ -267,6 +279,14 @@ fn ci_baseline_repo_key(snapshot: &GitSnapshot, repo: &GitRepoMonitor) -> String
         .and_then(canonicalize_github_repo)
         .map(|remote| format!("repo:{remote}"))
         .unwrap_or_else(|| format!("path:{}", repo.path))
+}
+
+fn unique_pending_identities(identities: &[String]) -> Vec<String> {
+    identities
+        .iter()
+        .filter(|identity| identity.starts_with("run:") || identity.starts_with("check:"))
+        .cloned()
+        .collect()
 }
 
 fn run_attempt_or_one(attempt: u32) -> u32 {
@@ -719,11 +739,11 @@ fn ack_pending_deliveries(
     path: Option<&Path>,
     delivered: &[PendingCiDelivery],
 ) -> Result<()> {
-    for repo in ci_baseline.repos.values_mut() {
-        repo.pending
-            .retain(|pending| !delivered.iter().any(|item| pending.same_event(item)));
-    }
     let Some(path) = path else {
+        for repo in ci_baseline.repos.values_mut() {
+            repo.pending
+                .retain(|pending| !delivered.iter().any(|item| pending.same_event(item)));
+        }
         return Ok(());
     };
     let _lock = acquire_baseline_lock(path)?;
@@ -1463,6 +1483,7 @@ fn collect_ci_events(
         if let Some(payload) = event.payload.as_object_mut() {
             if let Some(run_id) = &ci.run_id {
                 payload.insert("run_id".to_string(), json!(run_id));
+                payload.insert("run_attempt".to_string(), json!(ci.run_attempt()));
             }
             payload.insert("run_job_count".to_string(), json!(ci.run_job_count));
             payload.insert("run_all_terminal".to_string(), json!(ci.run_all_terminal));
@@ -2694,6 +2715,121 @@ mod tests {
             reloaded.repos.get("/repo"),
             &run
         ));
+    }
+
+    #[test]
+    fn issue_317_ack_save_failure_retains_live_pending_for_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let run = run_snapshot(77, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(std::slice::from_ref(&run)));
+        ci_baseline.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events,
+            &run_map(std::slice::from_ref(&run)),
+        );
+        save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
+        let pending = ci_baseline.repos["/repo"].pending.clone();
+        assert_eq!(pending.len(), 1);
+
+        let blocker = dir.path().join("blocked");
+        std::fs::write(&blocker, b"file").unwrap();
+        let bad_path = blocker.join("github-ci-baseline.json");
+        assert!(ack_pending_deliveries(&mut ci_baseline, Some(&bad_path), &pending).is_err());
+        assert_eq!(
+            ci_baseline.repos["/repo"].pending.len(),
+            1,
+            "live pending must survive an ACK persist failure so restart can retry"
+        );
+        assert_eq!(
+            load_ci_baseline(Some(&path)).repos["/repo"].pending.len(),
+            1
+        );
+
+        ack_pending_deliveries(&mut ci_baseline, Some(&path), &pending).unwrap();
+        assert!(ci_baseline.repos["/repo"].pending.is_empty());
+        assert!(
+            load_ci_baseline(Some(&path)).repos["/repo"]
+                .pending
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn issue_317_pending_equivalence_keeps_distinct_run_attempts() {
+        let attempt1 = GitHubCISnapshot {
+            run_attempt: 1,
+            ..run_snapshot(4242, "CI", Some("success"), "main")
+        };
+        let attempt2 = GitHubCISnapshot {
+            run_attempt: 2,
+            conclusion: Some("failure".into()),
+            ..run_snapshot(4242, "CI", Some("failure"), "main")
+        };
+        let events1 = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt1)),
+            None,
+        );
+        let events2 = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt2)),
+            None,
+        );
+        let pending1 = PendingCiDelivery::from_event(&events1[0], attempt1.identities());
+        let pending2 = PendingCiDelivery::from_event(&events2[0], attempt2.identities());
+        assert!(
+            !pending1.same_event(&pending2),
+            "attempt 2 must not coalesce with attempt 1 in outbox equivalence"
+        );
+
+        let mut dest = RepoCIBaseline::default();
+        dest.pending.push(pending1.clone());
+        merge_repo_baseline(
+            &mut dest,
+            RepoCIBaseline {
+                pending: vec![pending2.clone()],
+                ..RepoCIBaseline::default()
+            },
+        );
+        assert_eq!(dest.pending.len(), 2);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut left = CIBaseline::default();
+        left.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events1,
+            &run_map(std::slice::from_ref(&attempt1)),
+        );
+        commit_ci_baseline(Some(&path), &left).unwrap();
+        let mut right = CIBaseline::default();
+        right.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events2,
+            &run_map(std::slice::from_ref(&attempt2)),
+        );
+        commit_ci_baseline(Some(&path), &right).unwrap();
+        let loaded = load_ci_baseline(Some(&path));
+        assert_eq!(loaded.repos["/repo"].pending.len(), 2);
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -766,6 +766,7 @@ fn merge_ci_baseline(dest: &mut CIBaseline, source: &CIBaseline) {
     }
 }
 
+#[derive(Debug)]
 struct BaselineLock {
     file: File,
 }
@@ -782,7 +783,10 @@ fn acquire_baseline_lock(path: &Path) -> Result<BaselineLock> {
         fs::create_dir_all(parent)?;
     }
     if lock_path.is_dir() {
-        let _ = fs::remove_dir_all(&lock_path);
+        return Err(
+            "GitHub CI baseline lock path is a leftover directory lock; stop older clawhip processes and remove it before retrying"
+                .into(),
+        );
     }
     let file = OpenOptions::new()
         .create(true)
@@ -3605,8 +3609,19 @@ mod tests {
         let path = dir.path().join("github-ci-baseline.json");
         let lock_path = path.with_extension("json.lock");
         fs::create_dir_all(&lock_path).unwrap();
-        fs::write(lock_path.join("owner"), b"stale-token").unwrap();
+        fs::write(lock_path.join("owner"), b"live-legacy-owner").unwrap();
 
+        let err = acquire_baseline_lock(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("leftover directory lock"),
+            "new acquire must fail closed on a live legacy directory lock: {err}"
+        );
+        assert!(
+            lock_path.is_dir(),
+            "new acquire must not delete a live legacy directory lock"
+        );
+
+        fs::remove_dir_all(&lock_path).unwrap();
         let overlapping = Arc::new(AtomicUsize::new(0));
         let current = Arc::new(AtomicUsize::new(0));
         let errors = Arc::new(Mutex::new(Vec::new()));

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -464,9 +464,9 @@ where
         .collect())
 }
 
-const MAX_BASELINE_RUNS_PER_REPO: usize = 256;
 const CI_PAGE_SIZE: usize = 100;
 const MAX_CI_PAGES: usize = 5;
+const MAX_BASELINE_RUNS_PER_REPO: usize = CI_PAGE_SIZE * MAX_CI_PAGES;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
 const ACK_RETENTION_SECS: u64 = 7 * 24 * 3_600;
@@ -2062,9 +2062,7 @@ async fn poll_ci_statuses(
             } else {
                 Vec::new()
             };
-            let established = previous
-                .map(|entry| entry.ci_baseline_established)
-                .unwrap_or(true);
+            let established = true;
             Ok((ci, established, events, window_complete))
         }
         Err(error) => {

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -230,6 +230,7 @@ impl AckedDelivery {
         self.sha == pending.sha
             && self.workflow == pending.workflow
             && self.pr_number == pending.pr_number
+            && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(pending.run_attempt)
     }
 
     fn merge_aliases(&mut self, pending: &PendingCiDelivery) {
@@ -355,6 +356,7 @@ impl PendingCiDelivery {
         self.sha == other.sha
             && self.workflow == other.workflow
             && self.pr_number == other.pr_number
+            && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(other.run_attempt)
     }
 
     fn into_event(self) -> IncomingEvent {
@@ -504,25 +506,6 @@ fn run_identity(run_id: &str, attempt: u32) -> String {
     }
 }
 
-fn parse_run_identity(identity: &str) -> Option<(String, u32)> {
-    let rest = identity.strip_prefix("run:")?;
-    if rest.is_empty() {
-        return None;
-    }
-    if rest.matches(':').count() == 1
-        && let Some((id, attempt)) = rest.split_once(':')
-        && !id.is_empty()
-        && let Ok(attempt) = attempt.parse::<u32>()
-        && attempt >= 1
-    {
-        return Some((id.to_string(), attempt));
-    }
-    if rest.contains(':') {
-        return None;
-    }
-    Some((rest.to_string(), 1))
-}
-
 impl TerminalRunRecord {
     fn from_snapshot(ci: &GitHubCISnapshot) -> Self {
         Self {
@@ -574,19 +557,16 @@ impl TerminalRunRecord {
                 .any(|identity| snap_checks.iter().any(|candidate| candidate == identity));
             return overlap && run_attempt_or_one(self.run_attempt) == ci.run_attempt();
         }
+        if !snap_checks.is_empty() || !rec_checks.is_empty() {
+            return false;
+        }
         let unique = ci.unique_identities();
         if unique
             .iter()
             .any(|identity| self.contains_identity(identity))
         {
-            return run_attempt_or_one(self.run_attempt) == ci.run_attempt();
-        }
-        for identity in &self.identities {
-            if identity_matches_snapshot(identity, ci)
-                && (unique.is_empty() || self.unique_identities().next().is_none())
-            {
-                return true;
-            }
+            return run_attempt_or_one(self.run_attempt) == ci.run_attempt()
+                && self.conclusion == ci.conclusion;
         }
         false
     }
@@ -624,24 +604,6 @@ impl TerminalRunRecord {
         let ident = self.identities.first().cloned().unwrap_or_default();
         (created_rank, created, run_num, ident)
     }
-}
-
-fn identity_matches_snapshot(identity: &str, ci: &GitHubCISnapshot) -> bool {
-    if ci
-        .identities()
-        .iter()
-        .any(|candidate| candidate == identity)
-    {
-        return true;
-    }
-    let key = ci.dedupe_key();
-    if identity == key {
-        return true;
-    }
-    if let Some((run_id, attempt)) = parse_run_identity(identity) {
-        return ci.run_id.as_deref() == Some(run_id.as_str()) && ci.run_attempt() == attempt;
-    }
-    false
 }
 
 fn repo_ci_baseline_is_suppressed(
@@ -1187,6 +1149,37 @@ unsafe extern "system" {
     ) -> i32;
     #[link_name = "GetLastError"]
     fn get_last_error() -> u32;
+    #[link_name = "MoveFileExW"]
+    fn move_file_ex_w(existing_file_name: *const u16, new_file_name: *const u16, flags: u32)
+    -> i32;
+}
+
+#[cfg(windows)]
+fn replace_file_windows(from: &Path, to: &Path) -> Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+    let from_w: Vec<u16> = from
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let to_w: Vec<u16> = to
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    unsafe {
+        if move_file_ex_w(
+            from_w.as_ptr(),
+            to_w.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        ) == 0
+        {
+            return Err(std::io::Error::last_os_error().into());
+        }
+    }
+    Ok(())
 }
 
 fn unix_now() -> u64 {
@@ -1262,9 +1255,8 @@ fn write_ci_baseline_atomic(baseline: &CIBaseline, path: &Path) -> Result<()> {
         sync_file(&file)?;
         drop(file);
         #[cfg(windows)]
-        {
-            let _ = fs::remove_file(path);
-        }
+        replace_file_windows(&temp_path, path)?;
+        #[cfg(not(windows))]
         fs::rename(&temp_path, path)?;
         let dest = OpenOptions::new().read(true).write(true).open(path)?;
         sync_file(&dest)?;
@@ -1316,6 +1308,9 @@ async fn send_then_ack_prefix(
             std::slice::from_ref(delivery),
             unix_now(),
         )?;
+        if !outbox_contains(ci_baseline, delivery) {
+            continue;
+        }
         match send_event(tx, event).await {
             Ok(()) => {
                 ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(delivery))?;
@@ -1349,6 +1344,9 @@ async fn drain_pending_outbox(
             eprintln!("clawhip source github CI baseline outbox attempt persist failed");
             return Ok(());
         }
+        if !outbox_contains(ci_baseline, &delivery) {
+            continue;
+        }
         if send_event(tx, delivery.clone().into_event()).await.is_err() {
             dead_letter_unsent_final_attempts(ci_baseline, std::slice::from_ref(&delivery));
             let _ = commit_ci_baseline(path, ci_baseline);
@@ -1361,6 +1359,14 @@ async fn drain_pending_outbox(
         }
     }
     Ok(())
+}
+
+fn outbox_contains(ci_baseline: &CIBaseline, delivery: &PendingCiDelivery) -> bool {
+    ci_baseline.repos.values().any(|repo| {
+        repo.pending
+            .iter()
+            .any(|pending| pending.same_event(delivery) && pending.repo_name == delivery.repo_name)
+    })
 }
 
 fn persist_pending_send_attempts(
@@ -1459,14 +1465,25 @@ fn merge_incomplete_ci(
 }
 
 fn snapshots_same_run(left: &GitHubCISnapshot, right: &GitHubCISnapshot) -> bool {
-    let left_unique = left.unique_identities();
-    let right_unique = right.unique_identities();
-    if !left_unique.is_empty()
-        && left_unique
+    let left_ids = left.unique_identities();
+    let right_ids = right.unique_identities();
+    let left_checks = pending_check_identities(&left_ids);
+    let right_checks = pending_check_identities(&right_ids);
+    if !left_checks.is_empty() && !right_checks.is_empty() {
+        return left_checks
             .iter()
-            .any(|identity| right_unique.iter().any(|candidate| candidate == identity))
+            .any(|identity| right_checks.iter().any(|candidate| candidate == identity))
+            && left.run_attempt() == right.run_attempt();
+    }
+    if !left_checks.is_empty() || !right_checks.is_empty() {
+        return false;
+    }
+    if !left_ids.is_empty()
+        && left_ids
+            .iter()
+            .any(|identity| right_ids.iter().any(|candidate| candidate == identity))
     {
-        return true;
+        return left.run_attempt() == right.run_attempt();
     }
     left.dedupe_key() == right.dedupe_key()
 }
@@ -2018,7 +2035,15 @@ fn previous_snapshot_for_event<'a>(
         .unwrap_or(1);
     previous.values().find(|ci| {
         if let Some(check_run_id) = check_run_id {
-            return ci.check_run_id.as_deref() == Some(check_run_id);
+            if ci.check_run_id.as_deref() != Some(check_run_id) {
+                return false;
+            }
+            return match (run_id, ci.run_id.as_deref()) {
+                (Some(event_run), Some(ci_run)) => {
+                    ci_run == event_run && ci.run_attempt() == run_attempt_or_one(run_attempt)
+                }
+                _ => true,
+            };
         }
         if ci.check_run_id.is_some() {
             return false;
@@ -2033,6 +2058,7 @@ fn previous_snapshot_for_event<'a>(
                     .get("sha")
                     .and_then(|value| value.as_str())
                     .unwrap_or_default()
+            && ci.run_attempt() == run_attempt_or_one(run_attempt)
     })
 }
 
@@ -2143,16 +2169,29 @@ fn previous_snapshot<'a>(
     ci: &GitHubCISnapshot,
 ) -> Option<&'a GitHubCISnapshot> {
     if let Some(old) = previous.get(&ci.dedupe_key()) {
-        return Some(old);
+        let same_attempt = old.run_attempt() == ci.run_attempt()
+            && (old.run_id.is_none() || ci.run_id.is_none() || old.run_id == ci.run_id);
+        if same_attempt {
+            return Some(old);
+        }
     }
     let unique = ci.unique_identities();
     if unique.is_empty() {
         return None;
     }
     previous.values().find(|old| {
-        old.unique_identities()
+        let old_ids = old.unique_identities();
+        let old_checks = pending_check_identities(&old_ids);
+        let new_checks = pending_check_identities(&unique);
+        if !old_checks.is_empty() || !new_checks.is_empty() {
+            return old.check_run_id == ci.check_run_id
+                && old.run_id == ci.run_id
+                && old.run_attempt() == ci.run_attempt();
+        }
+        old_ids
             .iter()
             .any(|identity| unique.iter().any(|candidate| candidate == identity))
+            && old.run_attempt() == ci.run_attempt()
     })
 }
 
@@ -3172,8 +3211,8 @@ mod tests {
             ci_baseline.repos.get("/repo"),
         );
         assert!(
-            events.is_empty(),
-            "run-id representation of a fallback-persisted terminal run must stay suppressed"
+            !events.is_empty(),
+            "ambiguous fallback-to-run-id drift must fail open rather than suppress"
         );
 
         assert!(ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(&[with_run_id])));
@@ -4440,6 +4479,46 @@ mod tests {
         assert!(
             !repo_ci_baseline_is_suppressed(baseline.repos.get("/repo"), &test),
             "failed sibling must not be suppressed by a successful sibling in the same run"
+        );
+    }
+
+    #[test]
+    fn issue_317_run_only_receipt_does_not_suppress_check_jobs() {
+        let aggregate = run_snapshot(4242, "CI", Some("success"), "main");
+        let lint = check_job(4242, 11, "lint", "success");
+        let test = check_job(4242, 22, "test", "failure");
+        let mut baseline = CIBaseline::default();
+        baseline.record_terminal_runs("/repo", "/repo", &run_map(std::slice::from_ref(&aggregate)));
+        assert!(!repo_ci_baseline_is_suppressed(
+            baseline.repos.get("/repo"),
+            &lint
+        ));
+        assert!(
+            !repo_ci_baseline_is_suppressed(baseline.repos.get("/repo"), &test),
+            "run-only historical receipt must not suppress mixed check jobs"
+        );
+    }
+
+    #[test]
+    fn issue_317_same_check_id_same_conclusion_rerun_still_emits() {
+        let attempt1 = check_job(4242, 11, "CI", "success");
+        let attempt2 = GitHubCISnapshot {
+            run_attempt: 2,
+            check_run_id: Some("11".into()),
+            ..check_job(4242, 11, "CI", "success")
+        };
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &run_map(std::slice::from_ref(&attempt1)),
+            &run_map(std::slice::from_ref(&attempt2)),
+            None,
+        );
+        assert_eq!(
+            events.len(),
+            1,
+            "same check id and conclusion on a new attempt must emit"
         );
     }
 

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -88,6 +88,10 @@ struct RepoCIBaseline {
     /// crash between the write and the channel send.
     #[serde(default)]
     pending: Vec<PendingCiDelivery>,
+    /// Tombstones for ACKed deliveries so a stale concurrent merge cannot
+    /// restore a receipt that was already durably removed.
+    #[serde(default)]
+    acked: VecDeque<String>,
 }
 
 /// Durable receipt for one terminal run. Identities are aliases (run-id,
@@ -222,6 +226,26 @@ impl PendingCiDelivery {
             && self.pr_number == other.pr_number
     }
 
+    fn delivery_key(&self) -> String {
+        let outcome = format!("{}:{}", self.kind, self.conclusion.as_deref().unwrap_or(""));
+        if let Some(check) = pending_check_identities(&self.identities).first() {
+            return format!("{check}:{outcome}");
+        }
+        if let Some(run_id) = &self.run_id {
+            return format!(
+                "run:{run_id}:{}:{}:{outcome}",
+                run_attempt_or_one(self.run_attempt),
+                self.workflow
+            );
+        }
+        format!(
+            "fallback:{}:{}:{}:{outcome}",
+            self.sha,
+            self.workflow,
+            self.pr_number.unwrap_or(0)
+        )
+    }
+
     fn into_event(self) -> IncomingEvent {
         let mut event = IncomingEvent::github_ci(
             &self.kind,
@@ -289,6 +313,7 @@ const MAX_CI_PAGES: usize = 5;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
 const BASELINE_LOCK_STALE_SECS: u64 = 30;
+const MAX_ACKED_DELIVERIES: usize = 512;
 
 /// Beside the cron state file, matching `tmux-watch-registry.json` and
 /// `discord-watch-state.json`.
@@ -643,6 +668,21 @@ fn terminal_records_same_run(left: &TerminalRunRecord, right: &TerminalRunRecord
         .any(|identity| right.contains_identity(identity))
 }
 
+fn pending_is_acked(repo: &RepoCIBaseline, delivery: &PendingCiDelivery) -> bool {
+    let key = delivery.delivery_key();
+    repo.acked.iter().any(|acked| acked == &key)
+}
+
+fn record_acked(repo: &mut RepoCIBaseline, delivery: &PendingCiDelivery) {
+    let key = delivery.delivery_key();
+    if !repo.acked.iter().any(|acked| acked == &key) {
+        repo.acked.push_back(key);
+    }
+    while repo.acked.len() > MAX_ACKED_DELIVERIES {
+        repo.acked.pop_front();
+    }
+}
+
 fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     for record in source.terminal_runs {
         if let Some(existing) = dest
@@ -666,7 +706,18 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
         }
     }
     cap_repo_baseline(dest);
+    for key in source.acked {
+        if !dest.acked.iter().any(|acked| acked == &key) {
+            dest.acked.push_back(key);
+        }
+    }
+    while dest.acked.len() > MAX_ACKED_DELIVERIES {
+        dest.acked.pop_front();
+    }
     for delivery in source.pending {
+        if pending_is_acked(dest, &delivery) {
+            continue;
+        }
         if let Some(existing) = dest
             .pending
             .iter_mut()
@@ -677,6 +728,11 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
             dest.pending.push(delivery);
         }
     }
+    let acked = dest.acked.clone();
+    dest.pending.retain(|pending| {
+        let key = pending.delivery_key();
+        !acked.iter().any(|item| item == &key)
+    });
 }
 
 fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
@@ -721,27 +777,46 @@ fn merge_ci_baseline(dest: &mut CIBaseline, source: &CIBaseline) {
 
 struct BaselineLock {
     lock_path: PathBuf,
+    token: String,
 }
 
 impl Drop for BaselineLock {
     fn drop(&mut self) {
-        let _ = fs::remove_dir(&self.lock_path);
+        let owner = self.lock_path.join("owner");
+        if fs::read_to_string(&owner).ok().as_deref() == Some(self.token.as_str()) {
+            let _ = fs::remove_dir_all(&self.lock_path);
+        }
     }
 }
 
 fn acquire_baseline_lock(path: &Path) -> Result<BaselineLock> {
+    acquire_baseline_lock_inner(path, BASELINE_LOCK_STALE_SECS)
+}
+
+fn acquire_baseline_lock_inner(path: &Path, stale_secs: u64) -> Result<BaselineLock> {
     let lock_path = path.with_extension("json.lock");
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
+    let token = format!(
+        "{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0)
+    );
     for _ in 0..40 {
         match fs::create_dir(&lock_path) {
-            Ok(()) => return Ok(BaselineLock { lock_path }),
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                if baseline_lock_is_stale(&lock_path) {
-                    let _ = fs::remove_dir(&lock_path);
-                    continue;
+            Ok(()) => {
+                if let Err(error) = fs::write(lock_path.join("owner"), token.as_bytes()) {
+                    let _ = fs::remove_dir_all(&lock_path);
+                    return Err(error.into());
                 }
+                return Ok(BaselineLock { lock_path, token });
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                try_reclaim_stale_lock(&lock_path, stale_secs);
                 std::thread::sleep(Duration::from_millis(5));
             }
             Err(error) => return Err(error.into()),
@@ -750,7 +825,30 @@ fn acquire_baseline_lock(path: &Path) -> Result<BaselineLock> {
     Err("timed out waiting for GitHub CI baseline lock".into())
 }
 
-fn baseline_lock_is_stale(lock_path: &Path) -> bool {
+fn try_reclaim_stale_lock(lock_path: &Path, stale_secs: u64) {
+    if !baseline_lock_is_stale(lock_path, stale_secs) {
+        return;
+    }
+    let owner = lock_path.join("owner");
+    let observed = fs::read_to_string(&owner).unwrap_or_default();
+    let current = fs::read_to_string(&owner).unwrap_or_default();
+    if current != observed {
+        return;
+    }
+    let dead = lock_path.with_extension(format!(
+        "json.lock.dead.{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0)
+    ));
+    if fs::rename(lock_path, &dead).is_ok() {
+        let _ = fs::remove_dir_all(&dead);
+    }
+}
+
+fn baseline_lock_is_stale(lock_path: &Path, stale_secs: u64) -> bool {
     let Ok(metadata) = fs::metadata(lock_path) else {
         return true;
     };
@@ -759,7 +857,7 @@ fn baseline_lock_is_stale(lock_path: &Path) -> bool {
     };
     modified
         .elapsed()
-        .map(|elapsed| elapsed.as_secs() >= BASELINE_LOCK_STALE_SECS)
+        .map(|elapsed| elapsed.as_secs() >= stale_secs)
         .unwrap_or(true)
 }
 
@@ -901,6 +999,9 @@ fn ack_pending_deliveries(
 ) -> Result<()> {
     let Some(path) = path else {
         for repo in ci_baseline.repos.values_mut() {
+            for delivery in delivered {
+                record_acked(repo, delivery);
+            }
             repo.pending
                 .retain(|pending| !delivered.iter().any(|item| pending.same_event(item)));
         }
@@ -909,7 +1010,25 @@ fn ack_pending_deliveries(
     let _lock = acquire_baseline_lock(path)?;
     let mut disk = load_ci_baseline(Some(path));
     merge_ci_baseline(&mut disk, ci_baseline);
-    for repo in disk.repos.values_mut() {
+    for (key, repo) in disk.repos.iter_mut() {
+        let local_repo = ci_baseline.repos.get(key);
+        for delivery in delivered {
+            let in_disk = repo
+                .pending
+                .iter()
+                .any(|pending| pending.same_event(delivery));
+            let in_local = local_repo
+                .map(|local| {
+                    local
+                        .pending
+                        .iter()
+                        .any(|pending| pending.same_event(delivery))
+                })
+                .unwrap_or(false);
+            if in_disk || in_local {
+                record_acked(repo, delivery);
+            }
+        }
         repo.pending
             .retain(|pending| !delivered.iter().any(|item| pending.same_event(item)));
     }
@@ -2262,7 +2381,9 @@ fn classify_ci_event_kind(status: &str, conclusion: Option<&str>) -> &'static st
 mod tests {
     use std::collections::{HashMap, VecDeque};
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
     use std::time::Duration;
 
     use super::*;
@@ -3427,6 +3548,130 @@ mod tests {
             restarted.repos["/repo"].pending.len(),
             3,
             "restart must keep both jobs and the changed conclusion"
+        );
+    }
+
+    #[test]
+    fn issue_317_concurrent_acks_do_not_resurrect_acked_deliveries() {
+        let lint = check_job(4242, 11, "lint", "success");
+        let test = check_job(4242, 22, "test", "failure");
+        let current = run_map(&[lint.clone(), test.clone()]);
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &current,
+            None,
+        );
+        let pending_a = PendingCiDelivery::from_event(
+            events
+                .iter()
+                .find(|event| event.canonical_kind() == "github.ci-passed")
+                .unwrap(),
+            lint.identities(),
+        );
+        let pending_b = PendingCiDelivery::from_event(
+            events
+                .iter()
+                .find(|event| event.canonical_kind() == "github.ci-failed")
+                .unwrap(),
+            test.identities(),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut durable = CIBaseline::default();
+        durable.enqueue_pending("/repo", "/repo", &events, &current);
+        save_ci_baseline(&durable, Some(&path)).unwrap();
+
+        let mut proc1 = load_ci_baseline(Some(&path));
+        let mut proc2 = load_ci_baseline(Some(&path));
+        ack_pending_deliveries(&mut proc1, Some(&path), std::slice::from_ref(&pending_a)).unwrap();
+        ack_pending_deliveries(&mut proc2, Some(&path), std::slice::from_ref(&pending_b)).unwrap();
+
+        let restarted = load_ci_baseline(Some(&path));
+        assert!(
+            restarted.repos["/repo"].pending.is_empty(),
+            "stale concurrent ACK must not restore an already ACKed delivery"
+        );
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut drain_state = restarted.clone();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            drain_pending_outbox(&mut drain_state, Some(&path), &tx)
+                .await
+                .unwrap();
+        });
+        assert!(
+            rx.try_recv().is_err(),
+            "restart drain must not redeliver an ACKed event"
+        );
+    }
+
+    #[test]
+    fn issue_317_stale_lock_reclaim_does_not_delete_live_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let lock_path = path.with_extension("json.lock");
+        fs::create_dir_all(&lock_path).unwrap();
+        fs::write(lock_path.join("owner"), b"stale-token").unwrap();
+        std::process::Command::new("touch")
+            .args(["-t", "197001010000"])
+            .arg(&lock_path)
+            .status()
+            .unwrap();
+
+        let overlapping = Arc::new(AtomicUsize::new(0));
+        let current = Arc::new(AtomicUsize::new(0));
+        let live_deleted = Arc::new(AtomicUsize::new(0));
+        let errors = Arc::new(Mutex::new(Vec::new()));
+
+        thread::scope(|scope| {
+            for _ in 0..2 {
+                let overlapping = overlapping.clone();
+                let current = current.clone();
+                let live_deleted = live_deleted.clone();
+                let errors = errors.clone();
+                let path = path.clone();
+                scope.spawn(move || match acquire_baseline_lock_inner(&path, BASELINE_LOCK_STALE_SECS)
+                {
+                    Ok(lock) => {
+                        let owner = lock.lock_path.join("owner");
+                        let token = lock.token.clone();
+                        current.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(30));
+                        if current.load(Ordering::SeqCst) > 1 {
+                            overlapping.fetch_add(1, Ordering::SeqCst);
+                        }
+                        if fs::read_to_string(&owner).ok().as_deref() != Some(token.as_str()) {
+                            live_deleted.fetch_add(1, Ordering::SeqCst);
+                        }
+                        current.fetch_sub(1, Ordering::SeqCst);
+                        drop(lock);
+                    }
+                    Err(error) => errors.lock().unwrap().push(error.to_string()),
+                });
+            }
+        });
+
+        assert!(
+            errors.lock().unwrap().is_empty(),
+            "lock acquire failed: {:?}",
+            errors.lock().unwrap()
+        );
+        assert_eq!(
+            overlapping.load(Ordering::SeqCst),
+            0,
+            "two reclaimers must not enter the critical section together"
+        );
+        assert_eq!(
+            live_deleted.load(Ordering::SeqCst),
+            0,
+            "a reclaimer must not delete another owner's live lock"
         );
     }
 

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1785,9 +1785,27 @@ async fn fetch_ci_statuses(
         }
     }
 
-    let (workflow_runs, complete, attempts_by_run) =
+    let mut attempts_by_run = HashMap::new();
+    for (_, pr) in open_prs {
+        let pr_attempts =
+            fetch_workflow_attempts_by_head_sha(client, api_base, &github_repo, &pr.head_sha)
+                .await?;
+        for (run_id, attempt) in pr_attempts {
+            attempts_by_run
+                .entry(run_id)
+                .and_modify(|existing: &mut u32| *existing = (*existing).max(attempt))
+                .or_insert(attempt);
+        }
+    }
+    let (workflow_runs, complete, direct_attempts) =
         fetch_direct_workflow_runs(client, api_base, &github_repo, snapshot).await?;
     window_complete &= complete;
+    for (run_id, attempt) in direct_attempts {
+        attempts_by_run
+            .entry(run_id)
+            .and_modify(|existing: &mut u32| *existing = (*existing).max(attempt))
+            .or_insert(attempt);
+    }
     apply_workflow_run_attempts(&mut check_runs, &attempts_by_run);
     for workflow_run in workflow_runs {
         if workflow_run
@@ -1929,7 +1947,11 @@ async fn fetch_direct_workflow_runs(
     let mut window_complete = true;
     loop {
         let page_str = page.to_string();
-        let mut query = vec![("per_page", "100"), ("page", page_str.as_str())];
+        let mut query = vec![
+            ("per_page", "100"),
+            ("event", "push"),
+            ("page", page_str.as_str()),
+        ];
         if !snapshot.branch.is_empty() {
             query.push(("branch", snapshot.branch.as_str()));
         }
@@ -1996,6 +2018,46 @@ async fn fetch_direct_workflow_runs(
         window_complete,
         attempts_by_run,
     ))
+}
+
+async fn fetch_workflow_attempts_by_head_sha(
+    client: &reqwest::Client,
+    api_base: &str,
+    github_repo: &str,
+    head_sha: &str,
+) -> Result<HashMap<String, u32>> {
+    let mut attempts = HashMap::new();
+    let mut page = 1_usize;
+    loop {
+        let page_str = page.to_string();
+        let response = github_get(
+            client,
+            api_base,
+            &format!("repos/{github_repo}/actions/runs"),
+            &[
+                ("per_page", "100"),
+                ("head_sha", head_sha),
+                ("page", page_str.as_str()),
+            ],
+            &format!("workflow run attempts for {github_repo} sha {head_sha}"),
+        )
+        .await?;
+        let has_next = github_link_next(response.headers()).is_some();
+        let runs: GitHubWorkflowRunsResponse = response.json().await?;
+        let page_len = runs.workflow_runs.len();
+        for run in runs.workflow_runs {
+            let attempt = run_attempt_or_one(run.run_attempt);
+            attempts
+                .entry(run.id.to_string())
+                .and_modify(|existing: &mut u32| *existing = (*existing).max(attempt))
+                .or_insert(attempt);
+        }
+        if !has_next || page_len < CI_PAGE_SIZE || page >= MAX_CI_PAGES {
+            break;
+        }
+        page += 1;
+    }
+    Ok(attempts)
 }
 
 fn workflow_run_id(url: &str) -> Option<String> {
@@ -2885,13 +2947,17 @@ mod tests {
                     if check_polls <= 2 {
                         r#"{"check_runs":[{"id":11,"name":"CI","status":"completed","conclusion":"success","details_url":"https://github.com/org/repo/actions/runs/4242/jobs/11","head_sha":"prsha"}]}"#.to_string()
                     } else {
-                        r#"{"check_runs":[{"id":22,"name":"CI","status":"completed","conclusion":"failure","details_url":"https://github.com/org/repo/actions/runs/4242/attempts/2/jobs/22","head_sha":"prsha"}]}"#.to_string()
+                        r#"{"check_runs":[{"id":22,"name":"CI","status":"completed","conclusion":"failure","details_url":"https://github.com/org/repo/actions/runs/4242/jobs/22","head_sha":"prsha"}]}"#.to_string()
                     }
                 } else if request.contains("/actions/runs") {
-                    if check_polls <= 2 {
-                        r#"{"workflow_runs":[{"id":4242,"name":"CI","status":"completed","conclusion":"success","head_branch":"feat/pr","head_sha":"prsha","html_url":"https://github.com/org/repo/actions/runs/4242","run_attempt":1,"pull_requests":[{"number":42}]}]}"#.to_string()
+                    if request.contains("head_sha=prsha") {
+                        if check_polls <= 2 {
+                            r#"{"workflow_runs":[{"id":4242,"name":"CI","status":"completed","conclusion":"success","head_branch":"feat/pr","head_sha":"prsha","html_url":"https://github.com/org/repo/actions/runs/4242","run_attempt":1,"pull_requests":[{"number":42}]}]}"#.to_string()
+                        } else {
+                            r#"{"workflow_runs":[{"id":4242,"name":"CI","status":"completed","conclusion":"failure","head_branch":"feat/pr","head_sha":"prsha","html_url":"https://github.com/org/repo/actions/runs/4242","run_attempt":2,"pull_requests":[{"number":42}]}]}"#.to_string()
+                        }
                     } else {
-                        r#"{"workflow_runs":[{"id":4242,"name":"CI","status":"completed","conclusion":"failure","head_branch":"feat/pr","head_sha":"prsha","html_url":"https://github.com/org/repo/actions/runs/4242/attempts/2","run_attempt":2,"pull_requests":[{"number":42}]}]}"#.to_string()
+                        r#"{"workflow_runs":[]}"#.to_string()
                     }
                 } else {
                     "[]".to_string()
@@ -4269,6 +4335,7 @@ mod tests {
         let req = server.await.unwrap();
         assert!(req.contains("GET /repos/ultraworkers/claw-code/actions/runs?"));
         assert!(req.contains("branch=main"));
+        assert!(req.contains("event=push"));
         assert!(req.contains("per_page=100"));
     }
 
@@ -4292,28 +4359,30 @@ mod tests {
                 })
                 .to_string(),
                 json!({
-                    "workflow_runs": [
-                        {
-                            "id": 123_u64,
-                            "name": "CI",
-                            "status": "completed",
-                            "conclusion": "failure",
-                            "head_branch": "feat/pr",
-                            "head_sha": "prsha",
-                            "html_url": "https://github.com/org/repo/actions/runs/123",
-                            "pull_requests": [{"number": 42}]
-                        },
-                        {
-                            "id": 456_u64,
-                            "name": "Rust CI",
-                            "status": "completed",
-                            "conclusion": "failure",
-                            "head_branch": "main",
-                            "head_sha": "mainsha",
-                            "html_url": "https://github.com/org/repo/actions/runs/456",
-                            "pull_requests": []
-                        }
-                    ]
+                    "workflow_runs": [{
+                        "id": 123_u64,
+                        "name": "CI",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "head_branch": "feat/pr",
+                        "head_sha": "prsha",
+                        "html_url": "https://github.com/org/repo/actions/runs/123",
+                        "run_attempt": 1,
+                        "pull_requests": [{"number": 42}]
+                    }]
+                })
+                .to_string(),
+                json!({
+                    "workflow_runs": [{
+                        "id": 456_u64,
+                        "name": "Rust CI",
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "head_branch": "main",
+                        "head_sha": "mainsha",
+                        "html_url": "https://github.com/org/repo/actions/runs/456",
+                        "pull_requests": []
+                    }]
                 })
                 .to_string(),
             ];
@@ -4383,10 +4452,13 @@ mod tests {
         assert_eq!(direct.branch.as_deref(), Some("main"));
 
         let requests = server.await.unwrap();
-        assert_eq!(requests.len(), 2);
+        assert_eq!(requests.len(), 3);
         assert!(requests[0].contains("GET /repos/org/repo/commits/prsha/check-runs?"));
         assert!(requests[1].contains("GET /repos/org/repo/actions/runs?"));
-        assert!(requests[1].contains("branch=main"));
+        assert!(requests[1].contains("head_sha=prsha"));
+        assert!(requests[2].contains("GET /repos/org/repo/actions/runs?"));
+        assert!(requests[2].contains("branch=main"));
+        assert!(requests[2].contains("event=push"));
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -111,7 +111,9 @@ struct RepoCIBaseline {
     /// fetched window. Pinned against cap eviction so the live window —
     /// including an oversized fetched window (#317) — always survives merge
     /// and reload. Canonicalized, deduplicated, hard-capped at
-    /// [`MAX_CURRENT_WINDOW_IDS`]; superseded only by an epoch-unfenced
+    /// [`MAX_CURRENT_WINDOW_IDS_PER_SCOPE`] per scope; sibling scopes are
+    /// retained independently and are never evicted by a global union cap.
+    /// Superseded only by an epoch-unfenced
     /// writer whose pinned receipts are at least as recent, and never
     /// dropped by a fenced stale writer.
     #[serde(default)]
@@ -498,8 +500,11 @@ const MAX_BASELINE_RUNS_PER_REPO: usize = CI_PAGE_SIZE * MAX_CI_PAGES;
 // Pull-request inventory is fetched with the GitHub API's 100-item page cap
 // and is not paginated here. The aggregate CI window is therefore bounded by
 // 100 PR windows plus the direct push window, with two durable aliases per
-// snapshot. Keep the protection bound above that actual fetched scope.
-const MAX_CURRENT_WINDOW_IDS: usize = CI_PAGE_SIZE * MAX_CI_PAGES * (CI_PAGE_SIZE + 1) * 2;
+// A complete scope can contain every fetched check run for every paginated
+// pull request plus the direct push window. Bound each scope from that actual
+// fetch shape; never apply this bound to the union of independent scopes.
+const MAX_CURRENT_WINDOW_IDS_PER_SCOPE: usize =
+    (CI_PAGE_SIZE * MAX_CI_PAGES) * (CI_PAGE_SIZE * MAX_CI_PAGES + 1) * 2;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
 const ACK_RETENTION_SECS: u64 = 7 * 24 * 3_600;
@@ -614,7 +619,9 @@ impl TerminalRunRecord {
             let overlap = rec_checks
                 .iter()
                 .any(|identity| snap_checks.iter().any(|candidate| candidate == identity));
-            return overlap && run_attempt_or_one(self.run_attempt) == ci.run_attempt();
+            return overlap
+                && run_attempt_or_one(self.run_attempt) == ci.run_attempt()
+                && self.conclusion == ci.conclusion;
         }
         if !snap_checks.is_empty() || !rec_checks.is_empty() {
             return false;
@@ -684,7 +691,7 @@ fn snapshot_eviction_key(ci: &GitHubCISnapshot) -> (u8, String, u64, String) {
 
 /// Canonicalizes the pinned current-window identity set: only durable
 /// aliases (`run:` / `check:` prefixes), each stored once, order-stable by
-/// first appearance, hard-capped at [`MAX_CURRENT_WINDOW_IDS`]. Identities
+/// first appearance, hard-capped at [`MAX_CURRENT_WINDOW_IDS_PER_SCOPE`]. Identities
 /// arrive oldest-first (eviction-key order); when the bound trims, the
 /// OLDEST aliases drop so the newest fetched terminal runs — the ones still
 /// inside GitHub's fetch window — always stay protected. Fallback
@@ -698,7 +705,8 @@ fn canonicalize_current_window_ids(incoming: &[&GitHubCISnapshot]) -> Vec<String
 }
 
 /// Same canonical form for an already-pinned identity set (merge/load
-/// paths): deduplicated, order-stable, hard-capped keeping the newest.
+/// paths): deduplicated, order-stable, hard-capped keeping the newest within
+/// this one scope.
 fn canonicalize_current_window_ids_from(ids: &[String]) -> Vec<String> {
     cap_window_ids(canonical_window_identities(ids.iter().cloned()))
 }
@@ -718,7 +726,7 @@ fn canonical_window_identities(identities: impl Iterator<Item = String>) -> Vec<
 /// Applies the explicit window bound. Identities are oldest-first, so
 /// trimming drops from the front and the newest survive.
 fn cap_window_ids(mut ids: Vec<String>) -> Vec<String> {
-    let excess = ids.len().saturating_sub(MAX_CURRENT_WINDOW_IDS);
+    let excess = ids.len().saturating_sub(MAX_CURRENT_WINDOW_IDS_PER_SCOPE);
     ids.drain(..excess);
     ids
 }
@@ -759,16 +767,10 @@ fn canonicalize_loaded_window(repo_baseline: &mut RepoCIBaseline) {
             .into_iter()
             .flat_map(|ids| ids.iter().cloned())
     });
-    repo_baseline.current_window_ids = cap_window_ids(canonical_window_identities(ids));
-    let retained: std::collections::HashSet<&str> = repo_baseline
-        .current_window_ids
-        .iter()
-        .map(String::as_str)
-        .collect();
-    repo_baseline.current_window_ids_by_scope.retain(|_, ids| {
-        ids.retain(|id| retained.contains(id.as_str()));
-        !ids.is_empty()
-    });
+    // This union is an index for retention, not another bounded window. Each
+    // scope was bounded independently above; truncating the union would drop
+    // valid sibling-scope protection.
+    repo_baseline.current_window_ids = canonical_window_identities(ids);
     repo_baseline.current_window_generations.retain(|scope, _| {
         repo_baseline
             .current_window_ids_by_scope
@@ -906,7 +908,14 @@ impl CIBaseline {
         repo_path: &str,
         current: &HashMap<String, GitHubCISnapshot>,
     ) -> bool {
-        self.record_terminal_runs_filtered(repo_key, repo_path, repo_path, current, |_| true)
+        self.record_terminal_runs_filtered(
+            repo_key,
+            repo_path,
+            repo_path,
+            current,
+            (0, true),
+            |_| true,
+        )
     }
 
     fn record_terminal_runs_filtered(
@@ -915,6 +924,7 @@ impl CIBaseline {
         repo_path: &str,
         window_scope: &str,
         current: &HashMap<String, GitHubCISnapshot>,
+        window: (u64, bool),
         include: impl Fn(&GitHubCISnapshot) -> bool,
     ) -> bool {
         let mut incoming: Vec<&GitHubCISnapshot> = current
@@ -939,15 +949,28 @@ impl CIBaseline {
                 dirty = true;
             }
         }
-        let generation = next_window_generation(repo_baseline.window_generation);
-        repo_baseline.window_generation = generation;
-        repo_baseline.current_window_ids_by_scope.insert(
-            window_scope.to_string(),
-            canonicalize_current_window_ids(&incoming),
-        );
-        repo_baseline
-            .current_window_generations
-            .insert(window_scope.to_string(), generation);
+        if window.1 {
+            let generation = if window.0 == 0 {
+                next_window_generation(repo_baseline.window_generation)
+            } else {
+                window.0
+            };
+            let existing_generation = repo_baseline
+                .current_window_generations
+                .get(window_scope)
+                .copied()
+                .unwrap_or(0);
+            if generation >= existing_generation {
+                repo_baseline.window_generation = repo_baseline.window_generation.max(generation);
+                repo_baseline.current_window_ids_by_scope.insert(
+                    window_scope.to_string(),
+                    canonicalize_current_window_ids(&incoming),
+                );
+                repo_baseline
+                    .current_window_generations
+                    .insert(window_scope.to_string(), generation);
+            }
+        }
         canonicalize_loaded_window(repo_baseline);
         let keep_ids: std::collections::HashSet<String> =
             repo_baseline.current_window_ids.iter().cloned().collect();
@@ -963,7 +986,8 @@ fn terminal_records_same_run(left: &TerminalRunRecord, right: &TerminalRunRecord
         return left_checks
             .iter()
             .any(|identity| right_checks.iter().any(|candidate| candidate == identity))
-            && run_attempt_or_one(left.run_attempt) == run_attempt_or_one(right.run_attempt);
+            && run_attempt_or_one(left.run_attempt) == run_attempt_or_one(right.run_attempt)
+            && left.conclusion == right.conclusion;
     }
     let left_unique: Vec<&str> = left.unique_identities().collect();
     let right_unique: Vec<&str> = right.unique_identities().collect();
@@ -971,7 +995,8 @@ fn terminal_records_same_run(left: &TerminalRunRecord, right: &TerminalRunRecord
         return left_unique
             .iter()
             .any(|identity| right_unique.contains(identity))
-            && run_attempt_or_one(left.run_attempt) == run_attempt_or_one(right.run_attempt);
+            && run_attempt_or_one(left.run_attempt) == run_attempt_or_one(right.run_attempt)
+            && left.conclusion == right.conclusion;
     }
     left.identities
         .iter()
@@ -1960,6 +1985,12 @@ async fn poll_github(
         let repo_key = ci_baseline_repo_key(&snapshot, repo);
         let _ = ci_baseline.repo_baseline_mut(&repo_key, &repo.path);
         let repo_ci_baseline = ci_baseline.repos.get(&repo_key).cloned();
+        let fetch_generation = next_window_generation(
+            repo_ci_baseline
+                .as_ref()
+                .map(|baseline| baseline.window_generation)
+                .unwrap_or(0),
+        );
         let (ci, ci_baseline_established, ci_events, window_complete) = match poll_ci_statuses(
             config,
             github_client,
@@ -2000,6 +2031,7 @@ async fn poll_github(
             &repo.path,
             &repo.path,
             &ci,
+            (fetch_generation, window_complete),
             |snapshot| {
                 if previous_ci.is_none() || window_complete {
                     return true;
@@ -3965,16 +3997,16 @@ mod tests {
         let repo = &baseline.repos["/repo"];
         assert_eq!(repo.current_window_ids, vec!["run:77:2", "check:555"]);
 
-        let many = (0..(MAX_CURRENT_WINDOW_IDS as u64 + 60))
+        let many = (0..(MAX_CURRENT_WINDOW_IDS_PER_SCOPE as u64 + 60))
             .map(|id| format!("run:{id}"))
             .collect::<Vec<_>>();
         let bounded = canonicalize_current_window_ids_from(&many);
-        assert_eq!(bounded.len(), MAX_CURRENT_WINDOW_IDS);
+        assert_eq!(bounded.len(), MAX_CURRENT_WINDOW_IDS_PER_SCOPE);
         assert!(
             bounded.iter().all(|id| id.starts_with("run:")),
             "fallback identities must never be pinned"
         );
-        let pinned_newest = format!("run:{}", MAX_CURRENT_WINDOW_IDS as u64 + 59);
+        let pinned_newest = format!("run:{}", MAX_CURRENT_WINDOW_IDS_PER_SCOPE as u64 + 59);
         assert!(
             bounded.contains(&pinned_newest),
             "truncation must keep the newest window identities"
@@ -3985,7 +4017,7 @@ mod tests {
     fn issue_317_loaded_window_ids_are_rebounded() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("github-ci-baseline.json");
-        let mut ids: Vec<String> = (0..(MAX_CURRENT_WINDOW_IDS + 25) as u64)
+        let mut ids: Vec<String> = (0..(MAX_CURRENT_WINDOW_IDS_PER_SCOPE + 25) as u64)
             .map(|id| format!("run:{id}"))
             .collect();
         ids.push(ids[0].clone());
@@ -4002,7 +4034,7 @@ mod tests {
         let repo = &loaded.repos["/repo"];
         assert_eq!(
             repo.current_window_ids.len(),
-            MAX_CURRENT_WINDOW_IDS,
+            MAX_CURRENT_WINDOW_IDS_PER_SCOPE,
             "load must re-bound an over-long pinned window"
         );
         let mut unique = std::collections::HashSet::new();
@@ -4014,9 +4046,85 @@ mod tests {
         );
         assert_eq!(
             repo.current_window_ids.last().unwrap(),
-            &format!("run:{}", MAX_CURRENT_WINDOW_IDS as u64 + 24),
+            &format!("run:{}", MAX_CURRENT_WINDOW_IDS_PER_SCOPE as u64 + 24),
             "the load bound must keep the newest pinned identities"
         );
+    }
+
+    #[test]
+    fn issue_317_large_sibling_scopes_keep_their_full_protected_union() {
+        let old_global_cap = CI_PAGE_SIZE * MAX_CI_PAGES * (CI_PAGE_SIZE + 1) * 2;
+        let scope_size = old_global_cap + 1;
+        let mut repo = RepoCIBaseline::default();
+        repo.current_window_ids_by_scope.insert(
+            "branch-a".into(),
+            (0..scope_size).map(|id| format!("run:a-{id}")).collect(),
+        );
+        repo.current_window_ids_by_scope.insert(
+            "branch-b".into(),
+            (0..scope_size).map(|id| format!("run:b-{id}")).collect(),
+        );
+        canonicalize_loaded_window(&mut repo);
+        assert_eq!(repo.current_window_ids.len(), scope_size * 2);
+        assert!(repo.current_window_ids.contains(&"run:a-0".to_string()));
+        assert!(repo.current_window_ids.contains(&"run:b-0".to_string()));
+    }
+
+    #[test]
+    fn issue_317_partial_restart_poll_preserves_authoritative_scope() {
+        let mut baseline = CIBaseline::default();
+        let first = run_snapshot(1, "CI", Some("success"), "main");
+        let second = run_snapshot(2, "CI", Some("failure"), "main");
+        baseline.record_terminal_runs("/repo", "/repo", &run_map(std::slice::from_ref(&first)));
+        let generation = baseline.repos["/repo"].window_generation + 1;
+        baseline.record_terminal_runs_filtered(
+            "/repo",
+            "/repo",
+            "/repo",
+            &run_map(&[second]),
+            (generation, false),
+            |_| true,
+        );
+        let ids = &baseline.repos["/repo"].current_window_ids_by_scope["/repo"];
+        assert!(ids.contains(&"run:1".to_string()));
+        assert!(!ids.contains(&"run:2".to_string()));
+    }
+
+    #[test]
+    fn issue_317_out_of_order_window_response_cannot_overwrite_newer_generation() {
+        let mut baseline = CIBaseline::default();
+        let fresh = run_snapshot(20, "CI", Some("success"), "main");
+        let stale = run_snapshot(10, "CI", Some("success"), "main");
+        baseline.record_terminal_runs_filtered(
+            "/repo",
+            "/repo",
+            "/repo",
+            &run_map(&[fresh]),
+            (20, true),
+            |_| true,
+        );
+        baseline.record_terminal_runs_filtered(
+            "/repo",
+            "/repo",
+            "/repo",
+            &run_map(&[stale]),
+            (10, true),
+            |_| true,
+        );
+        let ids = &baseline.repos["/repo"].current_window_ids_by_scope["/repo"];
+        assert!(ids.contains(&"run:20".to_string()));
+        assert!(!ids.contains(&"run:10".to_string()));
+    }
+
+    #[test]
+    fn issue_317_same_attempt_conclusion_change_is_not_suppressed_after_merge() {
+        let success = check_job(42, 7, "CI", "success");
+        let mut failure = check_job(42, 7, "CI", "failure");
+        failure.run_attempt = success.run_attempt;
+        let success_record = TerminalRunRecord::from_snapshot(&success);
+        let failure_record = TerminalRunRecord::from_snapshot(&failure);
+        assert!(!success_record.matches_snapshot(&failure));
+        assert!(!terminal_records_same_run(&success_record, &failure_record));
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -835,8 +835,9 @@ fn persist_pending_send_attempts(
     items: &[PendingCiDelivery],
     now: u64,
 ) -> Result<()> {
-    bump_pending_send_attempts(ci_baseline, items, now);
-    *ci_baseline = commit_ci_baseline(path, ci_baseline)?;
+    let mut next = ci_baseline.clone();
+    bump_pending_send_attempts(&mut next, items, now);
+    *ci_baseline = commit_ci_baseline(path, &next)?;
     Ok(())
 }
 
@@ -1617,9 +1618,13 @@ fn collect_ci_events(
         let old = previous_snapshot(previous, ci);
         let changed = match old {
             Some(old) => {
-                old.status != ci.status
-                    || old.conclusion != ci.conclusion
-                    || old.run_all_terminal != ci.run_all_terminal
+                if ci.is_terminal() {
+                    !old.is_terminal() || old.conclusion != ci.conclusion
+                } else if ci.status != "completed" {
+                    old.status != ci.status || old.conclusion != ci.conclusion
+                } else {
+                    false
+                }
             }
             None => {
                 if ci.status != "completed" {
@@ -3397,6 +3402,86 @@ mod tests {
             stored[0].send_attempts >= 1,
             "durable attempt must be recorded before any send"
         );
+    }
+
+    #[test]
+    fn issue_317_failed_pre_send_persist_does_not_consume_retry_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("blocked");
+        std::fs::write(&blocker, b"file").unwrap();
+        let bad_path = blocker.join("github-ci-baseline.json");
+        let run = run_snapshot(77, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events,
+            &run_map(std::slice::from_ref(&run)),
+        );
+        let pending = ci_baseline.repos["/repo"].pending.clone();
+        assert!(
+            persist_pending_send_attempts(&mut ci_baseline, Some(&bad_path), &pending, unix_now())
+                .is_err()
+        );
+        assert_eq!(ci_baseline.repos["/repo"].pending[0].send_attempts, 0);
+        assert!(pending_due_for_send(
+            &ci_baseline.repos["/repo"].pending[0],
+            unix_now()
+        ));
+    }
+
+    #[test]
+    fn issue_317_in_progress_to_partial_complete_does_not_emit_until_all_jobs() {
+        let started = GitHubCISnapshot {
+            status: "in_progress".into(),
+            conclusion: None,
+            run_all_terminal: false,
+            run_job_count: 2,
+            ..run_snapshot(77, "CI", Some("success"), "main")
+        };
+        let partial = GitHubCISnapshot {
+            status: "completed".into(),
+            conclusion: Some("success".into()),
+            run_all_terminal: false,
+            run_job_count: 2,
+            ..run_snapshot(77, "CI", Some("success"), "main")
+        };
+        let complete = GitHubCISnapshot {
+            run_all_terminal: true,
+            run_job_count: 2,
+            ..run_snapshot(77, "CI", Some("success"), "main")
+        };
+        let repo = GitRepoMonitor::default();
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true,
+            &run_map(std::slice::from_ref(&started)),
+            &run_map(std::slice::from_ref(&partial)),
+            None,
+        );
+        assert!(
+            events.is_empty(),
+            "in-progress to completed-but-not-all-jobs must not publish"
+        );
+        let events = collect_ci_events(
+            &repo,
+            "org/repo",
+            true,
+            &run_map(std::slice::from_ref(&partial)),
+            &run_map(std::slice::from_ref(&complete)),
+            None,
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-passed");
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -116,6 +116,11 @@ struct RepoCIBaseline {
     /// dropped by a fenced stale writer.
     #[serde(default)]
     current_window_ids: Vec<String>,
+    /// Independently fetched windows keyed by monitor scope. Windows are
+    /// merged rather than selected by receipt recency so branch/checkout
+    /// scopes cannot evict one another's live receipts.
+    #[serde(default)]
+    current_window_ids_by_scope: HashMap<String, Vec<String>>,
 }
 
 /// Durable receipt for one terminal run. Identities are aliases (run-id,
@@ -482,7 +487,11 @@ const MAX_BASELINE_RUNS_PER_REPO: usize = CI_PAGE_SIZE * MAX_CI_PAGES;
 /// check-run ids) and an oversized fetch can exceed the receipt cap;
 /// protection stops here so alias multiplication cannot grow the pinned
 /// window unboundedly.
-const MAX_CURRENT_WINDOW_IDS: usize = MAX_BASELINE_RUNS_PER_REPO * 4;
+// Pull-request inventory is fetched with the GitHub API's 100-item page cap
+// and is not paginated here. The aggregate CI window is therefore bounded by
+// 100 PR windows plus the direct push window, with two durable aliases per
+// snapshot. Keep the protection bound above that actual fetched scope.
+const MAX_CURRENT_WINDOW_IDS: usize = CI_PAGE_SIZE * MAX_CI_PAGES * (CI_PAGE_SIZE + 1) * 2;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
 const ACK_RETENTION_SECS: u64 = 7 * 24 * 3_600;
@@ -700,16 +709,6 @@ fn canonicalize_current_window_ids_from(ids: &[String]) -> Vec<String> {
 /// pinned receipts are the newest reflects the latest GitHub fetch state
 /// and stays protected; a writer whose window pins only older receipts
 /// (restart with a stale view, fenced writer) must not evict or replace it.
-fn window_recency_key(repo: &RepoCIBaseline) -> Option<(u8, String, u64, String)> {
-    let pinned: std::collections::HashSet<&str> =
-        repo.current_window_ids.iter().map(String::as_str).collect();
-    repo.terminal_runs
-        .iter()
-        .filter(|record| record.unique_identities().any(|id| pinned.contains(id)))
-        .map(TerminalRunRecord::eviction_key)
-        .max()
-}
-
 fn canonical_window_identities(identities: impl Iterator<Item = String>) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     identities
@@ -729,8 +728,36 @@ fn cap_window_ids(mut ids: Vec<String>) -> Vec<String> {
 /// store a canonicalized set; this only guards files written by older or
 /// differently-shaped writers.
 fn canonicalize_loaded_window(repo_baseline: &mut RepoCIBaseline) {
-    repo_baseline.current_window_ids =
-        canonicalize_current_window_ids_from(&repo_baseline.current_window_ids);
+    if repo_baseline.current_window_ids_by_scope.is_empty()
+        && !repo_baseline.current_window_ids.is_empty()
+    {
+        repo_baseline.current_window_ids_by_scope.insert(
+            "legacy".to_string(),
+            repo_baseline.current_window_ids.clone(),
+        );
+    }
+    let mut scopes: Vec<(String, Vec<String>)> = repo_baseline
+        .current_window_ids_by_scope
+        .drain()
+        .map(|(scope, ids)| (scope, canonicalize_current_window_ids_from(&ids)))
+        .filter(|(_, ids)| !ids.is_empty())
+        .collect();
+    scopes.sort_by(|left, right| left.0.cmp(&right.0));
+    repo_baseline.current_window_ids_by_scope = scopes.into_iter().collect();
+    let ids = repo_baseline
+        .current_window_ids_by_scope
+        .values()
+        .flat_map(|ids| ids.iter().cloned());
+    repo_baseline.current_window_ids = cap_window_ids(canonical_window_identities(ids));
+    let retained: std::collections::HashSet<&str> = repo_baseline
+        .current_window_ids
+        .iter()
+        .map(String::as_str)
+        .collect();
+    repo_baseline.current_window_ids_by_scope.retain(|_, ids| {
+        ids.retain(|id| retained.contains(id.as_str()));
+        !ids.is_empty()
+    });
 }
 
 fn cap_repo_baseline_keeping_ids(
@@ -855,13 +882,14 @@ impl CIBaseline {
         repo_path: &str,
         current: &HashMap<String, GitHubCISnapshot>,
     ) -> bool {
-        self.record_terminal_runs_filtered(repo_key, repo_path, current, |_| true)
+        self.record_terminal_runs_filtered(repo_key, repo_path, repo_path, current, |_| true)
     }
 
     fn record_terminal_runs_filtered(
         &mut self,
         repo_key: &str,
         repo_path: &str,
+        window_scope: &str,
         current: &HashMap<String, GitHubCISnapshot>,
         include: impl Fn(&GitHubCISnapshot) -> bool,
     ) -> bool {
@@ -887,7 +915,11 @@ impl CIBaseline {
                 dirty = true;
             }
         }
-        repo_baseline.current_window_ids = canonicalize_current_window_ids(&incoming);
+        repo_baseline.current_window_ids_by_scope.insert(
+            window_scope.to_string(),
+            canonicalize_current_window_ids(&incoming),
+        );
+        canonicalize_loaded_window(repo_baseline);
         dirty |= cap_repo_baseline_keeping(repo_baseline, &incoming);
         dirty
     }
@@ -1017,24 +1049,21 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     // its window can cap-evict nothing from the pinned current window and
     // must not replace it either.
     let source_stale = dest.min_writer_epoch > 0 && source.epoch < dest.min_writer_epoch;
-    // Window authority is epoch-fenced recency: the window whose pinned
-    // receipts are newest reflects the latest GitHub fetch. A writer whose
-    // window pins only older receipts (restart with a stale view, fenced
-    // writer) must not evict or replace the live window, while a writer
-    // carrying genuinely newer receipts does supersede it.
-    let source_authoritative = !source_stale
-        && match (window_recency_key(dest), window_recency_key(&source)) {
-            (Some(dest_key), Some(source_key)) => source_key >= dest_key,
-            (None, _) => true,
-            _ => false,
-        };
-    // Eviction protection pins only the authoritative window: pinning both
-    // would pin two windows and defeat the bounded cap.
-    let keep_ids: std::collections::HashSet<String> = if source_authoritative {
-        source.current_window_ids.iter().cloned().collect()
-    } else {
-        dest.current_window_ids.iter().cloned().collect()
-    };
+    canonicalize_loaded_window(dest);
+    let mut source_windows = source.current_window_ids_by_scope;
+    if source_windows.is_empty() && !source.current_window_ids.is_empty() {
+        source_windows.insert("legacy".to_string(), source.current_window_ids);
+    }
+    for (scope, ids) in source_windows {
+        if source_stale {
+            dest.current_window_ids_by_scope.entry(scope).or_insert(ids);
+        } else {
+            dest.current_window_ids_by_scope.insert(scope, ids);
+        }
+    }
+    canonicalize_loaded_window(dest);
+    let keep_ids: std::collections::HashSet<String> =
+        dest.current_window_ids.iter().cloned().collect();
     for record in source.terminal_runs {
         if let Some(existing) = dest
             .terminal_runs
@@ -1057,9 +1086,6 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
         }
     }
     cap_repo_baseline_keeping_ids(dest, &keep_ids);
-    if source_authoritative {
-        dest.current_window_ids = canonicalize_current_window_ids_from(&source.current_window_ids);
-    }
     dest.epoch = dest.epoch.max(source.epoch);
     dest.min_writer_epoch = dest.min_writer_epoch.max(source.min_writer_epoch);
     dest.ci_established = dest.ci_established || source.ci_established;
@@ -1920,19 +1946,25 @@ async fn poll_github(
         // from the outbox on the next poll.
         let mut next_baseline = ci_baseline.clone();
         let previous_ci = previous.map(|entry| &entry.ci);
-        next_baseline.record_terminal_runs_filtered(&repo_key, &repo.path, &ci, |snapshot| {
-            if previous_ci.is_none() || window_complete {
-                return true;
-            }
-            previous_ci.is_some_and(|old_map| {
-                old_map
-                    .values()
-                    .any(|old| snapshots_same_run(old, snapshot) && old.is_terminal())
-            }) || ci_events.iter().any(|event| {
-                previous_snapshot_for_event(&ci, event)
-                    .is_some_and(|matched| snapshots_same_run(matched, snapshot))
-            })
-        });
+        next_baseline.record_terminal_runs_filtered(
+            &repo_key,
+            &repo.path,
+            &repo.path,
+            &ci,
+            |snapshot| {
+                if previous_ci.is_none() || window_complete {
+                    return true;
+                }
+                previous_ci.is_some_and(|old_map| {
+                    old_map
+                        .values()
+                        .any(|old| snapshots_same_run(old, snapshot) && old.is_terminal())
+                }) || ci_events.iter().any(|event| {
+                    previous_snapshot_for_event(&ci, event)
+                        .is_some_and(|matched| snapshots_same_run(matched, snapshot))
+                })
+            },
+        );
         next_baseline.enqueue_pending(&repo_key, &repo.path, &ci_events, &ci);
         if ci_baseline_established {
             next_baseline
@@ -2573,9 +2605,10 @@ async fn fetch_ci_statuses(
 
     let mut attempts_by_run = HashMap::new();
     for (_, pr) in open_prs {
-        let pr_attempts =
+        let (pr_attempts, attempts_complete) =
             fetch_workflow_attempts_by_head_sha(client, api_base, &github_repo, &pr.head_sha)
                 .await?;
+        window_complete &= attempts_complete;
         for (run_id, attempt) in pr_attempts {
             attempts_by_run
                 .entry(run_id)
@@ -2811,9 +2844,10 @@ async fn fetch_workflow_attempts_by_head_sha(
     api_base: &str,
     github_repo: &str,
     head_sha: &str,
-) -> Result<HashMap<String, u32>> {
+) -> Result<(HashMap<String, u32>, bool)> {
     let mut attempts = HashMap::new();
     let mut page = 1_usize;
+    let mut complete = true;
     loop {
         let page_str = page.to_string();
         let response = github_get(
@@ -2838,12 +2872,16 @@ async fn fetch_workflow_attempts_by_head_sha(
                 .and_modify(|existing: &mut u32| *existing = (*existing).max(attempt))
                 .or_insert(attempt);
         }
-        if !has_next || page_len < CI_PAGE_SIZE || page >= MAX_CI_PAGES {
+        if !has_next || page_len < CI_PAGE_SIZE {
+            break;
+        }
+        if page >= MAX_CI_PAGES {
+            complete = false;
             break;
         }
         page += 1;
     }
-    Ok(attempts)
+    Ok((attempts, complete))
 }
 
 fn workflow_run_id(url: &str) -> Option<String> {
@@ -3720,6 +3758,7 @@ mod tests {
         let path = dir.path().join("github-ci-baseline.json");
         let mut live = CIBaseline::default();
         live.record_terminal_runs("/repo", "/repo", &run_map(&current));
+        live.repos.get_mut("/repo").unwrap().min_writer_epoch = 1;
         save_ci_baseline(&live, Some(&path)).unwrap();
         let committed_epoch = load_ci_baseline(Some(&path)).repos["/repo"].epoch;
 
@@ -3777,25 +3816,18 @@ mod tests {
         let repo = &baseline.repos["/repo"];
         assert_eq!(repo.current_window_ids, vec!["run:77:2", "check:555"]);
 
-        let mut many = Vec::new();
-        for id in 0..(MAX_CURRENT_WINDOW_IDS as u64 + 60) {
-            let mut run = run_snapshot(id, "CI", Some("success"), "main");
-            run.created_at = Some(format!("2026-01-01T00:{:02}:{:02}Z", id / 60, id % 60));
-            many.push(run);
-        }
-        let mut oversized = CIBaseline::default();
-        oversized.record_terminal_runs("/repo", "/repo", &run_map(&many));
-        let repo = &oversized.repos["/repo"];
-        assert_eq!(repo.current_window_ids.len(), MAX_CURRENT_WINDOW_IDS);
+        let many = (0..(MAX_CURRENT_WINDOW_IDS as u64 + 60))
+            .map(|id| format!("run:{id}"))
+            .collect::<Vec<_>>();
+        let bounded = canonicalize_current_window_ids_from(&many);
+        assert_eq!(bounded.len(), MAX_CURRENT_WINDOW_IDS);
         assert!(
-            repo.current_window_ids
-                .iter()
-                .all(|id| id.starts_with("run:")),
+            bounded.iter().all(|id| id.starts_with("run:")),
             "fallback identities must never be pinned"
         );
         let pinned_newest = format!("run:{}", MAX_CURRENT_WINDOW_IDS as u64 + 59);
         assert!(
-            repo.current_window_ids.contains(&pinned_newest),
+            bounded.contains(&pinned_newest),
             "truncation must keep the newest window identities"
         );
     }

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -403,7 +403,10 @@ impl TerminalRunRecord {
     }
 
     fn eviction_key(&self) -> (u8, String, u64, String) {
-        let created_rank = u8::from(self.created_at.is_none());
+        // Unknown-age legacy receipts sort first so they evict before
+        // timestamped records. Tie-break by created_at, then run_id, then
+        // identity so mixed load/commit is deterministic.
+        let created_rank = u8::from(self.created_at.is_some());
         let created = self.created_at.clone().unwrap_or_default();
         let run_num = self
             .run_id
@@ -1782,9 +1785,10 @@ async fn fetch_ci_statuses(
         }
     }
 
-    let (workflow_runs, complete) =
+    let (workflow_runs, complete, attempts_by_run) =
         fetch_direct_workflow_runs(client, api_base, &github_repo, snapshot).await?;
     window_complete &= complete;
+    apply_workflow_run_attempts(&mut check_runs, &attempts_by_run);
     for workflow_run in workflow_runs {
         if workflow_run
             .run_id
@@ -1879,6 +1883,7 @@ async fn fetch_check_runs(
                     .and_then(|id| run_summaries.get(id).copied())
                     .unwrap_or((1, check_run.status == "completed"));
                 let run_all_terminal = summarized_terminal && window_complete;
+                let run_attempt = run_attempt_from_url(&url);
                 GitHubCISnapshot {
                     pr_number: Some(pr_number),
                     workflow: check_run.name,
@@ -1888,7 +1893,7 @@ async fn fetch_check_runs(
                     url,
                     branch: Some(pr.head_branch.clone()),
                     run_id,
-                    run_attempt: 1,
+                    run_attempt,
                     check_run_id: (check_run.id != 0).then(|| check_run.id.to_string()),
                     created_at: check_run.started_at.or(check_run.completed_at),
                     run_job_count,
@@ -1918,17 +1923,13 @@ async fn fetch_direct_workflow_runs(
     api_base: &str,
     github_repo: &str,
     snapshot: &GitSnapshot,
-) -> Result<(Vec<GitHubCISnapshot>, bool)> {
+) -> Result<(Vec<GitHubCISnapshot>, bool, HashMap<String, u32>)> {
     let mut all_runs = Vec::new();
     let mut page = 1_usize;
     let mut window_complete = true;
     loop {
         let page_str = page.to_string();
-        let mut query = vec![
-            ("per_page", "100"),
-            ("event", "push"),
-            ("page", page_str.as_str()),
-        ];
+        let mut query = vec![("per_page", "100"), ("page", page_str.as_str())];
         if !snapshot.branch.is_empty() {
             query.push(("branch", snapshot.branch.as_str()));
         }
@@ -1959,6 +1960,14 @@ async fn fetch_direct_workflow_runs(
         }
     }
 
+    let mut attempts_by_run = HashMap::new();
+    for run in &all_runs {
+        let attempt = run_attempt_or_one(run.run_attempt);
+        attempts_by_run
+            .entry(run.id.to_string())
+            .and_modify(|existing: &mut u32| *existing = (*existing).max(attempt))
+            .or_insert(attempt);
+    }
     Ok((
         all_runs
             .into_iter()
@@ -1985,6 +1994,7 @@ async fn fetch_direct_workflow_runs(
             })
             .collect(),
         window_complete,
+        attempts_by_run,
     ))
 }
 
@@ -1994,6 +2004,33 @@ fn workflow_run_id(url: &str) -> Option<String> {
         .and_then(|tail| tail.split('/').next())
         .filter(|part| !part.is_empty())
         .map(ToString::to_string)
+}
+
+fn run_attempt_from_url(url: &str) -> u32 {
+    url.split("/attempts/")
+        .nth(1)
+        .and_then(|tail| tail.split('/').next())
+        .and_then(|part| part.parse::<u32>().ok())
+        .filter(|attempt| *attempt >= 1)
+        .unwrap_or(1)
+}
+
+fn apply_workflow_run_attempts(
+    snapshots: &mut HashMap<String, GitHubCISnapshot>,
+    attempts: &HashMap<String, u32>,
+) {
+    if attempts.is_empty() {
+        return;
+    }
+    let existing: Vec<GitHubCISnapshot> = snapshots.drain().map(|(_, snapshot)| snapshot).collect();
+    for mut snapshot in existing {
+        if let Some(run_id) = &snapshot.run_id
+            && let Some(&attempt) = attempts.get(run_id)
+        {
+            snapshot.run_attempt = snapshot.run_attempt.max(attempt);
+        }
+        snapshots.insert(snapshot.dedupe_key(), snapshot);
+    }
 }
 
 fn build_github_client(token: Option<String>) -> Result<reqwest::Client> {
@@ -2782,6 +2819,161 @@ mod tests {
         assert!(!repo.contains_identity("run:19"));
         assert!(repo.contains_identity("run:20"));
         assert!(repo.contains_identity(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 19)));
+    }
+
+    #[test]
+    fn issue_317_mixed_legacy_eviction_keeps_timestamped_and_survives_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut records = Vec::new();
+        for id in 0..MAX_BASELINE_RUNS_PER_REPO {
+            records.push(format!(r#"{{"identities":["run:{id}"],"run_id":"{id}"}}"#));
+        }
+        let payload = format!(r#"{{"/repo":{{"terminal_runs":[{}]}}}}"#, records.join(","));
+        std::fs::write(&path, payload).unwrap();
+
+        let mut incoming = CIBaseline::default();
+        let mut fresh = run_snapshot(9_999, "CI", Some("success"), "main");
+        fresh.created_at = Some("2026-08-19T12:00:00Z".into());
+        incoming.record_terminal_runs("/repo", "/repo", &run_map(std::slice::from_ref(&fresh)));
+        commit_ci_baseline(Some(&path), &incoming).unwrap();
+
+        let loaded = load_ci_baseline(Some(&path));
+        let repo = &loaded.repos["/repo"];
+        assert_eq!(repo.terminal_runs.len(), MAX_BASELINE_RUNS_PER_REPO);
+        assert!(
+            repo.contains_identity("run:9999"),
+            "timestamped receipt must outrank unknown-age legacy records"
+        );
+        assert!(!repo.contains_identity("run:0"));
+
+        let restarted = load_ci_baseline(Some(&path));
+        assert!(restarted.repos["/repo"].contains_identity("run:9999"));
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&fresh)),
+            restarted.repos.get("/repo"),
+        );
+        assert!(
+            events.is_empty(),
+            "restart must still suppress the retained timestamped receipt"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_317_pr_check_rerun_attempt_is_distinct_on_production_path() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut check_polls = 0_u32;
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut buf = vec![0_u8; 4096];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                let body = if request.contains("/pulls") {
+                    r#"[{"number":42,"title":"PR","state":"open","html_url":"https://github.com/org/repo/pull/42","head":{"ref":"feat/pr","sha":"prsha"}}]"#.to_string()
+                } else if request.contains("/check-runs") {
+                    check_polls += 1;
+                    if check_polls <= 2 {
+                        r#"{"check_runs":[{"id":11,"name":"CI","status":"completed","conclusion":"success","details_url":"https://github.com/org/repo/actions/runs/4242/jobs/11","head_sha":"prsha"}]}"#.to_string()
+                    } else {
+                        r#"{"check_runs":[{"id":22,"name":"CI","status":"completed","conclusion":"failure","details_url":"https://github.com/org/repo/actions/runs/4242/attempts/2/jobs/22","head_sha":"prsha"}]}"#.to_string()
+                    }
+                } else if request.contains("/actions/runs") {
+                    if check_polls <= 2 {
+                        r#"{"workflow_runs":[{"id":4242,"name":"CI","status":"completed","conclusion":"success","head_branch":"feat/pr","head_sha":"prsha","html_url":"https://github.com/org/repo/actions/runs/4242","run_attempt":1,"pull_requests":[{"number":42}]}]}"#.to_string()
+                    } else {
+                        r#"{"workflow_runs":[{"id":4242,"name":"CI","status":"completed","conclusion":"failure","head_branch":"feat/pr","head_sha":"prsha","html_url":"https://github.com/org/repo/actions/runs/4242/attempts/2","run_attempt":2,"pull_requests":[{"number":42}]}]}"#.to_string()
+                    }
+                } else {
+                    "[]".to_string()
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nconnection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let baseline_path = dir.path().join("github-ci-baseline.json");
+        let mut config = AppConfig::default();
+        config.monitors.github_api_base = format!("http://{addr}");
+        config.monitors.git.repos = vec![GitRepoMonitor {
+            path: "/tmp/pr-rerun".into(),
+            name: Some("repo".into()),
+            github_repo: Some("org/repo".into()),
+            emit_pr_status: true,
+            emit_issue_opened: false,
+            emit_commits: false,
+            emit_branch_changes: false,
+            ..GitRepoMonitor::default()
+        }];
+        let client = build_github_client(None).unwrap();
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut state = HashMap::new();
+        let mut baseline = CIBaseline::default();
+        poll_once_with_baseline(
+            &config,
+            &client,
+            &mut state,
+            &mut baseline,
+            Some(&baseline_path),
+            &tx,
+        )
+        .await
+        .unwrap();
+        assert!(rx.try_recv().is_err(), "first poll primes attempt 1");
+
+        let mut state = HashMap::new();
+        let mut baseline = load_ci_baseline(Some(&baseline_path));
+        poll_once_with_baseline(
+            &config,
+            &client,
+            &mut state,
+            &mut baseline,
+            Some(&baseline_path),
+            &tx,
+        )
+        .await
+        .unwrap();
+        assert!(rx.try_recv().is_err(), "restart prime must not replay attempt 1");
+        poll_once_with_baseline(
+            &config,
+            &client,
+            &mut state,
+            &mut baseline,
+            Some(&baseline_path),
+            &tx,
+        )
+        .await
+        .unwrap();
+        let mut delivered = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            delivered.push(event);
+        }
+        assert_eq!(delivered.len(), 1, "attempt 2 must deliver exactly once");
+        assert_eq!(delivered[0].canonical_kind(), "github.ci-failed");
+        assert_eq!(delivered[0].payload["run_id"], json!("4242"));
+        assert_eq!(delivered[0].payload["run_attempt"], json!(2));
+        let stored = load_ci_baseline(Some(&baseline_path));
+        let repo = stored
+            .repos
+            .values()
+            .find(|repo| repo.contains_identity("run:4242") || repo.contains_identity("run:4242:2"))
+            .expect("repo baseline");
+        assert!(repo.contains_identity("run:4242"));
+        assert!(repo.contains_identity("run:4242:2"));
+        server.abort();
     }
 
     #[test]
@@ -4074,7 +4266,6 @@ mod tests {
         let req = server.await.unwrap();
         assert!(req.contains("GET /repos/ultraworkers/claw-code/actions/runs?"));
         assert!(req.contains("branch=main"));
-        assert!(req.contains("event=push"));
         assert!(req.contains("per_page=100"));
     }
 
@@ -4193,7 +4384,6 @@ mod tests {
         assert!(requests[0].contains("GET /repos/org/repo/commits/prsha/check-runs?"));
         assert!(requests[1].contains("GET /repos/org/repo/actions/runs?"));
         assert!(requests[1].contains("branch=main"));
-        assert!(requests[1].contains("event=push"));
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1298,25 +1298,25 @@ async fn send_then_ack_prefix(
     tx: &mpsc::Sender<IncomingEvent>,
     ci_baseline: &mut CIBaseline,
     path: Option<&Path>,
-    events: Vec<IncomingEvent>,
+    _events: Vec<IncomingEvent>,
     delivered: &[PendingCiDelivery],
 ) -> Result<()> {
-    for (event, delivery) in events.into_iter().zip(delivered.iter()) {
+    for delivery in delivered {
         persist_pending_send_attempts(
             ci_baseline,
             path,
             std::slice::from_ref(delivery),
             unix_now(),
         )?;
-        if !outbox_contains(ci_baseline, delivery) {
+        let Some(durable) = outbox_entry(ci_baseline, delivery) else {
             continue;
-        }
-        match send_event(tx, event).await {
+        };
+        match send_event(tx, durable.clone().into_event()).await {
             Ok(()) => {
-                ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(delivery))?;
+                ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(&durable))?;
             }
             Err(error) => {
-                dead_letter_unsent_final_attempts(ci_baseline, std::slice::from_ref(delivery));
+                dead_letter_unsent_final_attempts(ci_baseline, std::slice::from_ref(&durable));
                 let _ = commit_ci_baseline(path, ci_baseline);
                 return Err(error);
             }
@@ -1344,16 +1344,16 @@ async fn drain_pending_outbox(
             eprintln!("clawhip source github CI baseline outbox attempt persist failed");
             return Ok(());
         }
-        if !outbox_contains(ci_baseline, &delivery) {
+        let Some(durable) = outbox_entry(ci_baseline, &delivery) else {
             continue;
-        }
-        if send_event(tx, delivery.clone().into_event()).await.is_err() {
-            dead_letter_unsent_final_attempts(ci_baseline, std::slice::from_ref(&delivery));
+        };
+        if send_event(tx, durable.clone().into_event()).await.is_err() {
+            dead_letter_unsent_final_attempts(ci_baseline, std::slice::from_ref(&durable));
             let _ = commit_ci_baseline(path, ci_baseline);
             return Ok(());
         }
         if let Err(error) =
-            ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(&delivery))
+            ack_pending_deliveries(ci_baseline, path, std::slice::from_ref(&durable))
         {
             eprintln!("clawhip source github CI baseline outbox ack failed: {error}");
         }
@@ -1361,12 +1361,26 @@ async fn drain_pending_outbox(
     Ok(())
 }
 
-fn outbox_contains(ci_baseline: &CIBaseline, delivery: &PendingCiDelivery) -> bool {
-    ci_baseline.repos.values().any(|repo| {
-        repo.pending
-            .iter()
-            .any(|pending| pending.same_event(delivery) && pending.repo_name == delivery.repo_name)
-    })
+fn outbox_entry(
+    ci_baseline: &CIBaseline,
+    delivery: &PendingCiDelivery,
+) -> Option<PendingCiDelivery> {
+    for repo in ci_baseline.repos.values() {
+        if let Some(pending) = repo.pending.iter().find(|pending| {
+            pending.same_event(delivery)
+                && pending.repo_name == delivery.repo_name
+                && pending.channel == delivery.channel
+                && pending.mention == delivery.mention
+                && pending.format == delivery.format
+                && pending.template == delivery.template
+                && pending.url == delivery.url
+                && pending.status == delivery.status
+                && pending.branch == delivery.branch
+        }) {
+            return Some(pending.clone());
+        }
+    }
+    None
 }
 
 fn persist_pending_send_attempts(
@@ -1456,6 +1470,9 @@ fn merge_incomplete_ci(
     mut current: HashMap<String, GitHubCISnapshot>,
 ) -> HashMap<String, GitHubCISnapshot> {
     for old in previous.values() {
+        if current.contains_key(&old.dedupe_key()) {
+            continue;
+        }
         if current.values().any(|ci| snapshots_same_run(ci, old)) {
             continue;
         }
@@ -5387,6 +5404,30 @@ mod tests {
             "incomplete check-run pagination must not infer run_all_terminal"
         );
         server.abort();
+    }
+
+    #[test]
+    fn issue_317_incomplete_window_keeps_current_rerun_on_check_key_collision() {
+        let attempt1 = check_job(4242, 11, "CI", "success");
+        let attempt2 = GitHubCISnapshot {
+            run_attempt: 2,
+            check_run_id: Some("11".into()),
+            ..check_job(4242, 11, "CI", "success")
+        };
+        let previous = run_map(std::slice::from_ref(&attempt1));
+        let current = run_map(std::slice::from_ref(&attempt2));
+        let merged = merge_incomplete_ci(&previous, current);
+        let kept = merged.get(&attempt2.dedupe_key()).unwrap();
+        assert_eq!(kept.run_attempt(), 2);
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &previous,
+            &merged,
+            None,
+        );
+        assert_eq!(events.len(), 1);
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1296,11 +1296,15 @@ fn previous_snapshot_for_event<'a>(
     let payload = event.payload.as_object()?;
     let workflow = payload.get("workflow")?.as_str()?;
     let run_id = payload.get("run_id").and_then(|value| value.as_str());
+    let run_attempt = payload
+        .get("run_attempt")
+        .and_then(|value| value.as_u64())
+        .map(|value| value as u32)
+        .unwrap_or(1);
     previous.values().find(|ci| {
-        if let Some(run_id) = run_id
-            && ci.run_id.as_deref() == Some(run_id)
-        {
-            return true;
+        if let Some(run_id) = run_id {
+            return ci.run_id.as_deref() == Some(run_id)
+                && ci.run_attempt() == run_attempt_or_one(run_attempt);
         }
         ci.workflow == workflow
             && ci.sha
@@ -2830,6 +2834,73 @@ mod tests {
         commit_ci_baseline(Some(&path), &right).unwrap();
         let loaded = load_ci_baseline(Some(&path));
         assert_eq!(loaded.repos["/repo"].pending.len(), 2);
+    }
+
+    #[test]
+    fn issue_317_pending_recovery_does_not_match_across_run_attempts() {
+        let attempt1 = GitHubCISnapshot {
+            run_attempt: 1,
+            ..run_snapshot(4242, "CI", Some("success"), "main")
+        };
+        let attempt2 = GitHubCISnapshot {
+            run_attempt: 2,
+            conclusion: Some("failure".into()),
+            ..run_snapshot(4242, "CI", Some("failure"), "main")
+        };
+        let current = run_map(&[attempt1.clone(), attempt2.clone()]);
+        let events1 = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt1)),
+            None,
+        );
+        let events2 = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt2)),
+            None,
+        );
+        assert_eq!(
+            previous_snapshot_for_event(&current, &events1[0])
+                .unwrap()
+                .run_attempt(),
+            1
+        );
+        assert_eq!(
+            previous_snapshot_for_event(&current, &events2[0])
+                .unwrap()
+                .run_attempt(),
+            2
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.enqueue_pending("/repo", "/repo", &events1, &current);
+        ci_baseline.enqueue_pending("/repo", "/repo", &events2, &current);
+        save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
+
+        let restarted = load_ci_baseline(Some(&path));
+        assert_eq!(restarted.repos["/repo"].pending.len(), 2);
+        for pending in &restarted.repos["/repo"].pending {
+            let recovered = previous_snapshot_for_event(&current, &pending.clone().into_event())
+                .expect("pending must recover against its own attempt");
+            assert_eq!(
+                recovered.run_attempt(),
+                run_attempt_or_one(pending.run_attempt)
+            );
+            assert!(
+                recovered
+                    .unique_identities()
+                    .iter()
+                    .any(|identity| pending.identities.contains(identity)),
+                "recovered identities must stay on the same attempt"
+            );
+        }
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -177,10 +177,7 @@ impl AckedDelivery {
     }
 
     fn matches_pending(&self, pending: &PendingCiDelivery) -> bool {
-        if !self.repo_name.is_empty()
-            && !pending.repo_name.is_empty()
-            && self.repo_name != pending.repo_name
-        {
+        if self.repo_name != pending.repo_name {
             return false;
         }
         if self.kind != pending.kind || self.conclusion != pending.conclusion {
@@ -188,13 +185,22 @@ impl AckedDelivery {
         }
         let self_checks = pending_check_identities(&self.identities);
         let pending_checks = pending_check_identities(&pending.identities);
-        if !self_checks.is_empty() && !pending_checks.is_empty() {
-            return self_checks
-                .iter()
-                .any(|identity| pending_checks.iter().any(|candidate| candidate == identity));
-        }
         let self_has_run = self.run_id.is_some();
         let pending_has_run = pending.run_id.is_some();
+        if !self_checks.is_empty() && !pending_checks.is_empty() {
+            let check_match = self_checks
+                .iter()
+                .any(|identity| pending_checks.iter().any(|candidate| candidate == identity));
+            if !check_match {
+                return false;
+            }
+            if self_has_run && pending_has_run {
+                return self.run_id == pending.run_id
+                    && run_attempt_or_one(self.run_attempt)
+                        == run_attempt_or_one(pending.run_attempt);
+            }
+            return true;
+        }
         if self_has_run && pending_has_run {
             return self.run_id == pending.run_id
                 && run_attempt_or_one(self.run_attempt) == run_attempt_or_one(pending.run_attempt)
@@ -862,16 +868,17 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     dest.min_writer_epoch = dest.min_writer_epoch.max(source.min_writer_epoch);
     for acked in source.acked {
         if let Some(existing) = dest.acked.iter_mut().find(|candidate| {
-            candidate.kind == acked.kind
+            candidate.repo_name == acked.repo_name
+                && candidate.kind == acked.kind
                 && candidate.conclusion == acked.conclusion
+                && run_attempt_or_one(candidate.run_attempt)
+                    == run_attempt_or_one(acked.run_attempt)
                 && (pending_check_identities(&candidate.identities)
                     .iter()
                     .any(|identity| pending_check_identities(&acked.identities).contains(identity))
                     || (candidate.run_id.is_some()
                         && candidate.run_id == acked.run_id
-                        && candidate.workflow == acked.workflow
-                        && run_attempt_or_one(candidate.run_attempt)
-                            == run_attempt_or_one(acked.run_attempt)))
+                        && candidate.workflow == acked.workflow))
         }) {
             for identity in acked.identities {
                 if !existing.identities.iter().any(|item| item == &identity) {
@@ -1244,8 +1251,9 @@ fn ack_pending_deliveries(
         for repo in ci_baseline.repos.values_mut() {
             for delivery in delivered {
                 if repo.pending.iter().any(|pending| {
-                    pending.same_event(delivery)
-                        || AckedDelivery::from_pending(delivery, 0).matches_pending(pending)
+                    pending.repo_name == delivery.repo_name
+                        && (pending.same_event(delivery)
+                            || AckedDelivery::from_pending(delivery, 0).matches_pending(pending))
                 }) {
                     record_acked(repo, delivery);
                 }
@@ -1263,14 +1271,17 @@ fn ack_pending_deliveries(
         let local_repo = ci_baseline.repos.get(key);
         for delivery in delivered {
             let in_disk = repo.pending.iter().any(|pending| {
-                pending.same_event(delivery)
-                    || AckedDelivery::from_pending(delivery, 0).matches_pending(pending)
+                pending.repo_name == delivery.repo_name
+                    && (pending.same_event(delivery)
+                        || AckedDelivery::from_pending(delivery, 0).matches_pending(pending))
             });
             let in_local = local_repo
                 .map(|local| {
                     local.pending.iter().any(|pending| {
-                        pending.same_event(delivery)
-                            || AckedDelivery::from_pending(delivery, 0).matches_pending(pending)
+                        pending.repo_name == delivery.repo_name
+                            && (pending.same_event(delivery)
+                                || AckedDelivery::from_pending(delivery, 0)
+                                    .matches_pending(pending))
                     })
                 })
                 .unwrap_or(false);

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -73,7 +74,7 @@ impl Source for GitHubSource {
 /// restart and re-enrollment so historical workflow results never replay as
 /// fresh events (#317). Bounded: at most [`MAX_BASELINE_RUNS_PER_REPO`]
 /// records per repo, evicted oldest-first by GitHub timestamps / run ids.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct CIBaseline {
     repos: HashMap<String, RepoCIBaseline>,
 }
@@ -83,12 +84,14 @@ struct RepoCIBaseline {
     /// Terminal run records observed for this repo, oldest evicted first.
     #[serde(default, deserialize_with = "deserialize_terminal_runs")]
     terminal_runs: VecDeque<TerminalRunRecord>,
+    /// Durable outbox: events persisted before publish and retried after a
+    /// crash between the write and the channel send.
+    #[serde(default)]
+    pending: Vec<PendingCiDelivery>,
 }
 
 /// Durable receipt for one terminal run. Identities are aliases (run-id,
-/// check-run id, fallback) so representation drift still suppresses. Receipt
-/// records the persist-before-publish contract: a delivered event is always
-/// already in this set.
+/// check-run id, fallback) so representation drift still suppresses.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct TerminalRunRecord {
     identities: Vec<String>,
@@ -96,6 +99,113 @@ struct TerminalRunRecord {
     run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     created_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct PendingCiDelivery {
+    identities: Vec<String>,
+    kind: String,
+    repo_name: String,
+    pr_number: Option<u64>,
+    workflow: String,
+    status: String,
+    conclusion: Option<String>,
+    sha: String,
+    url: String,
+    branch: Option<String>,
+    run_id: Option<String>,
+    run_job_count: usize,
+    run_all_terminal: bool,
+    channel: Option<String>,
+    mention: Option<String>,
+}
+
+impl PendingCiDelivery {
+    fn from_event(event: &IncomingEvent, identities: Vec<String>) -> Self {
+        let payload = event.payload.as_object();
+        let field = |name: &str| {
+            payload
+                .and_then(|object| object.get(name))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        };
+        Self {
+            identities,
+            kind: event.kind.clone(),
+            repo_name: field("repo"),
+            pr_number: payload
+                .and_then(|object| object.get("number"))
+                .and_then(serde_json::Value::as_u64),
+            workflow: field("workflow"),
+            status: field("status"),
+            conclusion: payload
+                .and_then(|object| object.get("conclusion"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+            sha: field("sha"),
+            url: field("url"),
+            branch: payload
+                .and_then(|object| object.get("branch"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+            run_id: payload
+                .and_then(|object| object.get("run_id"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+            run_job_count: payload
+                .and_then(|object| object.get("run_job_count"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(1) as usize,
+            run_all_terminal: payload
+                .and_then(|object| object.get("run_all_terminal"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
+            channel: event.channel.clone(),
+            mention: event.mention.clone(),
+        }
+    }
+
+    fn same_event(&self, other: &Self) -> bool {
+        if !self.identities.is_empty()
+            && self.identities.iter().any(|identity| {
+                other
+                    .identities
+                    .iter()
+                    .any(|candidate| candidate == identity)
+            })
+        {
+            return true;
+        }
+        self.run_id.is_some() && self.run_id == other.run_id && self.workflow == other.workflow
+            || self.sha == other.sha
+                && self.workflow == other.workflow
+                && self.pr_number == other.pr_number
+    }
+
+    fn into_event(self) -> IncomingEvent {
+        let mut event = IncomingEvent::github_ci(
+            &self.kind,
+            self.repo_name,
+            self.pr_number,
+            self.workflow,
+            self.status,
+            self.conclusion,
+            self.sha,
+            self.url,
+            self.branch,
+            self.channel,
+        )
+        .with_mention(self.mention);
+        if let Some(payload) = event.payload.as_object_mut() {
+            if let Some(run_id) = &self.run_id {
+                payload.insert("run_id".to_string(), json!(run_id));
+            }
+            payload.insert("run_job_count".to_string(), json!(self.run_job_count));
+            payload.insert("run_all_terminal".to_string(), json!(self.run_all_terminal));
+        }
+        event
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -134,13 +244,61 @@ pub fn default_github_ci_baseline_path(cron_state_path: &Path) -> PathBuf {
     cron_state_path.with_file_name("github-ci-baseline.json")
 }
 
+fn canonicalize_github_repo(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let (owner, name) = trimmed.split_once('/')?;
+    let owner = owner.trim();
+    let name = name.trim();
+    if owner.is_empty() || name.is_empty() || name.contains('/') {
+        return None;
+    }
+    Some(format!(
+        "{}/{}",
+        owner.to_ascii_lowercase(),
+        name.to_ascii_lowercase()
+    ))
+}
+
 fn ci_baseline_repo_key(snapshot: &GitSnapshot, repo: &GitRepoMonitor) -> String {
     snapshot
         .github_repo
         .as_deref()
         .or(repo.github_repo.as_deref())
+        .and_then(canonicalize_github_repo)
         .map(|remote| format!("repo:{remote}"))
         .unwrap_or_else(|| format!("path:{}", repo.path))
+}
+
+fn run_attempt_or_one(attempt: u32) -> u32 {
+    attempt.max(1)
+}
+
+fn run_identity(run_id: &str, attempt: u32) -> String {
+    let attempt = run_attempt_or_one(attempt);
+    if attempt == 1 {
+        format!("run:{run_id}")
+    } else {
+        format!("run:{run_id}:{attempt}")
+    }
+}
+
+fn parse_run_identity(identity: &str) -> Option<(String, u32)> {
+    let rest = identity.strip_prefix("run:")?;
+    if rest.is_empty() {
+        return None;
+    }
+    if rest.matches(':').count() == 1
+        && let Some((id, attempt)) = rest.split_once(':')
+        && !id.is_empty()
+        && let Ok(attempt) = attempt.parse::<u32>()
+        && attempt >= 1
+    {
+        return Some((id.to_string(), attempt));
+    }
+    if rest.contains(':') {
+        return None;
+    }
+    Some((rest.to_string(), 1))
 }
 
 impl TerminalRunRecord {
@@ -240,15 +398,8 @@ fn identity_matches_snapshot(identity: &str, ci: &GitHubCISnapshot) -> bool {
     if identity == key {
         return true;
     }
-    if let Some(id) = identity.strip_prefix("run:")
-        && !id.contains(':')
-    {
-        if ci.run_id.as_deref() == Some(id) {
-            return true;
-        }
-        if key.starts_with(&format!("run:{id}:")) {
-            return true;
-        }
+    if let Some((run_id, attempt)) = parse_run_identity(identity) {
+        return ci.run_id.as_deref() == Some(run_id.as_str()) && ci.run_attempt() == attempt;
     }
     false
 }
@@ -293,24 +444,71 @@ impl RepoCIBaseline {
 
 impl CIBaseline {
     fn repo_baseline_mut(&mut self, repo_key: &str, repo_path: &str) -> &mut RepoCIBaseline {
-        if repo_key.starts_with("repo:") {
-            let mut inherited = Vec::new();
-            if let Some(legacy) = self.repos.remove(repo_path) {
-                inherited.push(legacy);
+        let mut inherited = Vec::new();
+        if let Some(legacy) = self.repos.remove(repo_path) {
+            inherited.push(legacy);
+        }
+        let path_key = format!("path:{repo_path}");
+        if path_key != repo_key
+            && let Some(legacy) = self.repos.remove(&path_key)
+        {
+            inherited.push(legacy);
+        }
+        if let Some(canonical) = repo_key.strip_prefix("repo:") {
+            let stale: Vec<String> = self
+                .repos
+                .keys()
+                .filter(|key| {
+                    *key != repo_key
+                        && key
+                            .strip_prefix("repo:")
+                            .and_then(canonicalize_github_repo)
+                            .as_deref()
+                            == Some(canonical)
+                })
+                .cloned()
+                .collect();
+            for key in stale {
+                if let Some(legacy) = self.repos.remove(&key) {
+                    inherited.push(legacy);
+                }
             }
-            let path_key = format!("path:{repo_path}");
-            if path_key != repo_key
-                && let Some(legacy) = self.repos.remove(&path_key)
+        }
+        let dest = self.repos.entry(repo_key.to_string()).or_default();
+        for legacy in inherited {
+            merge_repo_baseline(dest, legacy);
+        }
+        dest
+    }
+
+    fn enqueue_pending(
+        &mut self,
+        repo_key: &str,
+        repo_path: &str,
+        events: &[IncomingEvent],
+        current: &HashMap<String, GitHubCISnapshot>,
+    ) {
+        if events.is_empty() {
+            return;
+        }
+        let deliveries: Vec<PendingCiDelivery> = events
+            .iter()
+            .map(|event| {
+                let identities = previous_snapshot_for_event(current, event)
+                    .map(GitHubCISnapshot::identities)
+                    .unwrap_or_default();
+                PendingCiDelivery::from_event(event, identities)
+            })
+            .collect();
+        let repo_baseline = self.repo_baseline_mut(repo_key, repo_path);
+        for delivery in deliveries {
+            if !repo_baseline
+                .pending
+                .iter()
+                .any(|existing| existing.same_event(&delivery))
             {
-                inherited.push(legacy);
+                repo_baseline.pending.push(delivery);
             }
-            let dest = self.repos.entry(repo_key.to_string()).or_default();
-            for legacy in inherited {
-                merge_repo_baseline(dest, legacy);
-            }
-            dest
-        } else {
-            self.repos.entry(repo_key.to_string()).or_default()
         }
     }
 
@@ -371,6 +569,15 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
             dest.terminal_runs.push_back(record);
         }
     }
+    for delivery in source.pending {
+        if !dest
+            .pending
+            .iter()
+            .any(|existing| existing.same_event(&delivery))
+        {
+            dest.pending.push(delivery);
+        }
+    }
 }
 
 fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
@@ -406,10 +613,41 @@ fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
     }
 }
 
-fn save_ci_baseline(baseline: &CIBaseline, path: Option<&Path>) -> Result<()> {
-    let Some(path) = path else {
-        return Ok(());
-    };
+fn merge_ci_baseline(dest: &mut CIBaseline, source: &CIBaseline) {
+    for (key, repo) in &source.repos {
+        let dest_repo = dest.repos.entry(key.clone()).or_default();
+        merge_repo_baseline(dest_repo, repo.clone());
+    }
+}
+
+struct BaselineLock {
+    lock_path: PathBuf,
+}
+
+impl Drop for BaselineLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.lock_path);
+    }
+}
+
+fn acquire_baseline_lock(path: &Path) -> Result<BaselineLock> {
+    let lock_path = path.with_extension("json.lock");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    for _ in 0..200 {
+        match fs::create_dir(&lock_path) {
+            Ok(()) => return Ok(BaselineLock { lock_path }),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Err("timed out waiting for GitHub CI baseline lock".into())
+}
+
+fn write_ci_baseline_atomic(baseline: &CIBaseline, path: &Path) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -438,6 +676,92 @@ fn save_ci_baseline(baseline: &CIBaseline, path: Option<&Path>) -> Result<()> {
         return Err(error.into());
     }
     Ok(())
+}
+
+fn commit_ci_baseline(path: Option<&Path>, local: &CIBaseline) -> Result<CIBaseline> {
+    let Some(path) = path else {
+        return Ok(local.clone());
+    };
+    let _lock = acquire_baseline_lock(path)?;
+    let mut disk = load_ci_baseline(Some(path));
+    merge_ci_baseline(&mut disk, local);
+    write_ci_baseline_atomic(&disk, path)?;
+    Ok(disk)
+}
+
+#[cfg(test)]
+fn save_ci_baseline(baseline: &CIBaseline, path: Option<&Path>) -> Result<()> {
+    commit_ci_baseline(path, baseline).map(|_| ())
+}
+
+async fn drain_pending_outbox(
+    ci_baseline: &mut CIBaseline,
+    path: Option<&Path>,
+    tx: &mpsc::Sender<IncomingEvent>,
+) -> Result<()> {
+    let pending: Vec<PendingCiDelivery> = ci_baseline
+        .repos
+        .values()
+        .flat_map(|repo| repo.pending.iter().cloned())
+        .collect();
+    if pending.is_empty() {
+        return Ok(());
+    }
+    for delivery in &pending {
+        send_event(tx, delivery.clone().into_event()).await?;
+    }
+    ack_pending_deliveries(ci_baseline, path, &pending)?;
+    Ok(())
+}
+
+fn ack_pending_deliveries(
+    ci_baseline: &mut CIBaseline,
+    path: Option<&Path>,
+    delivered: &[PendingCiDelivery],
+) -> Result<()> {
+    for repo in ci_baseline.repos.values_mut() {
+        repo.pending
+            .retain(|pending| !delivered.iter().any(|item| pending.same_event(item)));
+    }
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let _lock = acquire_baseline_lock(path)?;
+    let mut disk = load_ci_baseline(Some(path));
+    merge_ci_baseline(&mut disk, ci_baseline);
+    for repo in disk.repos.values_mut() {
+        repo.pending
+            .retain(|pending| !delivered.iter().any(|item| pending.same_event(item)));
+    }
+    write_ci_baseline_atomic(&disk, path)?;
+    *ci_baseline = disk;
+    Ok(())
+}
+
+fn merge_incomplete_ci(
+    previous: &HashMap<String, GitHubCISnapshot>,
+    mut current: HashMap<String, GitHubCISnapshot>,
+) -> HashMap<String, GitHubCISnapshot> {
+    for old in previous.values() {
+        if current.values().any(|ci| snapshots_same_run(ci, old)) {
+            continue;
+        }
+        current.insert(old.dedupe_key(), old.clone());
+    }
+    current
+}
+
+fn snapshots_same_run(left: &GitHubCISnapshot, right: &GitHubCISnapshot) -> bool {
+    let left_unique = left.unique_identities();
+    let right_unique = right.unique_identities();
+    if !left_unique.is_empty()
+        && left_unique
+            .iter()
+            .any(|identity| right_unique.iter().any(|candidate| candidate == identity))
+    {
+        return true;
+    }
+    left.dedupe_key() == right.dedupe_key()
 }
 
 struct GitHubRepoState {
@@ -473,6 +797,7 @@ struct GitHubCISnapshot {
     url: String,
     branch: Option<String>,
     run_id: Option<String>,
+    run_attempt: u32,
     check_run_id: Option<String>,
     created_at: Option<String>,
     run_job_count: usize,
@@ -491,10 +816,14 @@ impl GitHubCISnapshot {
         )
     }
 
+    fn run_attempt(&self) -> u32 {
+        run_attempt_or_one(self.run_attempt)
+    }
+
     fn unique_identities(&self) -> Vec<String> {
         let mut identities = Vec::new();
         if let Some(run_id) = &self.run_id {
-            identities.push(format!("run:{run_id}"));
+            identities.push(run_identity(run_id, self.run_attempt()));
         }
         if let Some(check_run_id) = &self.check_run_id {
             identities.push(format!("check:{check_run_id}"));
@@ -510,7 +839,7 @@ impl GitHubCISnapshot {
 
     fn dedupe_key(&self) -> String {
         if let Some(run_id) = &self.run_id {
-            return format!("run:{run_id}:{}", self.workflow);
+            return format!("run:{run_id}:{}:{}", self.run_attempt(), self.workflow);
         }
         if let Some(check_run_id) = &self.check_run_id {
             return format!("check:{check_run_id}");
@@ -596,6 +925,8 @@ async fn poll_github(
     ci_baseline: &mut CIBaseline,
     ci_baseline_path: Option<&Path>,
 ) -> Result<()> {
+    drain_pending_outbox(ci_baseline, ci_baseline_path, tx).await?;
+
     for repo in &config.monitors.git.repos {
         if !repo.emit_issue_opened && !repo.emit_pr_status {
             continue;
@@ -644,7 +975,7 @@ async fn poll_github(
             };
         let repo_key = ci_baseline_repo_key(&snapshot, repo);
         let repo_ci_baseline = ci_baseline.repos.get(&repo_key).cloned();
-        let (ci, ci_baseline_established, mut ci_events) = match poll_ci_statuses(
+        let (ci, ci_baseline_established, ci_events) = match poll_ci_statuses(
             config,
             github_client,
             repo,
@@ -671,26 +1002,55 @@ async fn poll_github(
             }
         };
 
-        // Persist-before-publish: a delivered terminal event must already be
-        // in durable suppression state. If the receipt cannot be written, drop
-        // the events rather than open a restart-replay window.
-        let repo_baseline_dirty = ci_baseline.record_terminal_runs(&repo_key, &repo.path, &ci);
-        if repo_baseline_dirty && let Err(error) = save_ci_baseline(ci_baseline, ci_baseline_path) {
-            telemetry::emit(source_record(
-                telemetry::event_name::SOURCE_DEGRADED,
-                "ci_baseline_persist_failed",
-                Some(&repo.path),
-                Some(error.to_string()),
-            ));
-            eprintln!(
-                "clawhip source github CI baseline persist failed for {}: {error}",
-                repo.path
-            );
-            ci_events.clear();
+        // Durable outbox: persist pending receipts, then publish, then
+        // drop the outbox. Persistence failure must not mutate in-memory
+        // suppression state. A crash after persist and before send retries
+        // from the outbox on the next poll.
+        let mut next_baseline = ci_baseline.clone();
+        next_baseline.record_terminal_runs(&repo_key, &repo.path, &ci);
+        next_baseline.enqueue_pending(&repo_key, &repo.path, &ci_events, &ci);
+        match commit_ci_baseline(ci_baseline_path, &next_baseline) {
+            Ok(committed) => {
+                *ci_baseline = committed;
+            }
+            Err(error) => {
+                telemetry::emit(source_record(
+                    telemetry::event_name::SOURCE_DEGRADED,
+                    "ci_baseline_persist_failed",
+                    Some(&repo.path),
+                    Some(error.to_string()),
+                ));
+                eprintln!(
+                    "clawhip source github CI baseline persist failed for {}: {error}",
+                    repo.path
+                );
+                state.insert(
+                    repo.path.clone(),
+                    GitHubRepoState {
+                        issues,
+                        prs,
+                        ci: previous.map(|entry| entry.ci.clone()).unwrap_or_default(),
+                        ci_baseline_established: previous
+                            .map(|entry| entry.ci_baseline_established)
+                            .unwrap_or(false),
+                    },
+                );
+                continue;
+            }
         }
 
+        let delivered: Vec<PendingCiDelivery> = ci_events
+            .iter()
+            .map(|event| PendingCiDelivery::from_event(event, Vec::new()))
+            .collect();
         for event in ci_events {
             send_event(tx, event).await?;
+        }
+        if let Err(error) = ack_pending_deliveries(ci_baseline, ci_baseline_path, &delivered) {
+            eprintln!(
+                "clawhip source github CI baseline outbox ack failed for {}: {error}",
+                repo.path
+            );
         }
 
         state.insert(
@@ -861,21 +1221,25 @@ async fn poll_ci_statuses(
     )
     .await
     {
-        Ok((ci, window_complete)) => {
+        Ok((fetched, window_complete)) => {
+            let ci = if !window_complete {
+                if let Some(previous) = previous {
+                    merge_incomplete_ci(&previous.ci, fetched)
+                } else {
+                    fetched
+                }
+            } else {
+                fetched
+            };
             let events = if let Some(previous) = previous {
-                let mut events = collect_ci_events(
+                collect_ci_events(
                     repo,
                     &snapshot.repo_name,
                     previous.ci_baseline_established,
                     &previous.ci,
                     &ci,
                     repo_ci_baseline,
-                );
-                if !window_complete {
-                    events
-                        .retain(|event| previous_snapshot_for_event(&previous.ci, event).is_some());
-                }
-                events
+                )
             } else {
                 Vec::new()
             };
@@ -1327,6 +1691,7 @@ async fn fetch_check_runs(
                     url,
                     branch: Some(pr.head_branch.clone()),
                     run_id,
+                    run_attempt: 1,
                     check_run_id: (check_run.id != 0).then(|| check_run.id.to_string()),
                     created_at: check_run.started_at.or(check_run.completed_at),
                     run_job_count,
@@ -1414,6 +1779,7 @@ async fn fetch_direct_workflow_runs(
                     url: run.html_url,
                     branch: non_empty_string(run.head_branch),
                     run_id: Some(run.id.to_string()),
+                    run_attempt: run_attempt_or_one(run.run_attempt),
                     check_run_id: None,
                     created_at: run.created_at,
                     run_job_count: 1,
@@ -1521,8 +1887,14 @@ struct GitHubWorkflowRun {
     html_url: String,
     #[serde(default)]
     created_at: Option<String>,
+    #[serde(default = "default_run_attempt")]
+    run_attempt: u32,
     #[serde(default)]
     pull_requests: Vec<serde_json::Value>,
+}
+
+fn default_run_attempt() -> u32 {
+    1
 }
 
 fn non_empty_string(value: String) -> Option<String> {
@@ -1666,6 +2038,7 @@ mod tests {
             url: "https://github.com/Yeachan-Heo/clawhip/actions/runs/1".into(),
             branch: Some("feat/github-ci-events".into()),
             run_id: Some("1".into()),
+            run_attempt: 1,
             check_run_id: None,
             created_at: None,
             run_job_count: 1,
@@ -1688,6 +2061,7 @@ mod tests {
             url: format!("https://github.com/org/repo/actions/runs/{run_id}"),
             branch: Some(branch.into()),
             run_id: Some(run_id.to_string()),
+            run_attempt: 1,
             check_run_id: None,
             created_at: None,
             run_job_count: 1,
@@ -1921,6 +2295,7 @@ mod tests {
             url: "https://github.com/org/repo/pull/58".into(),
             branch: Some("feat/x".into()),
             run_id: None,
+            run_attempt: 1,
             check_run_id: None,
             created_at: None,
             run_job_count: 1,
@@ -2056,19 +2431,21 @@ mod tests {
     }
 
     #[test]
-    fn issue_317_persist_failure_does_not_publish_terminal_events() {
+    fn issue_317_persist_failure_does_not_mutate_in_memory_suppression() {
         let dir = tempfile::tempdir().unwrap();
         let blocker = dir.path().join("not-a-directory");
         std::fs::write(&blocker, b"file").unwrap();
         let path = blocker.join("github-ci-baseline.json");
 
-        let mut ci_baseline = CIBaseline::default();
+        let original = CIBaseline::default();
+        let mut next = original.clone();
         let runs = run_map(&[run_snapshot(9, "CI", Some("success"), "main")]);
-        assert!(ci_baseline.record_terminal_runs("repo:org/repo", "/repo", &runs));
-        assert!(save_ci_baseline(&ci_baseline, Some(&path)).is_err());
-
-        // Receipt contract: without a durable write, treat the run as unpublished.
-        // The in-memory baseline exists, but the failure boundary is the save.
+        assert!(next.record_terminal_runs("repo:org/repo", "/repo", &runs));
+        assert!(commit_ci_baseline(Some(&path), &next).is_err());
+        assert!(
+            original.repos.is_empty(),
+            "persist failure must leave the live baseline unmutated"
+        );
         assert!(!path.exists());
     }
 
@@ -2237,6 +2614,208 @@ mod tests {
         assert!(ci_window_complete(true, 1));
         assert!(!ci_window_complete(true, MAX_CI_PAGES));
         assert!(ci_window_complete(false, MAX_CI_PAGES));
+    }
+
+    #[test]
+    fn issue_317_workflow_rerun_attempt_is_distinct_from_legacy_run_id() {
+        let attempt1 = GitHubCISnapshot {
+            run_attempt: 1,
+            ..run_snapshot(4242, "CI", Some("success"), "main")
+        };
+        let attempt2 = GitHubCISnapshot {
+            run_attempt: 2,
+            conclusion: Some("failure".into()),
+            ..run_snapshot(4242, "CI", Some("failure"), "main")
+        };
+        assert_ne!(attempt1.dedupe_key(), attempt2.dedupe_key());
+        assert_eq!(run_map(&[attempt1.clone(), attempt2.clone()]).len(), 2);
+
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.record_terminal_runs(
+            "/repo",
+            "/repo",
+            &run_map(std::slice::from_ref(&attempt1)),
+        );
+        assert!(repo_ci_baseline_is_suppressed(
+            ci_baseline.repos.get("/repo"),
+            &attempt1
+        ));
+        assert!(
+            !repo_ci_baseline_is_suppressed(ci_baseline.repos.get("/repo"), &attempt2),
+            "attempt 2 must not be swallowed by a legacy run:<id> receipt for attempt 1"
+        );
+
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&attempt2)),
+            ci_baseline.repos.get("/repo"),
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-failed");
+    }
+
+    #[test]
+    fn issue_317_pending_outbox_retries_undelivered_terminal_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let run = run_snapshot(77, "CI", Some("success"), "main");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        assert_eq!(events.len(), 1);
+
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.record_terminal_runs("/repo", "/repo", &run_map(std::slice::from_ref(&run)));
+        ci_baseline.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events,
+            &run_map(std::slice::from_ref(&run)),
+        );
+        save_ci_baseline(&ci_baseline, Some(&path)).unwrap();
+
+        let restarted = load_ci_baseline(Some(&path));
+        assert_eq!(restarted.repos["/repo"].pending.len(), 1);
+        let pending = restarted.repos["/repo"].pending.clone();
+        assert_eq!(pending[0].kind, "github.ci-passed");
+        let mut acked = restarted;
+        ack_pending_deliveries(&mut acked, Some(&path), &pending).unwrap();
+        let reloaded = load_ci_baseline(Some(&path));
+        assert!(reloaded.repos["/repo"].pending.is_empty());
+        assert!(repo_ci_baseline_is_suppressed(
+            reloaded.repos.get("/repo"),
+            &run
+        ));
+    }
+
+    #[test]
+    fn issue_317_incomplete_window_keeps_omitted_in_progress_and_later_completion() {
+        let in_progress = GitHubCISnapshot {
+            status: "in_progress".into(),
+            conclusion: None,
+            run_all_terminal: false,
+            ..run_snapshot(88, "CI", Some("success"), "main")
+        };
+        let completed = run_snapshot(88, "CI", Some("success"), "main");
+        let visible = run_snapshot(99, "CI", Some("success"), "main");
+
+        let previous = run_map(&[in_progress.clone(), visible.clone()]);
+        let incomplete = run_map(std::slice::from_ref(&visible));
+        let merged = merge_incomplete_ci(&previous, incomplete);
+        assert!(
+            merged
+                .values()
+                .any(|ci| snapshots_same_run(ci, &in_progress)),
+            "omitted in-progress run must be retained across an incomplete page"
+        );
+
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &previous,
+            &merged,
+            None,
+        );
+        assert!(
+            events.is_empty(),
+            "reappearing omitted in-progress run must not duplicate github.ci-started"
+        );
+
+        let completed_window = run_map(&[completed.clone(), visible]);
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &merged,
+            &completed_window,
+            None,
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-passed");
+    }
+
+    #[test]
+    fn issue_317_repo_key_case_fold_merges_variants_without_cross_remote() {
+        let run = run_snapshot(55, "CI", Some("success"), "main");
+        let mut ci_baseline = CIBaseline::default();
+        ci_baseline.record_terminal_runs(
+            "repo:org/repo",
+            "/old",
+            &run_map(std::slice::from_ref(&run)),
+        );
+
+        let mixed = GitRepoMonitor {
+            path: "/new".into(),
+            github_repo: Some("Org/Repo".into()),
+            ..GitRepoMonitor::default()
+        };
+        let snapshot = GitSnapshot {
+            repo_name: "repo".into(),
+            repo_path: "/new".into(),
+            worktree_path: "/new".into(),
+            branch: "main".into(),
+            head: "sha-55".into(),
+            commits: Vec::new(),
+            github_repo: Some(" Org/Repo ".into()),
+        };
+        let key = ci_baseline_repo_key(&snapshot, &mixed);
+        assert_eq!(key, "repo:org/repo");
+        let _ = ci_baseline.repo_baseline_mut(&key, "/new");
+        assert!(repo_ci_baseline_is_suppressed(
+            ci_baseline.repos.get(&key),
+            &run
+        ));
+
+        let other = GitHubCISnapshot {
+            sha: "other".into(),
+            ..run_snapshot(55, "CI", Some("success"), "main")
+        };
+        assert!(!repo_ci_baseline_is_suppressed(
+            ci_baseline.repos.get("repo:other/remote"),
+            &other
+        ));
+    }
+
+    #[test]
+    fn issue_317_locked_reload_merge_write_preserves_concurrent_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        save_ci_baseline(&CIBaseline::default(), Some(&path)).unwrap();
+
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                let mut left = CIBaseline::default();
+                left.record_terminal_runs(
+                    "repo:org/repo",
+                    "/a",
+                    &run_map(&[run_snapshot(1, "CI", Some("success"), "main")]),
+                );
+                commit_ci_baseline(Some(&path), &left).unwrap();
+            });
+            scope.spawn(|| {
+                let mut right = CIBaseline::default();
+                right.record_terminal_runs(
+                    "repo:org/repo",
+                    "/a",
+                    &run_map(&[run_snapshot(2, "CI", Some("success"), "main")]),
+                );
+                commit_ci_baseline(Some(&path), &right).unwrap();
+            });
+        });
+
+        let loaded = load_ci_baseline(Some(&path));
+        let repo = loaded.repos.get("repo:org/repo").unwrap();
+        assert!(repo.contains_identity("run:1"));
+        assert!(repo.contains_identity("run:2"));
     }
 
     #[tokio::test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -1261,8 +1261,12 @@ fn write_ci_baseline_atomic(baseline: &CIBaseline, path: &Path) -> Result<()> {
         file.write_all(payload.as_bytes())?;
         sync_file(&file)?;
         drop(file);
+        #[cfg(windows)]
+        {
+            let _ = fs::remove_file(path);
+        }
         fs::rename(&temp_path, path)?;
-        let dest = File::open(path)?;
+        let dest = OpenOptions::new().read(true).write(true).open(path)?;
         sync_file(&dest)?;
         drop(dest);
         if let Some(parent) = path.parent() {

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -649,27 +649,22 @@ fn snapshot_eviction_key(ci: &GitHubCISnapshot) -> (u8, String, u64, String) {
     TerminalRunRecord::from_snapshot(ci).eviction_key()
 }
 
-fn cap_repo_baseline(repo_baseline: &mut RepoCIBaseline) -> bool {
-    if repo_baseline.terminal_runs.len() <= MAX_BASELINE_RUNS_PER_REPO {
-        return false;
-    }
-    let mut records: Vec<TerminalRunRecord> = repo_baseline.terminal_runs.drain(..).collect();
-    records.sort_by_key(|record| record.eviction_key());
-    let drop_count = records.len() - MAX_BASELINE_RUNS_PER_REPO;
-    records.drain(..drop_count);
-    repo_baseline.terminal_runs = records.into();
-    true
-}
-
 fn cap_repo_baseline_keeping(
     repo_baseline: &mut RepoCIBaseline,
     keep: &[&GitHubCISnapshot],
 ) -> bool {
+    let keep_ids: std::collections::HashSet<String> =
+        keep.iter().flat_map(|ci| ci.unique_identities()).collect();
+    cap_repo_baseline_keeping_ids(repo_baseline, &keep_ids)
+}
+
+fn cap_repo_baseline_keeping_ids(
+    repo_baseline: &mut RepoCIBaseline,
+    keep_ids: &std::collections::HashSet<String>,
+) -> bool {
     if repo_baseline.terminal_runs.len() <= MAX_BASELINE_RUNS_PER_REPO {
         return false;
     }
-    let keep_ids: std::collections::HashSet<String> =
-        keep.iter().flat_map(|ci| ci.unique_identities()).collect();
     let mut records: Vec<TerminalRunRecord> = repo_baseline.terminal_runs.drain(..).collect();
     records.sort_by_key(|record| record.eviction_key());
     let excess = records.len().saturating_sub(MAX_BASELINE_RUNS_PER_REPO);
@@ -942,6 +937,11 @@ fn normalize_repo_outbox(repo: &mut RepoCIBaseline) {
 }
 
 fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
+    let keep_ids: std::collections::HashSet<String> = source
+        .terminal_runs
+        .iter()
+        .flat_map(|record| record.unique_identities().map(str::to_string))
+        .collect();
     for record in source.terminal_runs {
         if let Some(existing) = dest
             .terminal_runs
@@ -963,7 +963,7 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
             dest.terminal_runs.push_back(record);
         }
     }
-    cap_repo_baseline(dest);
+    cap_repo_baseline_keeping_ids(dest, &keep_ids);
     dest.epoch = dest.epoch.max(source.epoch);
     dest.min_writer_epoch = dest.min_writer_epoch.max(source.min_writer_epoch);
     dest.ci_established = dest.ci_established || source.ci_established;
@@ -1055,7 +1055,6 @@ fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
         Ok(repos) => {
             let mut baseline = CIBaseline { repos };
             for repo_baseline in baseline.repos.values_mut() {
-                cap_repo_baseline(repo_baseline);
                 normalize_repo_outbox(repo_baseline);
             }
             baseline
@@ -3580,6 +3579,37 @@ mod tests {
     }
 
     #[test]
+    fn issue_317_current_window_over_cap_survives_reload() {
+        let mut runs = Vec::new();
+        for id in 0..(MAX_BASELINE_RUNS_PER_REPO + 20) {
+            let mut run = run_snapshot(id as u64, "CI", Some("success"), "main");
+            run.created_at = Some(format!("2026-01-01T00:{:02}:{:02}Z", id / 60, id % 60));
+            runs.push(run);
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut baseline = CIBaseline::default();
+        baseline.record_terminal_runs("/repo", "/repo", &run_map(&runs));
+        save_ci_baseline(&baseline, Some(&path)).unwrap();
+        let loaded = load_ci_baseline(Some(&path));
+        let repo = &loaded.repos["/repo"];
+        assert_eq!(repo.terminal_runs.len(), MAX_BASELINE_RUNS_PER_REPO + 20);
+        assert!(repo.contains_identity("run:0"));
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(&runs),
+            loaded.repos.get("/repo"),
+        );
+        assert!(
+            events.is_empty(),
+            "restart against the same oversized window must not replay"
+        );
+    }
+
+    #[test]
     fn issue_317_mixed_legacy_eviction_keeps_timestamped_and_survives_reload() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("github-ci-baseline.json");
@@ -3742,7 +3772,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_317_oversized_loaded_state_is_truncated_oldest_first() {
+    fn issue_317_oversized_loaded_state_is_preserved_across_restart() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("github-ci-baseline.json");
         let mut records = Vec::new();
@@ -3757,8 +3787,12 @@ mod tests {
         std::fs::write(&path, payload).unwrap();
         let loaded = load_ci_baseline(Some(&path));
         let repo = loaded.repos.get("/repo").unwrap();
-        assert_eq!(repo.terminal_runs.len(), MAX_BASELINE_RUNS_PER_REPO);
-        assert!(!repo.contains_identity("run:0"));
+        assert_eq!(
+            repo.terminal_runs.len(),
+            MAX_BASELINE_RUNS_PER_REPO + 12,
+            "load must not evict a stored current window"
+        );
+        assert!(repo.contains_identity("run:0"));
         assert!(repo.contains_identity(&format!("run:{}", MAX_BASELINE_RUNS_PER_REPO + 11)));
     }
 

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -114,6 +114,12 @@ struct TerminalRunRecord {
     identities: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     run_id: Option<String>,
+    #[serde(default = "default_run_attempt")]
+    run_attempt: u32,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    workflow: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    conclusion: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     created_at: Option<String>,
 }
@@ -137,6 +143,10 @@ struct PendingCiDelivery {
     run_all_terminal: bool,
     channel: Option<String>,
     mention: Option<String>,
+    #[serde(default)]
+    format: Option<crate::events::MessageFormat>,
+    #[serde(default)]
+    template: Option<String>,
     #[serde(default)]
     send_attempts: u32,
     #[serde(default)]
@@ -298,6 +308,8 @@ impl PendingCiDelivery {
                 .unwrap_or(false),
             channel: event.channel.clone(),
             mention: event.mention.clone(),
+            format: event.format.clone(),
+            template: event.template.clone(),
             send_attempts: 0,
             last_sent_unix: None,
         }
@@ -358,7 +370,9 @@ impl PendingCiDelivery {
             self.branch,
             self.channel,
         )
-        .with_mention(self.mention);
+        .with_mention(self.mention)
+        .with_format(self.format)
+        .with_template(self.template);
         if let Some(payload) = event.payload.as_object_mut() {
             if let Some(run_id) = &self.run_id {
                 payload.insert("run_id".to_string(), json!(run_id));
@@ -427,7 +441,6 @@ const CI_PAGE_SIZE: usize = 100;
 const MAX_CI_PAGES: usize = 5;
 const MAX_PENDING_SEND_ATTEMPTS: u32 = 3;
 const PENDING_RETRY_BACKOFF_SECS: u64 = 3_600;
-#[cfg(test)]
 const ACK_RETENTION_SECS: u64 = 7 * 24 * 3_600;
 const MAX_DEAD_LETTER: usize = 64;
 
@@ -515,6 +528,9 @@ impl TerminalRunRecord {
         Self {
             identities: ci.identities(),
             run_id: ci.run_id.clone(),
+            run_attempt: ci.run_attempt(),
+            workflow: ci.workflow.clone(),
+            conclusion: ci.conclusion.clone(),
             created_at: ci.created_at.clone(),
         }
     }
@@ -527,6 +543,9 @@ impl TerminalRunRecord {
         Self {
             identities: vec![identity],
             run_id,
+            run_attempt: 1,
+            workflow: String::new(),
+            conclusion: None,
             created_at: None,
         }
     }
@@ -546,12 +565,21 @@ impl TerminalRunRecord {
     }
 
     fn matches_snapshot(&self, ci: &GitHubCISnapshot) -> bool {
+        let snap_ids = ci.unique_identities();
+        let rec_checks = pending_check_identities(&self.identities);
+        let snap_checks = pending_check_identities(&snap_ids);
+        if !rec_checks.is_empty() && !snap_checks.is_empty() {
+            let overlap = rec_checks
+                .iter()
+                .any(|identity| snap_checks.iter().any(|candidate| candidate == identity));
+            return overlap && run_attempt_or_one(self.run_attempt) == ci.run_attempt();
+        }
         let unique = ci.unique_identities();
         if unique
             .iter()
             .any(|identity| self.contains_identity(identity))
         {
-            return true;
+            return run_attempt_or_one(self.run_attempt) == ci.run_attempt();
         }
         for identity in &self.identities {
             if identity_matches_snapshot(identity, ci)
@@ -775,12 +803,21 @@ impl CIBaseline {
 }
 
 fn terminal_records_same_run(left: &TerminalRunRecord, right: &TerminalRunRecord) -> bool {
+    let left_checks = pending_check_identities(&left.identities);
+    let right_checks = pending_check_identities(&right.identities);
+    if !left_checks.is_empty() && !right_checks.is_empty() {
+        return left_checks
+            .iter()
+            .any(|identity| right_checks.iter().any(|candidate| candidate == identity))
+            && run_attempt_or_one(left.run_attempt) == run_attempt_or_one(right.run_attempt);
+    }
     let left_unique: Vec<&str> = left.unique_identities().collect();
     let right_unique: Vec<&str> = right.unique_identities().collect();
     if !left_unique.is_empty() && !right_unique.is_empty() {
         return left_unique
             .iter()
-            .any(|identity| right_unique.contains(identity));
+            .any(|identity| right_unique.contains(identity))
+            && run_attempt_or_one(left.run_attempt) == run_attempt_or_one(right.run_attempt);
     }
     left.identities
         .iter()
@@ -825,25 +862,42 @@ fn retire_exhausted_pending(repo: &mut RepoCIBaseline) {
 fn dead_letter_unsent_final_attempts(ci_baseline: &mut CIBaseline, unsent: &[PendingCiDelivery]) {
     for repo in ci_baseline.repos.values_mut() {
         let mut keep = Vec::new();
+        let mut retired = Vec::new();
         for pending in repo.pending.drain(..) {
             if unsent
                 .iter()
                 .any(|item| pending.same_event(item) && pending.repo_name == item.repo_name)
                 && pending.send_attempts >= MAX_PENDING_SEND_ATTEMPTS
             {
-                repo.dead_letter.push_back(pending);
+                eprintln!(
+                    "clawhip source github CI outbox dead-lettered {} {} after {} send attempts",
+                    pending.repo_name, pending.workflow, pending.send_attempts
+                );
+                telemetry::emit(source_record(
+                    telemetry::event_name::SOURCE_DEGRADED,
+                    "ci_outbox_dead_lettered",
+                    Some(&pending.repo_name),
+                    Some(format!(
+                        "workflow={} attempts={}",
+                        pending.workflow, pending.send_attempts
+                    )),
+                ));
+                retired.push(pending);
             } else {
                 keep.push(pending);
             }
         }
         repo.pending = keep;
+        for pending in retired {
+            record_acked(repo, &pending);
+            repo.dead_letter.push_back(pending);
+        }
         while repo.dead_letter.len() > MAX_DEAD_LETTER {
             repo.dead_letter.pop_front();
         }
     }
 }
 
-#[cfg(test)]
 fn compact_acked(repo: &mut RepoCIBaseline, now: u64) {
     let before = repo.acked.len();
     repo.acked
@@ -851,6 +905,20 @@ fn compact_acked(repo: &mut RepoCIBaseline, now: u64) {
     if repo.acked.len() < before {
         repo.min_writer_epoch = repo.min_writer_epoch.max(repo.epoch);
     }
+}
+
+fn normalize_repo_outbox(repo: &mut RepoCIBaseline) {
+    while repo.dead_letter.len() > MAX_DEAD_LETTER {
+        repo.dead_letter.pop_front();
+    }
+    let acked = repo.acked.clone();
+    let dead = repo.dead_letter.clone();
+    repo.pending.retain(|pending| {
+        !acked.iter().any(|item| item.matches_pending(pending))
+            && !dead
+                .iter()
+                .any(|item| item.same_event(pending) && item.repo_name == pending.repo_name)
+    });
 }
 
 fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
@@ -913,8 +981,15 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
     while dest.dead_letter.len() > MAX_DEAD_LETTER {
         dest.dead_letter.pop_front();
     }
+    let source_stale = dest.min_writer_epoch > 0 && source.epoch < dest.min_writer_epoch;
     for delivery in source.pending {
-        if pending_is_acked(dest, &delivery) {
+        if source_stale
+            || pending_is_acked(dest, &delivery)
+            || dest
+                .dead_letter
+                .iter()
+                .any(|dead| dead.same_event(&delivery) && dead.repo_name == delivery.repo_name)
+        {
             continue;
         }
         if let Some(existing) = dest
@@ -928,8 +1003,16 @@ fn merge_repo_baseline(dest: &mut RepoCIBaseline, source: RepoCIBaseline) {
         }
     }
     let acked = dest.acked.clone();
-    dest.pending
-        .retain(|pending| !acked.iter().any(|item| item.matches_pending(pending)));
+    let dead = dest.dead_letter.clone();
+    dest.pending.retain(|pending| {
+        !acked.iter().any(|item| item.matches_pending(pending))
+            && !dead
+                .iter()
+                .any(|item| item.same_event(pending) && item.repo_name == pending.repo_name)
+    });
+    while dest.dead_letter.len() > MAX_DEAD_LETTER {
+        dest.dead_letter.pop_front();
+    }
 }
 
 fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
@@ -952,6 +1035,7 @@ fn load_ci_baseline(path: Option<&Path>) -> CIBaseline {
             let mut baseline = CIBaseline { repos };
             for repo_baseline in baseline.repos.values_mut() {
                 cap_repo_baseline(repo_baseline);
+                normalize_repo_outbox(repo_baseline);
             }
             baseline
         }
@@ -1027,38 +1111,82 @@ fn unlock_baseline_file(file: &File) {
 }
 
 #[cfg(windows)]
+#[repr(C)]
+struct WindowsOverlapped {
+    internal: usize,
+    internal_high: usize,
+    offset: u32,
+    offset_high: u32,
+    event: *mut core::ffi::c_void,
+}
+
+#[cfg(windows)]
 fn try_lock_baseline_file(file: &File) -> bool {
     use std::os::windows::io::AsRawHandle;
-    unsafe { lock_file(file.as_raw_handle(), 0, 0, 1, 0) != 0 }
+    const LOCKFILE_FAIL_IMMEDIATELY: u32 = 0x1;
+    const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x2;
+    let mut overlapped = WindowsOverlapped {
+        internal: 0,
+        internal_high: 0,
+        offset: 0,
+        offset_high: 0,
+        event: std::ptr::null_mut(),
+    };
+    unsafe {
+        let ok = lock_file_ex(
+            file.as_raw_handle(),
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            1,
+            0,
+            &mut overlapped,
+        );
+        if ok != 0 {
+            true
+        } else {
+            let _ = get_last_error();
+            false
+        }
+    }
 }
 
 #[cfg(windows)]
 fn unlock_baseline_file(file: &File) {
     use std::os::windows::io::AsRawHandle;
+    let mut overlapped = WindowsOverlapped {
+        internal: 0,
+        internal_high: 0,
+        offset: 0,
+        offset_high: 0,
+        event: std::ptr::null_mut(),
+    };
     unsafe {
-        unlock_file(file.as_raw_handle(), 0, 0, 1, 0);
+        let _ = unlock_file_ex(file.as_raw_handle(), 0, 1, 0, &mut overlapped);
     }
 }
 
 #[cfg(windows)]
 #[link(name = "kernel32")]
 unsafe extern "system" {
-    #[link_name = "LockFile"]
-    fn lock_file(
+    #[link_name = "LockFileEx"]
+    fn lock_file_ex(
         handle: *mut core::ffi::c_void,
-        offset_low: u32,
-        offset_high: u32,
+        flags: u32,
+        reserved: u32,
         length_low: u32,
         length_high: u32,
+        overlapped: *mut WindowsOverlapped,
     ) -> i32;
-    #[link_name = "UnlockFile"]
-    fn unlock_file(
+    #[link_name = "UnlockFileEx"]
+    fn unlock_file_ex(
         handle: *mut core::ffi::c_void,
-        offset_low: u32,
-        offset_high: u32,
+        reserved: u32,
         length_low: u32,
         length_high: u32,
+        overlapped: *mut WindowsOverlapped,
     ) -> i32;
+    #[link_name = "GetLastError"]
+    fn get_last_error() -> u32;
 }
 
 fn unix_now() -> u64 {
@@ -1155,8 +1283,11 @@ fn commit_ci_baseline(path: Option<&Path>, local: &CIBaseline) -> Result<CIBasel
     let _lock = acquire_baseline_lock(path)?;
     let mut disk = load_ci_baseline(Some(path));
     merge_ci_baseline(&mut disk, local);
+    let now = unix_now();
     for repo in disk.repos.values_mut() {
         repo.epoch = repo.epoch.saturating_add(1);
+        compact_acked(repo, now);
+        normalize_repo_outbox(repo);
     }
     write_ci_baseline_atomic(&disk, path)?;
     Ok(disk)
@@ -1548,6 +1679,7 @@ async fn poll_github(
                 }
             };
         let repo_key = ci_baseline_repo_key(&snapshot, repo);
+        let _ = ci_baseline.repo_baseline_mut(&repo_key, &repo.path);
         let repo_ci_baseline = ci_baseline.repos.get(&repo_key).cloned();
         let (ci, ci_baseline_established, ci_events, window_complete) = match poll_ci_statuses(
             config,
@@ -4227,10 +4359,9 @@ mod tests {
         };
         stale.pending.push(pending.clone());
         merge_repo_baseline(&mut dest, stale);
-        assert_eq!(
-            dest.pending.len(),
-            1,
-            "compaction must not drop a concurrent writer's pending set"
+        assert!(
+            dest.pending.is_empty(),
+            "stale writer below compacted epoch floor must not restore pending"
         );
     }
 
@@ -4251,6 +4382,178 @@ mod tests {
         );
         let loaded = load_ci_baseline(Some(&path));
         assert!(loaded.repos.contains_key("/repo"));
+    }
+
+    #[test]
+    fn issue_317_poll_merges_legacy_path_alias_before_suppression_lookup() {
+        let run = run_snapshot(4242, "CI", Some("success"), "main");
+        let mut baseline = CIBaseline::default();
+        baseline.record_terminal_runs(
+            "/old-path",
+            "/old-path",
+            &run_map(std::slice::from_ref(&run)),
+        );
+        let monitor = GitRepoMonitor {
+            path: "/old-path".into(),
+            github_repo: Some("Org/Repo".into()),
+            ..GitRepoMonitor::default()
+        };
+        let snapshot = crate::source::git::GitSnapshot {
+            repo_name: "repo".into(),
+            repo_path: "/old-path".into(),
+            worktree_path: "/old-path".into(),
+            branch: "main".into(),
+            head: "abc".into(),
+            commits: Vec::new(),
+            github_repo: Some("Org/Repo".into()),
+        };
+        let repo_key = ci_baseline_repo_key(&snapshot, &monitor);
+        let _ = baseline.repo_baseline_mut(&repo_key, &monitor.path);
+        let events = collect_ci_events(
+            &monitor,
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            baseline.repos.get(&repo_key),
+        );
+        assert!(
+            events.is_empty(),
+            "legacy path alias must suppress historical terminal runs after re-enrollment"
+        );
+    }
+
+    #[test]
+    fn issue_317_sibling_jobs_do_not_suppress_mixed_outcomes() {
+        let lint = check_job(4242, 11, "lint", "success");
+        let test = check_job(4242, 22, "test", "failure");
+        let mut baseline = CIBaseline::default();
+        baseline.record_terminal_runs("/repo", "/repo", &run_map(std::slice::from_ref(&lint)));
+        assert!(repo_ci_baseline_is_suppressed(
+            baseline.repos.get("/repo"),
+            &lint
+        ));
+        assert!(
+            !repo_ci_baseline_is_suppressed(baseline.repos.get("/repo"), &test),
+            "failed sibling must not be suppressed by a successful sibling in the same run"
+        );
+    }
+
+    #[test]
+    fn issue_317_fallback_kind_change_is_not_suppressed() {
+        let success = check_job(7, 1, "CI", "success");
+        let mut fallback = PendingCiDelivery::from_event(
+            &collect_ci_events(
+                &GitRepoMonitor::default(),
+                "org/repo",
+                true,
+                &HashMap::new(),
+                &run_map(std::slice::from_ref(&success)),
+                None,
+            )[0],
+            success.identities(),
+        );
+        fallback
+            .identities
+            .retain(|identity| !identity.starts_with("run:") && !identity.starts_with("check:"));
+        fallback.run_id = None;
+        let mut failed = fallback.clone();
+        failed.kind = "github.ci-failed".into();
+        failed.conclusion = Some("failure".into());
+        assert!(!fallback.same_event(&failed));
+        let mut repo = RepoCIBaseline::default();
+        record_acked(&mut repo, &fallback);
+        assert!(!pending_is_acked(&repo, &failed));
+    }
+
+    #[test]
+    fn issue_317_restart_preserves_nondefault_format_and_template() {
+        let run = run_snapshot(88, "CI", Some("success"), "main");
+        let mut events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&run)),
+            None,
+        );
+        events[0].format = Some(crate::events::MessageFormat::Alert);
+        events[0].template = Some("ci-alert".into());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut baseline = CIBaseline::default();
+        baseline.enqueue_pending(
+            "/repo",
+            "/repo",
+            &events,
+            &run_map(std::slice::from_ref(&run)),
+        );
+        save_ci_baseline(&baseline, Some(&path)).unwrap();
+        let restarted = load_ci_baseline(Some(&path));
+        let restored = restarted.repos["/repo"].pending[0].clone().into_event();
+        assert_eq!(restored.format, Some(crate::events::MessageFormat::Alert));
+        assert_eq!(restored.template.as_deref(), Some("ci-alert"));
+    }
+
+    #[test]
+    fn issue_317_dead_letter_tombstone_survives_stale_pending_merge() {
+        let job = check_job(3, 9, "CI", "failure");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&job)),
+            None,
+        );
+        let mut pending = PendingCiDelivery::from_event(&events[0], job.identities());
+        pending.send_attempts = MAX_PENDING_SEND_ATTEMPTS;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("github-ci-baseline.json");
+        let mut live = CIBaseline::default();
+        live.repos.insert("/repo".into(), RepoCIBaseline::default());
+        live.repos
+            .get_mut("/repo")
+            .unwrap()
+            .pending
+            .push(pending.clone());
+        save_ci_baseline(&live, Some(&path)).unwrap();
+        dead_letter_unsent_final_attempts(&mut live, std::slice::from_ref(&pending));
+        let _ = commit_ci_baseline(Some(&path), &live).unwrap();
+        let restarted = load_ci_baseline(Some(&path));
+        assert!(restarted.repos["/repo"].pending.is_empty());
+        assert_eq!(restarted.repos["/repo"].dead_letter.len(), 1);
+    }
+
+    #[test]
+    fn issue_317_stale_writer_below_epoch_floor_cannot_restore_pending() {
+        let start = std::sync::Arc::new(std::sync::Barrier::new(1));
+        let job = check_job(4, 1, "CI", "success");
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&job)),
+            None,
+        );
+        let pending = PendingCiDelivery::from_event(&events[0], job.identities());
+        let mut dest = RepoCIBaseline {
+            epoch: 10,
+            min_writer_epoch: 10,
+            ..RepoCIBaseline::default()
+        };
+        let mut stale = RepoCIBaseline {
+            epoch: 3,
+            ..RepoCIBaseline::default()
+        };
+        stale.pending.push(pending);
+        start.wait();
+        merge_repo_baseline(&mut dest, stale);
+        assert!(
+            dest.pending.is_empty(),
+            "stale writer below epoch floor must not restore pending"
+        );
     }
 
     #[test]

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -2042,11 +2042,7 @@ async fn poll_ci_statuses(
                     &ci,
                     repo_ci_baseline,
                 )
-            } else if repo_ci_baseline.is_some_and(|baseline| {
-                !baseline.terminal_runs.is_empty()
-                    || !baseline.pending.is_empty()
-                    || !baseline.acked.is_empty()
-            }) {
+            } else if repo_ci_baseline.is_some_and(|baseline| baseline.epoch > 0) {
                 collect_ci_events(
                     repo,
                     &snapshot.repo_name,
@@ -4586,6 +4582,23 @@ mod tests {
             true,
             &HashMap::new(),
             &run_map(&[historical.clone(), fresh.clone()]),
+            baseline.repos.get("/repo"),
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].canonical_kind(), "github.ci-failed");
+    }
+
+    #[test]
+    fn issue_317_empty_established_baseline_restart_emits_first_terminal() {
+        let fresh = run_snapshot(2, "CI", Some("failure"), "main");
+        let mut baseline = CIBaseline::default();
+        baseline.repo_baseline_mut("/repo", "/repo").epoch = 1;
+        let events = collect_ci_events(
+            &GitRepoMonitor::default(),
+            "org/repo",
+            true,
+            &HashMap::new(),
+            &run_map(std::slice::from_ref(&fresh)),
             baseline.repos.get("/repo"),
         );
         assert_eq!(events.len(), 1);

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -14,7 +14,7 @@ pub use git::{
     GitMonitorLifecycleCounts, GitSource, SharedGitMonitorDiagnostics,
     new_shared_git_monitor_diagnostics, snapshot_git_monitor_diagnostics,
 };
-pub use github::GitHubSource;
+pub use github::{GitHubSource, default_github_ci_baseline_path};
 pub use github_status::GitHubStatusSource;
 pub use subscription::{SubscriptionSnapshot, SubscriptionState, SubscriptionWorker};
 pub use tmux::{


### PR DESCRIPTION
## Summary

The GitHub monitor kept CI run identity only in process memory, so after a daemon restart or re-enrollment any terminal run that re-entered the `actions/runs` window — pagination drift, cursor loss, branch-filter change — was treated as a fresh transition and re-delivered as `github.ci-*` Discord events (#317).

At 2026-08-19 08:14 UTC this replayed months-old terminal runs in one burst (success `27620587146`/`27617650123`/`24176437242`/`24254308461`, failure `24244183277`/`24297690322`, cancelled `29691404856`) with repeated Discord 429 retries, despite no new push and an unchanged `main` head.

## Root cause

`collect_ci_events` in `src/source/github.rs` emitted any run key absent from the in-process `previous.ci` map once `ci_baseline_established` was true, and that state lived only in the source task's `HashMap` — nothing survived a restart. The stale historical workflow failure was unrelated noise.

## Fix

- Terminal run identities are persisted per monitored repo in a **bounded baseline**: `github-ci-baseline.json` beside the cron state file (same convention as `tmux-watch-registry.json` / `discord-watch-state.json`), written atomically via temp file + rename, capped at 256 identities per repo with oldest-first eviction — no unbounded history scan or ledger growth.
- `collect_ci_events` consults the baseline before emitting a terminal run that has no in-process record, suppressing replays across restart/re-enrollment/pagination-cursor recovery.
- A **failed** CI poll no longer reports `ci_baseline_established`, so a partial view re-primes on the next successful poll instead of replaying whatever the full window returns.
- Corrupt/unreadable baseline state fails safe to a fresh baseline (no crash).
- Preserved semantics: genuinely new in-progress runs (`github.ci-started`), completion transitions for all conclusions (success/failure/cancelled), and first-poll baseline priming.

## Acceptance

- [x] Deterministic reproduction of old success/failure/cancelled replay with a fake GitHub source (path-aware fixture server)
- [x] Bounded persisted baseline suppressing historical terminal outcomes across restart/re-enrollment
- [x] Genuinely new run and conclusion transitions preserved
- [x] Pagination/cursor-recovery and restart regression tests
- [x] No unbounded history scan or ledger growth (256-entry cap, atomic persistence)
- [x] Adversarial coverage: cross-repo monitor identity, run identity (run-id vs sha fallback), changed conclusions, partial API failure re-priming, corrupt-state fallback

## Test plan

Exact head `dbe90a6`:

- `cargo fmt --check` — clean
- `cargo check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --bin clawhip issue_317` — 4/4 new regression tests
- `cargo test` — 836 bin tests + 10 integration suites, all green

Closes #317

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
