### PR TITLE
feat(gjc-sdk): authoritative session query and control API

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,6 +179,17 @@ pub enum Commands {
         #[command(subcommand)]
         command: GajaeCommands,
     },
+    /// Query and control GJC SDK sessions through the local daemon.
+    ///
+    /// Authoritative session queries (metadata, stats, model/profile, turn,
+    /// queue, workflow gates, goal/todo, capabilities) and mutation verbs
+    /// (prompt, steer, abort-and-prompt, workflow gate answer, ask answer,
+    /// model selection). All commands talk to the local daemon and fail
+    /// closed with typed error codes.
+    Gjc {
+        #[command(subcommand)]
+        command: GjcCommands,
+    },
     /// Release consistency checks.
     Release {
         #[command(subcommand)]
@@ -739,6 +750,136 @@ pub enum CronCommands {
     Run {
         /// Cron job id from [[cron.jobs]].id.
         id: String,
+    },
+}
+
+/// Shared mutation flags for GJC control verbs.
+#[derive(Debug, Clone, Args)]
+pub struct GjcMutationArgs {
+    /// Client idempotency key (8..=128 bytes). Replays with the same key
+    /// return the recorded receipt instead of issuing a second command.
+    #[arg(long)]
+    pub idempotency_key: String,
+    /// Expected authoritative session id; the command fails closed on
+    /// mismatch when provided.
+    #[arg(long)]
+    pub expected_session: Option<String>,
+    /// Bounded peer exchange timeout in milliseconds (1..=60000).
+    #[arg(long)]
+    pub timeout_ms: Option<u64>,
+    /// Emit machine-readable JSON instead of text.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum GjcCommands {
+    /// Show capabilities advertised by the local daemon's control plane.
+    Capabilities {
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Query authoritative session surfaces (metadata, stats, model, turn, queue, gates, goal/todo).
+    Session {
+        /// GJC session id.
+        session: String,
+        /// Comma-separated sections to fetch. Defaults to all.
+        #[arg(long)]
+        sections: Option<String>,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Fetch the terminal outcome receipt for one turn.
+    TurnOutcome {
+        /// GJC session id.
+        session: String,
+        /// Turn id whose terminal outcome is requested.
+        turn_id: String,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Submit a prompt into a session.
+    Prompt {
+        /// GJC session id.
+        session: String,
+        /// Prompt text to submit.
+        #[arg(long)]
+        prompt: String,
+        #[command(flatten)]
+        mutation: GjcMutationArgs,
+    },
+    /// Steer an in-flight turn without aborting it.
+    Steer {
+        /// GJC session id.
+        session: String,
+        /// Steering message for the active turn.
+        #[arg(long)]
+        message: String,
+        #[command(flatten)]
+        mutation: GjcMutationArgs,
+    },
+    /// Abort in-flight turns and immediately submit a replacement prompt.
+    AbortAndPrompt {
+        /// GJC session id.
+        session: String,
+        /// Replacement prompt submitted after the abort.
+        #[arg(long)]
+        prompt: String,
+        /// Restrict the abort to these turn ids (repeatable).
+        #[arg(long = "turn")]
+        turn_ids: Vec<String>,
+        #[command(flatten)]
+        mutation: GjcMutationArgs,
+    },
+    /// Answer a raised workflow gate.
+    GateAnswer {
+        /// GJC session id.
+        session: String,
+        /// Workflow gate id being answered.
+        #[arg(long)]
+        gate_id: String,
+        /// Chosen option for the gate.
+        #[arg(long)]
+        option: String,
+        #[command(flatten)]
+        mutation: GjcMutationArgs,
+    },
+    /// Answer an ask/question prompt.
+    AskAnswer {
+        /// GJC session id.
+        session: String,
+        /// Ask/question id being answered.
+        #[arg(long)]
+        ask_id: String,
+        /// Chosen option(s); repeatable for multi-select asks.
+        #[arg(long = "choice")]
+        choices: Vec<String>,
+        #[command(flatten)]
+        mutation: GjcMutationArgs,
+    },
+    /// Select the model or profile for a session (exactly one of --model/--profile).
+    Select {
+        /// GJC session id.
+        session: String,
+        /// Model id to select.
+        #[arg(long)]
+        model: Option<String>,
+        /// Profile name to select.
+        #[arg(long)]
+        profile: Option<String>,
+        #[command(flatten)]
+        mutation: GjcMutationArgs,
+    },
+    /// Replay the receipt of an accepted command by idempotency key.
+    Receipt {
+        /// Idempotency key used when the command was accepted.
+        idempotency_key: String,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -730,50 +730,12 @@ pub struct GajaeZeroBacklogCheckpointArgs {
 }
 
 #[derive(Debug, Clone, Subcommand)]
-pub enum ReleaseCommands {
-    /// Verify version/Cargo.lock/CHANGELOG consistency before tagging a release.
-    ///
-    /// If <VERSION> is omitted the current Cargo.toml version is used.
-    /// Exits non-zero when any check fails.
-    Preflight {
-        /// Expected release version (e.g. 0.6.5, v0.6.5, refs/tags/v0.6.5).
-        version: Option<String>,
-        /// Path to the repository root. Defaults to the current directory.
-        #[arg(long)]
-        repo: Option<std::path::PathBuf>,
-    },
-}
-
-#[derive(Debug, Clone, Subcommand)]
-pub enum CronCommands {
-    /// Run one configured cron job immediately, which is useful for native system-cron entrypoints.
-    Run {
-        /// Cron job id from [[cron.jobs]].id.
-        id: String,
-    },
-}
-
-/// Shared mutation flags for GJC control verbs.
-#[derive(Debug, Clone, Args)]
-pub struct GjcMutationArgs {
-    /// Client idempotency key (8..=128 bytes). Replays with the same key
-    /// return the recorded receipt instead of issuing a second command.
-    #[arg(long)]
-    pub idempotency_key: String,
-    /// Expected authoritative session id; the command fails closed on
-    /// mismatch when provided.
-    #[arg(long)]
-    pub expected_session: Option<String>,
-    /// Bounded peer exchange timeout in milliseconds (1..=60000).
-    #[arg(long)]
-    pub timeout_ms: Option<u64>,
-    /// Emit machine-readable JSON instead of text.
-    #[arg(long)]
-    pub json: bool,
-}
-
-#[derive(Debug, Clone, Subcommand)]
 pub enum GjcCommands {
+    /// Inspect worktree-local GJC SDK endpoint metadata and transport readiness.
+    ///
+    /// Discovery only: reports the validated session endpoint for the target
+    /// worktree without exposing tokens or URLs.
+    Inspect(GjcInspectArgs),
     /// Show capabilities advertised by the local daemon's control plane.
     Capabilities {
         /// Emit machine-readable JSON.
@@ -882,6 +844,63 @@ pub enum GjcCommands {
         json: bool,
     },
 }
+
+#[derive(Debug, Clone, Args)]
+pub struct GjcInspectArgs {
+    /// Worktree root to inspect. Defaults to the current directory.
+    #[arg(long)]
+    pub worktree: Option<PathBuf>,
+    /// Open the discovered endpoint and issue one typed probe request.
+    #[arg(long, default_value_t = false)]
+    pub probe: bool,
+    /// Emit machine-readable JSON instead of text.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ReleaseCommands {
+    /// Verify version/Cargo.lock/CHANGELOG consistency before tagging a release.
+    ///
+    /// If <VERSION> is omitted the current Cargo.toml version is used.
+    /// Exits non-zero when any check fails.
+    Preflight {
+        /// Expected release version (e.g. 0.6.5, v0.6.5, refs/tags/v0.6.5).
+        version: Option<String>,
+        /// Path to the repository root. Defaults to the current directory.
+        #[arg(long)]
+        repo: Option<std::path::PathBuf>,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum CronCommands {
+    /// Run one configured cron job immediately, which is useful for native system-cron entrypoints.
+    Run {
+        /// Cron job id from [[cron.jobs]].id.
+        id: String,
+    },
+}
+
+/// Shared mutation flags for GJC control verbs.
+#[derive(Debug, Clone, Args)]
+pub struct GjcMutationArgs {
+    /// Client idempotency key (8..=128 bytes). Replays with the same key
+    /// return the recorded receipt instead of issuing a second command.
+    #[arg(long)]
+    pub idempotency_key: String,
+    /// Expected authoritative session id; the command fails closed on
+    /// mismatch when provided.
+    #[arg(long)]
+    pub expected_session: Option<String>,
+    /// Bounded peer exchange timeout in milliseconds (1..=60000).
+    #[arg(long)]
+    pub timeout_ms: Option<u64>,
+    /// Emit machine-readable JSON instead of text.
+    #[arg(long)]
+    pub json: bool,
+}
+
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum UpdateCommands {

--- a/src/client.rs
+++ b/src/client.rs
@@ -269,7 +269,79 @@ impl DaemonClient {
         )
         .await
     }
+    // --- GJC SDK control plane (#323) ---
 
+    pub async fn gjc_capabilities(&self) -> Result<Value> {
+        self.gjc_private_request(reqwest::Method::GET, "/api/gjc/capabilities", None)
+            .await
+    }
+
+    pub async fn gjc_session_query(&self, session: &str, sections: Option<&str>) -> Result<Value> {
+        let mut path = format!("/api/gjc/session/{}", urlencoding_lite(session));
+        if let Some(sections) = sections {
+            path.push_str("?sections=");
+            path.push_str(sections);
+        }
+        self.gjc_private_request(reqwest::Method::GET, &path, None)
+            .await
+    }
+
+    pub async fn gjc_turn_outcome(&self, session: &str, turn: &str) -> Result<Value> {
+        self.gjc_private_request(
+            reqwest::Method::GET,
+            &format!(
+                "/api/gjc/session/{}/turn/{}",
+                urlencoding_lite(session),
+                urlencoding_lite(turn)
+            ),
+            None,
+        )
+        .await
+    }
+
+    pub async fn gjc_command_receipt(&self, key: &str) -> Result<Value> {
+        self.gjc_private_request(
+            reqwest::Method::GET,
+            &format!("/api/gjc/command/{}", urlencoding_lite(key)),
+            None,
+        )
+        .await
+    }
+
+    pub async fn gjc_mutation(&self, verb: &str, payload: Value) -> Result<Value> {
+        self.gjc_private_request(
+            reqwest::Method::POST,
+            &format!("/api/gjc/{verb}"),
+            Some(payload),
+        )
+        .await
+    }
+
+    /// GJC endpoints are private control surfaces: loopback daemon URLs
+    /// only, local-control header always set, typed error bodies surfaced.
+    async fn gjc_private_request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        payload: Option<Value>,
+    ) -> Result<Value> {
+        self.ensure_loopback_daemon()?;
+        let mut request = self
+            .http
+            .request(method, format!("{}{}", self.base_url, path))
+            .header(LOCAL_CONTROL_HEADER, "1");
+        if let Some(payload) = payload.as_ref() {
+            request = request.json(payload);
+        }
+        let response = request.send().await?;
+        let status = response.status();
+        let body = response.json::<Value>().await.unwrap_or(Value::Null);
+        if status.is_success() {
+            Ok(body)
+        } else {
+            Err(std::io::Error::other(gjc_error_message(status, &body)).into())
+        }
+    }
     async fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
         let response = self
             .http
@@ -472,4 +544,25 @@ mod tests {
         assert_eq!(response.reason, "started");
         server.await.unwrap();
     }
+}
+
+fn urlencoding_lite(value: &str) -> String {
+    // Session/turn/key ids are validated to exclude whitespace and control
+    // characters, so only path-hostile separators need escaping here.
+    value
+        .replace('/', "%2F")
+        .replace('?', "%3F")
+        .replace('#', "%23")
+}
+
+fn gjc_error_message(status: reqwest::StatusCode, body: &Value) -> String {
+    let code = body
+        .get("error_code")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown_error");
+    let message = body
+        .get("error")
+        .and_then(Value::as_str)
+        .unwrap_or("gjc request failed");
+    format!("daemon gjc request failed with {status} [{code}]: {message}")
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -429,6 +429,27 @@ fn subscription_path_name(name: &str) -> String {
         .collect()
 }
 
+fn urlencoding_lite(value: &str) -> String {
+    // Session/turn/key ids are validated to exclude whitespace and control
+    // characters, so only path-hostile separators need escaping here.
+    value
+        .replace('/', "%2F")
+        .replace('?', "%3F")
+        .replace('#', "%23")
+}
+
+fn gjc_error_message(status: reqwest::StatusCode, body: &Value) -> String {
+    let code = body
+        .get("error_code")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown_error");
+    let message = body
+        .get("error")
+        .and_then(Value::as_str)
+        .unwrap_or("gjc request failed");
+    format!("daemon gjc request failed with {status} [{code}]: {message}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -544,25 +565,4 @@ mod tests {
         assert_eq!(response.reason, "started");
         server.await.unwrap();
     }
-}
-
-fn urlencoding_lite(value: &str) -> String {
-    // Session/turn/key ids are validated to exclude whitespace and control
-    // characters, so only path-hostile separators need escaping here.
-    value
-        .replace('/', "%2F")
-        .replace('?', "%3F")
-        .replace('#', "%23")
-}
-
-fn gjc_error_message(status: reqwest::StatusCode, body: &Value) -> String {
-    let code = body
-        .get("error_code")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown_error");
-    let message = body
-        .get("error")
-        .and_then(Value::as_str)
-        .unwrap_or("gjc request failed");
-    format!("daemon gjc request failed with {status} [{code}]: {message}")
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -105,6 +105,7 @@ struct AppState {
     discord_watch_lock: Arc<Mutex<()>>,
     subscriptions: SharedSubscriptionRegistry,
     git_monitor_diagnostics: SharedGitMonitorDiagnostics,
+    gjc: crate::gjc::control::GjcControlPlane,
 }
 
 type SharedSubscriptionRegistry = Arc<RwLock<BTreeMap<String, SubscriptionEntry>>>;
@@ -268,7 +269,23 @@ pub async fn run(
         .route("/api/ledger/status", get(ledger_status))
         .route("/api/ledger/query", get(ledger_query))
         .route("/api/subscriptions/{name}/start", post(start_subscription))
-        .route("/api/subscriptions/{name}/stop", post(stop_subscription));
+        .route("/api/subscriptions/{name}/stop", post(stop_subscription))
+        .route("/api/gjc/capabilities", get(gjc_capabilities))
+        .route("/api/gjc/session/{session}", get(gjc_session_query))
+        .route(
+            "/api/gjc/session/{session}/turn/{turn}",
+            get(gjc_turn_outcome),
+        )
+        .route("/api/gjc/prompt", post(gjc_prompt))
+        .route("/api/gjc/steer", post(gjc_steer))
+        .route("/api/gjc/abort-and-prompt", post(gjc_abort_and_prompt))
+        .route(
+            "/api/gjc/workflow-gate-answer",
+            post(gjc_workflow_gate_answer),
+        )
+        .route("/api/gjc/ask-answer", post(gjc_ask_answer))
+        .route("/api/gjc/model-selection", post(gjc_model_selection))
+        .route("/api/gjc/command/{key}", get(gjc_command_receipt));
     let port = port_override.unwrap_or(config.daemon.port);
 
     let app = app.with_state(AppState {
@@ -282,6 +299,11 @@ pub async fn run(
         discord_watch_lock: Arc::new(Mutex::new(())),
         subscriptions: subscriptions.clone(),
         git_monitor_diagnostics,
+        gjc: crate::gjc::control::GjcControlPlane::new(
+            std::sync::Arc::new(crate::gjc::model::TransportUnavailable),
+            crate::gjc::control::new_shared_command_registry(),
+            false,
+        ),
     });
     let addr: SocketAddr = format!("{}:{}", config.daemon.bind_host, port).parse()?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
@@ -751,6 +773,162 @@ async fn stop_subscription(
     match stop_subscription_entry(&state.subscription_registry(), &name).await {
         Ok(reason) => Json(json!({"ok": true, "name": name, "reason": reason})).into_response(),
         Err((status, reason)) => subscription_error(status, reason),
+    }
+}
+// --- GJC SDK control plane (#323): public-safe, loopback-guarded surface ---
+
+fn gjc_error_response(error: &crate::gjc::model::GjcError) -> axum::response::Response {
+    let (status, body) = crate::gjc::api::error_response(error);
+    (
+        StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_REQUEST),
+        Json(body),
+    )
+        .into_response()
+}
+
+async fn gjc_capabilities(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+) -> axum::response::Response {
+    let caps = crate::gjc::model::Capabilities::for_transport(state.gjc.transport_implemented());
+    Json(crate::gjc::api::capabilities_body(&caps)).into_response()
+}
+
+async fn gjc_session_query(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    axum::extract::Path(session): axum::extract::Path<String>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> axum::response::Response {
+    match crate::gjc::api::run_session_query(
+        &state.gjc,
+        &session,
+        params.get("sections").map(String::as_str),
+    )
+    .await
+    {
+        Ok(body) => Json(body).into_response(),
+        Err(error) => gjc_error_response(&error),
+    }
+}
+
+async fn gjc_turn_outcome(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    axum::extract::Path((session, turn)): axum::extract::Path<(String, String)>,
+) -> axum::response::Response {
+    let session = match crate::gjc::model::SessionId::new(session) {
+        Ok(session) => session,
+        Err(error) => return gjc_error_response(&error),
+    };
+    if turn.is_empty() || turn.len() > 128 {
+        return gjc_error_response(&crate::gjc::model::GjcError::InvalidRequest {
+            field: "turn_id",
+            reason: "must be 1..=128 bytes".into(),
+        });
+    }
+    match state.gjc.turn_outcome(&session, &turn).await {
+        Ok(outcome) => Json(crate::gjc::api::outcome_body(&outcome)).into_response(),
+        Err(error) => gjc_error_response(&error),
+    }
+}
+
+async fn gjc_prompt(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    Json(dto): Json<crate::gjc::api::PromptDto>,
+) -> axum::response::Response {
+    match dto.into_request() {
+        Ok(request) => match state.gjc.prompt(request).await {
+            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
+            Err(error) => gjc_error_response(&error),
+        },
+        Err(error) => gjc_error_response(&error),
+    }
+}
+
+async fn gjc_steer(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    Json(dto): Json<crate::gjc::api::SteerDto>,
+) -> axum::response::Response {
+    match dto.into_request() {
+        Ok(request) => match state.gjc.steer(request).await {
+            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
+            Err(error) => gjc_error_response(&error),
+        },
+        Err(error) => gjc_error_response(&error),
+    }
+}
+
+async fn gjc_abort_and_prompt(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    Json(dto): Json<crate::gjc::api::AbortAndPromptDto>,
+) -> axum::response::Response {
+    match dto.into_request() {
+        Ok(request) => match state.gjc.abort_and_prompt(request).await {
+            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
+            Err(error) => gjc_error_response(&error),
+        },
+        Err(error) => gjc_error_response(&error),
+    }
+}
+
+async fn gjc_workflow_gate_answer(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    Json(dto): Json<crate::gjc::api::WorkflowGateAnswerDto>,
+) -> axum::response::Response {
+    match dto.into_request() {
+        Ok(request) => match state.gjc.answer_workflow_gate(request).await {
+            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
+            Err(error) => gjc_error_response(&error),
+        },
+        Err(error) => gjc_error_response(&error),
+    }
+}
+
+async fn gjc_ask_answer(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    Json(dto): Json<crate::gjc::api::AskAnswerDto>,
+) -> axum::response::Response {
+    match dto.into_request() {
+        Ok(request) => match state.gjc.answer_ask(request).await {
+            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
+            Err(error) => gjc_error_response(&error),
+        },
+        Err(error) => gjc_error_response(&error),
+    }
+}
+
+async fn gjc_model_selection(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    Json(dto): Json<crate::gjc::api::ModelSelectionDto>,
+) -> axum::response::Response {
+    match dto.into_request() {
+        Ok(request) => match state.gjc.select_model(request).await {
+            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
+            Err(error) => gjc_error_response(&error),
+        },
+        Err(error) => gjc_error_response(&error),
+    }
+}
+
+async fn gjc_command_receipt(
+    _control: SubscriptionControlRequest,
+    State(state): State<AppState>,
+    axum::extract::Path(key): axum::extract::Path<String>,
+) -> axum::response::Response {
+    let key = match crate::gjc::model::IdempotencyKey::new(key) {
+        Ok(key) => key,
+        Err(error) => return gjc_error_response(&error),
+    };
+    match state.gjc.command_receipt(&key).await {
+        Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
+        Err(error) => gjc_error_response(&error),
     }
 }
 
@@ -2172,6 +2350,13 @@ async fn enqueue_event(tx: &mpsc::Sender<IncomingEvent>, event: IncomingEvent) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn test_gjc_plane() -> crate::gjc::control::GjcControlPlane {
+        crate::gjc::control::GjcControlPlane::new(
+            std::sync::Arc::new(crate::gjc::model::TransportUnavailable),
+            crate::gjc::control::new_shared_command_registry(),
+            false,
+        )
+    }
     use crate::config::AppConfig;
     use crate::config::{CronJob, CronJobKind};
     use crate::events::{MessageFormat, RoutingMetadata};
@@ -2200,6 +2385,7 @@ mod tests {
                 discord_watch_lock: Arc::new(Mutex::new(())),
                 subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
                 git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+                gjc: test_gjc_plane(),
             },
             rx,
         )
@@ -2345,6 +2531,7 @@ mod tests {
                 discord_watch_lock: Arc::new(Mutex::new(())),
                 subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
                 git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+                gjc: test_gjc_plane(),
             },
             rx,
         )
@@ -2695,6 +2882,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = accept_event(
@@ -2813,6 +3001,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = accept_event(
@@ -3312,6 +3501,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
         let event = IncomingEvent {
             kind: "tool.post".into(),
@@ -3353,6 +3543,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
         let event = IncomingEvent {
             kind: "tool.post".into(),
@@ -3387,6 +3578,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
         let event = IncomingEvent::agent_started(
             "worker-1".into(),
@@ -3433,6 +3625,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = accept_event(
@@ -3490,6 +3683,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = accept_event(
@@ -3552,6 +3746,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = accept_event(
@@ -3612,6 +3807,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let event = |id: &str| IncomingEvent {
@@ -3670,6 +3866,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = post_native_hook(State(state), Json(payload))
@@ -3700,6 +3897,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
         let payload = json!({"provider": "codex", "event_name": "Bogus"});
 
@@ -3729,6 +3927,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
         let dir = tempdir().expect("tempdir");
         let payload = json!({
@@ -3772,6 +3971,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = post_native_hook(State(state), Json(payload))
@@ -3814,6 +4014,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
         let payload = json!({
             "provider": "codex",
@@ -3885,6 +4086,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
         let payload = json!({
             "provider": "claude-code",
@@ -4053,6 +4255,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
         let dir = tempdir().expect("tempdir");
         let payload = json!({
@@ -4143,6 +4346,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = list_tmux(State(state)).await.into_response();
@@ -4191,6 +4395,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = update_status(State(state)).await.into_response();
@@ -4224,6 +4429,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = update_status(State(state)).await.into_response();
@@ -4250,6 +4456,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = approve_update(State(state)).await.into_response();
@@ -4288,6 +4495,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = dismiss_update(State(state)).await.into_response();
@@ -4314,6 +4522,7 @@ mod tests {
             discord_watch_lock: Arc::new(Mutex::new(())),
             subscriptions: Arc::new(RwLock::new(BTreeMap::new())),
             git_monitor_diagnostics: new_shared_git_monitor_diagnostics(),
+            gjc: test_gjc_plane(),
         };
 
         let response = dismiss_update(State(state)).await.into_response();
@@ -4322,5 +4531,93 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let json: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["ok"], Value::Bool(false));
+    }
+
+    #[tokio::test]
+    async fn gjc_handlers_fail_closed_and_validate_before_transport() {
+        let (state, _rx) = native_hook_test_state();
+
+        // Capabilities surface is honest about the missing transport.
+        let response = gjc_capabilities(SubscriptionControlRequest, State(state.clone()))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(body["transport_implemented"], Value::Bool(false));
+        assert_eq!(body["capabilities"], json!([]));
+
+        // Session queries require a transport and fail closed with 503.
+        let response = gjc_session_query(
+            SubscriptionControlRequest,
+            State(state.clone()),
+            axum::extract::Path("sess-1".into()),
+            Query(std::collections::HashMap::new()),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body: Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(body["error_code"], "transport_unavailable");
+
+        // Local validation runs before the transport check.
+        let invalid = crate::gjc::api::PromptDto {
+            base: crate::gjc::api::MutationDto {
+                session: "sess-1".into(),
+                idempotency_key: "short".into(),
+                expected_session: None,
+                timeout_ms: None,
+            },
+            prompt: "hello".into(),
+        };
+        let response = gjc_prompt(
+            SubscriptionControlRequest,
+            State(state.clone()),
+            Json(invalid),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(body["error_code"], "invalid_request");
+
+        // Well-formed mutations still fail closed without a transport.
+        let valid = crate::gjc::api::PromptDto {
+            base: crate::gjc::api::MutationDto {
+                session: "sess-1".into(),
+                idempotency_key: "idem-key-e2e1".into(),
+                expected_session: Some("sess-1".into()),
+                timeout_ms: None,
+            },
+            prompt: "hello".into(),
+        };
+        let response =
+            gjc_prompt(SubscriptionControlRequest, State(state.clone()), Json(valid))
+                .await
+                .into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        // Unknown receipts are 404; malformed keys are 400.
+        let response = gjc_command_receipt(
+            SubscriptionControlRequest,
+            State(state.clone()),
+            axum::extract::Path("idem-key-missing".into()),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let response = gjc_command_receipt(
+            SubscriptionControlRequest,
+            State(state),
+            axum::extract::Path("bad key!".into()),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -319,10 +319,18 @@ pub async fn run(
         discord_watch_lock: Arc::new(Mutex::new(())),
         subscriptions: subscriptions.clone(),
         git_monitor_diagnostics,
-        gjc: crate::gjc::control::GjcControlPlane::for_worktree(
-            &std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
-            crate::gjc::control::new_shared_command_registry(),
-        ),
+        gjc: match std::env::current_dir() {
+            Ok(cwd) => crate::gjc::control::GjcControlPlane::for_worktree(
+                &cwd,
+                crate::gjc::control::new_shared_command_registry(),
+            ),
+            // Without a resolvable worktree anchor the plane stays
+            // explicitly unavailable instead of silently re-scoping the
+            // trust boundary to ".".
+            Err(_) => crate::gjc::control::GjcControlPlane::unavailable(
+                crate::gjc::control::new_shared_command_registry(),
+            ),
+        },
         gjc_store,
         gjc_reconciler,
     });

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -299,10 +299,9 @@ pub async fn run(
         discord_watch_lock: Arc::new(Mutex::new(())),
         subscriptions: subscriptions.clone(),
         git_monitor_diagnostics,
-        gjc: crate::gjc::control::GjcControlPlane::new(
-            std::sync::Arc::new(crate::gjc::model::TransportUnavailable),
+        gjc: crate::gjc::control::GjcControlPlane::for_worktree(
+            &std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             crate::gjc::control::new_shared_command_registry(),
-            false,
         ),
     });
     let addr: SocketAddr = format!("{}:{}", config.daemon.bind_host, port).parse()?;
@@ -790,7 +789,7 @@ async fn gjc_capabilities(
     _control: SubscriptionControlRequest,
     State(state): State<AppState>,
 ) -> axum::response::Response {
-    let caps = crate::gjc::model::Capabilities::for_transport(state.gjc.transport_implemented());
+    let caps = state.gjc.capabilities().await;
     Json(crate::gjc::api::capabilities_body(&caps)).into_response()
 }
 
@@ -2351,10 +2350,8 @@ async fn enqueue_event(tx: &mpsc::Sender<IncomingEvent>, event: IncomingEvent) -
 mod tests {
     use super::*;
     fn test_gjc_plane() -> crate::gjc::control::GjcControlPlane {
-        crate::gjc::control::GjcControlPlane::new(
-            std::sync::Arc::new(crate::gjc::model::TransportUnavailable),
+        crate::gjc::control::GjcControlPlane::unavailable(
             crate::gjc::control::new_shared_command_registry(),
-            false,
         )
     }
     use crate::config::AppConfig;
@@ -4600,7 +4597,9 @@ mod tests {
             gjc_prompt(SubscriptionControlRequest, State(state.clone()), Json(valid))
                 .await
                 .into_response();
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        // Capability gate fires before the transport check: with no
+        // transport nothing is exercisable, so mutations are 501.
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 
         // Unknown receipts are 404; malformed keys are 400.
         let response = gjc_command_receipt(

--- a/src/gjc/api.rs
+++ b/src/gjc/api.rs
@@ -1,0 +1,473 @@
+//! Public-safe DTOs shared by the daemon HTTP surface and the CLI.
+
+use super::control::GjcControlPlane;
+use super::model::{
+    AbortAndPromptRequest, AskAnswerRequest, AskChoice, Capabilities, CommandReceipt,
+    ControlRequestEnvelope, GJC_CONTROL_SCHEMA, GjcError, GjcResult, IdempotencyKey,
+    ModelSelectionRequest, PromptRequest, SessionId, SessionQuery, SteerRequest,
+    WorkflowGateAnswer, WorkflowGateAnswerRequest,
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+/// Sections accepted on the session query surface. Unknown sections are
+/// rejected so callers cannot probe arbitrary peer fields.
+pub const SESSION_SECTIONS: &[&str] = &[
+    "metadata",
+    "stats",
+    "model_profile",
+    "turn",
+    "queue",
+    "workflow_gates",
+    "goal_todo",
+];
+
+pub fn parse_sections(raw: Option<&str>) -> GjcResult<Vec<String>> {
+    let Some(raw) = raw else {
+        return Ok(SESSION_SECTIONS.iter().map(|s| s.to_string()).collect());
+    };
+    let mut sections = Vec::new();
+    for part in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if !SESSION_SECTIONS.contains(&part) {
+            return Err(GjcError::InvalidRequest {
+                field: "sections",
+                reason: format!("unknown section `{part}`"),
+            });
+        }
+        if !sections.iter().any(|s: &String| s == part) {
+            sections.push(part.to_string());
+        }
+    }
+    if sections.is_empty() {
+        return Err(GjcError::InvalidRequest {
+            field: "sections",
+            reason: "at least one section is required".into(),
+        });
+    }
+    Ok(sections)
+}
+
+fn session_id(raw: &str) -> GjcResult<SessionId> {
+    SessionId::new(raw)
+}
+
+fn idempotency_key(raw: &str) -> GjcResult<IdempotencyKey> {
+    IdempotencyKey::new(raw)
+}
+
+fn envelope(raw: &MutationDto) -> GjcResult<ControlRequestEnvelope> {
+    Ok(ControlRequestEnvelope {
+        session: session_id(&raw.session)?,
+        expected_session: raw
+            .expected_session
+            .as_deref()
+            .map(session_id)
+            .transpose()?,
+        idempotency_key: idempotency_key(&raw.idempotency_key)?,
+        timeout_ms: raw
+            .timeout_ms
+            .unwrap_or(ControlRequestEnvelope::DEFAULT_TIMEOUT_MS),
+    })
+}
+
+/// Shared mutation DTO accepted by every control verb.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MutationDto {
+    pub session: String,
+    pub idempotency_key: String,
+    /// When set, the command fails closed unless the authoritative session
+    /// id matches exactly.
+    pub expected_session: Option<String>,
+    /// Bounded peer exchange timeout in milliseconds.
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PromptDto {
+    #[serde(flatten)]
+    pub base: MutationDto,
+    pub prompt: String,
+}
+
+impl PromptDto {
+    pub fn into_request(self) -> GjcResult<PromptRequest> {
+        let prompt_len = self.prompt.len();
+        if prompt_len == 0 || prompt_len > 16_384 {
+            return Err(GjcError::InvalidRequest {
+                field: "prompt",
+                reason: "must be 1..=16384 bytes".into(),
+            });
+        }
+        Ok(PromptRequest {
+            envelope: envelope(&self.base)?,
+            prompt: self.prompt,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SteerDto {
+    #[serde(flatten)]
+    pub base: MutationDto,
+    pub message: String,
+}
+
+impl SteerDto {
+    pub fn into_request(self) -> GjcResult<SteerRequest> {
+        let message_len = self.message.len();
+        if message_len == 0 || message_len > 16_384 {
+            return Err(GjcError::InvalidRequest {
+                field: "message",
+                reason: "must be 1..=16384 bytes".into(),
+            });
+        }
+        Ok(SteerRequest {
+            envelope: envelope(&self.base)?,
+            message: self.message,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AbortAndPromptDto {
+    #[serde(flatten)]
+    pub base: MutationDto,
+    #[serde(default)]
+    pub turn_ids: Vec<String>,
+    pub prompt: String,
+}
+
+impl AbortAndPromptDto {
+    pub fn into_request(self) -> GjcResult<AbortAndPromptRequest> {
+        let prompt_len = self.prompt.len();
+        if prompt_len == 0 || prompt_len > 16_384 {
+            return Err(GjcError::InvalidRequest {
+                field: "prompt",
+                reason: "must be 1..=16384 bytes".into(),
+            });
+        }
+        if self.turn_ids.len() > 64 {
+            return Err(GjcError::InvalidRequest {
+                field: "turn_ids",
+                reason: "at most 64 turn ids are accepted".into(),
+            });
+        }
+        Ok(AbortAndPromptRequest {
+            envelope: envelope(&self.base)?,
+            turn_ids: self
+                .turn_ids
+                .iter()
+                .map(|raw| super::model::TurnId::new(raw.as_str()))
+                .collect::<GjcResult<Vec<_>>>()?,
+            prompt: self.prompt,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WorkflowGateAnswerDto {
+    #[serde(flatten)]
+    pub base: MutationDto,
+    pub gate_id: String,
+    pub option: String,
+}
+
+impl WorkflowGateAnswerDto {
+    pub fn into_request(self) -> GjcResult<WorkflowGateAnswerRequest> {
+        if self.gate_id.is_empty() || self.gate_id.len() > 128 {
+            return Err(GjcError::InvalidRequest {
+                field: "gate_id",
+                reason: "must be 1..=128 bytes".into(),
+            });
+        }
+        if self.option.is_empty() || self.option.len() > 256 {
+            return Err(GjcError::InvalidRequest {
+                field: "option",
+                reason: "must be 1..=256 bytes".into(),
+            });
+        }
+        Ok(WorkflowGateAnswerRequest {
+            envelope: envelope(&self.base)?,
+            gate_id: self.gate_id,
+            answer: WorkflowGateAnswer {
+                option: self.option,
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AskAnswerDto {
+    #[serde(flatten)]
+    pub base: MutationDto,
+    pub ask_id: String,
+    #[serde(default)]
+    pub choices: Vec<String>,
+}
+
+impl AskAnswerDto {
+    pub fn into_request(self) -> GjcResult<AskAnswerRequest> {
+        if self.ask_id.is_empty() || self.ask_id.len() > 128 {
+            return Err(GjcError::InvalidRequest {
+                field: "ask_id",
+                reason: "must be 1..=128 bytes".into(),
+            });
+        }
+        if self.choices.is_empty() || self.choices.len() > 16 {
+            return Err(GjcError::InvalidRequest {
+                field: "choices",
+                reason: "1..=16 choices are required".into(),
+            });
+        }
+        Ok(AskAnswerRequest {
+            envelope: envelope(&self.base)?,
+            ask_id: self.ask_id,
+            choices: self
+                .choices
+                .into_iter()
+                .map(|option| {
+                    if option.is_empty() || option.len() > 256 {
+                        Err(GjcError::InvalidRequest {
+                            field: "choices",
+                            reason: "each choice must be 1..=256 bytes".into(),
+                        })
+                    } else {
+                        Ok(AskChoice { option })
+                    }
+                })
+                .collect::<GjcResult<Vec<_>>>()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelSelectionDto {
+    #[serde(flatten)]
+    pub base: MutationDto,
+    pub model: Option<String>,
+    pub profile: Option<String>,
+}
+
+impl ModelSelectionDto {
+    pub fn into_request(self) -> GjcResult<ModelSelectionRequest> {
+        for (field, value) in [("model", &self.model), ("profile", &self.profile)] {
+            if let Some(value) = value.as_deref()
+                && (value.is_empty() || value.len() > 128)
+            {
+                return Err(GjcError::InvalidRequest {
+                    field: "model",
+                    reason: format!("{field} must be 1..=128 bytes when present"),
+                });
+            }
+        }
+        Ok(ModelSelectionRequest {
+            envelope: envelope(&self.base)?,
+            model: self.model,
+            profile: self.profile,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public-safe rendering
+// ---------------------------------------------------------------------------
+
+/// Capabilities response body.
+pub fn capabilities_body(caps: &Capabilities) -> Value {
+    serde_json::to_value(caps).unwrap_or(Value::Null)
+}
+
+/// Session query response body: typed sections plus schema marker, with
+/// provider metadata filtered down to scalar values so nested provider
+/// objects cannot leak through the public surface.
+pub fn session_query_body(query: &SessionQuery) -> Value {
+    let mut body = json!({"schema": GJC_CONTROL_SCHEMA});
+    if let Some(metadata) = query.metadata.as_ref() {
+        let mut metadata = metadata.clone();
+        metadata.provider_metadata = metadata
+            .provider_metadata
+            .iter()
+            .filter(|(_, value)| {
+                value.is_string() || value.is_number() || value.is_boolean() || value.is_null()
+            })
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        body["metadata"] = serde_json::to_value(metadata).unwrap_or(Value::Null);
+    }
+    if let Some(stats) = query.stats.as_ref() {
+        body["stats"] = serde_json::to_value(stats).unwrap_or(Value::Null);
+    }
+    if let Some(model_profile) = query.model_profile.as_ref() {
+        body["model_profile"] = serde_json::to_value(model_profile).unwrap_or(Value::Null);
+    }
+    if let Some(turn) = query.turn.as_ref() {
+        body["turn"] = serde_json::to_value(turn).unwrap_or(Value::Null);
+    }
+    if let Some(queue) = query.queue.as_ref() {
+        body["queue"] = serde_json::to_value(queue).unwrap_or(Value::Null);
+    }
+    if let Some(gates) = query.workflow_gates.as_ref() {
+        body["workflow_gates"] = serde_json::to_value(gates).unwrap_or(Value::Null);
+    }
+    if let Some(goal_todo) = query.goal_todo.as_ref() {
+        body["goal_todo"] = serde_json::to_value(goal_todo).unwrap_or(Value::Null);
+    }
+    body
+}
+
+/// Command receipt response body.
+pub fn command_receipt_body(receipt: &CommandReceipt) -> Value {
+    serde_json::to_value(receipt).unwrap_or(Value::Null)
+}
+
+/// Terminal outcome response body.
+pub fn outcome_body(outcome: &Value) -> Value {
+    json!({
+        "schema": GJC_CONTROL_SCHEMA,
+        "outcome": outcome,
+    })
+}
+
+/// Map a control-plane error to an HTTP-ish (status, body) pair for both
+/// daemon handlers and CLI rendering.
+pub fn error_response(error: &GjcError) -> (u16, Value) {
+    (error.http_status(), error.public_body())
+}
+
+/// Run a session query through the control plane and render its body.
+pub async fn run_session_query(
+    plane: &GjcControlPlane,
+    session: &str,
+    sections: Option<&str>,
+) -> GjcResult<Value> {
+    let session = session_id(session)?;
+    let sections = parse_sections(sections)?;
+    let refs = sections.iter().map(String::as_str).collect::<Vec<_>>();
+    let query = plane.query_session(&session, &refs).await?;
+    Ok(session_query_body(&query))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sections_parse_defaults_to_all() {
+        let sections = parse_sections(None).unwrap();
+        assert_eq!(sections.len(), SESSION_SECTIONS.len());
+    }
+
+    #[test]
+    fn sections_reject_unknown_and_empty() {
+        assert!(parse_sections(Some("metadata,secret")).is_err());
+        assert!(parse_sections(Some(",,")).is_err());
+        assert!(parse_sections(Some("metadata,metadata")).unwrap().len() == 1);
+    }
+
+    #[test]
+    fn prompt_dto_validates_before_transport() {
+        let error = PromptDto {
+            base: base_dto(),
+            prompt: String::new(),
+        }
+        .into_request()
+        .unwrap_err();
+        assert_eq!(error.error_code(), "invalid_request");
+    }
+
+    #[test]
+    fn mutation_dto_rejects_short_idempotency_keys() {
+        let mut base = base_dto();
+        base.idempotency_key = "short".into();
+        let error = PromptDto {
+            base,
+            prompt: "hi".into(),
+        }
+        .into_request()
+        .unwrap_err();
+        assert_eq!(error.error_code(), "invalid_request");
+    }
+
+    #[test]
+    fn gate_answer_dto_validates_bounds() {
+        let error = WorkflowGateAnswerDto {
+            base: base_dto(),
+            gate_id: String::new(),
+            option: "ok".into(),
+        }
+        .into_request()
+        .unwrap_err();
+        assert_eq!(error.error_code(), "invalid_request");
+    }
+
+    #[test]
+    fn ask_answer_dto_requires_choices() {
+        let error = AskAnswerDto {
+            base: base_dto(),
+            ask_id: "ask-1".into(),
+            choices: vec![],
+        }
+        .into_request()
+        .unwrap_err();
+        assert_eq!(error.error_code(), "invalid_request");
+    }
+
+    #[test]
+    fn model_selection_dto_rejects_both_and_neither() {
+        let dto = ModelSelectionDto {
+            base: base_dto(),
+            model: Some("m".into()),
+            profile: Some("p".into()),
+        };
+        // DTO-level validation passes; exactly-one is enforced by the
+        // control plane (and surfaced as invalid_request there).
+        assert!(dto.clone().into_request().is_ok());
+    }
+
+    #[test]
+    fn session_query_body_filters_non_scalar_provider_metadata() {
+        let mut query = SessionQuery::default();
+        query.metadata = Some(super::super::model::SessionMetadata {
+            session_id: "sess-1".into(),
+            title: Some("t".into()),
+            project: None,
+            created_at: None,
+            last_active_at: None,
+            lane: None,
+            provider_metadata: [
+                ("safe".to_string(), Value::String("v".into())),
+                ("nested".to_string(), json!({"secret": true})),
+            ]
+            .into_iter()
+            .collect(),
+        });
+        let body = session_query_body(&query);
+        assert_eq!(body["metadata"]["provider_metadata"]["safe"], "v");
+        assert!(
+            body["metadata"]["provider_metadata"]
+                .get("nested")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn abort_dto_bounds_turn_ids() {
+        let mut dto = AbortAndPromptDto {
+            base: base_dto(),
+            turn_ids: (0..65).map(|i| format!("turn-{i}")).collect(),
+            prompt: "p".into(),
+        };
+        assert!(dto.clone().into_request().is_err());
+        dto.turn_ids.truncate(1);
+        assert!(dto.into_request().is_ok());
+    }
+
+    fn base_dto() -> MutationDto {
+        MutationDto {
+            session: "sess-1".into(),
+            idempotency_key: "idem-key-0001".into(),
+            expected_session: Some("sess-1".into()),
+            timeout_ms: None,
+        }
+    }
+}

--- a/src/gjc/api.rs
+++ b/src/gjc/api.rs
@@ -426,21 +426,23 @@ mod tests {
 
     #[test]
     fn session_query_body_filters_non_scalar_provider_metadata() {
-        let mut query = SessionQuery::default();
-        query.metadata = Some(super::super::model::SessionMetadata {
-            session_id: "sess-1".into(),
-            title: Some("t".into()),
-            project: None,
-            created_at: None,
-            last_active_at: None,
-            lane: None,
-            provider_metadata: [
-                ("safe".to_string(), Value::String("v".into())),
-                ("nested".to_string(), json!({"secret": true})),
-            ]
-            .into_iter()
-            .collect(),
-        });
+        let query = SessionQuery {
+            metadata: Some(super::super::model::SessionMetadata {
+                session_id: "sess-1".into(),
+                title: Some("t".into()),
+                project: None,
+                created_at: None,
+                last_active_at: None,
+                lane: None,
+                provider_metadata: [
+                    ("safe".to_string(), Value::String("v".into())),
+                    ("nested".to_string(), json!({"secret": true})),
+                ]
+                .into_iter()
+                .collect(),
+            }),
+            ..SessionQuery::default()
+        };
         let body = session_query_body(&query);
         assert_eq!(body["metadata"]["provider_metadata"]["safe"], "v");
         assert!(

--- a/src/gjc/cli.rs
+++ b/src/gjc/cli.rs
@@ -1,0 +1,249 @@
+//! CLI surface for the GJC SDK control plane (#323). Every command talks to
+//! the local daemon and renders public-safe JSON or text.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::Result;
+use crate::cli::GjcCommands;
+use crate::client::DaemonClient;
+use crate::config::AppConfig;
+use crate::gjc::model::{ControlRequestEnvelope, GJC_CONTROL_SCHEMA};
+
+fn mutation_payload(
+    session: &str,
+    mutation: &crate::cli::GjcMutationArgs,
+    extra: Value,
+) -> Result<Value> {
+    let mut payload = serde_json::json!({
+        "session": session,
+        "idempotency_key": mutation.idempotency_key,
+        "expected_session": mutation.expected_session,
+        "timeout_ms": mutation
+            .timeout_ms
+            .unwrap_or(ControlRequestEnvelope::DEFAULT_TIMEOUT_MS),
+    });
+    if let Value::Object(map) = extra {
+        for (key, value) in map {
+            payload[key] = value;
+        }
+    }
+    Ok(payload)
+}
+
+fn print_json(value: &Value) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+/// Compact public-safe text rendering used when `--json` is absent.
+fn print_text(value: &Value, keys: &[&str]) {
+    for key in keys.iter() {
+        let label = key.to_uppercase();
+        match value.get(*key) {
+            Some(Value::Null) | None => println!("{label}: -"),
+            Some(Value::String(text)) if text.is_empty() => println!("{label}: -"),
+            Some(other) => println!("{label}: {other}"),
+        }
+    }
+}
+
+pub async fn run(config: Arc<AppConfig>, command: GjcCommands) -> Result<()> {
+    let client = DaemonClient::from_config(config.as_ref());
+    match command {
+        GjcCommands::Capabilities { json } => {
+            let body = client.gjc_capabilities().await?;
+            render(
+                &body,
+                json,
+                &["schema", "transport_implemented", "capabilities"],
+            )
+        }
+        GjcCommands::Session {
+            session,
+            sections,
+            json,
+        } => {
+            let body = client
+                .gjc_session_query(&session, sections.as_deref())
+                .await?;
+            render(
+                &body,
+                json,
+                &[
+                    "metadata",
+                    "stats",
+                    "model_profile",
+                    "turn",
+                    "queue",
+                    "workflow_gates",
+                    "goal_todo",
+                ],
+            )
+        }
+        GjcCommands::TurnOutcome {
+            session,
+            turn_id,
+            json,
+        } => {
+            let body = client.gjc_turn_outcome(&session, &turn_id).await?;
+            render(&body, json, &["schema", "outcome"])
+        }
+        GjcCommands::Prompt {
+            session,
+            prompt,
+            mutation,
+        } => {
+            let payload =
+                mutation_payload(&session, &mutation, serde_json::json!({"prompt": prompt}))?;
+            let body = client.gjc_mutation("prompt", payload).await?;
+            render_receipt(&body, mutation.json)
+        }
+        GjcCommands::Steer {
+            session,
+            message,
+            mutation,
+        } => {
+            let payload =
+                mutation_payload(&session, &mutation, serde_json::json!({"message": message}))?;
+            let body = client.gjc_mutation("steer", payload).await?;
+            render_receipt(&body, mutation.json)
+        }
+        GjcCommands::AbortAndPrompt {
+            session,
+            prompt,
+            turn_ids,
+            mutation,
+        } => {
+            let payload = mutation_payload(
+                &session,
+                &mutation,
+                serde_json::json!({"prompt": prompt, "turn_ids": turn_ids}),
+            )?;
+            let body = client.gjc_mutation("abort-and-prompt", payload).await?;
+            render_receipt(&body, mutation.json)
+        }
+        GjcCommands::GateAnswer {
+            session,
+            gate_id,
+            option,
+            mutation,
+        } => {
+            let payload = mutation_payload(
+                &session,
+                &mutation,
+                serde_json::json!({"gate_id": gate_id, "option": option}),
+            )?;
+            let body = client.gjc_mutation("workflow-gate-answer", payload).await?;
+            render_receipt(&body, mutation.json)
+        }
+        GjcCommands::AskAnswer {
+            session,
+            ask_id,
+            choices,
+            mutation,
+        } => {
+            let payload = mutation_payload(
+                &session,
+                &mutation,
+                serde_json::json!({"ask_id": ask_id, "choices": choices}),
+            )?;
+            let body = client.gjc_mutation("ask-answer", payload).await?;
+            render_receipt(&body, mutation.json)
+        }
+        GjcCommands::Select {
+            session,
+            model,
+            profile,
+            mutation,
+        } => {
+            let payload = mutation_payload(
+                &session,
+                &mutation,
+                serde_json::json!({"model": model, "profile": profile}),
+            )?;
+            let body = client.gjc_mutation("model-selection", payload).await?;
+            render_receipt(&body, mutation.json)
+        }
+        GjcCommands::Receipt {
+            idempotency_key,
+            json,
+        } => {
+            let body = client.gjc_command_receipt(&idempotency_key).await?;
+            render_receipt(&body, json)
+        }
+    }
+}
+
+fn render(body: &Value, json: bool, keys: &[&str]) -> Result<()> {
+    if json {
+        print_json(body)?;
+    } else {
+        print_text(body, keys);
+    }
+    Ok(())
+}
+
+fn render_receipt(body: &Value, json: bool) -> Result<()> {
+    if json {
+        return print_json(body);
+    }
+    // Receipts always carry the schema marker; keep the output honest even
+    // on unexpected shapes.
+    if body.get("schema").and_then(Value::as_str) != Some(GJC_CONTROL_SCHEMA) {
+        println!("SCHEMA: -");
+        return Ok(());
+    }
+    print_text(
+        body,
+        &[
+            "command_id",
+            "kind",
+            "session_id",
+            "status",
+            "turn_id",
+            "outcome",
+            "created_at",
+        ],
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutation_payload_carries_common_envelope_fields() {
+        let mutation = crate::cli::GjcMutationArgs {
+            idempotency_key: "idem-key-0001".into(),
+            expected_session: Some("sess-1".into()),
+            timeout_ms: Some(2_500),
+            json: false,
+        };
+        let payload =
+            mutation_payload("sess-1", &mutation, serde_json::json!({"prompt": "hello"})).unwrap();
+        assert_eq!(payload["session"], "sess-1");
+        assert_eq!(payload["idempotency_key"], "idem-key-0001");
+        assert_eq!(payload["expected_session"], "sess-1");
+        assert_eq!(payload["timeout_ms"], 2_500);
+        assert_eq!(payload["prompt"], "hello");
+    }
+
+    #[test]
+    fn receipt_rendering_requires_schema_marker() {
+        // Text mode never invents fields; a non-receipt body prints a dash.
+        // (Rendering writes to stdout; here we only assert no panic.)
+        let _ = render_receipt(&serde_json::json!({"unexpected": true}), false);
+    }
+
+    #[test]
+    fn text_renderer_skips_null_and_empty_fields() {
+        // (Rendering writes to stdout; assert no panic on mixed shapes.)
+        print_text(
+            &serde_json::json!({"a": null, "b": "", "c": "x"}),
+            &["a", "b", "c"],
+        );
+    }
+}

--- a/src/gjc/cli.rs
+++ b/src/gjc/cli.rs
@@ -52,6 +52,14 @@ fn print_text(value: &Value, keys: &[&str]) {
 pub async fn run(config: Arc<AppConfig>, command: GjcCommands) -> Result<()> {
     let client = DaemonClient::from_config(config.as_ref());
     match command {
+        GjcCommands::Inspect(args) => {
+            crate::gjc_sdk::run_inspect(crate::gjc_sdk::InspectOptions {
+                worktree: args.worktree,
+                probe: args.probe,
+                json_output: args.json,
+            })
+            .await
+        }
         GjcCommands::Capabilities { json } => {
             let body = client.gjc_capabilities().await?;
             render(

--- a/src/gjc/control.rs
+++ b/src/gjc/control.rs
@@ -25,32 +25,124 @@ fn now_rfc3339() -> String {
     crate::source::tmux::current_timestamp_rfc3339()
 }
 
+/// Where the control plane obtains its peer transport.
+#[derive(Clone)]
+enum TransportSource {
+    /// Injected transport (tests, or an explicit endpoint binding).
+    #[allow(dead_code)] // exercised by in-crate tests only
+    Static(Arc<dyn GjcTransport>),
+    /// No transport is available on this daemon; everything fails closed.
+    Unavailable,
+    /// Discover the lane endpoint under this worktree root on demand
+    /// (production wiring over the #322 transport).
+    Discovery(std::path::PathBuf),
+}
+
+/// A live transport binding: the resolved endpoint and the session it serves.
+#[derive(Clone)]
+struct BoundTransport {
+    session_id: Option<String>,
+    transport: Arc<dyn GjcTransport>,
+}
+
 /// The authoritative control plane. One instance per daemon; CLI paths go
 /// through the daemon HTTP surface rather than constructing this directly.
 #[derive(Clone)]
 pub struct GjcControlPlane {
-    transport: Arc<dyn GjcTransport>,
+    source: TransportSource,
+    bound: Arc<RwLock<Option<BoundTransport>>>,
     registry: SharedGjcCommandRegistry,
-    transport_implemented: bool,
 }
 
 impl GjcControlPlane {
-    pub fn new(
-        transport: Arc<dyn GjcTransport>,
-        registry: SharedGjcCommandRegistry,
-        transport_implemented: bool,
-    ) -> Self {
+    /// Static-transport constructor (tests and explicit bindings).
+    #[cfg_attr(not(test), allow(dead_code))] // test injection seam
+    pub fn new(transport: Arc<dyn GjcTransport>, registry: SharedGjcCommandRegistry) -> Self {
         Self {
-            transport,
+            source: TransportSource::Static(transport),
+            bound: Arc::new(RwLock::new(None)),
             registry,
-            transport_implemented,
         }
     }
 
-    pub fn transport_implemented(&self) -> bool {
-        self.transport_implemented
+    /// Fail-closed plane with no transport at all.
+    #[cfg_attr(not(test), allow(dead_code))] // daemon tests only
+    pub fn unavailable(registry: SharedGjcCommandRegistry) -> Self {
+        Self {
+            source: TransportSource::Unavailable,
+            bound: Arc::new(RwLock::new(None)),
+            registry,
+        }
     }
 
+    /// Production constructor: resolve the lane endpoint under `worktree`
+    /// through the #322 discovery surface on demand.
+    pub fn for_worktree(worktree: &std::path::Path, registry: SharedGjcCommandRegistry) -> Self {
+        Self {
+            source: TransportSource::Discovery(worktree.to_path_buf()),
+            bound: Arc::new(RwLock::new(None)),
+            registry,
+        }
+    }
+
+
+    /// Resolve a usable transport, enforcing session binding for
+    /// discovery-sourced endpoints. `wanted` is the session about to be
+    /// addressed; a live endpoint bound to another session fails closed.
+    async fn resolve_transport(
+        &self,
+        wanted: Option<&SessionId>,
+    ) -> GjcResult<Option<BoundTransport>> {
+        match &self.source {
+            TransportSource::Static(transport) => Ok(Some(BoundTransport {
+                session_id: None,
+                transport: transport.clone(),
+            })),
+            TransportSource::Unavailable => Ok(None),
+            TransportSource::Discovery(root) => {
+                let cached = self.bound.read().await.clone();
+                if let Some(bound) = cached {
+                    let matches = match (bound.session_id.as_deref(), wanted) {
+                        (_, None) => true,
+                        (None, _) => true,
+                        (Some(bound_session), Some(wanted)) => bound_session == wanted.as_str(),
+                    };
+                    if matches {
+                        return Ok(Some(bound));
+                    }
+                }
+                match super::transport::discover_endpoint(root) {
+                    Ok(endpoint) => {
+                        if let Some(wanted) = wanted {
+                            let endpoint_session = endpoint.session_id().to_string();
+                            if endpoint_session != wanted.as_str() {
+                                return Err(GjcError::SessionMismatch {
+                                    expected: wanted.as_str().to_string(),
+                                });
+                            }
+                        }
+                        let bound = BoundTransport {
+                            session_id: Some(endpoint.session_id().to_string()),
+                            transport: Arc::new(endpoint),
+                        };
+                        *self.bound.write().await = Some(bound.clone());
+                        Ok(Some(bound))
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+        }
+    }
+
+    /// Capability snapshot for the public capabilities surface. Never
+    /// errors: unavailability is reported as `transport_implemented=false`.
+    pub async fn capabilities(&self) -> super::model::Capabilities {
+        let implemented = matches!(
+            self.resolve_transport(None).await,
+            Ok(Some(_)) | Err(GjcError::SessionMismatch { .. })
+        );
+        super::model::Capabilities::for_transport(implemented)
+    }
     // -----------------------------------------------------------------
     // Queries
     // -----------------------------------------------------------------
@@ -62,15 +154,16 @@ impl GjcControlPlane {
         session: &SessionId,
         sections: &[&str],
     ) -> GjcResult<SessionQuery> {
-        self.require_transport()?;
-        let capabilities = super::model::Capabilities::for_transport(self.transport_implemented);
-        capabilities.require(super::model::CAP_SESSION_QUERY)?;
+        let transport = self
+            .resolve_transport(Some(session))
+            .await?
+            .ok_or(GjcError::TransportUnavailable)?;
 
         let params = json!({
             "session_id": session.as_str(),
             "sections": sections,
         });
-        let reply = self.round_trip("session.get", params).await?;
+        let reply = self.round_trip(&transport, "session.get", params).await?;
         let result = reply.result;
         let mut query = SessionQuery::default();
         if let Some(value) = result.get("metadata") {
@@ -135,12 +228,15 @@ impl GjcControlPlane {
 
     /// Terminal outcome receipt for one turn.
     pub async fn turn_outcome(&self, session: &SessionId, turn_id: &str) -> GjcResult<Value> {
-        self.require_transport()?;
+        let transport = self
+            .resolve_transport(Some(session))
+            .await?
+            .ok_or(GjcError::TransportUnavailable)?;
         let params = json!({
             "session_id": session.as_str(),
             "turn_id": turn_id,
         });
-        let reply = self.round_trip("turn.outcome", params).await?;
+        let reply = self.round_trip(&transport, "turn.outcome", params).await?;
         let outcome =
             reply
                 .result
@@ -274,18 +370,15 @@ impl GjcControlPlane {
     // Internals
     // -----------------------------------------------------------------
 
-    fn require_transport(&self) -> GjcResult<()> {
-        if self.transport_implemented {
-            Ok(())
-        } else {
-            Err(GjcError::TransportUnavailable)
-        }
-    }
-
-    async fn round_trip(&self, method: &str, params: Value) -> GjcResult<GjcResponse> {
+    async fn round_trip(
+        &self,
+        transport: &BoundTransport,
+        method: &str,
+        params: Value,
+    ) -> GjcResult<GjcResponse> {
         let correlation_id = Uuid::new_v4().to_string();
         let request = GjcRequest::new(&correlation_id, method, params);
-        let reply = self.transport.round_trip(request).await?;
+        let reply = transport.transport.round_trip(request).await?;
         if reply.correlation_id != correlation_id {
             return Err(GjcError::AmbiguousAck {
                 method: method.into(),
@@ -304,9 +397,15 @@ impl GjcControlPlane {
         params: Value,
     ) -> GjcResult<CommandReceipt> {
         envelope.validate()?;
-        self.require_transport()?;
-        let capabilities = super::model::Capabilities::for_transport(self.transport_implemented);
-        capabilities.require(kind.required_capability())?;
+        // Capability gate: mutations fail closed on missing capability
+        // before any session or transport work happens.
+        self.capabilities()
+            .await
+            .require(kind.required_capability())?;
+        let transport = self
+            .resolve_transport(Some(&envelope.session))
+            .await?
+            .ok_or(GjcError::TransportUnavailable)?;
 
         // Idempotent replay: the identical key returns the recorded receipt.
         if let Some(existing) = self
@@ -365,7 +464,7 @@ impl GjcControlPlane {
         // closed; the recorded receipt stays non-terminal so a replay does
         // not fabricate an outcome.
         let mut reply = self
-            .round_trip(&format!("control.{}", kind.as_str()), request_params)
+            .round_trip(&transport, &format!("control.{}", kind.as_str()), request_params)
             .await?;
 
         let acked = reply
@@ -472,8 +571,7 @@ fn parse_prompt_status(raw: &str) -> Option<GjcPromptStatus> {
 mod tests {
     use super::*;
     use crate::gjc::model::{
-        AbortAndPromptRequest, Capabilities, ControlRequestEnvelope, IdempotencyKey,
-        ModelSelectionRequest, SessionId, TransportUnavailable,
+        Capabilities, ControlRequestEnvelope, IdempotencyKey, ModelSelectionRequest, SessionId,
     };
     use serde_json::json;
     use std::sync::Arc;
@@ -541,11 +639,7 @@ mod tests {
         replies: Vec<GjcResult<GjcResponse>>,
     ) -> (GjcControlPlane, Arc<MockTransport>) {
         let transport = Arc::new(MockTransport::new(replies));
-        let plane = GjcControlPlane::new(
-            transport.clone(),
-            new_shared_command_registry(),
-            true,
-        );
+        let plane = GjcControlPlane::new(transport.clone(), new_shared_command_registry());
         (plane, transport)
     }
 
@@ -751,11 +845,7 @@ mod tests {
     }
 
     fn plane() -> GjcControlPlane {
-        GjcControlPlane::new(
-            Arc::new(TransportUnavailable),
-            new_shared_command_registry(),
-            false,
-        )
+        GjcControlPlane::unavailable(new_shared_command_registry())
     }
 
     #[tokio::test]
@@ -773,7 +863,9 @@ mod tests {
             })
             .await
             .unwrap_err();
-        assert_eq!(error.error_code(), "transport_unavailable");
+        // Mutations gate on capabilities first: with no transport nothing is
+        // exercisable, so the typed failure is capability_missing.
+        assert_eq!(error.error_code(), "missing_capability");
     }
 
     #[tokio::test]

--- a/src/gjc/control.rs
+++ b/src/gjc/control.rs
@@ -162,7 +162,14 @@ impl GjcControlPlane {
             "session_id": session.as_str(),
             "sections": sections,
         });
-        let reply = self.round_trip(&transport, "session.get", params).await?;
+        let reply = self
+            .round_trip(
+                &transport,
+                "session.get",
+                params,
+                ControlRequestEnvelope::DEFAULT_TIMEOUT_MS,
+            )
+            .await?;
         let result = reply.result;
         let mut query = SessionQuery::default();
         if let Some(value) = result.get("metadata") {
@@ -235,7 +242,14 @@ impl GjcControlPlane {
             "session_id": session.as_str(),
             "turn_id": turn_id,
         });
-        let reply = self.round_trip(&transport, "turn.outcome", params).await?;
+        let reply = self
+            .round_trip(
+                &transport,
+                "turn.outcome",
+                params,
+                ControlRequestEnvelope::DEFAULT_TIMEOUT_MS,
+            )
+            .await?;
         let outcome =
             reply
                 .result
@@ -374,9 +388,10 @@ impl GjcControlPlane {
         transport: &BoundTransport,
         method: &str,
         params: Value,
+        timeout_ms: u64,
     ) -> GjcResult<GjcResponse> {
         let correlation_id = Uuid::new_v4().to_string();
-        let request = GjcRequest::new(&correlation_id, method, params);
+        let request = GjcRequest::new(&correlation_id, method, params, timeout_ms);
         let reply = transport.transport.round_trip(request).await?;
         if reply.correlation_id != correlation_id {
             return Err(GjcError::AmbiguousAck {
@@ -462,11 +477,12 @@ impl GjcControlPlane {
         // transport implementation (#322). Ambiguous or malformed acks fail
         // closed; the recorded receipt stays non-terminal so a replay does
         // not fabricate an outcome.
-        let mut reply = self
+        let reply = self
             .round_trip(
                 &transport,
                 &format!("control.{}", kind.as_str()),
                 request_params,
+                envelope.timeout_ms,
             )
             .await?;
 
@@ -519,28 +535,38 @@ impl GjcControlPlane {
         let mut updated = entry.clone();
         drop(write);
 
-        // Terminal receipt: peer outcome present means terminal now.
+        // Terminal receipt: a peer outcome is only trusted when it carries
+        // a parseable TERMINAL prompt status. Anything else (missing,
+        // non-terminal, or unparsable status) fails closed as an invalid
+        // peer reply; the record stays Acked so a replay cannot fabricate
+        // terminality from malformed input.
         if let Some(outcome) = outcome {
             let outcome_status = outcome
                 .get("status")
                 .and_then(Value::as_str)
                 .and_then(parse_prompt_status);
-            let mut write = self.registry.write().await;
-            if let Some(entry) = write.get_mut(envelope.idempotency_key.as_str()) {
-                let terminal = match outcome_status {
-                    Some(status) if status.is_terminal() => GjcCommandStatus::Completed,
-                    Some(_) => GjcCommandStatus::Failed,
-                    None => GjcCommandStatus::Failed,
-                };
-                if entry.status.can_transition_to(terminal) {
-                    entry.status = terminal;
-                    entry.outcome = Some(outcome);
-                    updated = entry.clone();
+            let terminal = match outcome_status {
+                Some(status) if status.is_terminal() => match status {
+                    GjcPromptStatus::Succeeded => GjcCommandStatus::Completed,
+                    _ => GjcCommandStatus::Failed,
+                },
+                _ => {
+                    return Err(GjcError::InvalidPeerReply {
+                        method: kind.as_str().into(),
+                        reason: "peer ack carried no terminal outcome status".into(),
+                    });
                 }
+            };
+            let mut write = self.registry.write().await;
+            if let Some(entry) = write.get_mut(envelope.idempotency_key.as_str())
+                && entry.status.can_transition_to(terminal)
+            {
+                entry.status = terminal;
+                entry.outcome = Some(outcome);
+                updated = entry.clone();
             }
         }
 
-        let _ = &mut reply;
         Ok(updated)
     }
 
@@ -585,6 +611,7 @@ mod tests {
     struct MockTransport {
         replies: Mutex<Vec<GjcResult<GjcResponse>>>,
         seen: Mutex<Vec<String>>,
+        timeouts: Mutex<Vec<u64>>,
     }
 
     impl MockTransport {
@@ -592,6 +619,7 @@ mod tests {
             Self {
                 replies: Mutex::new(replies),
                 seen: Mutex::new(Vec::new()),
+                timeouts: Mutex::new(Vec::new()),
             }
         }
     }
@@ -603,6 +631,7 @@ mod tests {
             request: GjcRequest,
         ) -> std::result::Result<GjcResponse, GjcError> {
             self.seen.lock().unwrap().push(request.method.clone());
+            self.timeouts.lock().unwrap().push(request.timeout_ms);
             let mut replies = self.replies.lock().unwrap();
             if replies.is_empty() {
                 return Err(GjcError::Timeout {
@@ -946,5 +975,48 @@ mod tests {
             .unwrap_err();
         // Unknown keys surface as not-found rather than leaking registry size.
         assert_eq!(error.error_code(), "session_not_found");
+    }
+    #[tokio::test]
+    async fn correlation_mismatch_fails_closed_as_ambiguous_ack() {
+        // A transport that echoes a DIFFERENT correlation id must trip the
+        // plane's defense-in-depth branch, which the scripted transport
+        // normally never exercises because it echoes verbatim.
+        struct WrongEcho;
+        #[async_trait::async_trait]
+        impl GjcTransport for WrongEcho {
+            async fn round_trip(
+                &self,
+                _request: GjcRequest,
+            ) -> std::result::Result<GjcResponse, GjcError> {
+                Ok(GjcResponse {
+                    correlation_id: "not-the-id".into(),
+                    result: json!({"accepted": true}),
+                })
+            }
+        }
+        let plane = GjcControlPlane::new(Arc::new(WrongEcho), new_shared_command_registry());
+        let error = plane
+            .prompt(PromptRequest {
+                envelope: envelope("idem-key-0108"),
+                prompt: "hi".into(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "ambiguous_ack");
+    }
+
+    #[tokio::test]
+    async fn mutation_timeout_budget_is_forwarded_to_the_transport() {
+        let (plane, transport) = implemented_plane_with(vec![ack_reply("turn-109")]).await;
+        let mut env = envelope("idem-key-0109");
+        env.timeout_ms = 4_321;
+        plane
+            .prompt(PromptRequest {
+                envelope: env,
+                prompt: "bounded".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(transport.timeouts.lock().unwrap()[0], 4_321);
     }
 }

--- a/src/gjc/control.rs
+++ b/src/gjc/control.rs
@@ -1,0 +1,857 @@
+//! Control plane over the typed GJC contract: idempotent command registry,
+//! capability gating, session-mismatch guards, and the mutation verbs.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use super::model::{
+    AbortAndPromptRequest, AskAnswerRequest, CommandId, CommandReceipt, ControlRequestEnvelope,
+    GJC_CONTROL_SCHEMA, GjcCommandKind, GjcCommandStatus, GjcError, GjcPromptStatus, GjcRequest,
+    GjcResponse, GjcResult, GjcTransport, IdempotencyKey, ModelSelectionRequest, PromptRequest,
+    SessionId, SessionQuery, SteerRequest, WorkflowGateAnswerRequest,
+};
+
+pub type SharedGjcCommandRegistry = Arc<RwLock<HashMap<String, CommandReceipt>>>;
+
+pub fn new_shared_command_registry() -> SharedGjcCommandRegistry {
+    Arc::new(RwLock::new(HashMap::new()))
+}
+
+fn now_rfc3339() -> String {
+    crate::source::tmux::current_timestamp_rfc3339()
+}
+
+/// The authoritative control plane. One instance per daemon; CLI paths go
+/// through the daemon HTTP surface rather than constructing this directly.
+#[derive(Clone)]
+pub struct GjcControlPlane {
+    transport: Arc<dyn GjcTransport>,
+    registry: SharedGjcCommandRegistry,
+    transport_implemented: bool,
+}
+
+impl GjcControlPlane {
+    pub fn new(
+        transport: Arc<dyn GjcTransport>,
+        registry: SharedGjcCommandRegistry,
+        transport_implemented: bool,
+    ) -> Self {
+        Self {
+            transport,
+            registry,
+            transport_implemented,
+        }
+    }
+
+    pub fn transport_implemented(&self) -> bool {
+        self.transport_implemented
+    }
+
+    // -----------------------------------------------------------------
+    // Queries
+    // -----------------------------------------------------------------
+
+    /// Authoritative multi-surface session query. Unknown sections stay
+    /// `None`; the peer never invents data and neither do we.
+    pub async fn query_session(
+        &self,
+        session: &SessionId,
+        sections: &[&str],
+    ) -> GjcResult<SessionQuery> {
+        self.require_transport()?;
+        let capabilities = super::model::Capabilities::for_transport(self.transport_implemented);
+        capabilities.require(super::model::CAP_SESSION_QUERY)?;
+
+        let params = json!({
+            "session_id": session.as_str(),
+            "sections": sections,
+        });
+        let reply = self.round_trip("session.get", params).await?;
+        let result = reply.result;
+        let mut query = SessionQuery::default();
+        if let Some(value) = result.get("metadata") {
+            query.metadata = serde_json::from_value(value.clone()).map_err(|error| {
+                GjcError::InvalidPeerReply {
+                    method: "session.get".into(),
+                    reason: format!("metadata section: {error}"),
+                }
+            })?;
+        }
+        if let Some(value) = result.get("stats") {
+            query.stats = serde_json::from_value(value.clone()).map_err(|error| {
+                GjcError::InvalidPeerReply {
+                    method: "session.get".into(),
+                    reason: format!("stats section: {error}"),
+                }
+            })?;
+        }
+        if let Some(value) = result.get("model_profile") {
+            query.model_profile = serde_json::from_value(value.clone()).map_err(|error| {
+                GjcError::InvalidPeerReply {
+                    method: "session.get".into(),
+                    reason: format!("model_profile section: {error}"),
+                }
+            })?;
+        }
+        if let Some(value) = result.get("turn") {
+            query.turn = serde_json::from_value(value.clone()).map_err(|error| {
+                GjcError::InvalidPeerReply {
+                    method: "session.get".into(),
+                    reason: format!("turn section: {error}"),
+                }
+            })?;
+        }
+        if let Some(value) = result.get("queue") {
+            query.queue = serde_json::from_value(value.clone()).map_err(|error| {
+                GjcError::InvalidPeerReply {
+                    method: "session.get".into(),
+                    reason: format!("queue section: {error}"),
+                }
+            })?;
+        }
+        if let Some(value) = result.get("workflow_gates") {
+            query.workflow_gates = serde_json::from_value(value.clone()).map_err(|error| {
+                GjcError::InvalidPeerReply {
+                    method: "session.get".into(),
+                    reason: format!("workflow_gates section: {error}"),
+                }
+            })?;
+        }
+        if let Some(value) = result.get("goal_todo") {
+            query.goal_todo = serde_json::from_value(value.clone()).map_err(|error| {
+                GjcError::InvalidPeerReply {
+                    method: "session.get".into(),
+                    reason: format!("goal_todo section: {error}"),
+                }
+            })?;
+        }
+        self.check_session_identity(session, &query)?;
+        Ok(query)
+    }
+
+    /// Terminal outcome receipt for one turn.
+    pub async fn turn_outcome(&self, session: &SessionId, turn_id: &str) -> GjcResult<Value> {
+        self.require_transport()?;
+        let params = json!({
+            "session_id": session.as_str(),
+            "turn_id": turn_id,
+        });
+        let reply = self.round_trip("turn.outcome", params).await?;
+        let outcome =
+            reply
+                .result
+                .get("outcome")
+                .cloned()
+                .ok_or_else(|| GjcError::InvalidPeerReply {
+                    method: "turn.outcome".into(),
+                    reason: "outcome missing".into(),
+                })?;
+        Ok(outcome)
+    }
+
+    // -----------------------------------------------------------------
+    // Mutations
+    // -----------------------------------------------------------------
+
+    pub async fn prompt(&self, request: PromptRequest) -> GjcResult<CommandReceipt> {
+        self.mutate(
+            request.envelope,
+            GjcCommandKind::Prompt,
+            json!({
+                "prompt": request.prompt,
+            }),
+        )
+        .await
+    }
+
+    pub async fn steer(&self, request: SteerRequest) -> GjcResult<CommandReceipt> {
+        self.mutate(
+            request.envelope,
+            GjcCommandKind::Steer,
+            json!({
+                "message": request.message,
+            }),
+        )
+        .await
+    }
+
+    pub async fn abort_and_prompt(
+        &self,
+        request: AbortAndPromptRequest,
+    ) -> GjcResult<CommandReceipt> {
+        self.mutate(
+            request.envelope,
+            GjcCommandKind::AbortAndPrompt,
+            json!({
+                "turn_ids": request
+                    .turn_ids
+                    .iter()
+                    .map(|turn| turn.as_str())
+                    .collect::<Vec<_>>(),
+                "prompt": request.prompt,
+            }),
+        )
+        .await
+    }
+
+    pub async fn answer_workflow_gate(
+        &self,
+        request: WorkflowGateAnswerRequest,
+    ) -> GjcResult<CommandReceipt> {
+        self.mutate(
+            request.envelope,
+            GjcCommandKind::WorkflowGateAnswer,
+            json!({
+                "gate_id": request.gate_id,
+                "option": request.answer.option,
+            }),
+        )
+        .await
+    }
+
+    pub async fn answer_ask(&self, request: AskAnswerRequest) -> GjcResult<CommandReceipt> {
+        self.mutate(
+            request.envelope,
+            GjcCommandKind::AskAnswer,
+            json!({
+                "ask_id": request.ask_id,
+                "choices": request
+                    .choices
+                    .iter()
+                    .map(|choice| choice.option.as_str())
+                    .collect::<Vec<_>>(),
+            }),
+        )
+        .await
+    }
+
+    pub async fn select_model(&self, request: ModelSelectionRequest) -> GjcResult<CommandReceipt> {
+        let ((Some(model), None) | (None, Some(model))) =
+            (request.model.as_deref(), request.profile.as_deref())
+        else {
+            return Err(GjcError::InvalidRequest {
+                field: "model",
+                reason: "exactly one of model or profile must be provided".into(),
+            });
+        };
+        self.mutate(
+            request.envelope,
+            GjcCommandKind::ModelSelection,
+            json!({
+                "selection": model,
+            }),
+        )
+        .await
+    }
+
+    /// Replay an accepted command by idempotency key.
+    pub async fn command_receipt(&self, key: &IdempotencyKey) -> GjcResult<CommandReceipt> {
+        self.registry
+            .read()
+            .await
+            .get(key.as_str())
+            .cloned()
+            .ok_or(GjcError::SessionNotFound {
+                session_id: key.as_str().to_string(),
+            })
+            .and_then(|receipt| {
+                if receipt.status.is_terminal() {
+                    Ok(receipt)
+                } else {
+                    Err(GjcError::InvalidRequest {
+                        field: "idempotency_key",
+                        reason: "command has not reached a terminal state".into(),
+                    })
+                }
+            })
+    }
+
+    // -----------------------------------------------------------------
+    // Internals
+    // -----------------------------------------------------------------
+
+    fn require_transport(&self) -> GjcResult<()> {
+        if self.transport_implemented {
+            Ok(())
+        } else {
+            Err(GjcError::TransportUnavailable)
+        }
+    }
+
+    async fn round_trip(&self, method: &str, params: Value) -> GjcResult<GjcResponse> {
+        let correlation_id = Uuid::new_v4().to_string();
+        let request = GjcRequest::new(&correlation_id, method, params);
+        let reply = self.transport.round_trip(request).await?;
+        if reply.correlation_id != correlation_id {
+            return Err(GjcError::AmbiguousAck {
+                method: method.into(),
+            });
+        }
+        Ok(reply)
+    }
+
+    /// Shared mutation path: capability gate, session guard, idempotent
+    /// replay, bounded exchange, receipt recording with forward-only
+    /// status progression.
+    async fn mutate(
+        &self,
+        envelope: ControlRequestEnvelope,
+        kind: GjcCommandKind,
+        params: Value,
+    ) -> GjcResult<CommandReceipt> {
+        envelope.validate()?;
+        self.require_transport()?;
+        let capabilities = super::model::Capabilities::for_transport(self.transport_implemented);
+        capabilities.require(kind.required_capability())?;
+
+        // Idempotent replay: the identical key returns the recorded receipt.
+        if let Some(existing) = self
+            .registry
+            .read()
+            .await
+            .get(envelope.idempotency_key.as_str())
+            && existing.status.is_terminal()
+        {
+            return Ok(existing.clone());
+        }
+
+        // Expected-session guard: fail closed before any dispatch when the
+        // caller's belief disagrees with the addressed session.
+        if let Some(expected) = envelope.expected_session.as_ref()
+            && expected.as_str() != envelope.session.as_str()
+        {
+            return Err(GjcError::SessionMismatch {
+                expected: envelope.session.as_str().to_string(),
+            });
+        }
+
+        let mut request_params = json!({
+            "session_id": envelope.session.as_str(),
+            "idempotency_key": envelope.idempotency_key.as_str(),
+            "kind": kind.as_str(),
+        });
+        if let Some(expected) = envelope.expected_session.as_ref() {
+            request_params["expected_session_id"] = Value::String(expected.as_str().to_string());
+        }
+        if let Value::Object(map) = params {
+            for (key, value) in map {
+                request_params[key] = value;
+            }
+        }
+
+        let command_id = CommandId::new(format!("gjc-cmd-{}", Uuid::new_v4()))?;
+        let receipt = CommandReceipt {
+            schema: GJC_CONTROL_SCHEMA.into(),
+            command_id: command_id.as_str().to_string(),
+            idempotency_key: envelope.idempotency_key.as_str().to_string(),
+            kind: kind.as_str().to_string(),
+            session_id: envelope.session.as_str().to_string(),
+            status: GjcCommandStatus::Accepted,
+            turn_id: None,
+            outcome: None,
+            created_at: now_rfc3339(),
+        };
+        self.registry.write().await.insert(
+            envelope.idempotency_key.as_str().to_string(),
+            receipt.clone(),
+        );
+
+        // Transport exchange with bounded timeout semantics owned by the
+        // transport implementation (#322). Ambiguous or malformed acks fail
+        // closed; the recorded receipt stays non-terminal so a replay does
+        // not fabricate an outcome.
+        let mut reply = self
+            .round_trip(&format!("control.{}", kind.as_str()), request_params)
+            .await?;
+
+        let acked = reply
+            .result
+            .get("accepted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !acked {
+            return Err(GjcError::AmbiguousAck {
+                method: kind.as_str().into(),
+            });
+        }
+
+        // Ack-side session guard: an ack naming a different session is
+        // treated as a mismatch and fails closed.
+        if let Some(echoed) = reply.result.get("session_id").and_then(Value::as_str)
+            && echoed != envelope.session.as_str()
+        {
+            return Err(GjcError::SessionMismatch {
+                expected: envelope.session.as_str().to_string(),
+            });
+        }
+        // Status progression Accepted -> Acked -> terminal.
+
+        let turn_id = reply
+            .result
+            .get("turn_id")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let outcome = reply.result.get("outcome").cloned();
+
+        let mut write = self.registry.write().await;
+        let entry =
+            write
+                .get_mut(envelope.idempotency_key.as_str())
+                .ok_or(GjcError::InvalidRequest {
+                    field: "idempotency_key",
+                    reason: "command registry entry vanished mid-flight".into(),
+                })?;
+        if !entry.status.can_transition_to(GjcCommandStatus::Acked) {
+            return Err(GjcError::AmbiguousAck {
+                method: kind.as_str().into(),
+            });
+        }
+        entry.status = GjcCommandStatus::Acked;
+        if let Some(turn_id) = turn_id.clone() {
+            entry.turn_id = Some(turn_id);
+        }
+        let mut updated = entry.clone();
+        drop(write);
+
+        // Terminal receipt: peer outcome present means terminal now.
+        if let Some(outcome) = outcome {
+            let outcome_status = outcome
+                .get("status")
+                .and_then(Value::as_str)
+                .and_then(parse_prompt_status);
+            let mut write = self.registry.write().await;
+            if let Some(entry) = write.get_mut(envelope.idempotency_key.as_str()) {
+                let terminal = match outcome_status {
+                    Some(status) if status.is_terminal() => GjcCommandStatus::Completed,
+                    Some(_) => GjcCommandStatus::Failed,
+                    None => GjcCommandStatus::Failed,
+                };
+                if entry.status.can_transition_to(terminal) {
+                    entry.status = terminal;
+                    entry.outcome = Some(outcome);
+                    updated = entry.clone();
+                }
+            }
+        }
+
+        let _ = &mut reply;
+        Ok(updated)
+    }
+
+    /// Fail closed when an expected session id disagrees with the
+    /// authoritative session metadata.
+    fn check_session_identity(&self, session: &SessionId, query: &SessionQuery) -> GjcResult<()> {
+        let Some(metadata) = query.metadata.as_ref() else {
+            return Ok(());
+        };
+        if metadata.session_id != session.as_str() {
+            return Err(GjcError::SessionMismatch {
+                expected: session.as_str().to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+fn parse_prompt_status(raw: &str) -> Option<GjcPromptStatus> {
+    match raw {
+        "queued" => Some(GjcPromptStatus::Queued),
+        "running" => Some(GjcPromptStatus::Running),
+        "succeeded" => Some(GjcPromptStatus::Succeeded),
+        "failed" => Some(GjcPromptStatus::Failed),
+        "aborted" => Some(GjcPromptStatus::Aborted),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gjc::model::{
+        AbortAndPromptRequest, Capabilities, ControlRequestEnvelope, IdempotencyKey,
+        ModelSelectionRequest, SessionId, TransportUnavailable,
+    };
+    use serde_json::json;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    /// Scripted transport: records requests and replays canned replies so
+    /// the full contract is exercised without the #322 transport track.
+    struct MockTransport {
+        replies: Mutex<Vec<GjcResult<GjcResponse>>>,
+        seen: Mutex<Vec<String>>,
+    }
+
+    impl MockTransport {
+        fn new(replies: Vec<GjcResult<GjcResponse>>) -> Self {
+            Self {
+                replies: Mutex::new(replies),
+                seen: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl GjcTransport for MockTransport {
+        async fn round_trip(
+            &self,
+            request: GjcRequest,
+        ) -> std::result::Result<GjcResponse, GjcError> {
+            self.seen.lock().unwrap().push(request.method.clone());
+            let mut replies = self.replies.lock().unwrap();
+            if replies.is_empty() {
+                return Err(GjcError::Timeout {
+                    method: request.method,
+                });
+            }
+            let reply = replies.remove(0);
+            match reply {
+                Ok(mut response) => {
+                    response.correlation_id = request.correlation_id;
+                    Ok(response)
+                }
+                Err(error) => Err(error),
+            }
+        }
+    }
+
+    fn ack_reply(turn_id: &str) -> GjcResult<GjcResponse> {
+        Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({"accepted": true, "turn_id": turn_id}),
+        })
+    }
+
+    fn terminal_ack_reply(turn_id: &str, status: &str, summary: &str) -> GjcResult<GjcResponse> {
+        Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({
+                "accepted": true,
+                "turn_id": turn_id,
+                "outcome": {"status": status, "summary": summary},
+            }),
+        })
+    }
+
+    async fn implemented_plane_with(
+        replies: Vec<GjcResult<GjcResponse>>,
+    ) -> (GjcControlPlane, Arc<MockTransport>) {
+        let transport = Arc::new(MockTransport::new(replies));
+        let plane = GjcControlPlane::new(
+            transport.clone(),
+            new_shared_command_registry(),
+            true,
+        );
+        (plane, transport)
+    }
+
+    #[tokio::test]
+    async fn query_session_parses_typed_sections_from_transport() {
+        let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({
+                "metadata": {"session_id": "sess-1", "title": "lane"},
+                "stats": {"turns_total": 3, "queue_depth": 1},
+            }),
+        })])
+        .await;
+        let query = plane
+            .query_session(&SessionId::new("sess-1").unwrap(), &["metadata", "stats"])
+            .await
+            .unwrap();
+        assert_eq!(query.metadata.as_ref().unwrap().session_id, "sess-1");
+        assert_eq!(query.stats.as_ref().unwrap().turns_total, 3);
+        assert!(query.turn.is_none());
+    }
+
+    #[tokio::test]
+    async fn query_session_fails_closed_on_malformed_sections() {
+        let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({"metadata": {"session_id": 42}}),
+        })])
+        .await;
+        let error = plane
+            .query_session(&SessionId::new("sess-1").unwrap(), &["metadata"])
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "invalid_peer_reply");
+    }
+
+    #[tokio::test]
+    async fn prompt_accepts_and_records_acked_receipt() {
+        let key = IdempotencyKey::new("idem-key-0100").unwrap();
+        let (plane, _transport) =
+            implemented_plane_with(vec![ack_reply("turn-100")]).await;
+        let receipt = plane
+            .prompt(PromptRequest {
+                envelope: envelope("idem-key-0100"),
+                prompt: "hello".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(receipt.status, GjcCommandStatus::Acked);
+        assert_eq!(receipt.turn_id.as_deref(), Some("turn-100"));
+        assert!(!receipt.status.is_terminal());
+        // Non-terminal receipts are not replayable as outcomes.
+        let error = plane.command_receipt(&key).await.unwrap_err();
+        assert_eq!(error.error_code(), "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn idempotent_replay_returns_recorded_terminal_receipt() {
+        let (plane, transport) =
+            implemented_plane_with(vec![terminal_ack_reply("turn-101", "succeeded", "done")])
+                .await;
+        let first = plane
+            .prompt(PromptRequest {
+                envelope: envelope("idem-key-0101"),
+                prompt: "once".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(first.status, GjcCommandStatus::Completed);
+        let second = plane
+            .prompt(PromptRequest {
+                envelope: envelope("idem-key-0101"),
+                prompt: "twice".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(second.command_id, first.command_id);
+        assert_eq!(
+            plane
+                .command_receipt(&IdempotencyKey::new("idem-key-0101").unwrap())
+                .await
+                .unwrap()
+                .command_id,
+            first.command_id
+        );
+        // Only one peer exchange happened; the replay never re-sent.
+        assert_eq!(transport.seen.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn ambiguous_ack_fails_closed_without_fabricating_outcome() {
+        let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({"accepted": false}),
+        })])
+        .await;
+        let error = plane
+            .prompt(PromptRequest {
+                envelope: envelope("idem-key-0102"),
+                prompt: "hi".into(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "ambiguous_ack");
+        let receipt = plane
+            .registry
+            .read()
+            .await
+            .get("idem-key-0102")
+            .cloned()
+            .expect("record kept");
+        // The record stays non-terminal so a replay cannot fake success.
+        assert_eq!(receipt.status, GjcCommandStatus::Accepted);
+    }
+
+    #[tokio::test]
+    async fn transport_errors_surface_their_taxonomy_code() {
+        for (reply, expected) in [
+            (
+                GjcResult::<GjcResponse>::Err(GjcError::Timeout {
+                    method: "control.prompt".into(),
+                }),
+                "timeout",
+            ),
+            (
+                GjcResult::<GjcResponse>::Err(GjcError::StaleEndpoint {
+                    capability: "session.control".into(),
+                }),
+                "stale_endpoint",
+            ),
+        ] {
+            let (plane, _transport) = implemented_plane_with(vec![reply]).await;
+            let error = plane
+                .steer(SteerRequest {
+                    envelope: envelope("idem-key-0103"),
+                    message: "nudge".into(),
+                })
+                .await
+                .unwrap_err();
+            assert_eq!(error.error_code(), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn session_identity_mismatch_is_detected_on_query() {
+        let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({"metadata": {"session_id": "sess-other"}}),
+        })])
+        .await;
+        let error = plane
+            .query_session(&SessionId::new("sess-1").unwrap(), &["metadata"])
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "session_mismatch");
+    }
+
+    #[tokio::test]
+    async fn expected_session_mismatch_fails_closed_before_dispatch() {
+        let (plane, transport) = implemented_plane_with(vec![ack_reply("turn-x")]).await;
+        let mut env = envelope("idem-key-0104");
+        env.expected_session = Some(SessionId::new("sess-other").unwrap());
+        let error = plane
+            .prompt(PromptRequest {
+                envelope: env,
+                prompt: "hi".into(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "session_mismatch");
+        // Nothing reached the transport.
+        assert!(transport.seen.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn ack_echoing_wrong_session_fails_closed() {
+        let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({
+                "accepted": true,
+                "session_id": "sess-other",
+                "turn_id": "turn-105",
+            }),
+        })])
+        .await;
+        let error = plane
+            .prompt(PromptRequest {
+                envelope: envelope("idem-key-0105"),
+                prompt: "hi".into(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "session_mismatch");
+    }
+
+    fn envelope(key: &str) -> ControlRequestEnvelope {
+        ControlRequestEnvelope {
+            session: SessionId::new("sess-1").unwrap(),
+            expected_session: Some(SessionId::new("sess-1").unwrap()),
+            idempotency_key: IdempotencyKey::new(key).unwrap(),
+            timeout_ms: ControlRequestEnvelope::DEFAULT_TIMEOUT_MS,
+        }
+    }
+
+    fn plane() -> GjcControlPlane {
+        GjcControlPlane::new(
+            Arc::new(TransportUnavailable),
+            new_shared_command_registry(),
+            false,
+        )
+    }
+
+    #[tokio::test]
+    async fn queries_and_mutations_fail_closed_without_transport() {
+        let plane = plane();
+        let error = plane
+            .query_session(&SessionId::new("s").unwrap(), &["metadata"])
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "transport_unavailable");
+        let error = plane
+            .prompt(PromptRequest {
+                envelope: envelope("idem-key-0001"),
+                prompt: "hi".into(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "transport_unavailable");
+    }
+
+    #[tokio::test]
+    async fn model_selection_requires_exactly_one_of_model_or_profile() {
+        let plane = plane();
+        let both = ModelSelectionRequest {
+            envelope: envelope("idem-key-0002"),
+            model: Some("m".into()),
+            profile: Some("p".into()),
+        };
+        let error = plane.select_model(both).await.unwrap_err();
+        assert_eq!(error.error_code(), "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn capabilities_gate_control_verbs_without_transport() {
+        let caps = Capabilities::for_transport(false);
+        assert!(
+            caps.require(GjcCommandKind::Prompt.required_capability())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn envelope_timeout_bounds_are_enforced() {
+        let mut env = envelope("idem-key-0003");
+        env.timeout_ms = 0;
+        assert!(env.validate().is_err());
+        env.timeout_ms = ControlRequestEnvelope::MAX_TIMEOUT_MS + 1;
+        assert!(env.validate().is_err());
+        env.timeout_ms = 1_000;
+        assert!(env.validate().is_ok());
+    }
+
+    #[test]
+    fn terminal_receipts_carry_outcome_and_turn_binding() {
+        let completed = CommandReceipt {
+            schema: GJC_CONTROL_SCHEMA.into(),
+            command_id: "cmd-1".into(),
+            idempotency_key: "idem-key-0004".into(),
+            kind: "prompt".into(),
+            session_id: "sess-1".into(),
+            status: GjcCommandStatus::Completed,
+            turn_id: Some("turn-1".into()),
+            outcome: Some(json!({"status": "succeeded", "summary": "done"})),
+            created_at: "2026-01-01T00:00:00Z".into(),
+        };
+        assert!(completed.status.is_terminal());
+        assert_eq!(
+            completed.outcome.as_ref().unwrap()["status"],
+            json!("succeeded")
+        );
+    }
+
+    #[test]
+    fn query_session_section_keys_are_stable() {
+        // The wire section names are part of the public contract.
+        for section in [
+            "metadata",
+            "stats",
+            "model_profile",
+            "turn",
+            "queue",
+            "workflow_gates",
+            "goal_todo",
+        ] {
+            assert!(section.chars().all(|c| c.is_ascii_lowercase() || c == '_'));
+        }
+    }
+
+    #[tokio::test]
+    async fn command_receipt_replay_requires_terminal_state() {
+        let plane = plane();
+        let error = plane
+            .command_receipt(&IdempotencyKey::new("idem-key-0007").unwrap())
+            .await
+            .unwrap_err();
+        // Unknown keys surface as not-found rather than leaking registry size.
+        assert_eq!(error.error_code(), "session_not_found");
+    }
+}

--- a/src/gjc/mod.rs
+++ b/src/gjc/mod.rs
@@ -1,0 +1,13 @@
+//! Authoritative GJC SDK session query and control API (#323).
+//!
+//! Typed queries and mutation verbs over a narrow transport boundary.
+//! The transport itself (endpoint discovery, authentication, websocket
+//! frames) is owned by the #322 transport track; this module only defines
+//! the envelope contract and the control plane on top of it. Until #322
+//! provides a real implementation the daemon fails closed with
+//! [`GjcError::TransportUnavailable`] rather than guessing.
+
+pub mod api;
+pub mod cli;
+pub mod control;
+pub mod model;

--- a/src/gjc/mod.rs
+++ b/src/gjc/mod.rs
@@ -11,3 +11,4 @@ pub mod api;
 pub mod cli;
 pub mod control;
 pub mod model;
+pub mod transport;

--- a/src/gjc/model.rs
+++ b/src/gjc/model.rs
@@ -8,8 +8,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::Result;
-
 /// Public contract schema version. Bumped only on breaking envelope change.
 pub const GJC_CONTROL_SCHEMA: &str = "gjc-control/1";
 
@@ -123,6 +121,12 @@ impl CommandId {
                 reason: "must be 1..=128 bytes".into(),
             });
         }
+        if value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+            return Err(GjcError::InvalidRequest {
+                field: "command_id",
+                reason: "control characters and whitespace are not allowed".into(),
+            });
+        }
         Ok(Self(value))
     }
 
@@ -162,6 +166,12 @@ impl TurnId {
             return Err(GjcError::InvalidRequest {
                 field: "turn_id",
                 reason: "must be 1..=128 bytes".into(),
+            });
+        }
+        if value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+            return Err(GjcError::InvalidRequest {
+                field: "turn_id",
+                reason: "control characters and whitespace are not allowed".into(),
             });
         }
         Ok(Self(value))
@@ -206,14 +216,23 @@ pub struct GjcRequest {
     pub method: String,
     /// Method parameters (public-safe; no tokens ever cross this boundary).
     pub params: Value,
+    /// Bounded exchange budget in milliseconds; the transport must clamp
+    /// its request timeout to at most this value.
+    pub timeout_ms: u64,
 }
 
 impl GjcRequest {
-    pub fn new(correlation_id: impl Into<String>, method: &str, params: Value) -> Self {
+    pub fn new(
+        correlation_id: impl Into<String>,
+        method: &str,
+        params: Value,
+        timeout_ms: u64,
+    ) -> Self {
         Self {
             correlation_id: correlation_id.into(),
             method: method.into(),
             params,
+            timeout_ms,
         }
     }
 }
@@ -363,6 +382,9 @@ pub const CAP_SESSION_CONTROL: &str = "session.control";
 pub const CAP_MODEL_SELECTION: &str = "session.model_selection";
 pub const CAP_WORKFLOW_GATES: &str = "workflow.gates";
 pub const CAP_ASK_ANSWERS: &str = "ask.answers";
+/// Pseudo-capability used by `stale_endpoint` when endpoint metadata
+/// itself is no longer trustworthy.
+pub const CAP_ENDPOINT: &str = "endpoint";
 
 /// Capabilities this control plane can exercise given a transport.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -721,10 +743,6 @@ pub struct CommandReceipt {
 // ---------------------------------------------------------------------------
 
 pub type GjcResult<T> = std::result::Result<T, GjcError>;
-
-// Keep the crate-wide alias referenced so the module compiles standalone.
-#[allow(dead_code)]
-fn _assert_result_alias_compatible(_: Result<()>) {}
 
 #[cfg(test)]
 mod tests {

--- a/src/gjc/model.rs
+++ b/src/gjc/model.rs
@@ -237,17 +237,6 @@ pub trait GjcTransport: Send + Sync {
     async fn round_trip(&self, request: GjcRequest) -> std::result::Result<GjcResponse, GjcError>;
 }
 
-/// Placeholder transport used until #322 lands. Every call fails closed.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct TransportUnavailable;
-
-#[async_trait]
-impl GjcTransport for TransportUnavailable {
-    async fn round_trip(&self, _request: GjcRequest) -> std::result::Result<GjcResponse, GjcError> {
-        Err(GjcError::TransportUnavailable)
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Error taxonomy
 // ---------------------------------------------------------------------------
@@ -810,13 +799,4 @@ mod tests {
         assert!(!Failed.can_transition_to(Acked));
     }
 
-    #[tokio::test]
-    async fn unimplemented_transport_fails_closed() {
-        let transport = TransportUnavailable;
-        let error = transport
-            .round_trip(GjcRequest::new("c1", "session.get", Value::Null))
-            .await
-            .unwrap_err();
-        assert_eq!(error, GjcError::TransportUnavailable);
-    }
 }

--- a/src/gjc/model.rs
+++ b/src/gjc/model.rs
@@ -1,0 +1,822 @@
+//! Typed GJC control-plane contract: requests, responses, error taxonomy,
+//! and the narrow transport boundary owned by the #322 track.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::Result;
+
+/// Public contract schema version. Bumped only on breaking envelope change.
+pub const GJC_CONTROL_SCHEMA: &str = "gjc-control/1";
+
+// ---------------------------------------------------------------------------
+// Identifiers
+// ---------------------------------------------------------------------------
+
+/// GJC session identifier. Opaque except for validation rules: non-empty,
+/// bounded, no control characters. Never echo raw provider ids in errors.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct SessionId(String);
+
+impl SessionId {
+    pub fn new(raw: impl Into<String>) -> std::result::Result<Self, GjcError> {
+        let value = raw.into();
+        let len = value.len();
+        if len == 0 || len > 128 {
+            return Err(GjcError::InvalidRequest {
+                field: "session_id",
+                reason: "must be 1..=128 bytes".into(),
+            });
+        }
+        if value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+            return Err(GjcError::InvalidRequest {
+                field: "session_id",
+                reason: "control characters and whitespace are not allowed".into(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for SessionId {
+    type Error = GjcError;
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<SessionId> for String {
+    fn from(value: SessionId) -> Self {
+        value.0
+    }
+}
+
+/// Client-supplied idempotency key for mutation verbs. Identical keys are
+/// replayed from the command registry instead of issuing a second command.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct IdempotencyKey(String);
+
+impl IdempotencyKey {
+    pub fn new(raw: impl Into<String>) -> std::result::Result<Self, GjcError> {
+        let value = raw.into();
+        let len = value.len();
+        if !(8..=128).contains(&len) {
+            return Err(GjcError::InvalidRequest {
+                field: "idempotency_key",
+                reason: "must be 8..=128 bytes".into(),
+            });
+        }
+        if value.chars().any(|c| c.is_control() || c.is_whitespace()) {
+            return Err(GjcError::InvalidRequest {
+                field: "idempotency_key",
+                reason: "control characters and whitespace are not allowed".into(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for IdempotencyKey {
+    type Error = GjcError;
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<IdempotencyKey> for String {
+    fn from(value: IdempotencyKey) -> Self {
+        value.0
+    }
+}
+
+/// Server-issued identifier of an accepted control command.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct CommandId(String);
+
+impl CommandId {
+    pub fn new(raw: impl Into<String>) -> std::result::Result<Self, GjcError> {
+        let value = raw.into();
+        if value.is_empty() || value.len() > 128 {
+            return Err(GjcError::InvalidRequest {
+                field: "command_id",
+                reason: "must be 1..=128 bytes".into(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CommandId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for CommandId {
+    type Error = GjcError;
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<CommandId> for String {
+    fn from(value: CommandId) -> Self {
+        value.0
+    }
+}
+
+/// Server-issued identifier of a turn created by an accepted prompt.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct TurnId(String);
+
+impl TurnId {
+    pub fn new(raw: impl Into<String>) -> std::result::Result<Self, GjcError> {
+        let value = raw.into();
+        if value.is_empty() || value.len() > 128 {
+            return Err(GjcError::InvalidRequest {
+                field: "turn_id",
+                reason: "must be 1..=128 bytes".into(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TurnId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for TurnId {
+    type Error = GjcError;
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<TurnId> for String {
+    fn from(value: TurnId) -> Self {
+        value.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transport boundary (owned by #322)
+// ---------------------------------------------------------------------------
+
+/// A single correlated transport exchange. The control plane never opens
+/// sockets itself; it issues one request and requires one unambiguously
+/// correlated reply.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GjcRequest {
+    /// Correlation id echoed verbatim by the peer.
+    pub correlation_id: String,
+    /// Dotted method name, e.g. `session.get`.
+    pub method: String,
+    /// Method parameters (public-safe; no tokens ever cross this boundary).
+    pub params: Value,
+}
+
+impl GjcRequest {
+    pub fn new(correlation_id: impl Into<String>, method: &str, params: Value) -> Self {
+        Self {
+            correlation_id: correlation_id.into(),
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+/// Peer reply. `correlation_id` must match the request exactly or the
+/// exchange fails closed as an ambiguous ack.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GjcResponse {
+    pub correlation_id: String,
+    pub result: Value,
+}
+
+/// Narrow transport boundary implemented by the #322 transport track.
+///
+/// Implementations MUST:
+/// - send exactly one request and resolve with at most one reply;
+/// - return [`GjcError::Timeout`] instead of an unbounded wait;
+/// - never surface endpoint metadata or tokens in errors.
+#[async_trait]
+pub trait GjcTransport: Send + Sync {
+    async fn round_trip(&self, request: GjcRequest) -> std::result::Result<GjcResponse, GjcError>;
+}
+
+/// Placeholder transport used until #322 lands. Every call fails closed.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TransportUnavailable;
+
+#[async_trait]
+impl GjcTransport for TransportUnavailable {
+    async fn round_trip(&self, _request: GjcRequest) -> std::result::Result<GjcResponse, GjcError> {
+        Err(GjcError::TransportUnavailable)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error taxonomy
+// ---------------------------------------------------------------------------
+
+/// Fail-closed error taxonomy for the GJC control plane. Every variant maps
+/// to a stable machine-readable `error_code` plus an HTTP status; none carry
+/// secrets, tokens, or endpoint internals.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GjcError {
+    /// The #322 transport layer has no usable implementation/endpoint.
+    TransportUnavailable,
+    /// Transport round trip exceeded its bounded timeout.
+    Timeout { method: String },
+    /// Peer reply correlation did not match the request.
+    AmbiguousAck { method: String },
+    /// Peer returned a malformed, oversized, or unexpected envelope.
+    InvalidPeerReply { method: String, reason: String },
+    /// The requested capability is not present on this build/daemon.
+    MissingCapability { capability: String },
+    /// The peer is reachable but its endpoint metadata is stale.
+    StaleEndpoint { capability: String },
+    /// Expected session id did not match the authoritative session.
+    SessionMismatch { expected: String },
+    /// The referenced session does not exist (or is not visible here).
+    SessionNotFound { session_id: String },
+    /// Request failed local validation before any transport call.
+    InvalidRequest { field: &'static str, reason: String },
+}
+
+impl GjcError {
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            GjcError::TransportUnavailable => "transport_unavailable",
+            GjcError::Timeout { .. } => "timeout",
+            GjcError::AmbiguousAck { .. } => "ambiguous_ack",
+            GjcError::InvalidPeerReply { .. } => "invalid_peer_reply",
+            GjcError::MissingCapability { .. } => "missing_capability",
+            GjcError::StaleEndpoint { .. } => "stale_endpoint",
+            GjcError::SessionMismatch { .. } => "session_mismatch",
+            GjcError::SessionNotFound { .. } => "session_not_found",
+            GjcError::InvalidRequest { .. } => "invalid_request",
+        }
+    }
+
+    pub fn http_status(&self) -> u16 {
+        match self {
+            GjcError::TransportUnavailable => 503,
+            GjcError::Timeout { .. } => 504,
+            GjcError::AmbiguousAck { .. } | GjcError::InvalidPeerReply { .. } => 502,
+            GjcError::MissingCapability { .. } => 501,
+            GjcError::StaleEndpoint { .. } => 409,
+            GjcError::SessionMismatch { .. } => 409,
+            GjcError::SessionNotFound { .. } => 404,
+            GjcError::InvalidRequest { .. } => 400,
+        }
+    }
+
+    /// Public-safe JSON body: stable code + message, never internals.
+    pub fn public_body(&self) -> Value {
+        let mut body = serde_json::json!({
+            "schema": GJC_CONTROL_SCHEMA,
+            "ok": false,
+            "error_code": self.error_code(),
+            "error": self.public_message(),
+        });
+        match self {
+            GjcError::MissingCapability { capability } | GjcError::StaleEndpoint { capability } => {
+                body["capability"] = Value::String(capability.clone());
+            }
+            GjcError::SessionMismatch { expected } => {
+                body["expected_session_id"] = Value::String(expected.clone());
+            }
+            _ => {}
+        }
+        body
+    }
+
+    pub fn public_message(&self) -> String {
+        match self {
+            GjcError::TransportUnavailable => {
+                "gjc transport is not available on this daemon".into()
+            }
+            GjcError::Timeout { method } => {
+                format!("gjc request timed out: {method}")
+            }
+            GjcError::AmbiguousAck { method } => {
+                format!("gjc reply correlation failed for {method}")
+            }
+            GjcError::InvalidPeerReply { method, reason } => {
+                format!("gjc reply rejected for {method}: {reason}")
+            }
+            GjcError::MissingCapability { capability } => {
+                format!("required gjc capability is missing: {capability}")
+            }
+            GjcError::StaleEndpoint { capability } => {
+                format!("gjc endpoint metadata is stale for capability: {capability}")
+            }
+            GjcError::SessionMismatch { .. } => {
+                "gjc session id did not match the expected session".into()
+            }
+            GjcError::SessionNotFound { .. } => "gjc session not found".into(),
+            GjcError::InvalidRequest { field, reason } => {
+                format!("invalid gjc request field `{field}`: {reason}")
+            }
+        }
+    }
+}
+
+impl fmt::Display for GjcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.error_code(), self.public_message())
+    }
+}
+
+impl std::error::Error for GjcError {}
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+/// Capability keys advertised by the daemon and required by verbs.
+pub const CAP_SESSION_QUERY: &str = "session.query";
+pub const CAP_SESSION_CONTROL: &str = "session.control";
+pub const CAP_MODEL_SELECTION: &str = "session.model_selection";
+pub const CAP_WORKFLOW_GATES: &str = "workflow.gates";
+pub const CAP_ASK_ANSWERS: &str = "ask.answers";
+
+/// Capabilities this control plane can exercise given a transport.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capabilities {
+    pub schema: String,
+    pub transport_implemented: bool,
+    pub capabilities: Vec<String>,
+}
+
+impl Capabilities {
+    pub fn for_transport(implemented: bool) -> Self {
+        let capabilities = if implemented {
+            vec![
+                CAP_SESSION_QUERY.to_string(),
+                CAP_SESSION_CONTROL.to_string(),
+                CAP_MODEL_SELECTION.to_string(),
+                CAP_WORKFLOW_GATES.to_string(),
+                CAP_ASK_ANSWERS.to_string(),
+            ]
+        } else {
+            // Fail closed: with no transport, no capability is exercisable.
+            Vec::new()
+        };
+        Self {
+            schema: GJC_CONTROL_SCHEMA.into(),
+            transport_implemented: implemented,
+            capabilities,
+        }
+    }
+
+    pub fn supports(&self, capability: &str) -> bool {
+        self.capabilities.iter().any(|c| c == capability)
+    }
+
+    /// Fail closed when a required capability is absent.
+    pub fn require(&self, capability: &str) -> std::result::Result<(), GjcError> {
+        if self.supports(capability) {
+            Ok(())
+        } else {
+            Err(GjcError::MissingCapability {
+                capability: capability.into(),
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Query responses
+// ---------------------------------------------------------------------------
+
+/// Authoritative session metadata. Peer replies may omit optional fields;
+/// only `session_id` is mandatory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMetadata {
+    pub session_id: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub last_active_at: Option<String>,
+    #[serde(default)]
+    pub lane: Option<String>,
+    /// Free-form provider metadata that has passed allow-list filtering.
+    #[serde(default)]
+    pub provider_metadata: BTreeMap<String, Value>,
+}
+
+/// Authoritative session statistics.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SessionStats {
+    pub turns_total: u64,
+    pub turns_failed: u64,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+    pub queue_depth: u64,
+    pub last_turn_started_at: Option<String>,
+    pub last_turn_finished_at: Option<String>,
+}
+
+/// Currently selected model and profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionModelProfile {
+    pub model: String,
+    pub profile: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+/// A queued item ahead of or behind the active turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueEntry {
+    pub position: u64,
+    pub kind: String,
+    pub summary: Option<String>,
+    pub enqueued_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct QueueSnapshot {
+    #[serde(default)]
+    pub depth: u64,
+    pub entries: Vec<QueueEntry>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GjcPromptStatus {
+    /// Accepted, not yet dispatched to the model.
+    Queued,
+    /// Actively executing.
+    Running,
+    /// Terminal success.
+    Succeeded,
+    /// Terminal failure.
+    Failed,
+    /// Superseded by abort-and-prompt.
+    Aborted,
+}
+
+impl GjcPromptStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, GjcPromptStatus::Succeeded | GjcPromptStatus::Failed)
+    }
+}
+
+/// A workflow gate awaiting an answer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowGate {
+    pub gate_id: String,
+    pub workflow_id: Option<String>,
+    pub state: WorkflowGateState,
+    pub title: Option<String>,
+    pub options: Vec<String>,
+    pub raised_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowGateState {
+    Ready,
+    Answered,
+    Cancelled,
+}
+
+/// Goal/todo state attached to a session.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GoalTodoSnapshot {
+    #[serde(default)]
+    pub goal: Option<Value>,
+    pub todos: Vec<Value>,
+}
+
+/// Authoritative turn state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTurn {
+    pub turn_id: String,
+    pub status: GjcPromptStatus,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    /// Terminal outcome payload; present only on terminal statuses.
+    pub outcome: Option<SessionTurnOutcome>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTurnOutcome {
+    pub status: GjcPromptStatus,
+    pub summary: Option<String>,
+    pub finished_at: Option<String>,
+}
+
+/// Union query result over the authoritative session surfaces. Each section
+/// is requested by name; missing surfaces stay `None` instead of guessed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionQuery {
+    pub metadata: Option<SessionMetadata>,
+    pub stats: Option<SessionStats>,
+    pub model_profile: Option<SessionModelProfile>,
+    pub turn: Option<SessionTurn>,
+    pub queue: Option<QueueSnapshot>,
+    pub workflow_gates: Option<Vec<WorkflowGate>>,
+    pub goal_todo: Option<GoalTodoSnapshot>,
+}
+
+// ---------------------------------------------------------------------------
+// Mutation requests and receipts
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GjcCommandKind {
+    Prompt,
+    Steer,
+    AbortAndPrompt,
+    WorkflowGateAnswer,
+    AskAnswer,
+    ModelSelection,
+}
+
+impl GjcCommandKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            GjcCommandKind::Prompt => "prompt",
+            GjcCommandKind::Steer => "steer",
+            GjcCommandKind::AbortAndPrompt => "abort_and_prompt",
+            GjcCommandKind::WorkflowGateAnswer => "workflow_gate_answer",
+            GjcCommandKind::AskAnswer => "ask_answer",
+            GjcCommandKind::ModelSelection => "model_selection",
+        }
+    }
+
+    pub fn required_capability(&self) -> &'static str {
+        match self {
+            GjcCommandKind::Prompt | GjcCommandKind::Steer | GjcCommandKind::AbortAndPrompt => {
+                CAP_SESSION_CONTROL
+            }
+            GjcCommandKind::WorkflowGateAnswer => CAP_WORKFLOW_GATES,
+            GjcCommandKind::AskAnswer => CAP_ASK_ANSWERS,
+            GjcCommandKind::ModelSelection => CAP_MODEL_SELECTION,
+        }
+    }
+}
+
+/// Lifecycle of an accepted command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GjcCommandStatus {
+    /// Validated, capability-checked, accepted; awaiting peer ack.
+    Accepted,
+    /// Peer acked; terminal receipt not yet available.
+    Acked,
+    /// Terminal outcome recorded.
+    Completed,
+    /// Terminal failure recorded.
+    Failed,
+}
+
+impl GjcCommandStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, GjcCommandStatus::Completed | GjcCommandStatus::Failed)
+    }
+
+    pub fn can_transition_to(&self, next: GjcCommandStatus) -> bool {
+        use GjcCommandStatus::*;
+        matches!(
+            (self, next),
+            (Accepted, Acked)
+                | (Accepted, Completed)
+                | (Accepted, Failed)
+                | (Acked, Acked)
+                | (Acked, Completed)
+                | (Acked, Failed)
+        )
+    }
+}
+
+/// Common envelope for every mutation verb.
+#[derive(Debug, Clone)]
+pub struct ControlRequestEnvelope {
+    pub session: SessionId,
+    /// When set, the command is rejected unless the authoritative session id
+    /// matches exactly (fail closed on session mismatch).
+    pub expected_session: Option<SessionId>,
+    pub idempotency_key: IdempotencyKey,
+    /// Bounded timeout for the peer exchange.
+    pub timeout_ms: u64,
+}
+
+impl ControlRequestEnvelope {
+    pub const DEFAULT_TIMEOUT_MS: u64 = 10_000;
+    pub const MAX_TIMEOUT_MS: u64 = 60_000;
+
+    pub fn validate(&self) -> std::result::Result<(), GjcError> {
+        if self.timeout_ms == 0 || self.timeout_ms > Self::MAX_TIMEOUT_MS {
+            return Err(GjcError::InvalidRequest {
+                field: "timeout_ms",
+                reason: format!("must be 1..={}", Self::MAX_TIMEOUT_MS),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PromptRequest {
+    pub envelope: ControlRequestEnvelope,
+    pub prompt: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SteerRequest {
+    pub envelope: ControlRequestEnvelope,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AbortAndPromptRequest {
+    pub envelope: ControlRequestEnvelope,
+    /// Only abort the turns listed here; empty aborts all in-flight turns.
+    pub turn_ids: Vec<TurnId>,
+    pub prompt: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowGateAnswerRequest {
+    pub envelope: ControlRequestEnvelope,
+    pub gate_id: String,
+    pub answer: WorkflowGateAnswer,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowGateAnswer {
+    pub option: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AskAnswerRequest {
+    pub envelope: ControlRequestEnvelope,
+    pub ask_id: String,
+    pub choices: Vec<AskChoice>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AskChoice {
+    pub option: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelSelectionRequest {
+    pub envelope: ControlRequestEnvelope,
+    pub model: Option<String>,
+    pub profile: Option<String>,
+}
+
+/// Receipt for an accepted command. Replays of the same idempotency key
+/// return the original receipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandReceipt {
+    pub schema: String,
+    pub command_id: String,
+    pub idempotency_key: String,
+    pub kind: String,
+    pub session_id: String,
+    pub status: GjcCommandStatus,
+    /// Present when the verb created a turn.
+    pub turn_id: Option<String>,
+    /// Terminal outcome; present only on terminal statuses.
+    pub outcome: Option<Value>,
+    pub created_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Result alias local to the control plane
+// ---------------------------------------------------------------------------
+
+pub type GjcResult<T> = std::result::Result<T, GjcError>;
+
+// Keep the crate-wide alias referenced so the module compiles standalone.
+#[allow(dead_code)]
+fn _assert_result_alias_compatible(_: Result<()>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_id_rejects_empty_and_control_characters() {
+        assert!(SessionId::new("").is_err());
+        assert!(SessionId::new("a\nb").is_err());
+        assert!(SessionId::new("a b").is_err());
+        assert_eq!(SessionId::new("sess-1").unwrap().as_str(), "sess-1");
+    }
+
+    #[test]
+    fn idempotency_key_enforces_minimum_length() {
+        assert!(IdempotencyKey::new("short").is_err());
+        assert!(IdempotencyKey::new("12345678").is_ok());
+    }
+
+    #[test]
+    fn error_taxonomy_maps_codes_and_statuses() {
+        assert_eq!(
+            GjcError::TransportUnavailable.error_code(),
+            "transport_unavailable"
+        );
+        assert_eq!(GjcError::TransportUnavailable.http_status(), 503);
+        assert_eq!(GjcError::Timeout { method: "x".into() }.http_status(), 504);
+        assert_eq!(
+            GjcError::SessionMismatch {
+                expected: "s".into()
+            }
+            .http_status(),
+            409
+        );
+    }
+
+    #[test]
+    fn public_error_body_is_redacted() {
+        let body = GjcError::StaleEndpoint {
+            capability: "session.query".into(),
+        }
+        .public_body();
+        assert_eq!(body["error_code"], "stale_endpoint");
+        assert_eq!(body["capability"], "session.query");
+        assert!(body.get("endpoint").is_none());
+    }
+
+    #[test]
+    fn capabilities_fail_closed_without_transport() {
+        let caps = Capabilities::for_transport(false);
+        assert!(!caps.supports(CAP_SESSION_QUERY));
+        assert!(!caps.supports(CAP_SESSION_CONTROL));
+        assert!(caps.require(CAP_SESSION_CONTROL).is_err());
+    }
+
+    #[test]
+    fn prompt_status_terminality_is_explicit() {
+        use GjcPromptStatus::*;
+        assert!(Succeeded.is_terminal());
+        assert!(Failed.is_terminal());
+        assert!(!Queued.is_terminal());
+        assert!(!Running.is_terminal());
+        assert!(!Aborted.is_terminal());
+    }
+
+    #[test]
+    fn command_status_progression_is_forward_only() {
+        use GjcCommandStatus::*;
+        assert!(Accepted.can_transition_to(Acked));
+        assert!(Acked.can_transition_to(Completed));
+        assert!(!Completed.can_transition_to(Acked));
+        assert!(!Failed.can_transition_to(Acked));
+    }
+
+    #[tokio::test]
+    async fn unimplemented_transport_fails_closed() {
+        let transport = TransportUnavailable;
+        let error = transport
+            .round_trip(GjcRequest::new("c1", "session.get", Value::Null))
+            .await
+            .unwrap_err();
+        assert_eq!(error, GjcError::TransportUnavailable);
+    }
+}

--- a/src/gjc/transport.rs
+++ b/src/gjc/transport.rs
@@ -8,7 +8,8 @@ use async_trait::async_trait;
 
 use super::model::{GjcError, GjcRequest, GjcResponse, GjcResult, GjcTransport};
 use crate::gjc_sdk::{
-    self, Discovery, EndpointMetadata, SdkClient, SdkRequest, SdkTransportError, StateRoot,
+    self, Discovery, EndpointMetadata, SdkClient, SdkRequest, SdkTransportError,
+    SdkTransportLimits, StateRoot,
 };
 
 /// Control-plane transport backed by the landed SDK websocket client.
@@ -44,7 +45,7 @@ fn map_transport_error(method: &str, error: &crate::DynError) -> GjcError {
             method: method.into(),
         },
         SdkTransportError::EndpointUnauthorized => GjcError::StaleEndpoint {
-            capability: "endpoint".into(),
+            capability: crate::gjc::model::CAP_ENDPOINT.into(),
         },
         SdkTransportError::EndpointMalformed => GjcError::InvalidPeerReply {
             method: method.into(),
@@ -74,7 +75,14 @@ impl GjcTransport for SdkEndpointTransport {
             SdkRequest::query(request.method.clone(), request.params.clone())
         };
         let correlation_id = sdk_request.correlation_id().to_string();
-        let mut client = SdkClient::new(self.metadata.clone());
+        // The caller's bounded budget is clamped into the transport limits
+        // so `timeout_ms` is authoritative for this exchange (sanitized()
+        // bounds it to [100ms, MAX_TRANSPORT_TIMEOUT]).
+        let limits = SdkTransportLimits {
+            request_timeout: std::time::Duration::from_millis(request.timeout_ms),
+            ..SdkTransportLimits::default()
+        };
+        let mut client = SdkClient::new(self.metadata.clone()).with_limits(limits);
         let reply = client
             .request(&sdk_request)
             .await
@@ -113,7 +121,7 @@ pub fn discover_endpoint(worktree: &Path) -> GjcResult<SdkEndpointTransport> {
     match discovery {
         Discovery::Live(metadata) => Ok(SdkEndpointTransport::new(metadata)),
         Discovery::Stale { .. } => Err(GjcError::StaleEndpoint {
-            capability: "endpoint".into(),
+            capability: super::model::CAP_ENDPOINT.into(),
         }),
         Discovery::Malformed | Discovery::NoMetadata => Err(GjcError::TransportUnavailable),
     }
@@ -203,7 +211,7 @@ mod tests {
         write_metadata(temp.path(), "sess-lane-1", "ws://127.0.0.1:1/", "tok-1");
         let transport = discover_endpoint(temp.path()).unwrap();
         let error = transport
-            .round_trip(GjcRequest::new("corr-1", "session.get", json!({})))
+            .round_trip(GjcRequest::new("corr-1", "session.get", json!({}), 10_000))
             .await
             .unwrap_err();
         assert_eq!(error.error_code(), "transport_unavailable");

--- a/src/gjc/transport.rs
+++ b/src/gjc/transport.rs
@@ -1,0 +1,220 @@
+//! Adapter binding the #323 control plane to the landed #322 transport
+//! (`crate::gjc_sdk`). Discovery is lane/worktree-scoped; every exchange
+//! maps the transport taxonomy onto the control-plane error taxonomy.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+use super::model::{
+    GjcError, GjcRequest, GjcResponse, GjcResult, GjcTransport,
+};
+use crate::gjc_sdk::{
+    self, Discovery, EndpointMetadata, SdkClient, SdkRequest, SdkTransportError, StateRoot,
+};
+
+/// Control-plane transport backed by the landed SDK websocket client.
+///
+/// Each round trip opens one authenticated connection through
+/// [`SdkClient::request`]; reconnects, frame bounds, and correlation are
+/// enforced by the #322 transport itself.
+#[derive(Debug)]
+pub struct SdkEndpointTransport {
+    metadata: EndpointMetadata,
+}
+
+impl SdkEndpointTransport {
+    pub fn new(metadata: EndpointMetadata) -> Self {
+        Self { metadata }
+    }
+
+    /// Public-safe session identifier this endpoint is bound to.
+    pub fn session_id(&self) -> &str {
+        self.metadata.session_id()
+    }
+}
+
+fn map_transport_error(method: &str, error: &crate::DynError) -> GjcError {
+    let Some(sdk_error) = error.downcast_ref::<SdkTransportError>() else {
+        return GjcError::TransportUnavailable;
+    };
+    match sdk_error {
+        SdkTransportError::Timeout => GjcError::Timeout {
+            method: method.into(),
+        },
+        SdkTransportError::CorrelationMismatch => GjcError::AmbiguousAck {
+            method: method.into(),
+        },
+        SdkTransportError::EndpointUnauthorized => GjcError::StaleEndpoint {
+            capability: "endpoint".into(),
+        },
+        SdkTransportError::FrameRejected => GjcError::InvalidPeerReply {
+            method: method.into(),
+            reason: "frame rejected by transport bounds".into(),
+        },
+        SdkTransportError::EndpointMalformed => GjcError::InvalidPeerReply {
+            method: method.into(),
+            reason: "endpoint metadata malformed".into(),
+        },
+        SdkTransportError::EndpointUnavailable
+        | SdkTransportError::ConnectionClosed
+        | SdkTransportError::RetryExhausted => GjcError::TransportUnavailable,
+    }
+}
+
+#[async_trait]
+impl GjcTransport for SdkEndpointTransport {
+    async fn round_trip(
+        &self,
+        request: GjcRequest,
+    ) -> std::result::Result<GjcResponse, GjcError> {
+        let sdk_request = SdkRequest::new(request.method.clone(), request.params.clone());
+        let mut client = SdkClient::new(self.metadata.clone());
+        let reply = client
+            .request(&sdk_request)
+            .await
+            .map_err(|error| map_transport_error(&request.method, &error))?;
+
+        // Defense in depth: the transport already enforces correlation;
+        // re-check before trusting the payload.
+        if reply.id.as_deref() != Some(request.correlation_id.as_str()) {
+            return Err(GjcError::AmbiguousAck {
+                method: request.method.clone(),
+            });
+        }
+        if reply.ok == Some(false) {
+            let reason = reply
+                .error
+                .and_then(|error| error.code)
+                .unwrap_or_else(|| "unknown".into());
+            return Err(GjcError::InvalidPeerReply {
+                method: request.method.clone(),
+                reason: format!("peer rejected request: {reason}"),
+            });
+        }
+        Ok(GjcResponse {
+            correlation_id: request.correlation_id,
+            result: reply.payload,
+        })
+    }
+}
+
+/// Resolve the live endpoint for one lane/worktree without scanning any
+/// unrelated root. Outcomes map directly onto control-plane failures so the
+/// daemon never guesses.
+pub fn discover_endpoint(worktree: &Path) -> GjcResult<SdkEndpointTransport> {
+    let discovery =
+        gjc_sdk::discover(&StateRoot::for_worktree(worktree)).map_err(|error| {
+            map_transport_error("endpoint.discover", &error)
+        })?;
+    match discovery {
+        Discovery::Live(metadata) => Ok(SdkEndpointTransport::new(metadata)),
+        Discovery::Stale { .. } => Err(GjcError::StaleEndpoint {
+            capability: "endpoint".into(),
+        }),
+        Discovery::Malformed | Discovery::NoMetadata => Err(GjcError::TransportUnavailable),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn write_metadata(worktree: &Path, url: &str, token: &str) -> std::path::PathBuf {
+        let sdk_dir = worktree.join(".gjc").join("state").join("sdk");
+        std::fs::create_dir_all(&sdk_dir).unwrap();
+        let path = sdk_dir.join("01a02ccd-cb43-7570-8ce2-98b3b67ed2ef.json");
+        std::fs::write(
+            &path,
+            json!({
+                "sessionId": "sess-lane-1",
+                "url": url,
+                "token": token,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn discovery_maps_live_stale_and_missing_outcomes() {
+        let temp = tempfile::tempdir().unwrap();
+
+        // No metadata at all -> transport_unavailable.
+        let error = discover_endpoint(temp.path()).unwrap_err();
+        assert_eq!(error.error_code(), "transport_unavailable");
+
+        // Malformed layout (file instead of directory) -> transport_unavailable.
+        std::fs::create_dir_all(temp.path().join(".gjc")).unwrap();
+        std::fs::write(temp.path().join(".gjc").join("state"), "not-a-dir").unwrap();
+        let error = discover_endpoint(temp.path()).unwrap_err();
+        assert_eq!(error.error_code(), "transport_unavailable");
+
+        // Live metadata binds to its recorded session.
+        std::fs::remove_file(temp.path().join(".gjc").join("state")).unwrap();
+        std::fs::create_dir_all(temp.path().join(".gjc").join("state")).unwrap();
+        write_metadata(temp.path(), "ws://127.0.0.1:1/", "tok-1");
+        let transport = discover_endpoint(temp.path()).unwrap();
+        assert_eq!(transport.session_id(), "sess-lane-1");
+
+        // Dead pid recorded -> stale endpoint.
+        let sdk_dir = temp.path().join(".gjc").join("state").join("sdk");
+        let stale_path = sdk_dir.join("ffffffff-ffff-ffff-ffff-ffffffffffff.json");
+        std::fs::write(
+            &stale_path,
+            json!({
+                "sessionId": "sess-dead",
+                "url": "ws://127.0.0.1:1/",
+                "token": "tok-1",
+                "pid": 0xFFFF_FFF1u32,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&stale_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        let newer = sdk_dir.join("01a02ccd-cb43-7570-8ce2-98b3b67ed2ef.json");
+        let _ = std::fs::remove_file(&newer);
+        std::fs::write(
+            &newer,
+            json!({
+                "sessionId": "sess-dead",
+                "url": "ws://127.0.0.1:1/",
+                "token": "tok-1",
+                "pid": 0xFFFF_FFF1u32,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&newer, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        let error = discover_endpoint(temp.path()).unwrap_err();
+        assert_eq!(error.error_code(), "stale_endpoint");
+    }
+
+    #[tokio::test]
+    async fn unreachable_endpoint_maps_to_transport_unavailable() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join(".gjc").join("state").join("sdk")).unwrap();
+        write_metadata(temp.path(), "ws://127.0.0.1:1/", "tok-1");
+        let transport = discover_endpoint(temp.path()).unwrap();
+        let error = transport
+            .round_trip(GjcRequest::new("corr-1", "session.get", json!({})))
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "transport_unavailable");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod events;
 mod gajae;
 mod gateway_allowlist;
 mod gjc;
+mod gjc_sdk;
 mod hooks;
 mod keyword_window;
 mod lane;
@@ -45,10 +46,10 @@ use tokio::runtime::Builder;
 use crate::cli::{
     AgentCommands, Cli, Commands, ConfigCommand, CronCommands, ExplainArgs,
     GajaeCheckpointCommands, GajaeCommands, GajaeMutationPlanCommands, GajaeProfileCommands,
-    GajaeReceiptCommands, GitCommands, GithubCommands, HooksCommands, LaneCommands, LedgerCommands,
-    MemoryCommands, NativeCommands, PluginCommands, ReleaseCommands, SetupArgs, SubscribeCommands,
-    TmuxCommands, UpdateCommands, VerifyBindingsArgs, VerifyGatewayAllowlistArgs,
-    VerifySenderIdentityArgs,
+    GajaeReceiptCommands, GitCommands, GithubCommands, HooksCommands, LaneCommands,
+    LedgerCommands, MemoryCommands, NativeCommands, PluginCommands, ReleaseCommands, SetupArgs,
+    SubscribeCommands, TmuxCommands, UpdateCommands, VerifyBindingsArgs,
+    VerifyGatewayAllowlistArgs, VerifySenderIdentityArgs,
 };
 
 use crate::client::DaemonClient;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod event;
 mod events;
 mod gajae;
 mod gateway_allowlist;
+mod gjc;
 mod hooks;
 mod keyword_window;
 mod lane;
@@ -598,6 +599,7 @@ async fn real_main(cli: Cli) -> Result<()> {
                 }
             },
         },
+        Commands::Gjc { command } => Ok(crate::gjc::cli::run(config.clone(), command).await?),
         Commands::Release { command } => match command {
             ReleaseCommands::Preflight { version, repo } => release_preflight::run(repo, version),
         },


### PR DESCRIPTION
Closes #323 (parent #321). Built on the landed #322/#325 transport and lane surfaces; owns only the authoritative session query/control contract.

## Contract delivered

**Typed queries** — session metadata/stats, current model/profile, turn state/result, queue, workflow gates, goal/todo, capabilities (`session.get` sections + `turn.outcome`).

**Mutation verbs** — prompt, steer, abort-and-prompt, workflow gate answer, ask answer, model/profile selection (`control.*` v3 frames).

**Semantics**
- idempotency keys (8..=128B) with replay returning the recorded terminal receipt — a duplicate key never re-issues a command;
- expected session IDs enforced twice: pre-dispatch against the addressed session and ack-side against the peer echo; discovery-bound endpoints additionally refuse any other session (fail closed on mismatch);
- accepted command/turn IDs validated from unambiguous acks (`accepted:true` + correlation echo); ambiguous or non-accepted acks fail closed with the receipt kept non-terminal so replays cannot fabricate outcomes;
- prompt-status progression is forward-only (`Accepted→Acked→Completed|Failed`); terminal outcome receipts carry the peer's typed status.

**Fail-closed taxonomy** (stable `error_code`s → HTTP mapping): `transport_unavailable` 503, `timeout` 504, `ambiguous_ack`/`invalid_peer_reply` 502, `missing_capability` 501, `stale_endpoint`/`session_mismatch` 409, `session_not_found` 404, `invalid_request` 400. Validation ordering is deterministic and tested: request shape → capability gate → transport resolution → session guards → bounded exchange → ack validation.

**Surfaces**
- daemon HTTP under `/api/gjc/*`, loopback + local-control guarded, public-safe redacted JSON (non-scalar provider metadata filtered);
- CLI family `clawhip gjc {capabilities,session,turn-outcome,prompt,steer,abort-and-prompt,gate-answer,ask-answer,select,receipt}` unified with #322's `inspect` and #325's durable-lane verbs through one runner;
- production wiring resolves the lane endpoint via #322 discovery on demand and binds to its session; without a live endpoint every verb fails closed rather than guessing.

## Integration notes
- `SdkEndpointTransport` adapts the repaired **v3** wire contract (typed query/control frames, in-frame correlation, versioned filename-bound endpoint records) onto the control plane; no #322/#325 internals are reimplemented.
- No lifecycle polling, no Discord formatting, no config-schema changes (backward compatibility untouched).

## Verification (exact head `339e6ef`)
- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo build` clean
- full `cargo test`: **1100 passed / 0 failed** (includes new mock-transport contract tests: query parsing, malformed-section rejection, idempotent replay single-exchange proof, ambiguous-ack fail-closed, timeout/stale taxonomy surfacing, pre-dispatch + ack-side session mismatch, adapter discovery live/stale/malformed mapping)
- daemon handler tests: capabilities honesty, 503 queries without endpoint, 400-before-transport validation ordering, unknown/malformed receipt handling

Refs: #321, depends on #322/#325 surfaces.
