### PR TITLE
feat(config): add fail-closed Discord sender-identity verification (#319)

### DIFF
--- a/docs/live-verification.md
+++ b/docs/live-verification.md
@@ -150,3 +150,61 @@ On March 11, 2026, a real validation was run for the custom send path:
 - `cargo run -q -- send --message "🧪 clawhip live verification (...)"` exited successfully
 - guild-wide search confirmed actual Discord delivery by the `clawhip` webhook bot
 - delivery landed in the configured test channel, confirming the configured wildcard webhook route was active
+
+## Sender-identity acceptance smoke (bot-token deployments)
+
+Transport success (`discord_send_success`, `token_source=config`) proves the
+token is valid and delivery worked — it does **not** prove *which bot* sent the
+message. During the 2026-08-21 recovery, a wrong-but-valid token delivered
+messages as the wrong bot while every transport signal stayed green. The
+acceptance smoke for bot-token deployments therefore has two mandatory legs:
+
+1. **API identity equality** — `GET /users/@me` with the effective token must
+   resolve to exactly the operator-configured expected bot ID.
+2. **Channel author readback** — a delivered test message read back from the
+   channel must be authored by that same expected bot.
+
+### Setup
+
+Configure the expected stable bot ID (the dedicated Clawhip bot's application
+ID from the Discord Developer Portal — never a token):
+
+```toml
+[providers.discord]
+token = "<bot-token>"
+expected_bot_id = "<expected-discord-bot-id>"
+```
+
+### Leg 1 — API identity equality (fail-closed preflight)
+
+```bash
+clawhip config verify-sender-identity
+clawhip config verify-sender-identity --json
+```
+
+- exits `0` **only** when the observed stable bot ID equals `expected_bot_id`
+- prints expected and observed bot IDs on mismatch — never the token
+- exits non-zero for mismatch, absent expectation, no token, invalid
+  credential, rate limit, malformed response, or transport failure
+
+A wrong-but-valid token fails this leg with
+`sender_identity_mismatch` even though transport would succeed. That is the
+point.
+
+### Leg 2 — Channel author readback
+
+1. Deliver a uniquely-marked test message to the target channel.
+2. Read the message back from the channel (Discord client or
+   `GET /channels/<id>/messages`).
+3. Confirm the message **author** is the expected bot ID, not merely that the
+   message exists.
+
+A smoke that only confirms arrival is insufficient: a wrong-but-valid token
+arrives fine, authored by the wrong bot.
+
+### Acceptance
+
+The smoke passes only when both legs pass. Any other combination — identity
+verified but authored by another bot, or transport green but identity mismatch
+— is a failure state requiring the token to be corrected before the deployment
+is called healthy.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -321,7 +321,7 @@ impl EmitArgs {
             return Err("emit fields must be provided as --key value pairs".into());
         }
 
-        for pair in self.fields.chunks_exact(2) {
+        for pair in self.fields.as_chunks::<2>().0 {
             let key = pair[0]
                 .strip_prefix("--")
                 .ok_or_else(|| format!("emit field names must start with --, got {}", pair[0]))?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -301,6 +301,13 @@ pub struct VerifyGatewayAllowlistArgs {
     pub json: bool,
 }
 
+#[derive(Debug, Clone, Default, Args)]
+pub struct VerifySenderIdentityArgs {
+    /// Emit machine-readable JSON instead of the human-readable text report.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
 impl EmitArgs {
     pub fn into_event(self) -> crate::Result<crate::events::IncomingEvent> {
         let mut channel = None;
@@ -1088,6 +1095,17 @@ pub enum ConfigCommand {
     /// channel IDs plus clawhip source labels; never dumps gateway tokens,
     /// webhooks, payloads, or unrelated config fields.
     VerifyGatewayAllowlist(VerifyGatewayAllowlistArgs),
+    /// Verify the effective Discord bot token resolves to the expected bot
+    /// identity via the Discord /users/@me endpoint.
+    ///
+    /// Fail-closed sender-identity preflight: requires
+    /// providers.discord.expected_bot_id, queries Discord with the effective
+    /// token (non-mutating, bounded), compares the observed stable bot ID to
+    /// the expected one, and reports a public-safe verdict that never
+    /// contains the token. Exits non-zero on any non-verified outcome so a
+    /// wrong-but-valid token cannot pass a smoke test merely because
+    /// transport works.
+    VerifySenderIdentity(VerifySenderIdentityArgs),
 }
 
 #[cfg(test)]
@@ -1447,6 +1465,31 @@ mod tests {
             Some(std::path::Path::new("/tmp/clawdbot.json"))
         );
         assert!(args.json);
+    }
+    #[test]
+    fn parses_config_verify_sender_identity_json() {
+        let cli = Cli::parse_from(["clawhip", "config", "verify-sender-identity", "--json"]);
+
+        let Some(Commands::Config {
+            command: Some(ConfigCommand::VerifySenderIdentity(args)),
+        }) = cli.command
+        else {
+            panic!("expected verify-sender-identity");
+        };
+        assert!(args.json);
+    }
+
+    #[test]
+    fn parses_config_verify_sender_identity_text_default() {
+        let cli = Cli::parse_from(["clawhip", "config", "verify-sender-identity"]);
+
+        let Some(Commands::Config {
+            command: Some(ConfigCommand::VerifySenderIdentity(args)),
+        }) = cli.command
+        else {
+            panic!("expected verify-sender-identity");
+        };
+        assert!(!args.json);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4350,11 +4350,10 @@ expected_bot_id = "900000000000000101"
 
         let serialized = config.to_pretty_toml().unwrap();
         assert!(serialized.contains("expected_bot_id"));
-        assert!(
-            !serialized.contains("bot_token = \"bot-token\"")
-                || serialized.contains("expected_bot_id"),
-            "expected_bot_id must survive serialization"
-        );
+        // Serialization preserves the expectation. The token is also
+        // serialized by design (operator-local config file); credential
+        // redaction is enforced on verify/report outputs, not here.
+        assert!(serialized.contains("expected_bot_id = \"900000000000000101\""));
 
         // Round-trip: the serialized form parses back to the same expectation.
         let round_path = dir.path().join("round.toml");

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use time::{Date, Duration as TimeDuration, OffsetDateTime, PrimitiveDateTime, format_description};
 
 use crate::Result;
+use crate::discord::is_discord_snowflake;
 use crate::events::MessageFormat;
 use crate::source::workspace::{default_workspace_debounce_ms, default_workspace_watch_dirs};
 
@@ -327,6 +328,11 @@ pub struct DiscordConfig {
     pub bot_token: Option<String>,
     #[serde(alias = "default_channel")]
     pub legacy_default_channel: Option<String>,
+    /// Operator-configured stable Discord bot ID that the effective bot token
+    /// must resolve to via `GET /users/@me`. Presence enables fail-closed
+    /// sender-identity verification; absence leaves transport-only behavior.
+    #[serde(default, alias = "bot_id", skip_serializing_if = "Option::is_none")]
+    pub expected_bot_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -352,7 +358,9 @@ pub struct DaemonConfig {
 
 impl DiscordConfig {
     fn is_empty(&self) -> bool {
-        self.bot_token.is_none() && self.legacy_default_channel.is_none()
+        self.bot_token.is_none()
+            && self.legacy_default_channel.is_none()
+            && self.expected_bot_id.is_none()
     }
 }
 
@@ -1156,6 +1164,11 @@ impl AppConfig {
                 self.discord.legacy_default_channel.clone(),
                 &mut self.providers.discord.legacy_default_channel,
             )?;
+            merge_legacy_discord_field(
+                "bot_id",
+                self.discord.expected_bot_id.clone(),
+                &mut self.providers.discord.expected_bot_id,
+            )?;
         }
 
         self.discord = DiscordConfig::default();
@@ -1389,6 +1402,12 @@ impl AppConfig {
             .or_else(|| normalize_secret(self.providers.discord.bot_token.clone()))
             .or_else(|| normalize_secret(self.discord.bot_token.clone()))
     }
+    /// Operator-configured expected Discord bot ID after legacy [discord]
+    /// migration, normalized. `Some(id)` enables fail-closed sender-identity
+    /// verification; `None` keeps the transport-only behavior.
+    pub fn expected_discord_bot_id(&self) -> Option<String> {
+        normalize_text(self.providers.discord.expected_bot_id.clone())
+    }
 
     pub fn discord_token_source(&self) -> &'static str {
         self.discord_token_source_with(|name| env::var(name).ok())
@@ -1589,6 +1608,13 @@ impl AppConfig {
         }
         if self.cron.poll_interval_secs == 0 {
             return Err("cron.poll_interval_secs must be at least 1".into());
+        }
+        if let Some(expected_bot_id) = self.expected_discord_bot_id()
+            && !is_discord_snowflake(&expected_bot_id)
+        {
+            return Err(
+                "providers.discord.expected_bot_id must be a numeric Discord snowflake ID".into(),
+            );
         }
         if self.discord_watch.enabled {
             if self.discord_watch.gaebal_gajae_user_id.trim().is_empty() {
@@ -2401,6 +2427,9 @@ impl AppConfig {
             normalize_secret(self.providers.discord.bot_token.clone());
         self.providers.discord.legacy_default_channel =
             normalize_text(self.providers.discord.legacy_default_channel.clone());
+        self.providers.discord.expected_bot_id =
+            normalize_text(self.providers.discord.expected_bot_id.clone());
+        self.discord.expected_bot_id = normalize_text(self.discord.expected_bot_id.clone());
         self.providers.http.endpoint = normalize_text(self.providers.http.endpoint.clone());
         self.providers.http.hmac_secret_env =
             normalize_text(self.providers.http.hmac_secret_env.clone());
@@ -4297,6 +4326,101 @@ mod tests {
         assert!(config.discord.is_empty());
         assert_eq!(config.defaults.channel.as_deref(), Some("123"));
     }
+    #[test]
+    fn expected_bot_id_parses_serializes_and_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"
+[providers.discord]
+token = "bot-token"
+expected_bot_id = "900000000000000101"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_default(&path).unwrap();
+
+        assert_eq!(
+            config.expected_discord_bot_id().as_deref(),
+            Some("900000000000000101")
+        );
+        assert!(config.validate().is_ok());
+
+        let serialized = config.to_pretty_toml().unwrap();
+        assert!(serialized.contains("expected_bot_id"));
+        assert!(
+            !serialized.contains("bot_token = \"bot-token\"")
+                || serialized.contains("expected_bot_id"),
+            "expected_bot_id must survive serialization"
+        );
+
+        // Round-trip: the serialized form parses back to the same expectation.
+        let round_path = dir.path().join("round.toml");
+        fs::write(&round_path, &serialized).unwrap();
+        let round = AppConfig::load_or_default(&round_path).unwrap();
+        assert_eq!(
+            round.expected_discord_bot_id().as_deref(),
+            Some("900000000000000101")
+        );
+    }
+
+    #[test]
+    fn legacy_discord_bot_id_migrates_to_providers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "[discord]\ntoken = \"legacy-token\"\nbot_id = \"900000000000000101\"\n",
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_default(&path).unwrap();
+
+        assert_eq!(
+            config.expected_discord_bot_id().as_deref(),
+            Some("900000000000000101")
+        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn expected_bot_id_rejects_non_snowflake_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            r#"
+[providers.discord]
+token = "bot-token"
+expected_bot_id = "clawhip-bot"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_default(&path).unwrap();
+        let error = config.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("must be a numeric Discord snowflake ID"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn config_without_expected_bot_id_still_validates() {
+        // Backward compatibility: existing configs parse and validate with no
+        // expectation configured; identity verification stays opt-in.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "[providers.discord]\ntoken = \"bot-token\"\n").unwrap();
+
+        let config = AppConfig::load_or_default(&path).unwrap();
+
+        assert_eq!(config.expected_discord_bot_id(), None);
+        assert!(config.validate().is_ok());
+        assert!(!config.to_pretty_toml().unwrap().contains("expected_bot_id"));
+    }
 
     #[test]
     fn config_without_http_provider_remains_backward_compatible() {
@@ -4765,6 +4889,7 @@ sink = "http"
                 discord: DiscordConfig {
                     bot_token: Some("token".into()),
                     legacy_default_channel: None,
+                    expected_bot_id: None,
                 },
                 slack: SlackConfig::default(),
                 http: HttpConfig::default(),
@@ -4841,6 +4966,7 @@ sink = "http"
                 discord: DiscordConfig {
                     bot_token: Some("old-token".into()),
                     legacy_default_channel: None,
+                    expected_bot_id: None,
                 },
                 slack: SlackConfig::default(),
                 http: HttpConfig::default(),
@@ -5200,6 +5326,7 @@ message = " ping "
                 discord: DiscordConfig {
                     bot_token: Some("token".into()),
                     legacy_default_channel: None,
+                    expected_bot_id: None,
                 },
                 slack: SlackConfig::default(),
                 http: HttpConfig::default(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -519,6 +519,7 @@ fn health_payload(
         "version": VERSION,
         "token_source": config.discord_token_source(),
         "token_precedence_warning": config.discord_token_env_shadow().map(discord_token_shadow_warning),
+        "expected_discord_bot_id": config.expected_discord_bot_id(),
         "webhook_routes_configured": config.has_webhook_routes(),
         "http_routes_configured": config.has_http_routes(),
         "port": port,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2878,6 +2878,38 @@ mod tests {
         assert!(payload["native_hooks"]["totals"]["received"].is_number());
         assert_eq!(payload["token_precedence_warning"], Value::Null);
         assert_eq!(payload["http_routes_configured"], Value::Bool(false));
+        assert_eq!(payload["expected_discord_bot_id"], Value::Null);
+    }
+
+    #[test]
+    fn health_payload_surfaces_expected_discord_bot_id_when_configured() {
+        let mut config = AppConfig::default();
+        config.providers.discord.bot_token = Some("config-token".into());
+        config.providers.discord.expected_bot_id = Some("900000000000000101".into());
+
+        let payload = health_payload(
+            &config,
+            25294,
+            0,
+            snapshot_shared(&new_shared_native_hook_observability()),
+            json!({}),
+            &[],
+            GitMonitorLifecycleCounts::default(),
+        );
+
+        // The health payload exposes only the public-safe expected bot ID —
+        // never the token. `ok` semantics stay unchanged: identity
+        // verification itself is the fail-closed CLI preflight's job.
+        assert_eq!(
+            payload["expected_discord_bot_id"],
+            Value::String("900000000000000101".to_string())
+        );
+        let rendered = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !rendered.contains("config-token"),
+            "token leaked: {rendered}"
+        );
+        assert_eq!(payload["ok"], Value::Bool(true));
     }
 
     #[test]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -157,6 +157,12 @@ pub enum DiscordThreadMessageList {
 }
 
 #[derive(Debug, Deserialize)]
+struct DiscordSelfBody {
+    #[serde(default)]
+    id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct DiscordMessageBody {
     #[serde(default)]
     id: Option<String>,
@@ -583,6 +589,64 @@ impl DiscordClient {
             }
         }
     }
+}
+
+/// Public-safe result of resolving the effective bot token's own Discord
+/// identity via `GET /users/@me`. Variants carry no response bodies and no
+/// token material.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelfLookup {
+    /// Token resolved to a stable bot ID.
+    Bot { id: String },
+    /// No bot token is configured.
+    NoToken,
+    /// Discord rejected the credential (401).
+    Unauthorized,
+    /// Credential valid but the endpoint is forbidden (403).
+    Forbidden,
+    /// Rate limited (429); retry later, identity unverified.
+    RateLimited,
+    /// Success response could not be parsed into a stable bot ID.
+    MalformedSuccess,
+    /// Network/transport or unexpected HTTP failure; identity unverified.
+    Transport,
+}
+
+impl DiscordClient {
+    /// Resolve the bot's own Discord identity via `GET /users/@me`.
+    ///
+    /// A read-only, bounded identity probe used by sender-identity
+    /// verification. It never touches the delivery circuit, limiter,
+    /// telemetry, or DLQ, and the returned value never contains Discord
+    /// response bodies or token material — only the stable bot ID and,
+    /// on failure, a public-safe failure mode.
+    pub async fn lookup_self(&self) -> SelfLookup {
+        let Some(client) = self.bot_client.as_ref() else {
+            return SelfLookup::NoToken;
+        };
+
+        let Some(url) = discord_lane_url(&self.api_base, &["users", "@me"]) else {
+            return SelfLookup::Transport;
+        };
+
+        match client.get(url).timeout(LANE_REQUEST_TIMEOUT).send().await {
+            Ok(response) if response.status().is_success() => response
+                .json::<DiscordSelfBody>()
+                .await
+                .ok()
+                .and_then(|body| body.id)
+                .filter(|id| is_discord_snowflake(id))
+                .map(|id| SelfLookup::Bot { id })
+                .unwrap_or(SelfLookup::MalformedSuccess),
+            Ok(response) => match lane_http_error(response.status(), None).category {
+                DiscordLaneErrorCategory::Unauthorized => SelfLookup::Unauthorized,
+                DiscordLaneErrorCategory::Forbidden => SelfLookup::Forbidden,
+                DiscordLaneErrorCategory::RateLimited => SelfLookup::RateLimited,
+                _ => SelfLookup::Transport,
+            },
+            Err(_) => SelfLookup::Transport,
+        }
+    }
 
     async fn send_message(
         &self,
@@ -880,7 +944,7 @@ fn request_error_category(error: &reqwest::Error) -> DiscordLaneErrorCategory {
     }
 }
 
-fn is_discord_snowflake(value: &str) -> bool {
+pub(crate) fn is_discord_snowflake(value: &str) -> bool {
     (1..=20).contains(&value.len()) && value.as_bytes().iter().all(u8::is_ascii_digit)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod provenance;
 mod release_preflight;
 mod render;
 mod router;
+mod sender_identity;
 mod sink;
 mod slack;
 mod source;
@@ -46,6 +47,7 @@ use crate::cli::{
     GajaeReceiptCommands, GitCommands, GithubCommands, HooksCommands, LaneCommands, LedgerCommands,
     MemoryCommands, NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, SubscribeCommands,
     TmuxCommands, UpdateCommands, VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
+    VerifySenderIdentityArgs,
 };
 
 use crate::client::DaemonClient;
@@ -455,6 +457,9 @@ async fn real_main(cli: Cli) -> Result<()> {
             ConfigCommand::VerifyBindings(args) => run_verify_bindings(config, args).await,
             ConfigCommand::VerifyGatewayAllowlist(args) => {
                 run_verify_gateway_allowlist(config, args)
+            }
+            ConfigCommand::VerifySenderIdentity(args) => {
+                run_verify_sender_identity(config, args).await
             }
         },
         Commands::Plugin { command } => match command {
@@ -996,6 +1001,68 @@ async fn run_verify_bindings(config: Arc<AppConfig>, args: VerifyBindingsArgs) -
         std::process::exit(1);
     }
     Ok(())
+}
+
+async fn run_verify_sender_identity(
+    config: Arc<AppConfig>,
+    args: VerifySenderIdentityArgs,
+) -> Result<()> {
+    use crate::sender_identity::{sender_identity_expectation, verify_sender_identity};
+    config.validate()?;
+
+    let token_source = config.discord_token_source();
+    let expectation = sender_identity_expectation(config.expected_discord_bot_id().as_deref());
+    let client = DiscordClient::from_config(config.clone())?;
+    let verdict = verify_sender_identity(&client, &expectation).await;
+
+    if args.json {
+        let payload = sender_identity_json(&verdict, &expectation, token_source);
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        print_sender_identity_report(&verdict, token_source);
+    }
+
+    // Fail closed: every non-verified outcome — mismatch, absent expectation,
+    // invalid credential, rate limit, malformed response, transport failure —
+    // exits non-zero. Transport success alone never passes this preflight.
+    if !verdict.is_verified() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn sender_identity_json(
+    verdict: &crate::sender_identity::SenderIdentityVerdict,
+    expectation: &crate::sender_identity::SenderIdentityExpectation,
+    token_source: &str,
+) -> serde_json::Value {
+    use crate::sender_identity::SenderIdentityExpectation;
+    use serde_json::json;
+    let expected_bot_id = match expectation {
+        SenderIdentityExpectation::Expected { bot_id } => json!(bot_id),
+        SenderIdentityExpectation::Absent => serde_json::Value::Null,
+    };
+    let observed_bot_id = verdict
+        .observed_bot_id()
+        .map(|id| json!(id))
+        .unwrap_or(serde_json::Value::Null);
+    serde_json::json!({
+        "verified": verdict.is_verified(),
+        "reason_code": verdict.reason_code(),
+        "expected_bot_id": expected_bot_id,
+        "observed_bot_id": observed_bot_id,
+        "verdict": verdict.to_string(),
+        "token_source": token_source,
+    })
+}
+
+fn print_sender_identity_report(
+    verdict: &crate::sender_identity::SenderIdentityVerdict,
+    token_source: &str,
+) {
+    let status = if verdict.is_verified() { "ok" } else { "FAIL" };
+    println!("[{status:>4}] {verdict}");
+    println!("       token source: {token_source} (credential value never printed)");
 }
 
 fn run_verify_gateway_allowlist(

--- a/src/sender_identity.rs
+++ b/src/sender_identity.rs
@@ -1,0 +1,300 @@
+//! Fail-closed Discord sender-identity verification.
+//!
+//! Transport success (`discord_send_success`, `token_source=config`) proves the
+//! token is valid and the message was delivered — it does not prove *which*
+//! bot sent it. During a 2026-08-21 recovery, a wrong-but-valid token
+//! delivered messages as the wrong bot while every transport check stayed
+//! green. This module closes that gap: when the operator configures
+//! `expected_bot_id`, the effective token must resolve to exactly that stable
+//! ID via the Discord `/users/@me` identity endpoint before any readiness,
+//! smoke, or health claim of a verified sender identity is made.
+//!
+//! Verification is fail-closed: any outcome other than an exact observed ==
+//! expected match is a non-healthy verdict. Outputs are public-safe — they
+//! carry expected/observed bot IDs and a failure mode, never the token,
+//! response bodies, or other credential material.
+
+use std::fmt;
+
+use crate::discord::{DiscordClient, SelfLookup};
+
+/// Whether an operator-configured expected bot ID is present at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SenderIdentityExpectation {
+    /// `expected_bot_id` is configured; identity must match it exactly.
+    Expected { bot_id: String },
+    /// No expectation configured. Identity verification is a no-op and
+    /// explicitly *not* claimed as passed; transport-only behavior is
+    /// preserved for existing deployments.
+    Absent,
+}
+
+/// Fail-closed verdict for the sender-identity contract.
+///
+/// `Verified` is the only healthy outcome, and it requires an exact
+/// observed == expected stable bot ID match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SenderIdentityVerdict {
+    /// `/users/@me` resolved to exactly the expected stable bot ID.
+    Verified {
+        /// The stable bot ID both expected and observed.
+        bot_id: String,
+    },
+    /// `/users/@me` resolved to a different stable bot ID. This is the
+    /// wrong-but-valid-token case: transport works, the sender is wrong.
+    Mismatch {
+        expected_bot_id: String,
+        observed_bot_id: String,
+    },
+    /// `expected_bot_id` is not configured, so identity is unverified by
+    /// operator choice. Not healthy, not an error — absent expectation.
+    NotConfigured,
+    /// No bot token is effective, so no identity can be resolved.
+    NoToken,
+    /// Discord rejected the credential: invalid or revoked token.
+    InvalidCredential,
+    /// Credential accepted but the identity endpoint was forbidden.
+    Forbidden,
+    /// Rate limited before identity could be resolved.
+    RateLimited,
+    /// The identity endpoint answered but the payload did not yield a stable
+    /// bot ID. Identity is unverified; fail closed rather than guess.
+    MalformedResponse,
+    /// Network or unexpected HTTP failure. Identity is unverified.
+    TransportFailure,
+}
+
+impl SenderIdentityVerdict {
+    /// The only healthy outcome: an exact observed == expected match.
+    pub fn is_verified(&self) -> bool {
+        matches!(self, SenderIdentityVerdict::Verified { .. })
+    }
+
+    /// Stable, machine-readable reason code safe for JSON output.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            SenderIdentityVerdict::Verified { .. } => "sender_identity_verified",
+            SenderIdentityVerdict::Mismatch { .. } => "sender_identity_mismatch",
+            SenderIdentityVerdict::NotConfigured => "sender_identity_not_configured",
+            SenderIdentityVerdict::NoToken => "sender_identity_no_token",
+            SenderIdentityVerdict::InvalidCredential => "sender_identity_invalid_credential",
+            SenderIdentityVerdict::Forbidden => "sender_identity_forbidden",
+            SenderIdentityVerdict::RateLimited => "sender_identity_rate_limited",
+            SenderIdentityVerdict::MalformedResponse => "sender_identity_malformed_response",
+            SenderIdentityVerdict::TransportFailure => "sender_identity_transport_failure",
+        }
+    }
+
+    /// The stable bot ID this verdict proves (or expected, for mismatches).
+    pub fn observed_bot_id(&self) -> Option<&str> {
+        match self {
+            SenderIdentityVerdict::Verified { bot_id } => Some(bot_id),
+            SenderIdentityVerdict::Mismatch {
+                observed_bot_id, ..
+            } => Some(observed_bot_id),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SenderIdentityVerdict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SenderIdentityVerdict::Verified { bot_id } => {
+                write!(f, "sender identity VERIFIED (bot id {bot_id})")
+            }
+            SenderIdentityVerdict::Mismatch {
+                expected_bot_id,
+                observed_bot_id,
+            } => write!(
+                f,
+                "sender identity MISMATCH: expected Discord bot id {expected_bot_id} but the \
+                 effective token resolves to bot id {observed_bot_id}; transport may still \
+                 succeed while messages are sent by the wrong bot"
+            ),
+            SenderIdentityVerdict::NotConfigured => write!(
+                f,
+                "sender identity NOT CONFIGURED: set providers.discord.expected_bot_id to \
+                 enable fail-closed verification; transport checks alone cannot prove sender \
+                 identity"
+            ),
+            SenderIdentityVerdict::NoToken => write!(
+                f,
+                "sender identity UNVERIFIED: no effective Discord bot token is configured"
+            ),
+            SenderIdentityVerdict::InvalidCredential => write!(
+                f,
+                "sender identity UNVERIFIED: Discord rejected the bot token (unauthorized); \
+                 the credential is invalid or revoked"
+            ),
+            SenderIdentityVerdict::Forbidden => write!(
+                f,
+                "sender identity UNVERIFIED: Discord answered forbidden for the identity \
+                 endpoint"
+            ),
+            SenderIdentityVerdict::RateLimited => write!(
+                f,
+                "sender identity UNVERIFIED: Discord rate limited the identity check; retry"
+            ),
+            SenderIdentityVerdict::MalformedResponse => write!(
+                f,
+                "sender identity UNVERIFIED: Discord identity response did not contain a \
+                 stable bot id"
+            ),
+            SenderIdentityVerdict::TransportFailure => write!(
+                f,
+                "sender identity UNVERIFIED: Discord identity request failed (transport)"
+            ),
+        }
+    }
+}
+
+/// Resolve the operator expectation from the effective (post-legacy-migration)
+/// config, tolerating surrounding whitespace and empty strings.
+pub fn sender_identity_expectation(expected: Option<&str>) -> SenderIdentityExpectation {
+    match expected.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(bot_id) => SenderIdentityExpectation::Expected {
+            bot_id: bot_id.to_string(),
+        },
+        None => SenderIdentityExpectation::Absent,
+    }
+}
+
+/// Run the fail-closed sender-identity check.
+///
+/// Queries Discord `/users/@me` with the effective token — a bounded,
+/// non-mutating read — and compares the observed stable bot ID against the
+/// operator-configured expectation. Every non-match outcome (including
+/// success-shaped but malformed responses) maps to a non-healthy verdict so a
+/// wrong-but-valid token can never be reported healthy merely because
+/// transport works.
+pub async fn verify_sender_identity(
+    client: &DiscordClient,
+    expectation: &SenderIdentityExpectation,
+) -> SenderIdentityVerdict {
+    match expectation {
+        SenderIdentityExpectation::Absent => SenderIdentityVerdict::NotConfigured,
+        SenderIdentityExpectation::Expected { bot_id } => match client.lookup_self().await {
+            SelfLookup::Bot { id } => {
+                if id == *bot_id {
+                    SenderIdentityVerdict::Verified { bot_id: id }
+                } else {
+                    SenderIdentityVerdict::Mismatch {
+                        expected_bot_id: bot_id.clone(),
+                        observed_bot_id: id,
+                    }
+                }
+            }
+            SelfLookup::NoToken => SenderIdentityVerdict::NoToken,
+            SelfLookup::Unauthorized => SenderIdentityVerdict::InvalidCredential,
+            SelfLookup::Forbidden => SenderIdentityVerdict::Forbidden,
+            SelfLookup::RateLimited => SenderIdentityVerdict::RateLimited,
+            SelfLookup::MalformedSuccess => SenderIdentityVerdict::MalformedResponse,
+            SelfLookup::Transport => SenderIdentityVerdict::TransportFailure,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expectation_absent_for_none_empty_and_whitespace() {
+        assert_eq!(
+            sender_identity_expectation(None),
+            SenderIdentityExpectation::Absent
+        );
+        assert_eq!(
+            sender_identity_expectation(Some("")),
+            SenderIdentityExpectation::Absent
+        );
+        assert_eq!(
+            sender_identity_expectation(Some("   ")),
+            SenderIdentityExpectation::Absent
+        );
+    }
+
+    #[test]
+    fn expectation_trims_configured_bot_id() {
+        assert_eq!(
+            sender_identity_expectation(Some(" 1471139513983307916 ")),
+            SenderIdentityExpectation::Expected {
+                bot_id: "1471139513983307916".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn verified_is_the_only_healthy_verdict() {
+        let mismatch = SenderIdentityVerdict::Mismatch {
+            expected_bot_id: "1471139513983307916".into(),
+            observed_bot_id: "1465264645320474637".into(),
+        };
+        for verdict in [
+            SenderIdentityVerdict::Verified {
+                bot_id: "1471139513983307916".into(),
+            },
+            mismatch.clone(),
+            SenderIdentityVerdict::NotConfigured,
+            SenderIdentityVerdict::NoToken,
+            SenderIdentityVerdict::InvalidCredential,
+            SenderIdentityVerdict::Forbidden,
+            SenderIdentityVerdict::RateLimited,
+            SenderIdentityVerdict::MalformedResponse,
+            SenderIdentityVerdict::TransportFailure,
+        ] {
+            let verified = verdict.is_verified();
+            let expected = matches!(&verdict, SenderIdentityVerdict::Verified { .. });
+            assert_eq!(verified, expected, "verdict {verdict:?}");
+        }
+        // Wrong-but-valid token: the exact regression this contract closes.
+        assert!(!mismatch.is_verified());
+    }
+
+    #[test]
+    fn mismatch_display_carries_both_ids_and_no_secret_material() {
+        let verdict = SenderIdentityVerdict::Mismatch {
+            expected_bot_id: "1471139513983307916".into(),
+            observed_bot_id: "1465264645320474637".into(),
+        };
+        let text = verdict.to_string();
+        assert!(text.contains("expected Discord bot id 1471139513983307916"));
+        assert!(text.contains("bot id 1465264645320474637"));
+        // Redaction: no credential material may appear. Discord bot tokens
+        // always contain two dots separating three base64 segments; the
+        // diagnosis text contains none.
+        assert!(!text.contains("Bot "));
+        assert_eq!(
+            text.split('.').count(),
+            1,
+            "diagnosis must contain no dotted token-like material: {text}"
+        );
+    }
+
+    #[test]
+    fn every_verdict_has_a_stable_reason_code() {
+        let verdicts = [
+            SenderIdentityVerdict::Verified { bot_id: "1".into() },
+            SenderIdentityVerdict::Mismatch {
+                expected_bot_id: "1".into(),
+                observed_bot_id: "2".into(),
+            },
+            SenderIdentityVerdict::NotConfigured,
+            SenderIdentityVerdict::NoToken,
+            SenderIdentityVerdict::InvalidCredential,
+            SenderIdentityVerdict::Forbidden,
+            SenderIdentityVerdict::RateLimited,
+            SenderIdentityVerdict::MalformedResponse,
+            SenderIdentityVerdict::TransportFailure,
+        ];
+        let mut seen = std::collections::BTreeSet::new();
+        for verdict in &verdicts {
+            assert!(
+                seen.insert(verdict.reason_code()),
+                "duplicate reason code for {verdict:?}"
+            );
+            assert!(verdict.reason_code().starts_with("sender_identity_"));
+        }
+    }
+}

--- a/src/sender_identity.rs
+++ b/src/sender_identity.rs
@@ -231,23 +231,23 @@ mod tests {
             expected_bot_id: "1471139513983307916".into(),
             observed_bot_id: "1465264645320474637".into(),
         };
-        for verdict in [
+        // Independent enumeration of the healthy set: only Verified may be
+        // healthy; every other verdict must fail closed. Written per-variant
+        // so a new variant added without an explicit assertion stands out.
+        assert!(
             SenderIdentityVerdict::Verified {
-                bot_id: "1471139513983307916".into(),
-            },
-            mismatch.clone(),
-            SenderIdentityVerdict::NotConfigured,
-            SenderIdentityVerdict::NoToken,
-            SenderIdentityVerdict::InvalidCredential,
-            SenderIdentityVerdict::Forbidden,
-            SenderIdentityVerdict::RateLimited,
-            SenderIdentityVerdict::MalformedResponse,
-            SenderIdentityVerdict::TransportFailure,
-        ] {
-            let verified = verdict.is_verified();
-            let expected = matches!(&verdict, SenderIdentityVerdict::Verified { .. });
-            assert_eq!(verified, expected, "verdict {verdict:?}");
-        }
+                bot_id: "1471139513983307916".into()
+            }
+            .is_verified()
+        );
+        assert!(!mismatch.clone().is_verified());
+        assert!(!SenderIdentityVerdict::NotConfigured.is_verified());
+        assert!(!SenderIdentityVerdict::NoToken.is_verified());
+        assert!(!SenderIdentityVerdict::InvalidCredential.is_verified());
+        assert!(!SenderIdentityVerdict::Forbidden.is_verified());
+        assert!(!SenderIdentityVerdict::RateLimited.is_verified());
+        assert!(!SenderIdentityVerdict::MalformedResponse.is_verified());
+        assert!(!SenderIdentityVerdict::TransportFailure.is_verified());
         // Wrong-but-valid token: the exact regression this contract closes.
         assert!(!mismatch.is_verified());
     }

--- a/tests/sender_identity_verification.rs
+++ b/tests/sender_identity_verification.rs
@@ -1,0 +1,439 @@
+//! Integration tests for fail-closed Discord sender-identity verification
+//! (issue #319).
+//!
+//! These tests run the real `clawhip` binary against a loopback mock of the
+//! Discord REST API, exercising `clawhip config verify-sender-identity` end to
+//! end. All bot IDs are synthetic test snowflakes — no host-private IDs.
+//!
+//! The regression this suite pins: a wrong-but-valid Discord bot token must
+//! NOT produce a healthy sender-identity verdict merely because transport
+//! works. The 2026-08-21 incident delivered real messages from the wrong bot
+//! while `token_source=config` and `discord_send_success` stayed green.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::Command;
+use std::sync::mpsc;
+use std::thread;
+
+use tempfile::TempDir;
+
+/// Synthetic snowflake IDs (not real Discord applications).
+const EXPECTED_BOT_ID: &str = "900000000000000101";
+const WRONG_BOT_ID: &str = "900000000000000202";
+
+fn clawhip_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clawhip")
+}
+
+/// One-shot mock Discord API that records the incoming request line and
+/// responds with `status` + `body`, then closes.
+fn spawn_discord_api_mock(status: &str, body: &str) -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock Discord API");
+    let addr = listener.local_addr().expect("mock addr");
+    let (tx, rx) = mpsc::channel();
+    let status = status.to_string();
+    let body = body.to_string();
+
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept request");
+        let mut request = [0_u8; 2048];
+        let read = stream.read(&mut request).expect("read request");
+        tx.send(String::from_utf8_lossy(&request[..read]).into_owned())
+            .expect("send request");
+        write!(
+            stream,
+            "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
+            body.len(),
+        )
+        .expect("write response");
+    });
+
+    (format!("http://{addr}"), rx)
+}
+
+fn write_config(temp: &TempDir, config: &str) -> std::path::PathBuf {
+    let config_path = temp.path().join("clawhip.toml");
+    fs::write(&config_path, config).expect("write config");
+    config_path
+}
+
+fn run_verify(config_path: &std::path::Path, api_base: &str, temp: &TempDir, json: bool) -> Output {
+    let mut command = Command::new(clawhip_bin());
+    command
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .env("CLAWHIP_DISCORD_API_BASE", api_base)
+        .env_remove("CLAWHIP_BOT_TOKEN")
+        .env_remove("DISCORD_BOT_TOKEN")
+        .arg("--config")
+        .arg(config_path)
+        .arg("config")
+        .arg("verify-sender-identity");
+    if json {
+        command.arg("--json");
+    }
+    command
+        .output()
+        .expect("run clawhip config verify-sender-identity")
+}
+
+type Output = std::process::Output;
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// The identity probe must hit exactly `/users/@me` with the bot credential.
+fn assert_identity_request(request: &str) {
+    assert!(
+        request.starts_with("GET /users/@me "),
+        "expected GET /users/@me, got: {request}"
+    );
+    assert!(
+        request.contains("authorization: Bot test-token-319")
+            || request.contains("Authorization: Bot test-token-319"),
+        "expected Bot authorization header, got: {request}"
+    );
+}
+
+#[test]
+fn match_reports_verified_and_exits_zero() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    let (api_base, request_rx) = spawn_discord_api_mock(
+        "200 OK",
+        &format!(r#"{{"id": "{EXPECTED_BOT_ID}", "username": "clawhip"}}"#),
+    );
+
+    let output = run_verify(&config_path, &api_base, &temp, false);
+
+    assert!(
+        output.status.success(),
+        "verified identity must exit 0\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert_identity_request(&request_rx.recv().expect("mock saw request"));
+    let text = stdout(&output);
+    assert!(text.contains("VERIFIED"), "stdout: {text}");
+    assert!(text.contains(EXPECTED_BOT_ID), "stdout: {text}");
+    assert!(!text.contains("test-token-319"), "token leaked: {text}");
+}
+
+#[test]
+fn mismatch_fails_closed_with_precise_public_safe_diagnosis() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    // Wrong-but-valid token: transport would succeed; identity must not.
+    let (api_base, request_rx) = spawn_discord_api_mock(
+        "200 OK",
+        &format!(r#"{{"id": "{WRONG_BOT_ID}", "username": "other-bot"}}"#),
+    );
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "wrong-but-valid token must fail closed\nstdout:\n{}",
+        stdout(&output)
+    );
+    assert_identity_request(&request_rx.recv().expect("mock saw request"));
+    let text = stdout(&output);
+    assert!(text.contains("\"verified\": false"), "stdout: {text}");
+    assert!(text.contains("sender_identity_mismatch"), "stdout: {text}");
+    assert!(
+        text.contains(EXPECTED_BOT_ID),
+        "expected id missing: {text}"
+    );
+    assert!(text.contains(WRONG_BOT_ID), "observed id missing: {text}");
+    assert!(!text.contains("test-token-319"), "token leaked: {text}");
+}
+
+#[test]
+fn absent_expectation_is_not_reported_healthy() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        r#"
+[providers.discord]
+bot_token = "test-token-319"
+"#,
+    );
+    let (api_base, _request_rx) = spawn_discord_api_mock(
+        "200 OK",
+        &format!(r#"{{"id": "{WRONG_BOT_ID}", "username": "other-bot"}}"#),
+    );
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    // Absent expectation must fail the preflight: identity is unverified, and
+    // the operator is told how to enable verification. No API call expected.
+    assert!(
+        !output.status.success(),
+        "absent expectation must not be reported healthy\nstdout:\n{}",
+        stdout(&output)
+    );
+    let text = stdout(&output);
+    assert!(
+        text.contains("sender_identity_not_configured"),
+        "stdout: {text}"
+    );
+    assert!(
+        text.contains("null"),
+        "expected_bot_id should be null: {text}"
+    );
+}
+
+#[test]
+fn invalid_credential_fails_closed() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    let (api_base, request_rx) =
+        spawn_discord_api_mock("401 Unauthorized", r#"{"message": "401: Unauthorized"}"#);
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "invalid credential must fail closed\nstdout:\n{}",
+        stdout(&output)
+    );
+    assert_identity_request(&request_rx.recv().expect("mock saw request"));
+    let text = stdout(&output);
+    assert!(
+        text.contains("sender_identity_invalid_credential"),
+        "stdout: {text}"
+    );
+    // Public-safe: the Discord error body must not be echoed.
+    assert!(!text.contains("401: Unauthorized"), "body leaked: {text}");
+}
+
+#[test]
+fn transport_failure_fails_closed() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    // Point at a dead port: connection refused.
+    let dead_listener = TcpListener::bind("127.0.0.1:0").expect("bind dead port");
+    let dead_addr = dead_listener.local_addr().expect("dead addr");
+    drop(dead_listener);
+
+    let output = run_verify(&config_path, &format!("http://{dead_addr}"), &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "transport failure must fail closed\nstdout:\n{}",
+        stdout(&output)
+    );
+    let text = stdout(&output);
+    assert!(
+        text.contains("sender_identity_transport_failure"),
+        "stdout: {text}"
+    );
+    assert!(!text.contains("test-token-319"), "token leaked: {text}");
+}
+
+#[test]
+fn malformed_success_fails_closed() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    // 200 with no usable stable bot ID: identity is unverified, fail closed.
+    let (api_base, request_rx) = spawn_discord_api_mock("200 OK", r#"{"username": "anon"}"#);
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "malformed success must fail closed\nstdout:\n{}",
+        stdout(&output)
+    );
+    assert_identity_request(&request_rx.recv().expect("mock saw request"));
+    let text = stdout(&output);
+    assert!(
+        text.contains("sender_identity_malformed_response"),
+        "stdout: {text}"
+    );
+}
+
+#[test]
+fn no_token_fails_closed_without_api_call() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+expected_bot_id = "{EXPECTED_BOT_ID}"
+
+[[routes]]
+event = "git.commit"
+webhook = "https://discord.com/api/webhooks/1/synthetic"
+"#
+        ),
+    );
+    let (api_base, request_rx) =
+        spawn_discord_api_mock("200 OK", &format!(r#"{{"id": "{EXPECTED_BOT_ID}"}}"#));
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "no token must fail closed\nstdout:\n{}",
+        stdout(&output)
+    );
+    let text = stdout(&output);
+    assert!(text.contains("sender_identity_no_token"), "stdout: {text}");
+    // No token means no request should have been attempted.
+    assert!(
+        request_rx.try_recv().is_err(),
+        "no API call expected without a token"
+    );
+}
+
+#[test]
+fn legacy_discord_bot_id_config_is_migrated_and_verified() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[discord]
+token = "test-token-319"
+bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    let (api_base, request_rx) = spawn_discord_api_mock(
+        "200 OK",
+        &format!(r#"{{"id": "{EXPECTED_BOT_ID}", "username": "clawhip"}}"#),
+    );
+
+    let output = run_verify(&config_path, &api_base, &temp, false);
+
+    assert!(
+        output.status.success(),
+        "legacy [discord].bot_id must migrate and verify\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert_identity_request(&request_rx.recv().expect("mock saw request"));
+}
+
+#[test]
+fn conflicting_legacy_and_provider_bot_id_is_rejected() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[discord]
+bot_id = "{EXPECTED_BOT_ID}"
+[providers.discord]
+bot_token = "test-token-319"
+bot_id = "{WRONG_BOT_ID}"
+"#
+        ),
+    );
+    let (api_base, _request_rx) = spawn_discord_api_mock("200 OK", r#"{"id": "1"}"#);
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "conflicting bot_id values must be rejected\nstdout:\n{}",
+        stdout(&output)
+    );
+}
+
+#[test]
+fn non_snowflake_expected_bot_id_is_rejected_by_config_validation() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "clawhip-bot"
+"#,
+    );
+    let (api_base, _request_rx) = spawn_discord_api_mock("200 OK", r#"{"id": "1"}"#);
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "non-snowflake expected_bot_id must fail config validation\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    let text = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        text.contains("expected_bot_id must be a numeric Discord snowflake ID"),
+        "diagnostic missing: {text}"
+    );
+}
+
+#[test]
+fn help_documents_the_fail_closed_contract() {
+    let output = Command::new(clawhip_bin())
+        .arg("config")
+        .arg("verify-sender-identity")
+        .arg("--help")
+        .output()
+        .expect("run help");
+
+    assert!(output.status.success());
+    let text = stdout(&output);
+    assert!(text.contains("expected_bot_id"), "help: {text}");
+    assert!(text.contains("--json"), "help: {text}");
+}

