### PR TITLE
docs: use permanent Gajae community Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 > **⭐ Optional support:** the interactive repo-local install paths (`./install.sh` and `clawhip install` from a clone) can offer to star this repo after a successful install when `gh` is installed and authenticated. Skip it with `--skip-star-prompt` or `CLAWHIP_SKIP_STAR_PROMPT=1`.
-> **Community:** Join the clawhip Discord at https://discord.gg/jq6jnSGABY.
+> **Community:** Join the clawhip Discord at https://discord.gg/wSyUQYfhAw.
 
 **gajae-claw (clawhip) is the control plane for agents:** route events from GitHub, Discord, tmux, and other tools to the right human or agent, record what happened, and separate automatic actions from approval-required actions.
 


### PR DESCRIPTION
## Summary
- replace the stale Clawhip community Discord invite with the owner-confirmed permanent Gajae community invite
- docs-only direct-to-main maintenance as explicitly authorized by the repository owner

## Validation
- `git diff --check`
- old invite absent from README
- new invite appears exactly once

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*