### PR TITLE
fix(sdk): harden envelope validation and stray-frame deadline bounds

### DIFF
--- a/src/gjc_sdk.rs
+++ b/src/gjc_sdk.rs
@@ -903,8 +903,11 @@ async fn exchange(
     frame: &str,
     limits: &SdkTransportLimits,
 ) -> Result<SdkResponse> {
+    // One absolute deadline for the whole exchange: id-less frames consume
+    // the bounded tolerance but can never extend the caller's wait window.
+    let deadline = tokio::time::Instant::now() + limits.request_timeout;
     let send = stream.send(Message::Text(frame.into()));
-    tokio::time::timeout(limits.request_timeout, send)
+    tokio::time::timeout_at(deadline, send)
         .await
         .map_err(|_| SdkTransportError::Timeout)?
         .map_err(|_| SdkTransportError::ConnectionClosed)?;
@@ -912,7 +915,7 @@ async fn exchange(
     // cannot be correlated to this request.
     let mut uncorrelated = 0u8;
     loop {
-        let next = tokio::time::timeout(limits.request_timeout, stream.next()).await;
+        let next = tokio::time::timeout_at(deadline, stream.next()).await;
         let message = match next {
             Ok(Some(message)) => message.map_err(|_| SdkTransportError::ConnectionClosed)?,
             Ok(None) => return Err(SdkTransportError::ConnectionClosed.into()),
@@ -2030,6 +2033,19 @@ mod tests {
                             .await;
                     }
                 }
+                if mode == "slow-drip" {
+                    // Drip id-less frames just inside any per-read window: the
+                    // absolute exchange deadline must still terminate on time.
+                    for _ in 0..30 {
+                        let _ = writer
+                            .send(Message::Text(Utf8Bytes::from(
+                                r#"{"type":"hello","connectionId":"drip"}"#,
+                            )))
+                            .await;
+                        tokio::time::sleep(Duration::from_millis(250)).await;
+                    }
+                    return;
+                }
                 let response_type = match value.get("type").and_then(Value::as_str) {
                     Some("control_request") => "control_response",
                     Some("broker_request") => "broker_response",
@@ -2059,6 +2075,13 @@ mod tests {
                         .as_object_mut()
                         .expect("response object")
                         .remove("ok");
+                }
+                if mode == "bad-error" {
+                    // Malformed envelope: failure without structured error data.
+                    let object = response.as_object_mut().expect("response object");
+                    object.insert("ok".to_string(), Value::Bool(false));
+                    object.remove("error");
+                    object.remove("result");
                 }
                 if mode == "paged" && response_type == "query_response" {
                     response["page"] = json!({"items": [{"n": 1}], "complete": true});
@@ -2206,6 +2229,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn client_fails_closed_on_malformed_error_envelope() {
+        let fixture = loopback::spawn("bad-error").await;
+        let mut client =
+            SdkClient::new(fixture.metadata).with_limits(loopback::probe_limits_short());
+        client.connect().await.unwrap();
+        let error = client
+            .request(&SdkRequest::query("session.metadata", Value::Null))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<SdkTransportError>().unwrap().reason(),
+            "frame_rejected",
+            "an ok:false response without structured error data must be a protocol violation"
+        );
+    }
+
+    #[tokio::test]
     async fn client_terminates_under_hello_frame_flood() {
         let fixture = loopback::spawn("hello-flood").await;
         let mut client =
@@ -2223,5 +2263,34 @@ mod tests {
             "correlation_mismatch"
         );
         assert!(started.elapsed() < loopback::probe_limits_short().request_timeout * 2);
+    }
+
+    #[tokio::test]
+    async fn client_times_out_under_slow_dripping_id_less_frames() {
+        let fixture = loopback::spawn("slow-drip").await;
+        let limits = loopback::probe_limits_short();
+        let mut client = SdkClient::new(fixture.metadata).with_limits(limits);
+        client.connect().await.unwrap();
+        // Drips every 250ms previously reset a per-read timeout indefinitely
+        // (30 frames ≈ many request windows). The absolute exchange deadline
+        // must terminate at ~one window with Timeout instead.
+        let started = std::time::Instant::now();
+        let error = client
+            .request(&SdkRequest::query("session.metadata", Value::Null))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<SdkTransportError>().unwrap().reason(),
+            "timeout"
+        );
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= limits.request_timeout,
+            "terminated early: {elapsed:?}"
+        );
+        assert!(
+            elapsed < limits.request_timeout * 2,
+            "deadline extended beyond one exchange window: {elapsed:?}"
+        );
     }
 }

--- a/src/gjc_sdk.rs
+++ b/src/gjc_sdk.rs
@@ -924,25 +924,32 @@ async fn exchange(
         let response = parse_response(&text, limits)?;
         match response.id.as_deref() {
             Some(id) if id == request.correlation_id() => {
-                if response.frame_type == request.response_frame_type() {
-                    return Ok(response);
+                if response.frame_type != request.response_frame_type() {
+                    // A correlated frame of the wrong family is a protocol
+                    // violation, not a matchable response.
+                    return Err(SdkTransportError::FrameRejected.into());
                 }
-                // A correlated frame of the wrong family is a protocol
-                // violation, not a matchable response.
-                return Err(SdkTransportError::FrameRejected.into());
+                // Fail-closed envelope validation: a terminal response must
+                // carry an explicit success flag, and every failure must be
+                // backed by a structured error block.
+                match response.ok {
+                    Some(true) => return Ok(response),
+                    Some(false) if response.error.is_some() => return Ok(response),
+                    _ => return Err(SdkTransportError::FrameRejected.into()),
+                }
             }
             // A correlated frame for a different request is a protocol
             // violation on a single-request diagnostic transport.
             Some(_) => return Err(SdkTransportError::CorrelationMismatch.into()),
-            None => match response.frame_type.as_str() {
-                "hello" => continue,
-                _ => {
-                    uncorrelated = uncorrelated.saturating_add(1);
-                    if uncorrelated >= 16 {
-                        return Err(SdkTransportError::CorrelationMismatch.into());
-                    }
+            None => {
+                // Every id-less frame — including stray post-gate hellos —
+                // consumes the bounded tolerance so a chatty endpoint can
+                // never starve the correlated read past its deadline.
+                uncorrelated = uncorrelated.saturating_add(1);
+                if uncorrelated >= 16 {
+                    return Err(SdkTransportError::CorrelationMismatch.into());
                 }
-            },
+            }
         }
     }
 }
@@ -1092,10 +1099,10 @@ async fn probe_transport(metadata: EndpointMetadata) -> ProbeReport {
         Ok(response) => ProbeReport {
             hello_connection_id: client.hello().and_then(|hello| hello.connection_id.clone()),
             hello_reason: None,
-            request_ok: Some(response.ok.unwrap_or(true)),
+            request_ok: Some(matches!(response.ok, Some(true))),
             request_correlated: Some(response.id.as_deref() == Some(correlation_id.as_str())),
             request_reason: None,
-            request_error_code: (!response.ok.unwrap_or(true))
+            request_error_code: (!matches!(response.ok, Some(true)))
                 .then(|| {
                     sanitize_error_code(response.error.as_ref().and_then(|e| e.code.as_deref()))
                 })
@@ -2012,6 +2019,17 @@ mod tests {
                     // re-authenticate against a fresh identity.
                     return;
                 }
+                if mode == "hello-flood" {
+                    // Stream id-less hello frames before answering: the client
+                    // must terminate via its bounded tolerance.
+                    for _ in 0..20 {
+                        let _ = writer
+                            .send(Message::Text(Utf8Bytes::from(
+                                r#"{"type":"hello","connectionId":"flood"}"#,
+                            )))
+                            .await;
+                    }
+                }
                 let response_type = match value.get("type").and_then(Value::as_str) {
                     Some("control_request") => "control_response",
                     Some("broker_request") => "broker_response",
@@ -2035,6 +2053,13 @@ mod tests {
                         "result": {"echo": value.get("query").or_else(|| value.get("operation")).cloned().unwrap_or(Value::Null)},
                     })
                 };
+                if mode == "no-ok" {
+                    // Malformed envelope: terminal response without ok.
+                    response
+                        .as_object_mut()
+                        .expect("response object")
+                        .remove("ok");
+                }
                 if mode == "paged" && response_type == "query_response" {
                     response["page"] = json!({"items": [{"n": 1}], "complete": true});
                 }
@@ -2161,5 +2186,42 @@ mod tests {
         assert_eq!(fixture.connections.load(Ordering::SeqCst), 2);
         let second_hello = client.hello().and_then(|hello| hello.connection_id.clone());
         assert_eq!(second_hello.as_deref(), Some("conn-1"));
+    }
+
+    #[tokio::test]
+    async fn client_fails_closed_on_missing_ok_envelope() {
+        let fixture = loopback::spawn("no-ok").await;
+        let mut client =
+            SdkClient::new(fixture.metadata).with_limits(loopback::probe_limits_short());
+        client.connect().await.unwrap();
+        let error = client
+            .request(&SdkRequest::query("session.metadata", Value::Null))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<SdkTransportError>().unwrap().reason(),
+            "frame_rejected",
+            "a terminal response without ok must be a protocol violation"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_terminates_under_hello_frame_flood() {
+        let fixture = loopback::spawn("hello-flood").await;
+        let mut client =
+            SdkClient::new(fixture.metadata).with_limits(loopback::probe_limits_short());
+        client.connect().await.unwrap();
+        // Twenty id-less hello frames exceed the bounded uncorrelated-frame
+        // tolerance: the read must terminate, never starve past its deadline.
+        let started = std::time::Instant::now();
+        let error = client
+            .request(&SdkRequest::query("session.metadata", Value::Null))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<SdkTransportError>().unwrap().reason(),
+            "correlation_mismatch"
+        );
+        assert!(started.elapsed() < loopback::probe_limits_short().request_timeout * 2);
     }
 }


### PR DESCRIPTION
## Summary

Successor protocol hardening tracked by #330 after PR #329 merged at reviewed head `768bbad1328c84de0d6e84ae27bc497bee0bea4b` (`dev@aba8093d804939fb14ddbc436c645475d058cd67`) while the sole-owner lane still held additional fix-forward work (binding stale-readiness evidence: [PR #329 comment](https://github.com/Yeachan-Heo/clawhip/pull/329#issuecomment-5384510995)). The merged live v3 transport behavior, bounded retries/output/redaction, and no-leak guarantees from #329 are preserved unchanged; this PR reconstructs only the preserved hardening onto fresh current dev.

### Hardening (reconstructed from preserved lane evidence)

- **Fail-closed correlated envelopes** — a terminal response must carry an explicit `ok`; a missing `ok` is a typed `frame_rejected` protocol violation instead of being tolerated (and previously treated as success on the probe path). `ok:false` requires structured error data; failures without an error block are rejected.
- **Bounded stray-frame tolerance** — every id-less post-gate frame, including repeat `hello` frames, consumes the same bounded uncorrelated budget (16), so a chatty endpoint terminates via `correlation_mismatch` and can never starve a correlated read past its deadline.
- **Absolute exchange deadline** — the send and each read now share one absolute deadline (`timeout_at`); id-less frames consume tolerance but can never extend the caller's wait window, so frames dripped just inside per-read windows still terminate at ~one request window with `timeout`.
- **Strict live-probe success semantics** — the probe reports success only for an explicit `ok:true`, never an inferred default.

### Fixtures

- missing-`ok` envelope → `frame_rejected`
- malformed error envelope (`ok:false` without structured error) → `frame_rejected`
- 20-hello flood → terminates via `correlation_mismatch` well inside the deadline
- 30-frame slow-drip at 250ms → terminates via `timeout` within `[request_timeout, 2×request_timeout)`

### Validation

- Focused fixtures green (all four above plus preserved wrong-hello / pre-hello gate / typed families / paged + application-error shapes / re-auth suite).
- `cargo test --all-targets`: 1,038 passed · `cargo build --locked`: pass · `cargo fmt --all -- --check`: pass · `cargo clippy --all-targets -- -D warnings`: pass.
- Live GJC endpoint probe: `{"status":"live",...,"probe":{"hello_connection_id":"<server-id>","request_ok":true,"request_correlated":true}}`, exit 0, zero token/URL leakage.

Closes #330

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