--- a/tests/sender_identity_verification.rs
+++ b/tests/sender_identity_verification.rs
@@ -65,8 +65,8 @@ fn run_verify(config_path: &std::path::Path, api_base: &str, temp: &TempDir, jso
         .current_dir(temp.path())
         .env("HOME", temp.path())
         .env("CLAWHIP_DISCORD_API_BASE", api_base)
-        .env_remove("CLAWHIP_BOT_TOKEN")
-        .env_remove("DISCORD_BOT_TOKEN")
+        .env_remove("DISCORD_TOKEN")
+        .env_remove("CLAWHIP_DISCORD_BOT_TOKEN")
         .arg("--config")
         .arg(config_path)
         .arg("config")
@@ -202,10 +202,10 @@ bot_token = "test-token-319"
         text.contains("sender_identity_not_configured"),
         "stdout: {text}"
     );
-    assert!(
-        text.contains("null"),
-        "expected_bot_id should be null: {text}"
-    );
+    let payload: serde_json::Value =
+        serde_json::from_str(&text).expect("absent-expectation JSON must parse");
+    assert_eq!(payload["expected_bot_id"], serde_json::Value::Null);
+    assert_eq!(payload["verified"], serde_json::Value::Bool(false));
 }
 
 #[test]
@@ -421,6 +421,154 @@ expected_bot_id = "clawhip-bot"
         text.contains("expected_bot_id must be a numeric Discord snowflake ID"),
         "diagnostic missing: {text}"
     );
