### PR TITLE
fix(sdk): repair GJC SDK v3 transport hello gating and typed frames

### DIFF
--- a/src/gjc_sdk.rs
+++ b/src/gjc_sdk.rs
@@ -1,14 +1,20 @@
 //! Safe worktree-local GJC SDK endpoint discovery and typed websocket transport.
 //!
-//! This module owns issue #322's reusable transport layer:
+//! This module owns the reusable GJC SDK v3 transport layer (#322, repaired by
+//! #328):
 //!
-//! - [`discover`] reads `<worktree>/.gjc/state/sdk/*.json` session endpoint
-//!   metadata for one registered lane/worktree, never scanning unrelated
-//!   roots, and never exposing tokens through errors or debug output.
-//! - [`SdkClient`] performs authenticated (`?token=` query parameter), framed,
-//!   bounded websocket requests against the discovered loopback endpoint with
-//!   correlation IDs, bounded timeouts, bounded frame/output sizes, a typed
-//!   error taxonomy, and bounded reconnect.
+//! - [`discover`] reads `<worktree>/.gjc/state/sdk/<session-id>.json` session
+//!   endpoint metadata for one registered lane/worktree, binds identity to the
+//!   endpoint filename, honors supported `version`/`stale` record semantics,
+//!   never scans unrelated roots, and never exposes tokens through errors or
+//!   debug output.
+//! - [`SdkClient`] speaks the installed SDK v3 wire contract: one authenticated
+//!   (`?token=` query parameter), hello-gated persistent websocket connection
+//!   per client, strict `hello` type/identity validation, typed
+//!   [`SdkRequest::query`] / [`SdkRequest::control`] / [`SdkRequest::broker`]
+//!   frames with object inputs and their matching `*_response` envelopes,
+//!   bounded timeouts, bounded frame/output sizes, a typed error taxonomy, and
+//!   bounded reconnect with re-authentication.
 //!
 //! The trust boundary is strictly local: only `ws://` loopback endpoints read
 //! from worktree-local metadata under the same user are accepted, and the
@@ -42,6 +48,17 @@ const MAX_URL_CHARS: usize = 512;
 const MAX_SESSION_ID_CHARS: usize = 64;
 /// Ceiling applied to every inbound frame regardless of configuration.
 const ABSOLUTE_MAX_FRAME_BYTES: usize = 262_144;
+/// Endpoint record schema version supported by this transport.
+///
+/// The installed GJC host publishes `{"version":1, ...}` endpoint records;
+/// anything else fails discovery closed.
+const SUPPORTED_ENDPOINT_RECORD_VERSION: u32 = 1;
+/// Maximum accepted hello `connectionId` length.
+const MAX_CONNECTION_ID_CHARS: usize = 128;
+/// Maximum accepted query/operation name length.
+const MAX_OPERATION_NAME_CHARS: usize = 128;
+/// Non-mutating, always-installed query used by the diagnostic probe.
+const PROBE_QUERY: &str = "session.metadata";
 
 /// Typed, public-safe transport error taxonomy.
 ///