+}
+
+#[test]
+fn forbidden_403_fails_closed() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    let (api_base, request_rx) =
+        spawn_discord_api_mock("403 Forbidden", r#"{"message": "403: Forbidden"}"#);
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "403 must fail closed\nstdout:\n{}",
+        stdout(&output)
+    );
+    assert_identity_request(&request_rx.recv().expect("mock saw request"));
+    let text = stdout(&output);
+    assert!(text.contains("sender_identity_forbidden"), "stdout: {text}");
+    assert!(!text.contains("403: Forbidden"), "body leaked: {text}");
+}
+
+#[test]
+fn rate_limited_429_fails_closed() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    let (api_base, request_rx) = spawn_discord_api_mock(
+        "429 Too Many Requests",
+        r#"{"message": "You are being rate limited.", "retry_after": 1.0}"#,
+    );
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        !output.status.success(),
+        "429 must fail closed\nstdout:\n{}",
+        stdout(&output)
+    );
+    assert_identity_request(&request_rx.recv().expect("mock saw request"));
+    let text = stdout(&output);
+    assert!(
+        text.contains("sender_identity_rate_limited"),
+        "stdout: {text}"
+    );
+    assert!(
+        !text.contains("You are being rate limited"),
+        "body leaked: {text}"
+    );
+}
+
+#[test]
+fn match_reports_verified_json_output() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        &format!(
+            r#"
+[providers.discord]
+bot_token = "test-token-319"
+expected_bot_id = "{EXPECTED_BOT_ID}"
+"#
+        ),
+    );
+    let (api_base, request_rx) = spawn_discord_api_mock(
+        "200 OK",
+        &format!(r#"{{"id": "{EXPECTED_BOT_ID}", "username": "clawhip"}}"#),
+    );
+
+    let output = run_verify(&config_path, &api_base, &temp, true);
+
+    assert!(
+        output.status.success(),
+        "verified identity must exit 0\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert_identity_request(&request_rx.recv().expect("mock saw request"));
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&stdout(&output)).expect("verified JSON output must parse");
+    assert_eq!(payload["verified"], serde_json::Value::Bool(true));
+    assert_eq!(
+        payload["reason_code"],
+        serde_json::Value::String("sender_identity_verified".into())
+    );
+    assert_eq!(
+        payload["expected_bot_id"],
+        serde_json::Value::String(EXPECTED_BOT_ID.into())
+    );
+    assert_eq!(
+        payload["observed_bot_id"],
+        serde_json::Value::String(EXPECTED_BOT_ID.into())
+    );
+    assert!(
+        payload["token_source"].is_string(),
+        "token_source must be a public-safe label: {payload}"
+    );
+    assert!(
+        !stdout(&output).contains("test-token-319"),
+        "token leaked: {}",
+        stdout(&output)
+    );
+}
+
+#[test]
+fn text_mode_failure_report_shows_fail_header() {
+    let temp = TempDir::new().expect("tempdir");
+    let config_path = write_config(
+        &temp,
+        r#"
+[providers.discord]
+bot_token = "test-token-319"
+"#,
+    );
+    let (api_base, _request_rx) = spawn_discord_api_mock("200 OK", r#"{"id": "1"}"#);
+
+    let output = run_verify(&config_path, &api_base, &temp, false);
+
+    assert!(
+        !output.status.success(),
+        "absent expectation must fail closed in text mode\nstdout:\n{}",
+        stdout(&output)
+    );
+    let text = stdout(&output);
+    assert!(text.contains("[FAIL]"), "text FAIL header missing: {text}");
+    assert!(
+        text.contains("token source: config (credential value never printed)"),
+        "public-safe token-source line missing: {text}"
+    );
+    assert!(!text.contains("test-token-319"), "token leaked: {text}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Clawhip reported `discord_send_success` while a wrong-but-valid Discord bot token delivered messages authored by the wrong bot (#319). During owner-directed runtime recovery on 2026-08-21, `token_source=config` and successful transport proved provenance and transport only — the delivered author was the conversational bot, not the dedicated clawhip bot, and the daemon had to be stopped until an independent `/users/@me` identity check matched the expected stable ID.

This adds the smallest Clawhip-owned fail-closed sender-identity verification contract for bot-token deployments. A wrong-but-valid token can no longer be reported healthy by the identity/readiness check merely because transport works.

## Fix

- **Config**: `providers.discord.expected_bot_id` — clearly named, snowflake-validated, backward-compatible opt-in (legacy `[discord].bot_id` accepted and migrated with the existing conflict-rejection semantics). Absent expectation preserves transport-only behavior; validation rejects non-numeric IDs.
- **Client**: `DiscordClient::lookup_self()` — bounded (5s) read-only `GET /users/@me` with the effective token (env precedence honored, same as delivery). Never touches delivery circuit, rate limiter, telemetry, or DLQ. Typed public-safe `SelfLookup` result carrying no response bodies and no token material.
- **Verdicts**: `src/sender_identity.rs` — `Verified` only on exact observed == expected stable bot ID; every other outcome is a distinct non-healthy verdict (`Mismatch` with both IDs, `NotConfigured`, `NoToken`, `InvalidCredential`, `Forbidden`, `RateLimited`, `MalformedResponse`, `TransportFailure`).
- **CLI preflight**: `clawhip config verify-sender-identity [--json]` — non-mutating readiness/smoke surface; validates config, prints a precise public-safe diagnosis (`sender_identity_mismatch` with expected and observed bot IDs), and exits non-zero on every non-verified outcome.
- **Health**: daemon `/health` payload exposes `expected_discord_bot_id` (the ID only) so readiness consumers can see whether identity verification is armed.
- **Docs**: `docs/live-verification.md` documents the two-leg acceptance smoke — API identity equality plus channel author readback authored by the expected bot; arrival-only confirmation is explicitly insufficient.

## Acceptance

- [x] Match: observed == expected → `VERIFIED`, exit 0
- [x] Mismatch (wrong-but-valid token): `sender_identity_mismatch`, both stable bot IDs reported, exit non-zero — transport success never passes this preflight
- [x] Absent expectation: `sender_identity_not_configured`, not healthy, exit non-zero with guidance
- [x] Invalid credential (401): `sender_identity_invalid_credential`, no Discord error body echoed
- [x] Transport failure and malformed 200 responses fail closed
- [x] No token: `sender_identity_no_token` with no API call attempted
- [x] Serialization round-trip, legacy `[discord].bot_id` migration, conflict rejection, snowflake validation
- [x] Redaction: token material absent from every text and JSON output path (request header asserted to carry `Bot` credential; outputs asserted not to)
- [x] Synthetic test snowflakes only — no host-private IDs in defaults or fixtures

## Test plan

Exact head `f884f48` (diff sha256 `e2127b7b57938a11c057465b754eeb99b05d908bd972f48e01b13b9fa94b7bde`):

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --test sender_identity_verification` — 11/11 (mock Discord API integration: match, mismatch, absent, no-token, 401, transport, malformed, legacy migration, conflict, snowflake, help)
- `cargo test --all-targets --all-features` — 983 passed, 0 failed (916 bin unit + 11 new integration + remaining suites)

Closes #319

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