@@ -55,6 +72,8 @@ pub enum SdkTransportError {
     EndpointMalformed,
     /// The websocket handshake or authentication was rejected.
     EndpointUnauthorized,
+    /// The post-connect `hello` frame violated the v3 contract.
+    InvalidHello,
     /// The operation exceeded its bounded timeout.
     Timeout,
     /// The server closed or errored the connection mid-exchange.
@@ -74,6 +93,7 @@ impl SdkTransportError {
             Self::EndpointUnavailable => "endpoint_unavailable",
             Self::EndpointMalformed => "endpoint_malformed",
             Self::EndpointUnauthorized => "endpoint_unauthorized",
+            Self::InvalidHello => "invalid_hello",
             Self::Timeout => "timeout",
             Self::ConnectionClosed => "connection_closed",
             Self::FrameRejected => "frame_rejected",
@@ -101,6 +121,7 @@ pub struct EndpointMetadata {
     url: String,
     token: String,
     pid: Option<u32>,
+    stale: bool,
 }
 
 impl std::fmt::Debug for EndpointMetadata {
@@ -110,6 +131,7 @@ impl std::fmt::Debug for EndpointMetadata {
             .field("url", &"<redacted>")
             .field("token", &"<redacted>")
             .field("pid", &self.pid)
+            .field("stale", &self.stale)
             .finish()
     }
 }
@@ -125,6 +147,11 @@ impl EndpointMetadata {
         self.pid
     }
 
+    /// Whether the endpoint record was explicitly marked stale by its writer.
+    pub fn stale(&self) -> bool {
+        self.stale
+    }
+
     /// Authenticated websocket URL with the token applied as a query param.
     fn authenticated_url(&self) -> Result<Url> {
         let mut url = Url::parse(&self.url).map_err(|_| SdkTransportError::EndpointMalformed)?;
@@ -135,8 +162,9 @@ impl EndpointMetadata {
 
 /// Raw metadata file schema (`<state-root>/sdk/<session-id>.json`).
 ///
-/// GJC writes `sessionId` (camelCase); the snake_case alias is accepted for
-/// hand-authored fixtures.
+/// GJC publishes `version: 1` records keyed by the `<sessionId>.json`
+/// filename; `stale` marks records superseded before removal. Unknown fields
+/// are ignored so newer writers stay readable.
 #[derive(Deserialize)]
 struct RawEndpointMetadata {
     #[serde(rename = "sessionId", alias = "session_id")]
@@ -145,6 +173,10 @@ struct RawEndpointMetadata {
     token: String,
     #[serde(default)]
     pid: Option<u32>,
+    #[serde(default)]
+    version: Option<u32>,
+    #[serde(default)]
+    stale: bool,
 }
 
 fn valid_session_id(value: &str) -> bool {
@@ -161,6 +193,14 @@ fn valid_token(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+}
+
+fn valid_operation_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_OPERATION_NAME_CHARS
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'/' | b'-'))
 }
 
 /// Validate a loopback-only endpoint URL from metadata.
@@ -302,9 +342,17 @@ fn non_zero_uid(uid: u32) -> Option<u32> {
     (uid != 0).then_some(uid)
 }
 
+/// Parse and validate one endpoint record.
+///
+/// Supported semantics: `version` must name a schema this transport
+/// understands ([`SUPPORTED_ENDPOINT_RECORD_VERSION`]); the payload session id
+/// must be well-formed; the URL must be loopback-only.
 fn parse_metadata(contents: &[u8]) -> Result<EndpointMetadata> {
     let raw: RawEndpointMetadata =
         serde_json::from_slice(contents).map_err(|_| SdkTransportError::EndpointMalformed)?;
+    if raw.version != Some(SUPPORTED_ENDPOINT_RECORD_VERSION) {
+        return Err(SdkTransportError::EndpointMalformed.into());
+    }
     if !valid_session_id(&raw.session_id) {
         return Err(SdkTransportError::EndpointMalformed.into());
     }
@@ -317,7 +365,25 @@ fn parse_metadata(contents: &[u8]) -> Result<EndpointMetadata> {
         url: raw.url,
         token: raw.token,
         pid: raw.pid,
+        stale: raw.stale,
     })
+}
+
+/// Parse one candidate metadata file and bind it to its filename identity.
+///
+/// The endpoint filename is authority: `<session-id>.json` must exactly match
+/// the recorded `sessionId`. A disagreement fails closed as malformed so a
+/// renamed/copied record can never impersonate another session's endpoint.
+fn parse_metadata_file(path: &Path, contents: &[u8]) -> Result<EndpointMetadata> {
+    let metadata = parse_metadata(contents)?;
+    let matches_filename = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem == metadata.session_id());
+    if !matches_filename {
+        return Err(SdkTransportError::EndpointMalformed.into());
+    }
+    Ok(metadata)
 }
 
 /// Check whether the endpoint's owning process is still alive.
@@ -341,7 +407,8 @@ pub enum Discovery {
     Live(EndpointMetadata),
     /// The lane has no endpoint metadata at all.
     NoMetadata,
-    /// Metadata exists but no owning process is alive.
+    /// Metadata exists but its owning process is gone or the record was
+    /// explicitly marked stale by its writer.
     Stale {
         /// Public-safe session identifier of the stale metadata.
         session_id: String,
@@ -352,10 +419,11 @@ pub enum Discovery {
 
 /// Discover endpoint metadata for one registered lane/worktree.
 ///
-/// Only `*.json` files directly inside `<state-root>/sdk` are considered —
-/// unrelated roots are never scanned. The most recently modified valid
-/// metadata file wins; liveness of its recorded pid is checked so dead
-/// sessions surface as [`Discovery::Stale`]. Outcome precedence is
+/// Only `<session-id>.json` files directly inside `<state-root>/sdk` are
+/// considered — unrelated roots are never scanned. Identity is bound to the
+/// filename; the most recently modified valid metadata file wins. Liveness of
+/// its recorded pid and its explicit `stale` flag fence dead or superseded
+/// sessions as [`Discovery::Stale`]. Outcome precedence is
 /// Live > Stale > Malformed > NoMetadata.
 pub fn discover(root: &StateRoot) -> Result<Discovery> {
     // Expected filesystem states are outcomes, not errors: a missing lane
@@ -391,14 +459,14 @@ pub fn discover(root: &StateRoot) -> Result<Discovery> {
         let Ok(contents) = std::fs::read(&path) else {
             continue;
         };
-        let Ok(metadata) = parse_metadata(&contents) else {
+        let Ok(metadata) = parse_metadata_file(&path, &contents) else {
             continue;
         };
         let modified = entry
             .metadata()
             .and_then(|meta| meta.modified())
             .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        if metadata.pid().is_some_and(|pid| !process_alive(pid)) {
+        if metadata.stale() || metadata.pid().is_some_and(|pid| !process_alive(pid)) {
             stale = Some(metadata.session_id().to_string());
             continue;
         }
@@ -459,30 +527,78 @@ impl SdkTransportLimits {
     }
 }
 
-/// Typed request envelope sent to the SDK endpoint.
+/// Typed SDK v3 request frame sent to the endpoint.
+///
+/// The v3 wire contract carries exactly one of `query` (for
+/// `query_request`) or `operation` (for `control_request`/`broker_request`)
+/// plus a JSON-object `input`; responses echo the correlation `id` on the
+/// matching `*_response` frame.
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct SdkRequest {
     /// Correlation ID echoed by the server on the matching response.
     pub id: String,
-    /// Frame discriminator; always `request` for client frames.
+    /// Frame discriminator: `query_request`, `control_request`, or
+    /// `broker_request`.
     #[serde(rename = "type")]
     pub frame_type: &'static str,
-    /// SDK method name.
-    pub method: String,
-    /// Method parameters.
-    #[serde(default, skip_serializing_if = "Value::is_null")]
-    pub params: serde_json::Value,
+    /// Query name; set only on `query_request` frames.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    /// Operation name; set only on `control_request`/`broker_request` frames.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation: Option<String>,
+    /// Object-shaped call input; serialized as `{}` when absent.
+    pub input: Value,
 }
 
 impl SdkRequest {
-    /// Build a request with a fresh correlation ID.
-    pub fn new(method: impl Into<String>, params: Value) -> Self {
+    /// Build a typed v3 request with a fresh correlation ID.
+    fn v3(
+        frame_type: &'static str,
+        selector: Option<(&'static str, String)>,
+        input: Value,
+    ) -> Self {
+        let (query, operation) = match selector {
+            Some(("query", name)) => (Some(name), None),
+            Some(("operation", name)) => (None, Some(name)),
+            _ => (None, None),
+        };
         Self {
             id: new_correlation_id(),
-            frame_type: "request",
-            method: method.into(),
-            params,
+            frame_type,
+            query,
+            operation,
+            input: normalize_input(input),
         }
+    }
+
+    /// Build a `query_request` for one host-published query.
+    pub fn query(query: impl Into<String>, input: Value) -> Self {
+        Self::v3("query_request", Some(("query", query.into())), input)
+    }
+
+    /// Build a `control_request` for one session control operation.
+    /// Reusable v3 surface for the planned control/event consumers (#323-#326);
+    /// the diagnostic probe itself only exercises queries.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn control(operation: impl Into<String>, input: Value) -> Self {
+        Self::v3(
+            "control_request",
+            Some(("operation", operation.into())),
+            input,
+        )
+    }
+
+    /// Build a `broker_request` for one broker-global operation.
+    /// Reusable v3 surface for the planned control/event consumers (#323-#326);
+    /// the diagnostic probe itself only exercises queries.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn broker(operation: impl Into<String>, input: Value) -> Self {
+        Self::v3(
+            "broker_request",
+            Some(("operation", operation.into())),
+            input,
+        )
     }
 
     /// Correlation ID of this request.
@@ -490,7 +606,28 @@ impl SdkRequest {
         &self.id
     }
 
+    /// The `*_response` frame family that correlates to this request.
+    fn response_frame_type(&self) -> &'static str {
+        match self.frame_type {
+            "control_request" => "control_response",
+            "broker_request" => "broker_response",
+            _ => "query_response",
+        }
+    }
+
     fn encode(&self) -> Result<String> {
+        if !self.input.is_object() {
+            return Err(SdkTransportError::FrameRejected.into());
+        }
+        let selector_ok = match (self.frame_type, &self.query, &self.operation) {
+            ("query_request", Some(query), None) => valid_operation_name(query),
+            ("control_request", None, Some(operation))
+            | ("broker_request", None, Some(operation)) => valid_operation_name(operation),
+            _ => false,
+        };
+        if !selector_ok {
+            return Err(SdkTransportError::FrameRejected.into());
+        }
         let frame = serde_json::to_string(self).map_err(|_| SdkTransportError::FrameRejected)?;
         if frame.len() > ABSOLUTE_MAX_FRAME_BYTES {
             return Err(SdkTransportError::FrameRejected.into());
@@ -499,20 +636,36 @@ impl SdkRequest {
     }
 }
 
+/// Coerce absent inputs to the empty object the v3 contract requires.
+fn normalize_input(input: Value) -> Value {
+    if input.is_null() {
+        Value::Object(serde_json::Map::new())
+    } else {
+        input
+    }
+}
+
 /// Typed response envelope received from the SDK endpoint.
+///
+/// Successful v3 responses carry `ok: true` plus a `result` and/or paged
+/// `page` payload; failures carry `ok: false` with a structured `error`.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct SdkResponse {
     /// Correlation ID matching the request this responds to.
     pub id: Option<String>,
-    /// Frame discriminator from the server (`response`, `hello`, `error`...).
+    /// Response discriminator (`query_response`, `control_response`,
+    /// `broker_response`, ...).
     #[serde(rename = "type")]
     pub frame_type: String,
     /// Server-reported success flag when present.
     #[serde(default)]
     pub ok: Option<bool>,
-    /// Response payload.
+    /// Unpaged response result.
     #[serde(default)]
-    pub payload: Value,
+    pub result: Value,
+    /// Paged response envelope (`items`, `complete`, ...).
+    #[serde(default)]
+    pub page: Value,
     /// Server-reported error code when present.
     #[serde(default)]
     pub error: Option<SdkServerError>,
@@ -542,12 +695,44 @@ pub fn new_correlation_id() -> String {
     id
 }
 
-/// Hello frame emitted by the server after authentication.
+/// Hello frame emitted by the server immediately after authentication.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct HelloFrame {
     /// Server-assigned connection identifier.
     #[serde(default, rename = "connectionId")]
     pub connection_id: Option<String>,
+}
+
+fn valid_connection_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_CONNECTION_ID_CHARS
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+}
+
+/// Strictly parse the post-authentication `hello` frame.
+///
+/// The first server frame MUST be a JSON object with `type == "hello"` and a
+/// bounded, well-formed `connectionId`; anything else violates the v3
+/// handshake contract and fails closed as [`SdkTransportError::InvalidHello`].
+fn parse_hello(frame: &str, limits: &SdkTransportLimits) -> Result<HelloFrame> {
+    if frame.len() > limits.max_frame_bytes {
+        return Err(SdkTransportError::FrameRejected.into());
+    }
+    let value: Value = serde_json::from_str(frame).map_err(|_| SdkTransportError::InvalidHello)?;
+    if value.get("type").and_then(Value::as_str) != Some("hello") {
+        return Err(SdkTransportError::InvalidHello.into());
+    }
+    let hello: HelloFrame =
+        serde_json::from_value(value).map_err(|_| SdkTransportError::InvalidHello)?;
+    let connection_id = hello
+        .connection_id
+        .as_deref()
+        .filter(|id| valid_connection_id(id))
+        .ok_or(SdkTransportError::InvalidHello)?;
+    debug_assert!(connection_id.len() <= MAX_CONNECTION_ID_CHARS);
+    Ok(hello)
 }
 
 fn parse_response(frame: &str, limits: &SdkTransportLimits) -> Result<SdkResponse> {
@@ -556,18 +741,28 @@ fn parse_response(frame: &str, limits: &SdkTransportLimits) -> Result<SdkRespons
     }
     let response: SdkResponse =
         serde_json::from_str(frame).map_err(|_| SdkTransportError::FrameRejected)?;
-    if serde_json::to_string(&response.payload)
-        .is_ok_and(|encoded| encoded.len() > limits.max_payload_bytes)
-    {
-        return Err(SdkTransportError::FrameRejected.into());
+    for payload in [&response.result, &response.page] {
+        if serde_json::to_string(payload)
+            .is_ok_and(|encoded| encoded.len() > limits.max_payload_bytes)
+        {
+            return Err(SdkTransportError::FrameRejected.into());
+        }
     }
     Ok(response)
 }
 
 /// Authenticated, typed websocket client for one SDK endpoint.
+///
+/// The client owns one hello-gated connection: [`SdkClient::connect`]
+/// establishes it and validates the server `hello`, and every
+/// [`SdkClient::request`] flows over that same authenticated connection until
+/// it drops. A lost connection is re-established (hello gate included) up to
+/// the bounded reconnect budget before [`SdkTransportError::RetryExhausted`].
 pub struct SdkClient {
     metadata: EndpointMetadata,
     limits: SdkTransportLimits,
+    stream: Option<WebSocketStream<MaybeTlsStream<TcpStream>>>,
+    hello: Option<HelloFrame>,
 }
 
 impl SdkClient {
@@ -576,6 +771,8 @@ impl SdkClient {
         Self {
             metadata,
             limits: SdkTransportLimits::default(),
+            stream: None,
+            hello: None,
         }
     }
 
@@ -625,58 +822,76 @@ impl SdkClient {
         }
     }
 
-    /// Open an authenticated connection and return the server `hello` frame.
+    /// Open an authenticated connection, await the server `hello`, and keep
+    /// the connection for subsequent requests.
+    ///
+    /// No request frame may precede the validated hello: the connection is
+    /// returned to the caller only after the server's identity frame passed
+    /// strict type/identity validation.
     pub async fn connect(&mut self) -> Result<HelloFrame> {
         let mut stream = self.connect_once().await?;
-        let hello = tokio::time::timeout(self.limits.connect_timeout, stream.next()).await;
-        let Some(hello) = hello.map_err(|_| SdkTransportError::Timeout)? else {
-            return Err(SdkTransportError::ConnectionClosed.into());
+        let next = tokio::time::timeout(self.limits.connect_timeout, stream.next()).await;
+        let message = match next {
+            Err(_elapsed) => {
+                return Err(SdkTransportError::Timeout.into());
+            }
+            Ok(None) => {
+                return Err(SdkTransportError::ConnectionClosed.into());
+            }
+            Ok(Some(message)) => message.map_err(|_| SdkTransportError::ConnectionClosed)?,
         };
-        let message = hello.map_err(|_| SdkTransportError::ConnectionClosed)?;
         let Message::Text(text) = message else {
-            return Err(SdkTransportError::FrameRejected.into());
+            return Err(SdkTransportError::InvalidHello.into());
         };
-        if text.len() > self.limits.max_frame_bytes {
-            return Err(SdkTransportError::FrameRejected.into());
-        }
-        serde_json::from_str::<HelloFrame>(&text)
-            .map_err(|_| SdkTransportError::FrameRejected)
-            .map_err(Into::into)
+        let hello = parse_hello(&text, &self.limits)?;
+        self.stream = Some(stream);
+        self.hello = Some(hello.clone());
+        Ok(hello)
     }
 
-    /// Send one typed request and await its correlated response.
+    /// Identity of the currently pooled authenticated connection, when the
+    /// hello gate has most recently passed.
+    pub fn hello(&self) -> Option<&HelloFrame> {
+        self.hello.as_ref()
+    }
+
+    /// Send one typed v3 request over the authenticated connection and await
+    /// its correlated `*_response`.
     ///
-    /// Each attempt opens one fresh authenticated connection. Connect failures
-    /// are terminal for the call; a connection lost mid-exchange is retried up
-    /// to `max_reconnect_attempts` times before surfacing
-    /// [`SdkTransportError::RetryExhausted`].
+    /// The first call connects and completes the hello gate implicitly. A
+    /// connection lost mid-exchange is re-established (re-authenticated) up to
+    /// `max_reconnect_attempts` times before surfacing
+    /// [`SdkTransportError::RetryExhausted`]; connect failures are terminal
+    /// for the call.
     pub async fn request(&mut self, request: &SdkRequest) -> Result<SdkResponse> {
         let frame = request.encode()?;
         let mut attempts = 0u64;
         loop {
             attempts = attempts.saturating_add(1);
-            let stream = self.connect_once().await?;
-            let mut stream = stream;
-            match exchange(&mut stream, request, &frame, &self.limits).await {
+            if self.stream.is_none() {
+                self.connect().await?;
+            }
+            let Some(stream) = self.stream.as_mut() else {
+                return Err(SdkTransportError::ConnectionClosed.into());
+            };
+            match exchange(stream, request, &frame, &self.limits).await {
                 Ok(response) => return Ok(response),
-                Err(error)
-                    if attempts <= self.limits.max_reconnect_attempts
-                        && matches!(
-                            error.downcast_ref::<SdkTransportError>(),
-                            Some(SdkTransportError::ConnectionClosed)
-                        ) =>
-                {
-                    continue;
+                Err(error) => {
+                    // Any mid-exchange failure poisons the pooled connection;
+                    // the next attempt starts from a fresh authenticated
+                    // handshake instead of trusting a half-dead socket.
+                    self.stream = None;
+                    self.hello = None;
+                    let connection_lost = error
+                        .downcast_ref::<SdkTransportError>()
+                        .is_some_and(|e| *e == SdkTransportError::ConnectionClosed);
+                    if !(connection_lost && attempts <= self.limits.max_reconnect_attempts) {
+                        if connection_lost {
+                            return Err(SdkTransportError::RetryExhausted.into());
+                        }
+                        return Err(error);
+                    }
                 }
-                Err(error)
-                    if matches!(
-                        error.downcast_ref::<SdkTransportError>(),
-                        Some(SdkTransportError::ConnectionClosed)
-                    ) =>
-                {
-                    return Err(SdkTransportError::RetryExhausted.into());
-                }
-                Err(error) => return Err(error),
             }
         }
     }
@@ -693,8 +908,8 @@ async fn exchange(
         .await
         .map_err(|_| SdkTransportError::Timeout)?
         .map_err(|_| SdkTransportError::ConnectionClosed)?;
-    // Bounded tolerance for id-less server frames (notifications) that cannot
-    // be correlated to this request.
+    // Bounded tolerance for id-less server frames (notifications, events) that
+    // cannot be correlated to this request.
     let mut uncorrelated = 0u8;
     loop {
         let next = tokio::time::timeout(limits.request_timeout, stream.next()).await;
@@ -707,14 +922,21 @@ async fn exchange(
             return Err(SdkTransportError::FrameRejected.into());
         };
         let response = parse_response(&text, limits)?;
-        match response.frame_type.as_str() {
-            "hello" => continue,
-            _ => match response.id.as_deref() {
-                Some(id) if id == request.correlation_id() => return Ok(response),
-                // A correlated frame for a different request is a protocol
-                // violation on a single-request diagnostic transport.
-                Some(_) => return Err(SdkTransportError::CorrelationMismatch.into()),
-                None => {
+        match response.id.as_deref() {
+            Some(id) if id == request.correlation_id() => {
+                if response.frame_type == request.response_frame_type() {
+                    return Ok(response);
+                }
+                // A correlated frame of the wrong family is a protocol
+                // violation, not a matchable response.
+                return Err(SdkTransportError::FrameRejected.into());
+            }
+            // A correlated frame for a different request is a protocol
+            // violation on a single-request diagnostic transport.
+            Some(_) => return Err(SdkTransportError::CorrelationMismatch.into()),
+            None => match response.frame_type.as_str() {
+                "hello" => continue,
+                _ => {
                     uncorrelated = uncorrelated.saturating_add(1);
                     if uncorrelated >= 16 {
                         return Err(SdkTransportError::CorrelationMismatch.into());
@@ -747,6 +969,7 @@ pub fn redact_error(error: &crate::DynError, session_id: Option<&str>) -> SdkDia
         "endpoint_unavailable" => "no SDK endpoint metadata under the lane state root",
         "endpoint_malformed" => "SDK endpoint metadata failed validation",
         "endpoint_unauthorized" => "SDK endpoint rejected authentication",
+        "invalid_hello" => "SDK endpoint hello violated the v3 handshake contract",
         "timeout" => "SDK transport exceeded its bounded timeout",
         "connection_closed" => "SDK endpoint closed the connection",
         "frame_rejected" => "SDK frame violated size or shape bounds",
@@ -809,6 +1032,9 @@ pub struct ProbeReport {
     /// Request failure reason code when the round-trip failed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_reason: Option<&'static str>,
+    /// Server-reported stable error code for an application-level failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_error_code: Option<String>,
 }
 
 impl ProbeReport {
@@ -819,7 +1045,23 @@ impl ProbeReport {
             request_ok: None,
             request_correlated: None,
             request_reason: None,
+            request_error_code: None,
         }
+    }
+}
+
+/// Bound a server-reported error code to a safe diagnostic token.
+fn sanitize_error_code(code: Option<&str>) -> Option<String> {
+    let mut sanitized: String = code?
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+        .take(MAX_OPERATION_NAME_CHARS)
+        .collect();
+    sanitized.truncate(MAX_OPERATION_NAME_CHARS);
+    if sanitized.is_empty() {
+        None
+    } else {
+        Some(sanitized)
     }
 }
 
@@ -837,25 +1079,27 @@ fn probe_limits() -> SdkTransportLimits {
 #[allow(clippy::too_many_lines)]
 async fn probe_transport(metadata: EndpointMetadata) -> ProbeReport {
     let mut client = SdkClient::new(metadata).with_limits(probe_limits());
-    let connection_id = match client.connect().await {
-        Ok(hello) => hello.connection_id,
-        Err(error) => {
-            let reason = error
-                .downcast_ref::<SdkTransportError>()
-                .map(|error: &SdkTransportError| error.reason())
-                .unwrap_or("transport_failed");
-            return ProbeReport::failed(reason);
-        }
-    };
-    let request = SdkRequest::new("status.get", serde_json::Value::Null);
+    if let Err(error) = client.connect().await {
+        let reason = error
+            .downcast_ref::<SdkTransportError>()
+            .map(|error: &SdkTransportError| error.reason())
+            .unwrap_or("transport_failed");
+        return ProbeReport::failed(reason);
+    }
+    let request = SdkRequest::query(PROBE_QUERY, serde_json::Value::Null);
     let correlation_id = request.correlation_id().to_string();
     match client.request(&request).await {
         Ok(response) => ProbeReport {
-            hello_connection_id: connection_id,
+            hello_connection_id: client.hello().and_then(|hello| hello.connection_id.clone()),
             hello_reason: None,
             request_ok: Some(response.ok.unwrap_or(true)),
             request_correlated: Some(response.id.as_deref() == Some(correlation_id.as_str())),
             request_reason: None,
+            request_error_code: (!response.ok.unwrap_or(true))
+                .then(|| {
+                    sanitize_error_code(response.error.as_ref().and_then(|e| e.code.as_deref()))
+                })
+                .flatten(),
         },
         Err(error) => {
             let reason = error
@@ -863,11 +1107,12 @@ async fn probe_transport(metadata: EndpointMetadata) -> ProbeReport {
                 .map(|error: &SdkTransportError| error.reason())
                 .unwrap_or("transport_failed");
             ProbeReport {
-                hello_connection_id: connection_id,
+                hello_connection_id: client.hello().and_then(|hello| hello.connection_id.clone()),
                 hello_reason: None,
                 request_ok: Some(false),
                 request_correlated: None,
                 request_reason: Some(reason),
+                request_error_code: None,
             }
         }
     }
@@ -984,12 +1229,17 @@ fn render_inspect(snapshot: &InspectSnapshot) {
         if let Some(reason) = probe.request_reason {
             println!("  request_reason: {reason}");
         }
+        if let Some(code) = &probe.request_error_code {
+            println!("  request_error_code: {code}");
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use std::sync::atomic::Ordering;
 
     fn temp_worktree(name: &str) -> (tempfile::TempDir, StateRoot) {
         let dir = tempfile::tempdir().unwrap();
@@ -1045,7 +1295,7 @@ mod tests {
     }
 
     #[test]
-    fn token_and_session_id_charset_bounds() {
+    fn token_session_id_and_operation_charset_bounds() {
         assert!(valid_token("abcABC123_-."));
         assert!(valid_token("0ECXWhpn0Bm6KtlhGxhqz8PEOX1Y6Xzi"));
         assert!(!valid_token(""));
@@ -1058,28 +1308,77 @@ mod tests {
         assert!(!valid_session_id("../escape"));
         assert!(!valid_session_id("has_underscore"));
         assert!(!valid_session_id(&"x".repeat(MAX_SESSION_ID_CHARS + 1)));
+
+        assert!(valid_operation_name("session.metadata"));
+        assert!(valid_operation_name("providers.list/active"));
+        assert!(valid_operation_name("turn.abort"));
+        assert!(!valid_operation_name(""));
+        assert!(!valid_operation_name("has space"));
+        assert!(!valid_operation_name(
+            &"x".repeat(MAX_OPERATION_NAME_CHARS + 1)
+        ));
     }
 
     #[test]
-    fn parse_metadata_accepts_camel_case_and_snake_alias() {
-        let camel = metadata_json("ws://127.0.0.1:43065/", "tok0ECXWhpn", Some(42));
-        let parsed = parse_metadata(camel.as_bytes()).unwrap();
+    fn parse_metadata_enforces_supported_version_stale_and_identity() {
+        let parsed = parse_metadata(
+            metadata_json("ws://127.0.0.1:43065/", "tok0ECXWhpn", Some(42)).as_bytes(),
+        )
+        .unwrap();
         assert_eq!(parsed.session_id(), SESSION_ID);
         assert_eq!(parsed.pid(), Some(42));
+        assert!(!parsed.stale());
 
-        let snake = "{\"session_id\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok\"}";
+        let snake = "{\"session_id\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok\",\"version\":1}";
         let parsed = parse_metadata(snake.as_bytes()).unwrap();
         assert_eq!(parsed.session_id(), SESSION_ID);
-        assert_eq!(parsed.pid(), None);
+
+        // Explicitly stale records stay parseable; discovery fences them.
+        let stale = "{\"version\":1,\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok\",\"stale\":true}";
+        let parsed = parse_metadata(stale.as_bytes()).unwrap();
+        assert!(parsed.stale());
+
+        // Unsupported or missing record versions fail closed.
+        for bad_version in [
+            "{\"version\":2,\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok\"}",
+            "{\"version\":0,\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok\"}",
+            "{\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok\"}",
+        ] {
+            assert!(
+                parse_metadata(bad_version.as_bytes()).is_err(),
+                "expected version rejection: {bad_version}"
+            );
+        }
 
         // Missing fields / wrong types are malformed.
         for bad in [
             "{}",
-            "{\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\"}",
-            "{\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"token\":\"tok\"}",
+            "{\"version\":1,\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\"}",
+            "{\"version\":1,\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"token\":\"tok\"}",
         ] {
             assert!(parse_metadata(bad.as_bytes()).is_err(), "{bad}");
         }
+    }
+
+    #[test]
+    fn endpoint_filename_is_the_identity_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("{SESSION_ID}.json"));
+        std::fs::write(&path, metadata_json("ws://127.0.0.1:1/", "tok", None)).unwrap();
+        let parsed = parse_metadata_file(&path, std::fs::read(&path).unwrap().as_slice()).unwrap();
+        assert_eq!(parsed.session_id(), SESSION_ID);
+
+        // Renamed/copied records cannot impersonate another session.
+        let impostor = dir.path().join("01a00000-0000-0000-0000-000000000009.json");
+        std::fs::write(&impostor, metadata_json("ws://127.0.0.1:1/", "tok", None)).unwrap();
+        assert!(
+            parse_metadata_file(&impostor, std::fs::read(&impostor).unwrap().as_slice()).is_err()
+        );
+
+        // Non-UTF8 stems can never match either.
+        let odd = dir.path().join("weird name.json");
+        std::fs::write(&odd, metadata_json("ws://127.0.0.1:1/", "tok", None)).unwrap();
+        assert!(parse_metadata_file(&odd, std::fs::read(&odd).unwrap().as_slice()).is_err());
     }
 
     #[test]
@@ -1106,11 +1405,12 @@ mod tests {
     #[test]
     fn discover_live_and_newest_wins() {
         let (_dir, root) = temp_worktree("wt");
-        write_metadata_at(
-            &root,
-            "01a00000-0000-0000-0000-000000000001.json",
-            &metadata_json("ws://127.0.0.1:11111/", "tokold", Some(std::process::id())),
-        );
+        write_metadata_at(&root, "01a00000-0000-0000-0000-000000000001.json", &{
+            let mut body =
+                metadata_json("ws://127.0.0.1:11111/", "tokold", Some(std::process::id()));
+            body = body.replace(SESSION_ID, "01a00000-0000-0000-0000-000000000001");
+            body
+        });
         std::thread::sleep(std::time::Duration::from_millis(20));
         write_metadata_at(
             &root,
@@ -1127,7 +1427,7 @@ mod tests {
     }
 
     #[test]
-    fn discover_stale_when_pid_dead() {
+    fn discover_stale_when_pid_dead_or_record_flagged() {
         let (_dir, root) = temp_worktree("wt");
         write_metadata_at(
             &root,
@@ -1137,6 +1437,33 @@ mod tests {
         match discover(&root).unwrap() {
             Discovery::Stale { session_id } => assert_eq!(session_id, SESSION_ID),
             other => panic!("expected Stale, got {other:?}"),
+        }
+
+        // An explicit stale flag fences even a live pid.
+        let flagged = format!(
+            "{{\"version\":1,\"sessionId\":\"{SESSION_ID}\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok\",\"pid\":{},\"stale\":true}}",
+            std::process::id()
+        );
+        let (_dir2, root2) = temp_worktree("wt2");
+        write_metadata_at(&root2, &format!("{SESSION_ID}.json"), &flagged);
+        match discover(&root2).unwrap() {
+            Discovery::Stale { session_id } => assert_eq!(session_id, SESSION_ID),
+            other => panic!("expected Stale for flagged record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn discover_fails_closed_on_filename_mismatch() {
+        let (_dir, root) = temp_worktree("wt");
+        // Payload claims another session than its filename authorizes.
+        write_metadata_at(
+            &root,
+            "01a00000-0000-0000-0000-000000000002.json",
+            &metadata_json("ws://127.0.0.1:1/", "tok", Some(std::process::id())),
+        );
+        match discover(&root).unwrap() {
+            Discovery::Malformed => {}
+            other => panic!("filename mismatch must fail closed, got {other:?}"),
         }
     }
 
@@ -1271,6 +1598,7 @@ mod tests {
                 SdkTransportError::EndpointUnauthorized,
                 "endpoint_unauthorized",
             ),
+            (SdkTransportError::InvalidHello, "invalid_hello"),
             (SdkTransportError::Timeout, "timeout"),
             (SdkTransportError::ConnectionClosed, "connection_closed"),
             (SdkTransportError::FrameRejected, "frame_rejected"),
@@ -1294,18 +1622,142 @@ mod tests {
     }
 
     #[test]
-    fn request_envelope_encodes_typed_frame_with_correlation() {
-        let request = SdkRequest::new("status.get", serde_json::Value::Null);
-        assert_eq!(request.frame_type, "request");
-        let encoded = request.encode().unwrap();
-        let value: serde_json::Value = serde_json::from_str(&encoded).unwrap();
-        assert_eq!(value["type"], "request");
-        assert_eq!(value["method"], "status.get");
-        assert_eq!(value["id"], serde_json::json!(request.correlation_id()));
-        // Correlation IDs are unique and UUID-shaped.
-        let other = SdkRequest::new("status.get", serde_json::Value::Null);
-        assert_ne!(request.correlation_id(), other.correlation_id());
-        assert_eq!(request.correlation_id().len(), 36);
+    fn typed_requests_encode_v3_frames_with_object_input() {
+        let query = SdkRequest::query("session.metadata", Value::Null);
+        assert_eq!(query.frame_type, "query_request");
+        let encoded = query.encode().unwrap();
+        let value: Value = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(value["type"], json!("query_request"));
+        assert_eq!(value["query"], json!("session.metadata"));
+        assert_eq!(value["input"], json!({}));
+        assert_eq!(value["id"], json!(query.correlation_id()));
+        assert!(value.get("operation").is_none());
+        assert_eq!(query.response_frame_type(), "query_response");
+
+        let control = SdkRequest::control("turn.abort", json!({"mode": "terminal"}));
+        let encoded = control.encode().unwrap();
+        let value: Value = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(value["type"], json!("control_request"));
+        assert_eq!(value["operation"], json!("turn.abort"));
+        assert_eq!(value["input"], json!({"mode": "terminal"}));
+        assert!(value.get("query").is_none());
+        assert_eq!(control.response_frame_type(), "control_response");
+
+        let broker = SdkRequest::broker("session.list", Value::Null);
+        let encoded = broker.encode().unwrap();
+        let value: Value = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(value["type"], json!("broker_request"));
+        assert_eq!(value["operation"], json!("session.list"));
+        assert_eq!(value["input"], json!({}));
+        assert_eq!(broker.response_frame_type(), "broker_response");
+
+        // Correlation IDs are unique and UUID-shaped across all builders.
+        let other = SdkRequest::query("session.metadata", Value::Null);
+        assert_ne!(query.correlation_id(), other.correlation_id());
+        assert_eq!(query.correlation_id().len(), 36);
+    }
+
+    #[test]
+    fn typed_requests_fail_closed_on_bad_shapes() {
+        // Inputs must be objects (null normalizes to {}).
+        let bad_input = SdkRequest::query("session.metadata", json!([1, 2]));
+        assert_eq!(
+            bad_input
+                .encode()
+                .unwrap_err()
+                .downcast_ref::<SdkTransportError>()
+                .unwrap()
+                .reason(),
+            "frame_rejected"
+        );
+
+        // Selector names must be bounded and well-formed.
+        let bad_name = SdkRequest::query("has space", Value::Null);
+        assert!(bad_name.encode().is_err());
+        let long_name = SdkRequest::control("x".repeat(MAX_OPERATION_NAME_CHARS + 1), Value::Null);
+        assert!(long_name.encode().is_err());
+
+        // Frame selectors must match their family.
+        let mismatched = SdkRequest {
+            input: json!({}),
+            ..SdkRequest::query("session.metadata", Value::Null)
+        };
+        let mismatched = SdkRequest {
+            frame_type: "control_request",
+            ..mismatched
+        };
+        assert!(mismatched.encode().is_err());
+
+        // Oversized frames are rejected before serialization leaves the crate.
+        let oversized = SdkRequest::query(
+            "session.metadata",
+            json!({ "pad": "x".repeat(ABSOLUTE_MAX_FRAME_BYTES) }),
+        );
+        assert!(oversized.encode().is_err());
+    }
+
+    #[test]
+    fn parse_hello_requires_typed_bounded_identity() {
+        let limits = SdkTransportLimits::default();
+        let hello = parse_hello(
+            r#"{"type":"hello","connectionId":"890c00fd-3800-4cef-b25b-2d3070aba530"}"#,
+            &limits,
+        )
+        .unwrap();
+        assert_eq!(
+            hello.connection_id.as_deref(),
+            Some("890c00fd-3800-4cef-b25b-2d3070aba530")
+        );
+
+        // Wrong frame type fails closed as invalid_hello...
+        for wrong in [
+            r#"{"type":"welcome","connectionId":"abc"}"#,
+            r#"{"type":"server_hello","connectionId":"abc"}"#,
+            r#"{"type":"query_response","id":"x"}"#,
+            r#"{"method":"status.get"}"#,
+            "not json",
+            "[]",
+        ] {
+            let error = parse_hello(wrong, &limits).unwrap_err();
+            assert_eq!(
+                error.downcast_ref::<SdkTransportError>().unwrap().reason(),
+                "invalid_hello",
+                "{wrong}"
+            );
+        }
+
+        // ...as does a missing, empty, oversized, or ill-formed identity.
+        for bad_identity in [
+            r#"{"type":"hello"}"#,
+            r#"{"type":"hello","connectionId":""}"#,
+            r#"{"type":"hello","connectionId":"has space"}"#,
+            &format!(
+                r#"{{"type":"hello","connectionId":"{}"}}"#,
+                "x".repeat(MAX_CONNECTION_ID_CHARS + 1)
+            ),
+        ] {
+            assert!(
+                parse_hello(bad_identity, &limits).is_err(),
+                "{bad_identity}"
+            );
+        }
+
+        // Oversized hello frames are frame violations.
+        let oversized_limits = SdkTransportLimits {
+            max_frame_bytes: 32,
+            ..SdkTransportLimits::default()
+        };
+        assert_eq!(
+            parse_hello(
+                r#"{"type":"hello","connectionId":"890c00fd-3800-4cef-b25b-2d3070aba530"}"#,
+                &oversized_limits
+            )
+            .unwrap_err()
+            .downcast_ref::<SdkTransportError>()
+            .unwrap()
+            .reason(),
+            "frame_rejected"
+        );
     }
 
     #[test]
@@ -1313,17 +1765,33 @@ mod tests {
         let limits = SdkTransportLimits {
             connect_timeout: Duration::from_secs(1),
             request_timeout: Duration::from_secs(1),
-            max_frame_bytes: 64,
+            max_frame_bytes: 256,
             max_payload_bytes: 32,
             max_reconnect_attempts: 0,
         };
-        let ok = r#"{"type":"response","id":"abc","ok":true,"payload":{"k":1}}"#;
+        let ok = r#"{"type":"query_response","id":"abc","ok":true,"result":{"k":1}}"#;
         let parsed = parse_response(ok, &limits).unwrap();
         assert_eq!(parsed.id.as_deref(), Some("abc"));
         assert_eq!(parsed.ok, Some(true));
+        assert_eq!(parsed.frame_type, "query_response");
+
+        let paged =
+            r#"{"type":"query_response","id":"abc","ok":true,"page":{"items":[],"complete":true}}"#;
+        assert!(parse_response(paged, &limits).is_ok());
+
+        let errored = r#"{"type":"control_response","id":"e2","ok":false,"error":{"code":"unknown_operation","message":"no"}}"#;
+        let parsed = parse_response(errored, &limits).unwrap();
+        assert_eq!(parsed.ok, Some(false));
+        assert_eq!(
+            parsed.error.and_then(|error| error.code),
+            Some("unknown_operation".to_string())
+        );
 
         // Oversized frame text is rejected before parsing.
-        let oversized = format!("{{\"type\":\"response\",\"pad\":\"{}\"}}", "x".repeat(80));
+        let oversized = format!(
+            "{{\"type\":\"query_response\",\"pad\":\"{}\"}}",
+            "x".repeat(300)
+        );
         assert_eq!(
             parse_response(&oversized, &limits)
                 .unwrap_err()
@@ -1334,21 +1802,44 @@ mod tests {
         );
 
         // Payload beyond bounds is rejected even when framed small.
-        let big_payload = format!(
-            "{{\"type\":\"response\",\"payload\":{{\"p\":\"{}\"}}}}",
+        let big_result = format!(
+            "{{\"type\":\"query_response\",\"result\":{{\"p\":\"{}\"}}}}",
             "y".repeat(40)
         );
         assert_eq!(
-            parse_response(&big_payload, &limits)
+            parse_response(&big_result, &limits)
                 .unwrap_err()
                 .downcast_ref::<SdkTransportError>()
                 .unwrap()
                 .reason(),
             "frame_rejected"
         );
+        let big_page = format!(
+            "{{\"type\":\"query_response\",\"page\":{{\"p\":\"{}\"}}}}",
+            "z".repeat(40)
+        );
+        assert!(parse_response(&big_page, &limits).is_err());
 
         // Non-JSON frames are rejected.
         assert!(parse_response("hello world", &limits).is_err());
+    }
+
+    #[test]
+    fn sanitize_error_code_bounds_server_values() {
+        assert_eq!(
+            sanitize_error_code(Some("operation_not_session_owned")),
+            Some("operation_not_session_owned".to_string())
+        );
+        assert_eq!(
+            sanitize_error_code(Some("bad code; DROP TABLE")),
+            Some("badcodeDROPTABLE".to_string())
+        );
+        assert_eq!(
+            sanitize_error_code(Some(&"x".repeat(MAX_OPERATION_NAME_CHARS + 10))),
+            Some("x".repeat(MAX_OPERATION_NAME_CHARS))
+        );
+        assert_eq!(sanitize_error_code(Some("!!!")), None);
+        assert_eq!(sanitize_error_code(None), None);
     }
 
     #[test]
@@ -1379,5 +1870,296 @@ mod tests {
             url.query()
                 .is_some_and(|query| query == "token=tokvalue123")
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Focused v3 transport fixtures over a real in-process loopback server.
+    //
+    // The black-box CLI fixtures (tests/gjc_sdk_transport.rs) exercise the
+    // query path through `gjc inspect --probe`; these white-box fixtures cover
+    // the full hello gate, pre-hello ordering, and the control/broker frame
+    // families on the shared client.
+    // -----------------------------------------------------------------------
+
+    mod loopback {
+        use super::*;
+        use std::net::{IpAddr, Ipv4Addr};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use tokio::net::{TcpListener, TcpStream};
+        use tokio_tungstenite::accept_hdr_async;
+        use tokio_tungstenite::tungstenite::Utf8Bytes;
+        use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+
+        pub(super) struct Fixture {
+            pub metadata: EndpointMetadata,
+            /// True when any client frame reached the server before its hello.
+            pub prehello_violation: Arc<AtomicBool>,
+            /// Number of accepted connections (reconnect identity tracking).
+            pub connections: Arc<AtomicUsize>,
+        }
+
+        fn fixture_metadata(port: u16) -> EndpointMetadata {
+            let body = format!(
+                "{{\"version\":1,\"sessionId\":\"{SESSION_ID}\",\"url\":\"ws://127.0.0.1:{port}/\",\"token\":\"tok_fixture_v3\",\"pid\":{}}}",
+                std::process::id()
+            );
+            parse_metadata(body.as_bytes()).unwrap()
+        }
+
+        /// Start one fixture server; `mode` selects the wire behavior.
+        pub(super) async fn spawn(mode: &'static str) -> Fixture {
+            let listener = TcpListener::bind((IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+                .await
+                .unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let prehello_violation = Arc::new(AtomicBool::new(false));
+            let connections = Arc::new(AtomicUsize::new(0));
+            let violation = Arc::clone(&prehello_violation);
+            let conn_counter = Arc::clone(&connections);
+            tokio::spawn(async move {
+                loop {
+                    let Ok((stream, _)) = listener.accept().await else {
+                        return;
+                    };
+                    let violation = Arc::clone(&violation);
+                    let conn_counter = Arc::clone(&conn_counter);
+                    tokio::spawn(async move {
+                        handle_connection(stream, mode, violation, conn_counter).await;
+                    });
+                }
+            });
+            Fixture {
+                metadata: fixture_metadata(port),
+                prehello_violation,
+                connections,
+            }
+        }
+
+        #[allow(clippy::result_large_err)] // fixture-only 401 rejection path
+        async fn handle_connection(
+            stream: TcpStream,
+            mode: &'static str,
+            prehello_violation: Arc<AtomicBool>,
+            connections: Arc<AtomicUsize>,
+        ) {
+            let token = "tok_fixture_v3".to_string();
+            let accepted = accept_hdr_async(stream, |request: &Request, response: Response| {
+                let authenticated = request
+                    .uri()
+                    .query()
+                    .and_then(|query| {
+                        query.split('&').find_map(|pair| {
+                            let (key, value) = pair.split_once('=')?;
+                            (key == "token").then(|| value.to_string())
+                        })
+                    })
+                    .is_some_and(|value| value == token);
+                if !authenticated {
+                    return Err(Response::builder()
+                        .status(401)
+                        .body::<Option<String>>(None)
+                        .expect("static unauthorized response"));
+                }
+                Ok(response)
+            })
+            .await;
+            let Ok(socket) = accepted else {
+                return;
+            };
+            let connection_index = connections.fetch_add(1, Ordering::SeqCst);
+            let (mut writer, mut reader) = socket.split();
+            let connection_id = format!("conn-{connection_index}");
+
+            if mode == "wrong-hello" {
+                // Violate the handshake contract with a non-hello first frame.
+                let _ = writer
+                    .send(Message::Text(Utf8Bytes::from(
+                        r#"{"type":"welcome","connectionId":"not-a-hello"}"#,
+                    )))
+                    .await;
+                while let Some(Ok(_)) = reader.next().await {}
+                return;
+            }
+
+            if mode == "prehello" {
+                // Prove ordering: a correct client sends nothing until the
+                // hello lands, so this bounded read must time out empty.
+                let early = tokio::time::timeout(Duration::from_millis(300), reader.next()).await;
+                if let Ok(Some(Ok(_))) = early {
+                    prehello_violation.store(true, Ordering::SeqCst);
+                }
+            }
+
+            let hello = format!(r#"{{"type":"hello","connectionId":"{connection_id}"}}"#);
+            if writer
+                .send(Message::Text(Utf8Bytes::from(hello)))
+                .await
+                .is_err()
+            {
+                return;
+            }
+
+            while let Some(Ok(message)) = reader.next().await {
+                let Message::Text(text) = message else {
+                    continue;
+                };
+                let Ok(value) = serde_json::from_slice::<Value>(text.as_bytes()) else {
+                    continue;
+                };
+                if mode == "close-first" && connection_index == 0 {
+                    // Drop without answering so the client must reconnect and
+                    // re-authenticate against a fresh identity.
+                    return;
+                }
+                let response_type = match value.get("type").and_then(Value::as_str) {
+                    Some("control_request") => "control_response",
+                    Some("broker_request") => "broker_response",
+                    _ => "query_response",
+                };
+                let mut response = if mode == "app-error" {
+                    json!({
+                        "type": response_type,
+                        "id": value.get("id").cloned().unwrap_or(Value::Null),
+                        "ok": false,
+                        "error": {
+                            "code": "operation_not_session_owned",
+                            "message": "fixture error surface",
+                        },
+                    })
+                } else {
+                    json!({
+                        "type": response_type,
+                        "id": value.get("id").cloned().unwrap_or(Value::Null),
+                        "ok": true,
+                        "result": {"echo": value.get("query").or_else(|| value.get("operation")).cloned().unwrap_or(Value::Null)},
+                    })
+                };
+                if mode == "paged" && response_type == "query_response" {
+                    response["page"] = json!({"items": [{"n": 1}], "complete": true});
+                }
+                if writer
+                    .send(Message::Text(Utf8Bytes::from(
+                        serde_json::to_string(&response).unwrap(),
+                    )))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }
+
+        pub(super) fn probe_limits_short() -> SdkTransportLimits {
+            SdkTransportLimits {
+                connect_timeout: Duration::from_secs(2),
+                request_timeout: Duration::from_secs(2),
+                ..SdkTransportLimits::default()
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn client_round_trips_all_typed_families_over_one_hello_gated_connection() {
+        let fixture = loopback::spawn("standard").await;
+        let mut client =
+            SdkClient::new(fixture.metadata).with_limits(loopback::probe_limits_short());
+        let hello = client.connect().await.unwrap();
+        assert_eq!(hello.connection_id.as_deref(), Some("conn-0"));
+
+        for request in [
+            SdkRequest::query("session.metadata", Value::Null),
+            SdkRequest::control("session.rename", json!({"name": "probe"})),
+            SdkRequest::broker("session.list", Value::Null),
+        ] {
+            let correlation_id = request.correlation_id().to_string();
+            let expected_family = request.response_frame_type();
+            let response = client.request(&request).await.unwrap();
+            assert_eq!(response.frame_type, expected_family);
+            assert_eq!(response.id.as_deref(), Some(correlation_id.as_str()));
+            assert_eq!(response.ok, Some(true));
+        }
+        // Every exchange reused the single authenticated connection.
+        assert_eq!(fixture.connections.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn client_surfaces_paged_query_and_application_error_codes() {
+        for (mode, expect_ok, expect_code) in [
+            ("paged", true, None),
+            (
+                "app-error",
+                false,
+                Some("operation_not_session_owned".to_string()),
+            ),
+        ] {
+            let fixture = loopback::spawn(mode).await;
+            let mut client =
+                SdkClient::new(fixture.metadata).with_limits(loopback::probe_limits_short());
+            let hello = client.connect().await.unwrap();
+            assert_eq!(hello.connection_id.as_deref(), Some("conn-0"));
+            let request = SdkRequest::query("session.metadata", Value::Null);
+            let correlation_id = request.correlation_id().to_string();
+            let response = client.request(&request).await.unwrap();
+            assert_eq!(response.id.as_deref(), Some(correlation_id.as_str()));
+            assert_eq!(response.ok, Some(expect_ok));
+            assert_eq!(
+                response.error.and_then(|error| error.code),
+                expect_code,
+                "{mode}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn client_fails_closed_on_wrong_hello_type() {
+        let fixture = loopback::spawn("wrong-hello").await;
+        let mut client =
+            SdkClient::new(fixture.metadata).with_limits(loopback::probe_limits_short());
+        let error = client.connect().await.unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<SdkTransportError>().unwrap().reason(),
+            "invalid_hello"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_never_sends_a_frame_before_the_hello_gate() {
+        let fixture = loopback::spawn("prehello").await;
+        let mut client =
+            SdkClient::new(fixture.metadata).with_limits(loopback::probe_limits_short());
+        let hello = client.connect().await.unwrap();
+        assert_eq!(hello.connection_id.as_deref(), Some("conn-0"));
+        let response = client
+            .request(&SdkRequest::query("session.metadata", Value::Null))
+            .await
+            .unwrap();
+        assert_eq!(response.ok, Some(true));
+        assert!(
+            !fixture.prehello_violation.load(Ordering::SeqCst),
+            "client transmitted before the server hello"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_reauthenticates_with_new_identity_after_mid_exchange_loss() {
+        let fixture = loopback::spawn("close-first").await;
+        let mut client = SdkClient::new(fixture.metadata).with_limits(SdkTransportLimits {
+            max_reconnect_attempts: 3,
+            ..loopback::probe_limits_short()
+        });
+        let first_hello = client.connect().await.unwrap();
+        assert_eq!(first_hello.connection_id.as_deref(), Some("conn-0"));
+
+        // The first connection drops mid-exchange; the bounded retry must
+        // re-handshake (new hello identity) and still complete the request.
+        let request = SdkRequest::query("session.metadata", Value::Null);
+        let correlation_id = request.correlation_id().to_string();
+        let response = client.request(&request).await.unwrap();
+        assert_eq!(response.id.as_deref(), Some(correlation_id.as_str()));
+        assert_eq!(response.ok, Some(true));
+        assert_eq!(fixture.connections.load(Ordering::SeqCst), 2);
+        let second_hello = client.hello().and_then(|hello| hello.connection_id.clone());
+        assert_eq!(second_hello.as_deref(), Some("conn-1"));
     }
 }

--- a/tests/gjc_sdk_transport.rs
+++ b/tests/gjc_sdk_transport.rs
@@ -1,14 +1,19 @@
-//! Integration fixtures for the worktree-local GJC SDK transport (#322).
+//! Integration fixtures for the worktree-local GJC SDK transport (#322/#328).
 //!
-//! Covers the six required cases against a real loopback websocket server:
-//! unavailable, stale, malformed, unauthorized, timeout, and success — plus
-//! the filesystem trust boundary (symlink/permission/path validation) and
+//! Covers discovery (unavailable, stale, stale-flagged, filename mismatch,
+//! unsupported record version, malformed, newest-wins), the filesystem trust
+//! boundary (symlink/permission/path validation), and the repaired SDK v3
+//! wire contract against a real loopback websocket fixture server: strict
+//! hello gating, pre-hello ordering, typed correlated responses, typed
+//! application errors, bounded reconnect with re-authentication, and
 //! redacted diagnostics. The transport API is exercised black-box through
-//! `CARGO_BIN_EXE_clawhip gjc inspect` plus an in-process fixture server.
+//! `CARGO_BIN_EXE_clawhip gjc inspect --probe` plus an in-process server.
 
 use std::net::{IpAddr, Ipv4Addr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
@@ -39,9 +44,17 @@ fn metadata_json(url: &str, token: &str, pid: Option<u32>) -> String {
 }
 
 fn write_metadata(state_root: &Path, contents: &str) -> PathBuf {
+    write_metadata_as(
+        state_root,
+        "01a02ccd-c754-7656-95c7-f40b5a140bc3.json",
+        contents,
+    )
+}
+
+fn write_metadata_as(state_root: &Path, file_name: &str, contents: &str) -> PathBuf {
     let sdk_dir = state_root.join("sdk");
     std::fs::create_dir_all(&sdk_dir).unwrap();
-    let path = sdk_dir.join("01a02ccd-c754-7656-95c7-f40b5a140bc3.json");
+    let path = sdk_dir.join(file_name);
     std::fs::write(&path, contents).unwrap();
     restrict_owner_only(&path);
     path
@@ -76,6 +89,22 @@ fn inspect_stdout(worktree: &Path) -> Value {
         String::from_utf8_lossy(&output.stderr)
     );
     serde_json::from_slice(&output.stdout).expect("parse inspect json")
+}
+
+fn probe_stdout(worktree: &Path) -> Value {
+    let output = Command::new(bin())
+        .args(["gjc", "inspect", "--probe"])
+        .arg("--worktree")
+        .arg(worktree)
+        .arg("--json")
+        .output()
+        .expect("run probe");
+    assert!(
+        output.status.success(),
+        "probe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("parse probe json")
 }
 
 fn state_root(worktree: &Path) -> PathBuf {
@@ -149,6 +178,64 @@ fn stale_when_owning_process_is_dead() {
 }
 
 #[test]
+fn stale_flag_fences_even_a_live_pid() {
+    let temp = TempDir::new().unwrap();
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir_all(state_root(&worktree)).unwrap();
+    let flagged = format!(
+        "{{\"version\":1,\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok_abc123\",\"pid\":{},\"stale\":true}}",
+        std::process::id()
+    );
+    write_metadata(&state_root(&worktree), &flagged);
+    let snapshot = inspect_stdout(&worktree);
+    assert_eq!(snapshot["status"], json!("stale"), "{snapshot}");
+    assert_eq!(snapshot["diagnostic"]["reason"], json!("endpoint_stale"));
+}
+
+#[test]
+fn filename_identity_mismatch_fails_discovery_closed() {
+    let temp = TempDir::new().unwrap();
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir_all(state_root(&worktree)).unwrap();
+    // Payload claims a session its filename does not authorize.
+    write_metadata_as(
+        &state_root(&worktree),
+        "01a00000-0000-0000-0000-000000000042.json",
+        &metadata_json("ws://127.0.0.1:1/", "tok_abc123", Some(std::process::id())),
+    );
+    let snapshot = inspect_stdout(&worktree);
+    assert_eq!(snapshot["status"], json!("malformed"), "{snapshot}");
+    assert_eq!(
+        snapshot["diagnostic"]["reason"],
+        json!("endpoint_malformed")
+    );
+}
+
+#[test]
+fn unsupported_or_missing_record_version_is_malformed() {
+    for (name, version_field) in [
+        ("unsupported version", "\"version\":2,"),
+        ("zero version", "\"version\":0,"),
+        ("missing version", ""),
+    ] {
+        let temp = TempDir::new().unwrap();
+        let worktree = temp.path().join("worktree");
+        std::fs::create_dir_all(state_root(&worktree)).unwrap();
+        let body = format!(
+            "{{{version_field}\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"tok_abc123\",\"pid\":{}}}",
+            std::process::id()
+        );
+        write_metadata(&state_root(&worktree), &body);
+        let snapshot = inspect_stdout(&worktree);
+        assert_eq!(
+            snapshot["status"],
+            json!("malformed"),
+            "case {name}: {snapshot}"
+        );
+    }
+}
+
+#[test]
 fn malformed_metadata_is_rejected() {
     let temp = TempDir::new().unwrap();
     let worktree = temp.path().join("worktree");
@@ -157,22 +244,34 @@ fn malformed_metadata_is_rejected() {
     let cases: Vec<(&str, String)> = vec![
         ("non-json", "not json at all".to_string()),
         ("missing fields", "{\"version\":1}".to_string()),
-        ("remote host", metadata_json("ws://10.0.0.5:1234/", "tok_abc123", None)),
-        ("wss scheme", metadata_json("wss://example.com/", "tok_abc123", None)),
+        (
+            "remote host",
+            metadata_json("ws://10.0.0.5:1234/", "tok_abc123", None),
+        ),
+        (
+            "wss scheme",
+            metadata_json("wss://example.com/", "tok_abc123", None),
+        ),
         (
             "url credentials",
             metadata_json("ws://user:pass@127.0.0.1:1/", "tok_abc123", None),
         ),
-        ("url query", metadata_json("ws://127.0.0.1:1/?x=1", "tok_abc123", None)),
-        ("url fragment", metadata_json("ws://127.0.0.1:1/#frag", "tok_abc123", None)),
+        (
+            "url query",
+            metadata_json("ws://127.0.0.1:1/?x=1", "tok_abc123", None),
+        ),
+        (
+            "url fragment",
+            metadata_json("ws://127.0.0.1:1/#frag", "tok_abc123", None),
+        ),
         (
             "bad session id",
-            "{\"session_id\":\"../escape\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"t\"}"
+            "{\"version\":1,\"session_id\":\"../escape\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"t\"}"
                 .to_string(),
         ),
         (
             "bad token charset",
-            "{\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"has spaces\"}"
+            "{\"version\":1,\"sessionId\":\"01a02ccd-c754-7656-95c7-f40b5a140bc3\",\"url\":\"ws://127.0.0.1:1/\",\"token\":\"has spaces\"}"
                 .to_string(),
         ),
         ("host not ip", metadata_json("ws://localhost:1/", "tok_abc123", None)),
@@ -322,11 +421,11 @@ fn newest_live_metadata_wins_over_older_stale_metadata() {
 
     // Stale (dead pid) file first, then a fresh live file that is newer.
     let stale_path = sdk_dir.join("01a00000-0000-0000-0000-000000000001.json");
-    std::fs::write(
-        &stale_path,
-        metadata_json("ws://127.0.0.1:1/", "tok_old", Some(0xFFFF_FFF1u32)),
-    )
-    .unwrap();
+    let stale_body = metadata_json("ws://127.0.0.1:1/", "tok_old", Some(0xFFFF_FFF1u32)).replace(
+        "01a02ccd-c754-7656-95c7-f40b5a140bc3",
+        "01a00000-0000-0000-0000-000000000001",
+    );
+    std::fs::write(&stale_path, stale_body).unwrap();
     restrict_owner_only(&stale_path);
     std::thread::sleep(Duration::from_millis(20));
     write_metadata(
@@ -342,33 +441,50 @@ fn newest_live_metadata_wins_over_older_stale_metadata() {
 }
 
 // ---------------------------------------------------------------------------
-// Transport cases against a real loopback websocket fixture server
+// SDK v3 transport cases against a real loopback websocket fixture server
 // ---------------------------------------------------------------------------
 
+/// Wire behaviors the v3 fixture server can exhibit per connection.
 #[derive(Clone, Copy, PartialEq)]
 enum ServerBehavior {
-    /// Correct token: hello + correlated responses.
+    /// Correct token: hello first, then correlated typed responses.
     Authenticated,
     /// Reject every handshake (401).
     RejectAuth,
     /// Accept handshake, hello, then never answer requests.
     Silent,
-    /// Accept handshake, hello, then reply with a mismatched correlation id.
+    /// Accept handshake, hello, then reply with a foreign correlation id.
     Mismatch,
-    /// Accept handshake, hello, then close before answering.
+    /// First connection drops mid-exchange; later connections answer.
+    ReconnectNewIdentity,
+    /// First server frame is not a `hello` (handshake contract violation).
+    WrongHelloType,
+    /// Detects any client frame transmitted before the hello.
+    PreHelloOrdering,
+    /// Answers with `ok:false` and a structured error block.
+    ApplicationError,
+    /// Accept handshake + hello, then close before answering every request.
     CloseBeforeAnswer,
 }
 
 struct TestServer {
     port: u16,
     token: String,
+    /// True when a client frame reached the server before its hello.
+    prehello_violation: Arc<AtomicBool>,
+    /// Number of accepted websocket connections.
+    connections: Arc<AtomicUsize>,
 }
 
 fn start_server(behavior: ServerBehavior) -> TestServer {
     use std::sync::mpsc;
     let token = "tok_fixture_0123456789".to_string();
     let (port_tx, port_rx) = mpsc::channel();
+    let prehello_violation = Arc::new(AtomicBool::new(false));
+    let connections = Arc::new(AtomicUsize::new(0));
     let server_token = token.clone();
+    let violation = Arc::clone(&prehello_violation);
+    let conn_counter = Arc::clone(&connections);
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -385,8 +501,10 @@ fn start_server(behavior: ServerBehavior) -> TestServer {
                     return;
                 };
                 let token = server_token.clone();
+                let violation = Arc::clone(&violation);
+                let conn_counter = Arc::clone(&conn_counter);
                 tokio::spawn(async move {
-                    run_connection(stream, behavior, token).await;
+                    run_connection(stream, behavior, token, violation, conn_counter).await;
                 });
             }
         });
@@ -394,7 +512,12 @@ fn start_server(behavior: ServerBehavior) -> TestServer {
     let port = port_rx
         .recv_timeout(Duration::from_secs(5))
         .expect("fixture server started");
-    TestServer { port, token }
+    TestServer {
+        port,
+        token,
+        prehello_violation,
+        connections,
+    }
 }
 
 fn extract_query_token(request: &Request) -> Option<String> {
@@ -406,7 +529,13 @@ fn extract_query_token(request: &Request) -> Option<String> {
 }
 
 #[allow(clippy::result_large_err)] // fixture-only 401 rejection path
-async fn run_connection(stream: AsyncTcpStream, behavior: ServerBehavior, token: String) {
+async fn run_connection(
+    stream: AsyncTcpStream,
+    behavior: ServerBehavior,
+    token: String,
+    prehello_violation: Arc<AtomicBool>,
+    connections: Arc<AtomicUsize>,
+) {
     let accepted = accept_hdr_async(stream, |request: &Request, response: Response| {
         let authenticated = extract_query_token(request) == Some(token);
         if matches!(behavior, ServerBehavior::RejectAuth) || !authenticated {
@@ -421,16 +550,41 @@ async fn run_connection(stream: AsyncTcpStream, behavior: ServerBehavior, token:
     let Ok(ws_stream) = accepted else {
         return;
     };
+    let connection_index = connections.fetch_add(1, Ordering::SeqCst);
     let (mut writer, mut reader) = ws_stream.split();
-    let hello = r#"{"type":"hello","connectionId":"fixture-connection"}"#;
+    let connection_id = format!("fixture-connection-{connection_index}");
+
+    if behavior == ServerBehavior::WrongHelloType {
+        // Violate the handshake contract: first frame is not a hello.
+        let welcome = r#"{"type":"welcome","connectionId":"not-a-hello"}"#;
+        let _ = writer
+            .send(Message::Text(Utf8Bytes::from_static(welcome)))
+            .await;
+        while let Some(Ok(_)) = reader.next().await {}
+        return;
+    }
+
+    if behavior == ServerBehavior::PreHelloOrdering {
+        // A correct client sends nothing until its hello lands, so this
+        // bounded read must time out empty.
+        let early = tokio::time::timeout(Duration::from_millis(300), reader.next()).await;
+        if let Ok(Some(Ok(_))) = early {
+            prehello_violation.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let hello = format!(r#"{{"type":"hello","connectionId":"{connection_id}"}}"#);
     writer
-        .send(Message::Text(Utf8Bytes::from_static(hello)))
+        .send(Message::Text(Utf8Bytes::from(hello)))
         .await
         .unwrap();
+
     match behavior {
         ServerBehavior::Authenticated
         | ServerBehavior::Mismatch
-        | ServerBehavior::CloseBeforeAnswer => {
+        | ServerBehavior::ReconnectNewIdentity
+        | ServerBehavior::ApplicationError
+        | ServerBehavior::PreHelloOrdering => {
             while let Some(Ok(message)) = reader.next().await {
                 let Message::Text(text) = message else {
                     continue;
@@ -438,23 +592,42 @@ async fn run_connection(stream: AsyncTcpStream, behavior: ServerBehavior, token:
                 let Ok(value) = serde_json::from_slice::<Value>(text.as_bytes()) else {
                     continue;
                 };
-                if behavior == ServerBehavior::CloseBeforeAnswer {
-                    // Drop without answering so the client observes a
-                    // connection lost mid-exchange.
+                if behavior == ServerBehavior::ReconnectNewIdentity && connection_index == 0 {
+                    // Drop without answering so the client must reconnect and
+                    // re-authenticate against a fresh hello identity.
                     return;
                 }
-                let id = value.get("id").cloned().unwrap_or(Value::Null);
+                let response_type = match value.get("type").and_then(Value::as_str) {
+                    Some("control_request") => "control_response",
+                    Some("broker_request") => "broker_response",
+                    _ => "query_response",
+                };
                 let response_id = if behavior == ServerBehavior::Mismatch {
                     json!("foreign-correlation-id")
                 } else {
-                    id
+                    value.get("id").cloned().unwrap_or(Value::Null)
                 };
-                let response = json!({
-                    "type": "response",
-                    "id": response_id,
-                    "ok": true,
-                    "payload": {"echo": value.get("method").cloned().unwrap_or(Value::Null)},
-                });
+                let response = if behavior == ServerBehavior::ApplicationError {
+                    json!({
+                        "type": response_type,
+                        "id": response_id,
+                        "ok": false,
+                        "error": {
+                            "code": "operation_not_session_owned",
+                            "message": "fixture application error",
+                        },
+                    })
+                } else {
+                    json!({
+                        "type": response_type,
+                        "id": response_id,
+                        "ok": true,
+                        "page": {
+                            "items": [{"sessionId": "01a02ccd-c754-7656-95c7-f40b5a140bc3"}],
+                            "complete": true,
+                        },
+                    })
+                };
                 writer
                     .send(Message::Text(Utf8Bytes::from(
                         serde_json::to_string(&response).unwrap(),
@@ -464,21 +637,16 @@ async fn run_connection(stream: AsyncTcpStream, behavior: ServerBehavior, token:
             }
         }
         ServerBehavior::Silent => while let Some(Ok(_)) = reader.next().await {},
-        ServerBehavior::RejectAuth => unreachable!(),
+        // Drop without answering so the client observes a connection lost
+        // mid-exchange on every attempt.
+        ServerBehavior::CloseBeforeAnswer => {
+            reader.next().await;
+        }
+        ServerBehavior::WrongHelloType | ServerBehavior::RejectAuth => unreachable!(),
     }
 }
 
-// The transport request path is exercised through the reusable API inside the
-// binary's own unit tests (src/gjc_sdk.rs) because integration tests link the
-// bin target, not the crate's internals. These black-box tests prove the
-// transport contract through `gjc inspect` plus fixture-driven handshakes:
-// each server behavior below is pointed at by metadata files and validated
-// through a transport probe subcommand.
-
-#[test]
-fn transport_success_round_trip_with_correlation() {
-    let server = start_server(ServerBehavior::Authenticated);
-    let temp = TempDir::new().unwrap();
+fn write_live_metadata_for(server: &TestServer, temp: &TempDir) -> PathBuf {
     let worktree = temp.path().join("worktree");
     std::fs::create_dir_all(state_root(&worktree)).unwrap();
     write_metadata(
@@ -489,28 +657,95 @@ fn transport_success_round_trip_with_correlation() {
             Some(std::process::id()),
         ),
     );
-    let output = Command::new(bin())
-        .args(["gjc", "inspect", "--probe"])
-        .arg("--worktree")
-        .arg(&worktree)
-        .arg("--json")
-        .output()
-        .expect("run probe");
-    assert!(
-        output.status.success(),
-        "probe failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let snapshot: Value = serde_json::from_slice(&output.stdout).expect("parse probe json");
+    worktree
+}
+
+#[test]
+fn transport_success_round_trip_with_correlation() {
+    let server = start_server(ServerBehavior::Authenticated);
+    let temp = TempDir::new().unwrap();
+    let worktree = write_live_metadata_for(&server, &temp);
+    let snapshot = probe_stdout(&worktree);
     assert_eq!(snapshot["status"], json!("live"));
     assert_eq!(
         snapshot["probe"]["hello_connection_id"],
-        json!("fixture-connection")
+        json!("fixture-connection-0")
     );
     assert_eq!(snapshot["probe"]["request_ok"], json!(true));
     assert_eq!(snapshot["probe"]["request_correlated"], json!(true));
+    assert!(snapshot["probe"].get("request_error_code").is_none());
     let encoded = snapshot.to_string();
     assert!(!encoded.contains(&server.token), "token leaked: {encoded}");
+    assert!(
+        !encoded.contains("127.0.0.1"),
+        "endpoint url leaked: {encoded}"
+    );
+}
+
+#[test]
+fn transport_wrong_hello_type_fails_closed() {
+    let server = start_server(ServerBehavior::WrongHelloType);
+    let temp = TempDir::new().unwrap();
+    let worktree = write_live_metadata_for(&server, &temp);
+    let snapshot = probe_stdout(&worktree);
+    assert_eq!(snapshot["status"], json!("live"));
+    assert_eq!(
+        snapshot["probe"]["hello_reason"],
+        json!("invalid_hello"),
+        "{snapshot}"
+    );
+    assert!(snapshot["probe"].get("request_ok").is_none());
+}
+
+#[test]
+fn transport_never_sends_before_the_hello_gate() {
+    let server = start_server(ServerBehavior::PreHelloOrdering);
+    let temp = TempDir::new().unwrap();
+    let worktree = write_live_metadata_for(&server, &temp);
+    let snapshot = probe_stdout(&worktree);
+    assert_eq!(snapshot["status"], json!("live"));
+    assert_eq!(snapshot["probe"]["request_ok"], json!(true), "{snapshot}");
+    assert!(
+        !server.prehello_violation.load(Ordering::SeqCst),
+        "the binary transmitted before receiving hello"
+    );
+}
+
+#[test]
+fn transport_surfaces_typed_application_errors() {
+    let server = start_server(ServerBehavior::ApplicationError);
+    let temp = TempDir::new().unwrap();
+    let worktree = write_live_metadata_for(&server, &temp);
+    let snapshot = probe_stdout(&worktree);
+    assert_eq!(snapshot["status"], json!("live"));
+    assert_eq!(snapshot["probe"]["request_ok"], json!(false), "{snapshot}");
+    assert_eq!(
+        snapshot["probe"]["request_correlated"],
+        json!(true),
+        "{snapshot}"
+    );
+    assert_eq!(
+        snapshot["probe"]["request_error_code"],
+        json!("operation_not_session_owned")
+    );
+}
+
+#[test]
+fn transport_reconnect_reauthenticates_with_new_identity() {
+    let server = start_server(ServerBehavior::ReconnectNewIdentity);
+    let temp = TempDir::new().unwrap();
+    let worktree = write_live_metadata_for(&server, &temp);
+    let snapshot = probe_stdout(&worktree);
+    assert_eq!(snapshot["status"], json!("live"));
+    // Connection 0 drops mid-exchange; the bounded retry re-authenticates and
+    // completes against the fresh hello identity.
+    assert_eq!(
+        snapshot["probe"]["hello_connection_id"],
+        json!("fixture-connection-1"),
+        "{snapshot}"
+    );
+    assert_eq!(snapshot["probe"]["request_ok"], json!(true));
+    assert_eq!(server.connections.load(Ordering::SeqCst), 2);
 }
 
 #[test]
@@ -527,14 +762,7 @@ fn transport_unauthorized_is_typed() {
             Some(std::process::id()),
         ),
     );
-    let output = Command::new(bin())
-        .args(["gjc", "inspect", "--probe"])
-        .arg("--worktree")
-        .arg(&worktree)
-        .arg("--json")
-        .output()
-        .expect("run probe");
-    let snapshot: Value = serde_json::from_slice(&output.stdout).expect("parse probe json");
+    let snapshot = probe_stdout(&worktree);
     assert_eq!(snapshot["status"], json!("live"));
     // A 401 handshake rejection surfaces at the hello stage.
     assert_eq!(
@@ -547,24 +775,8 @@ fn transport_unauthorized_is_typed() {
 fn transport_timeout_is_typed() {
     let server = start_server(ServerBehavior::Silent);
     let temp = TempDir::new().unwrap();
-    let worktree = temp.path().join("worktree");
-    std::fs::create_dir_all(state_root(&worktree)).unwrap();
-    write_metadata(
-        &state_root(&worktree),
-        &metadata_json(
-            &format!("ws://127.0.0.1:{}/", server.port),
-            &server.token,
-            Some(std::process::id()),
-        ),
-    );
-    let output = Command::new(bin())
-        .args(["gjc", "inspect", "--probe"])
-        .arg("--worktree")
-        .arg(&worktree)
-        .arg("--json")
-        .output()
-        .expect("run probe");
-    let snapshot: Value = serde_json::from_slice(&output.stdout).expect("parse probe json");
+    let worktree = write_live_metadata_for(&server, &temp);
+    let snapshot = probe_stdout(&worktree);
     assert_eq!(snapshot["status"], json!("live"));
     assert_eq!(snapshot["probe"]["request_reason"], json!("timeout"));
 }
@@ -573,24 +785,8 @@ fn transport_timeout_is_typed() {
 fn transport_correlation_mismatch_is_typed() {
     let server = start_server(ServerBehavior::Mismatch);
     let temp = TempDir::new().unwrap();
-    let worktree = temp.path().join("worktree");
-    std::fs::create_dir_all(state_root(&worktree)).unwrap();
-    write_metadata(
-        &state_root(&worktree),
-        &metadata_json(
-            &format!("ws://127.0.0.1:{}/", server.port),
-            &server.token,
-            Some(std::process::id()),
-        ),
-    );
-    let output = Command::new(bin())
-        .args(["gjc", "inspect", "--probe"])
-        .arg("--worktree")
-        .arg(&worktree)
-        .arg("--json")
-        .output()
-        .expect("run probe");
-    let snapshot: Value = serde_json::from_slice(&output.stdout).expect("parse probe json");
+    let worktree = write_live_metadata_for(&server, &temp);
+    let snapshot = probe_stdout(&worktree);
     assert_eq!(snapshot["status"], json!("live"));
     assert_eq!(
         snapshot["probe"]["request_reason"],
@@ -612,14 +808,7 @@ fn transport_unavailable_endpoint_is_typed() {
             Some(std::process::id()),
         ),
     );
-    let output = Command::new(bin())
-        .args(["gjc", "inspect", "--probe"])
-        .arg("--worktree")
-        .arg(&worktree)
-        .arg("--json")
-        .output()
-        .expect("run probe");
-    let snapshot: Value = serde_json::from_slice(&output.stdout).expect("parse probe json");
+    let snapshot = probe_stdout(&worktree);
     assert_eq!(snapshot["status"], json!("live"));
     // Nothing listens on the port: connect fails before any HTTP status, so
     // the taxonomy surfaces transport-level unavailability at the hello stage.
@@ -631,31 +820,16 @@ fn transport_unavailable_endpoint_is_typed() {
 
 #[test]
 fn transport_close_before_answer_exhausts_bounded_reconnect() {
+    // Every connection drops mid-exchange; the probe's bounded reconnect
+    // budget is exhausted and reported under the retry taxonomy.
     let server = start_server(ServerBehavior::CloseBeforeAnswer);
     let temp = TempDir::new().unwrap();
-    let worktree = temp.path().join("worktree");
-    std::fs::create_dir_all(state_root(&worktree)).unwrap();
-    write_metadata(
-        &state_root(&worktree),
-        &metadata_json(
-            &format!("ws://127.0.0.1:{}/", server.port),
-            &server.token,
-            Some(std::process::id()),
-        ),
-    );
-    let output = Command::new(bin())
-        .args(["gjc", "inspect", "--probe"])
-        .arg("--worktree")
-        .arg(&worktree)
-        .arg("--json")
-        .output()
-        .expect("run probe");
-    let snapshot: Value = serde_json::from_slice(&output.stdout).expect("parse probe json");
+    let worktree = write_live_metadata_for(&server, &temp);
+    let snapshot = probe_stdout(&worktree);
     assert_eq!(snapshot["status"], json!("live"));
-    // The server drops every connection mid-exchange; bounded reconnect
-    // attempts are exhausted and reported under the retry taxonomy.
     assert_eq!(
         snapshot["probe"]["request_reason"],
-        json!("retry_exhausted")
+        json!("retry_exhausted"),
+        "{snapshot}"
     );
 }


### PR DESCRIPTION
## Summary

Repairs the post-merge GJC SDK v3 transport regression filed in #328 (binding review: [PR #327 dedicated audit](https://github.com/Yeachan-Heo/clawhip/pull/327#pullrequestreview-5001731019), REGRESSION_FOUND at exact head `a3e8338dbd6c2ed720e21c117444727ab195e101`).

The merged client opened a fresh socket per request **without completing the hello gate** and emitted a generic `{type:"request",method:"status.get"}` envelope the installed v3 host silently tolerates (unknown frame types are dropped per the forward-compatibility contract). Live reproduction on `dev@ccf66212032d130368ef30915e262c0a5678e04a`: hello succeeded, then `clawhip gjc inspect --probe --json` returned `{"status":"live","request_ok":false,"request_reason":"timeout"}` every time.

### Repair (smallest correct v3 transport fix)

- **Authenticated hello-gated ordering** — one persistent connection per `SdkClient`; no frame is sent before the server hello passes strict validation (`type == "hello"`, bounded `connectionId`); violations are typed `invalid_hello`.
- **Typed v3 frames** — `SdkRequest::query` / `control` / `broker` emit `query_request` / `control_request` / `broker_request` with object inputs and bounded, well-formed selector names; responses correlate by id within the matching `query_response` / `control_response` / `broker_response` family; application errors surface `ok:false` with sanitized error codes. Control/broker builders are the tested reusable surface for #323-#326 — their operations/events/reconcile scope is deliberately not implemented.
- **Supported non-mutating probe** — the probe now issues `session.metadata` via `query_request` (verified live: answered `ok:true` with a correlated id).
- **Discovery fail-closed semantics** — endpoint identity bound to the `<sessionId>.json` filename; supported record `version` enforced; explicit `stale` flag fences records even with live pids.
- **Bounded retries/output/redaction retained** — timeouts, frame/payload ceilings, reconnect budget, and token/URL redaction unchanged and re-tested.

### Validation

- Focused fixtures: wrong hello type, pre-hello ordering sentinel, all three v3 families + paged/error shapes, stale flag, filename mismatch, unsupported/missing version, reconnect identity change (`conn-0` → `conn-1` with full re-auth).
- `cargo test --all-targets`: 1,034 passed. `cargo build --locked`: pass. `cargo fmt --all -- --check`: pass. `cargo clippy --all-targets -- -D warnings`: pass.
- Live GJC endpoint probe: `{"status":"live",...,"probe":{"hello_connection_id":"<server-id>","request_ok":true,"request_correlated":true}}` with zero token/URL leakage.

Closes #328

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
