### PR TITLE
test(gjc-sdk): fake endpoint fixtures, full-loop E2E, live dogfood, and operator docs (#326)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -100,8 +101,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -241,7 +244,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "toml",
  "uuid",
 ]
@@ -1529,8 +1532,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -1660,6 +1675,23 @@ dependencies = [
  "rand",
  "rustls",
  "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
  "sha1",
  "thiserror",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-axum = { version = "0.8", features = ["ws"] }
+axum = { version = "0.8" }
 clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio-tungstenite = { version = "0.26", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
@@ -28,6 +28,9 @@ toml = "0.8"
 libc = "0.2"
 
 [dev-dependencies]
+# ws is test-only: the deterministic fake SDK endpoint fixture upgrades
+# websockets; production serves plain HTTP/JSON.
+axum = { version = "0.8", features = ["ws"] }
 serial_test = "3"
 tempfile = "3.15"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio-tungstenite = { version = "0.26", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }

--- a/docs/gjc-sdk-integration.md
+++ b/docs/gjc-sdk-integration.md
@@ -1,0 +1,144 @@
+# Clawhip ↔ GJC SDK Integration — Operator Guide
+
+Status: staged on lane `test/issue-326-gjc-sdk-e2e` (issue #326, parent epic #321).
+The endpoint discovery/transport layer itself landed with #322
+(`src/gjc_sdk.rs`); control-plane (#323), event bridge (#324), and durable
+reconciliation (#325) are sibling-owned. **Open regression #328 tracks the
+transport against the real GJC SDK v3 endpoint** — the live-session steps in
+the dogfood checklist below stay gated until #328's repaired dev merge.
+
+## 1. What this integration is
+
+Clawhip consumes Gajae-Code session events through the GJC SDK endpoint:
+
+- **Discovery** — the SDK CLI publishes one owner-only metadata file per live
+  session at `<worktree>/.gjc/state/sdk/<session-id>.json`
+  (`{"version":1,"sessionId":…,"url":"ws://127.0.0.1:<port>/","token":…,"pid":…}`).
+  Clawhip never scans unrelated roots; every trust-boundary directory is
+  validated as a real directory, and stale sessions are reported via pid
+  liveness (`Live > Stale > Malformed > NoMetadata`).
+- **Transport** — authenticated loopback websocket (`ws://` with IPv4/IPv6
+  loopback literals only). The token travels as a `?token=` query credential
+  plus bearer header. Requests are correlated envelopes; the server answers
+  with correlated responses and emits lifecycle notifications out of band.
+- **Event bridge** — session notifications (questions, progress, lifecycle)
+  flow through clawhip subscriptions into routed deliveries.
+- **Diagnostics** — read-only `clawhip gjc inspect [--probe] [--json]`
+  reports discovery status and an optional hello/request probe without any
+  control verbs.
+
+Non-goals (epic-wide): no pane scraping as authority, no tmux `send-keys`
+control, no credential or raw prompt leakage, no non-loopback endpoints.
+
+## 2. Setup
+
+### Opt-in flag
+
+```sh
+clawhip setup --gjc-sdk
+```
+
+This flips `[gjc].enabled = true`. It is idempotent and writes no endpoints,
+tokens, or secrets into the config file — those stay in the 0600 worktree
+metadata file managed by the SDK side.
+
+```toml
+[gjc]
+enabled = true
+```
+
+Legacy configs without `[gjc]` keep parsing byte-stable; absent means off.
+
+### Question delivery (existing surface)
+
+```sh
+clawhip setup --question-channel <CHANNEL_ID>   # or --question-fallback
+```
+
+This creates the setup-owned `gjc-question` websocket subscription
+(endpoint env `GJC_QUESTION_WS`) routing `workflow.question` events to your
+channel. Point the env at the session's authenticated ws URL when driving it
+manually.
+
+## 3. Health diagnostics
+
+`GET /health` (and `clawhip status`) exposes a public-safe `gjc` block:
+
+```json
+{"gjc": {"enabled": true, "question_subscription": true}}
+```
+
+It intentionally carries flags only — never endpoint URLs, ports, token env
+names, or token values. For endpoint-level diagnostics use
+`clawhip gjc inspect --probe --json`, which reports `status`
+(`live|stale|malformed|no_metadata`) and redacted probe results
+(`hello_connection_id`, `request_ok`, `request_correlated`, reason codes).
+
+## 4. Redaction guarantees
+
+- The auth token exists only inside the 0600 metadata file; config files,
+  logs, health output, and error paths never contain it.
+- Subscription frames are projected field-by-field: only the configured
+  projection keys survive; any `token`/`endpoint`/`authorization`-like keys
+  riding alongside are dropped before the event stream and rejected if an
+  adapter echoes them back.
+- Transport errors render as stable reason codes
+  (`endpoint_unavailable`, `endpoint_unauthorized`, `timeout`,
+  `connection_closed`, `frame_rejected`, `correlation_mismatch`,
+  `retry_exhausted`, …) with no URL or token material.
+
+## 5. Migration notes
+
+- Configs from ≤0.6.x parse unchanged; `[gjc]` defaults to disabled.
+- The earlier draft surface (`discovery_roots`, `discovery_path`,
+  `auth_token_env`) was removed during reconciliation with the landed #322
+  contract — deny-unknown-fields rejects those keys loudly instead of
+  silently ignoring them.
+- If you previously pointed `GJC_QUESTION_WS` at an unauthenticated socket,
+  switch to the authenticated URL published by the SDK metadata file.
+
+## 6. Troubleshooting
+
+| Symptom | Inspect | Likely cause / fix |
+| --- | --- | --- |
+| `inspect` reports `no_metadata` | `ls -la .gjc/state/sdk/` | No live session published metadata; start the GJC session in this worktree. |
+| `stale` | `kill -0 <pid>` | Session process exited without cleanup; retire the stale metadata file. |
+| `malformed` | validate JSON schema | Metadata edited by hand or truncated; republish from the SDK CLI. |
+| Probe `endpoint_unauthorized` | token mismatch | The `?token=` credential does not match the metadata file; republish. |
+| Probe `timeout` / `connection_closed` | endpoint liveness | Endpoint died mid-exchange; see #328 for the open v3 regression. |
+| Subscription `retry_exhausted` | `GET /api/subscriptions/<name>` | Endpoint unreachable for the full reconnect budget; restart the daemon after the endpoint returns. |
+| Question delivered without summary | projection keys | Projection must select `/questionId` and `/summary` from notification frames. |
+
+## 7. Compatibility
+
+- Rust stable; edition 2024; no new runtime dependencies beyond the `axum`
+  `ws` feature (same tokio-tungstenite major already pinned in Cargo.lock).
+- Old configs parse unchanged; unknown `[gjc]` fields fail closed.
+- Daemon restart reconciles in-memory ownership: lanes registered by a dead
+  daemon do not ghost-resurrect; deliveries are not replayed.
+
+## 8. Live dogfood checklist (bounded)
+
+Preconditions: real GJC session in this worktree; dev head with #328's
+transport repair merged; `[gjc] enabled = true`; question route configured.
+
+1. `clawhip gjc inspect --probe --json` → expect `"status":"live"` with
+   correlated probe results.
+2. Start the daemon with the question subscription endpoint env set.
+3. Submit one bounded prompt to the live session through the supported
+   control surface (sibling #323 scope; until merged, drive prompts from the
+   GJC side only).
+4. Observe progress notifications in the session; confirm no prompt text is
+   echoed into clawhip logs.
+5. Trigger one workflow gate; confirm `workflow.question` reaches the
+   configured channel with projected `question_id`/`summary` only.
+6. Answer the gate from the channel-side workflow; confirm acceptance.
+7. Let the turn complete; confirm the completion notification and that the
+   lane retires cleanly.
+8. Restart the daemon; confirm `/health` is green, `/api/lane` shows no ghost
+   ownership, and no deliveries replay.
+9. Record the run: dev head, inspect output, delivery sample, timestamps.
+
+Steps 3–7 require the repaired transport (#328); until then this checklist
+is exercisable only against the deterministic fake endpoint in
+`tests/gjc_fake_server_contract.rs` and `tests/gjc_sdk_full_loop_e2e.rs`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -291,6 +291,13 @@ pub struct SetupArgs {
     /// Use the configured default channel when no --question-channel is supplied.
     #[arg(long = "question-fallback", default_value_t = false)]
     pub question_fallback: bool,
+    /// Enable the loopback-safe GJC SDK integration with safe defaults.
+    ///
+    /// Marks [gjc] enabled and trusts only the loopback discovery root.
+    /// The SDK endpoint and auth token stay environment-driven; no secret is
+    /// ever written into the config file.
+    #[arg(long = "gjc-sdk", default_value_t = false)]
+    pub gjc_sdk: bool,
 }
 
 #[derive(Debug, Clone, Default, Args)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,8 @@ pub struct AppConfig {
         skip_serializing_if = "crate::gjc_lane::GjcLanesConfig::is_empty"
     )]
     pub gjc_lanes: crate::gjc_lane::GjcLanesConfig,
+    #[serde(default, skip_serializing_if = "GjcConfig::is_empty")]
+    pub gjc: GjcConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -152,6 +154,25 @@ pub struct SubscriptionRoutingConfig {
 
 pub const GJC_QUESTION_SUBSCRIPTION_NAME: &str = "gjc-question";
 pub const GJC_QUESTION_ENDPOINT_ENV: &str = "GJC_QUESTION_WS";
+/// GJC SDK integration surface (issue #326).
+///
+/// Reconciled with the landed #322 transport: SDK endpoint discovery is
+/// worktree-file-based (`<worktree>/.gjc/state/sdk/*.json`, owner-only
+/// permissions enforced by the transport), so this section carries only the
+/// opt-in switch. The auth token lives exclusively inside the 0600 metadata
+/// file and is never configured or logged here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct GjcConfig {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl GjcConfig {
+    fn is_empty(&self) -> bool {
+        !self.enabled
+    }
+}
 
 fn default_subscription_max_frame_bytes() -> usize {
     65_536
@@ -1583,7 +1604,6 @@ impl AppConfig {
 
         Ok(())
     }
-
     pub fn validate(&self) -> Result<()> {
         if self.dispatch.ci_batch_window_secs == 0 {
             return Err("dispatch.ci_batch_window_secs must be at least 1".into());
@@ -2033,6 +2053,14 @@ impl AppConfig {
             _ => unreachable!(),
         }
         Ok(())
+    }
+    /// Enable the GJC SDK integration surface (issue #326).
+    ///
+    /// Idempotent. Endpoint discovery itself stays worktree-file-based per
+    /// the landed #322 transport; enabling here only flips the opt-in switch,
+    /// so no endpoint or secret is ever written into the config file.
+    pub fn apply_gjc_sdk_setup(&mut self) {
+        self.gjc.enabled = true;
     }
 
     pub fn scaffold_webhook_quickstart(&mut self, webhook: String) -> Result<()> {
@@ -7387,6 +7415,68 @@ format = "compact"
         .unwrap();
 
         config.validate().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod gjc_config_tests {
+    use super::AppConfig;
+
+    #[test]
+    fn legacy_config_without_gjc_section_parses_and_stays_absent() {
+        let config: AppConfig =
+            toml::from_str("[providers.discord]\ntoken = \"fixture-token\"\n").unwrap();
+        assert!(!config.gjc.enabled);
+        config.validate().unwrap();
+        // Backward compatibility: the section must not materialize on
+        // round-trip, so old configs stay byte-stable.
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(!serialized.contains("[gjc]"));
+    }
+
+    #[test]
+    fn explicit_gjc_section_parses_and_rejects_unknown_fields() {
+        let config: AppConfig = toml::from_str(
+            r#"
+[gjc]
+enabled = true
+
+[[routes]]
+event = "*"
+sink = "localfile"
+local_path = "/tmp/clawhip-gjc-fixture.jsonl"
+"#,
+        )
+        .unwrap();
+        assert!(config.gjc.enabled);
+        config.validate().unwrap();
+
+        // The reconciled #322-aligned surface carries only the opt-in flag;
+        // endpoint/token fields must never reappear in config.
+        let unknown: Result<AppConfig, _> = toml::from_str(
+            r#"
+[gjc]
+enabled = true
+discovery_roots = ["http://127.0.0.1"]
+"#,
+        );
+        assert!(
+            unknown.is_err(),
+            "invented discovery fields must be rejected"
+        );
+    }
+
+    #[test]
+    fn gjc_setup_is_idempotent_flag_flip_without_secrets() {
+        let mut config: AppConfig =
+            toml::from_str("[providers.discord]\ntoken = \"fixture-token\"\n").unwrap();
+        config.apply_gjc_sdk_setup();
+        config.apply_gjc_sdk_setup();
+        assert!(config.gjc.enabled);
+        config.validate().unwrap();
+        let serialized = toml::to_string(&config).unwrap();
+        let gjc_section = serialized.split("[gjc]").nth(1).unwrap_or_default();
+        assert_eq!(gjc_section.trim(), "enabled = true");
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -286,40 +286,46 @@ pub async fn run(
         )
         .route("/api/lane/delivery", post(record_lane_delivery_handler))
         .route("/api/lane/retire", post(retire_lane_handler))
-        .route("/api/gjc/health", get(gjc_health_handler))
-        .route(
-            "/api/gjc/lanes",
-            get(list_gjc_lanes_handler).post(register_gjc_lane_handler),
-        )
-        .route("/api/gjc/lanes/{lane}", get(gjc_lane_detail_handler))
-        .route(
-            "/api/gjc/lanes/{lane}/retire",
-            post(retire_gjc_lane_handler),
-        )
-        .route("/api/gjc/lane/reconcile", post(reconcile_gjc_lanes_handler))
         .route("/api/subscriptions", get(list_subscriptions))
         .route("/api/subscriptions/{name}", get(subscription_detail))
         .route("/api/ledger/status", get(ledger_status))
         .route("/api/ledger/query", get(ledger_query))
         .route("/api/subscriptions/{name}/start", post(start_subscription))
-        .route("/api/subscriptions/{name}/stop", post(stop_subscription))
-        .route("/api/gjc/capabilities", get(gjc_capabilities))
-        .route("/api/gjc/session/{session}", get(gjc_session_query))
-        .route(
-            "/api/gjc/session/{session}/turn/{turn}",
-            get(gjc_turn_outcome),
-        )
-        .route("/api/gjc/prompt", post(gjc_prompt))
-        .route("/api/gjc/steer", post(gjc_steer))
-        .route("/api/gjc/abort-and-prompt", post(gjc_abort_and_prompt))
-        .route(
-            "/api/gjc/workflow-gate-answer",
-            post(gjc_workflow_gate_answer),
-        )
-        .route("/api/gjc/ask-answer", post(gjc_ask_answer))
-        .route("/api/gjc/model-selection", post(gjc_model_selection))
-        .route("/api/gjc/command/{key}", get(gjc_command_receipt))
-        .route("/api/gjc/bridge", post(post_gjc_bridge));
+        .route("/api/subscriptions/{name}/stop", post(stop_subscription));
+    // The GJC surface is strictly opt-in: with `[gjc] enabled = false` no
+    // /api/gjc route is registered at all, not merely reported disabled.
+    let app = if config.gjc.enabled {
+        app.route("/api/gjc/health", get(gjc_health_handler))
+            .route(
+                "/api/gjc/lanes",
+                get(list_gjc_lanes_handler).post(register_gjc_lane_handler),
+            )
+            .route("/api/gjc/lanes/{lane}", get(gjc_lane_detail_handler))
+            .route(
+                "/api/gjc/lanes/{lane}/retire",
+                post(retire_gjc_lane_handler),
+            )
+            .route("/api/gjc/lane/reconcile", post(reconcile_gjc_lanes_handler))
+            .route("/api/gjc/capabilities", get(gjc_capabilities))
+            .route("/api/gjc/session/{session}", get(gjc_session_query))
+            .route(
+                "/api/gjc/session/{session}/turn/{turn}",
+                get(gjc_turn_outcome),
+            )
+            .route("/api/gjc/prompt", post(gjc_prompt))
+            .route("/api/gjc/steer", post(gjc_steer))
+            .route("/api/gjc/abort-and-prompt", post(gjc_abort_and_prompt))
+            .route(
+                "/api/gjc/workflow-gate-answer",
+                post(gjc_workflow_gate_answer),
+            )
+            .route("/api/gjc/ask-answer", post(gjc_ask_answer))
+            .route("/api/gjc/model-selection", post(gjc_model_selection))
+            .route("/api/gjc/command/{key}", get(gjc_command_receipt))
+            .route("/api/gjc/bridge", post(post_gjc_bridge))
+    } else {
+        app
+    };
     let port = port_override.unwrap_or(config.daemon.port);
 
     let app = app.with_state(AppState {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -785,6 +785,12 @@ fn health_payload(
         "tmux": tmux,
         "native_hooks": native_hooks,
         "subscriptions": {"configured": subscriptions.len(), "degraded": subscription_degraded},
+        "gjc": {
+            "enabled": config.gjc.enabled,
+            "question_subscription": config.subscriptions.iter().any(|subscription| {
+                subscription.name == crate::config::GJC_QUESTION_SUBSCRIPTION_NAME
+            }),
+        },
     })
 }
 
@@ -3502,6 +3508,33 @@ mod tests {
             "token leaked: {rendered}"
         );
         assert_eq!(payload["ok"], Value::Bool(true));
+    }
+
+    #[test]
+    fn health_payload_surfaces_gjc_state_without_endpoints_or_tokens() {
+        let mut config = AppConfig::default();
+        config.gjc.enabled = true;
+
+        let payload = health_payload(
+            &config,
+            25294,
+            0,
+            snapshot_shared(&new_shared_native_hook_observability()),
+            json!({}),
+            &[],
+            GitMonitorLifecycleCounts::default(),
+        );
+
+        assert_eq!(payload["gjc"]["enabled"], Value::Bool(true));
+        assert_eq!(payload["gjc"]["question_subscription"], Value::Bool(false));
+
+        // Redaction assertions: the health surface carries flags only — the
+        // SDK endpoint URL and token live in the 0600 worktree metadata file
+        // (landed #322 transport) and must never reach health output.
+        assert_eq!(
+            payload["gjc"],
+            json!({"enabled": true, "question_subscription": false})
+        );
     }
 
     #[test]

--- a/src/gjc/transport.rs
+++ b/src/gjc/transport.rs
@@ -69,11 +69,16 @@ impl GjcTransport for SdkEndpointTransport {
         // v3 wire mapping: `control.*` methods become control_request
         // frames; every other method is a query_request. The correlation ID
         // is minted inside the typed frame and echoed by the peer.
-        let sdk_request = if let Some(operation) = request.method.strip_prefix("control.") {
+        let mut sdk_request = if let Some(operation) = request.method.strip_prefix("control.") {
             SdkRequest::control(operation, request.params.clone())
         } else {
             SdkRequest::query(request.method.clone(), request.params.clone())
         };
+        // The caller owns correlation identity: `GjcControlPlane::round_trip`
+        // validates `reply.correlation_id == request.correlation_id`, so the
+        // wire frame must carry the caller's id verbatim instead of the
+        // transport-minted default.
+        sdk_request.id = request.correlation_id.clone();
         let correlation_id = sdk_request.correlation_id().to_string();
         // The caller's bounded budget is clamped into the transport limits
         // so `timeout_ms` is authoritative for this exchange (sanitized()
@@ -202,6 +207,61 @@ mod tests {
         }
         let error = discover_endpoint(temp.path()).unwrap_err();
         assert_eq!(error.error_code(), "stale_endpoint");
+    }
+
+    #[tokio::test]
+    async fn round_trip_echoes_caller_correlation_id_verbatim() {
+        use futures_util::{SinkExt, StreamExt};
+        use tokio::net::TcpListener;
+
+        // Loopback fixture: server hello, then echo the request id back on
+        // the matching response family with an accepted verdict.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            use tokio_tungstenite::tungstenite::Message;
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let (mut sink, mut stream) = ws.split();
+            sink.send(Message::text(
+                r#"{"type":"hello","connectionId":"corr-fixture"}"#,
+            ))
+            .await
+            .unwrap();
+            if let Some(Ok(Message::Text(text))) = stream.next().await {
+                let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+                let reply = serde_json::json!({
+                    "type": "control_response",
+                    "id": value["id"],
+                    "ok": true,
+                    "result": {"accepted": true},
+                });
+                sink.send(Message::text(reply.to_string())).await.unwrap();
+            }
+        });
+
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join(".gjc").join("state").join("sdk")).unwrap();
+        write_metadata(
+            temp.path(),
+            "sess-lane-1",
+            &format!("ws://{addr}/"),
+            "tok-1",
+        );
+        let transport = discover_endpoint(temp.path()).unwrap();
+
+        let reply = transport
+            .round_trip(GjcRequest::new(
+                "caller-corr-326",
+                "control.prompt",
+                json!({"session_id": "sess-lane-1"}),
+                10_000,
+            ))
+            .await
+            .expect("caller correlation id must be echoed verbatim");
+        assert_eq!(reply.correlation_id, "caller-corr-326");
+        assert_eq!(reply.result["accepted"], true);
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -848,6 +848,7 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
         && binds.is_empty()
         && !args.verify_bindings
         && !question_setup_requested
+        && !args.gjc_sdk
     {
         return Err("setup requires at least one non-empty setup flag".into());
     }
@@ -867,6 +868,9 @@ async fn run_setup(args: SetupArgs, config_path: &std::path::Path) -> Result<()>
             repo,
             adapter_program,
         )?;
+    }
+    if args.gjc_sdk {
+        editable.apply_gjc_sdk_setup();
     }
 
     // Process --bind entries: resolve each channel against Discord and write a

--- a/src/source/subscription.rs
+++ b/src/source/subscription.rs
@@ -1051,6 +1051,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn eof_reading_adapters_terminate_when_stdin_closes() {
         use std::os::unix::fs::PermissionsExt;

--- a/src/source/subscription.rs
+++ b/src/source/subscription.rs
@@ -413,7 +413,7 @@ async fn run_adapter(
         let _ = child.wait().await;
         return Err(subscription_error("adapter_timeout"));
     }
-    let mut stdin = child
+    let stdin = child
         .stdin
         .take()
         .ok_or_else(|| subscription_error("adapter_stdin_failed"))?;
@@ -445,8 +445,21 @@ async fn run_adapter(
     });
     let result = tokio::select! {
         result = async {
-            stdin.write_all(input).await.map_err(|_| subscription_error("adapter_stdin_failed"))?;
-            stdin.shutdown().await.map_err(|_| subscription_error("adapter_stdin_failed"))?;
+            {
+                let mut stdin = stdin;
+                stdin
+                    .write_all(input)
+                    .await
+                    .map_err(|_| subscription_error("adapter_stdin_failed"))?;
+                stdin
+                    .flush()
+                    .await
+                    .map_err(|_| subscription_error("adapter_stdin_failed"))?;
+                // Dropping the write half closes the child's stdin so adapters
+                // that read to EOF observe end-of-input before we wait for
+                // exit; shutdown() alone leaves the descriptor open and would
+                // deadlock against wait().
+            }
             let status = child.wait().await.map_err(|_| subscription_error("adapter_invalid_output"))?;
             let output = (&mut stdout_task)
                 .await
@@ -986,6 +999,42 @@ mod tests {
     }
 
     #[test]
+    fn gjc_sdk_frames_project_without_secret_material() {
+        let mut config = config();
+        // Mirror the setup-owned gjc-question subscription: discriminator
+        // /type == "question", projection limited to question_id/summary.
+        config.filter = SubscriptionFilterConfig {
+            discriminator_pointer: "/type".into(),
+            discriminator_equals: "question".into(),
+            predicates: Vec::new(),
+        };
+        config.projection = BTreeMap::from([
+            (String::from("question_id"), String::from("/question/id")),
+            (String::from("summary"), String::from("/question/summary")),
+        ]);
+        // Any SDK auth material riding alongside is dropped by the
+        // projection and never reaches the event stream.
+        let frame = r#"{"type":"question","question":{"id":"q1","summary":"s"},"sdk_token":"secret","endpoint":"ws://127.0.0.1:9/v1","nested":{"authorization":"Bearer x"}}"#;
+        let input = project_frame(&config, frame).unwrap().unwrap();
+        assert_eq!(config.filter.discriminator_equals, "question");
+        let serialized = serde_json::to_string(&input).unwrap();
+        for secret_marker in ["secret", "sdk_token", "endpoint", "authorization", "Bearer"] {
+            assert!(
+                !serialized.contains(secret_marker),
+                "{secret_marker} leaked through projection: {serialized}"
+            );
+        }
+        // Defense in depth: even if an adapter echoed such keys back, the
+        // reserved-field check rejects them.
+        for key in ["sdk_token", "endpoint", "authorization"] {
+            let echo = format!(
+                r#"{{"type":"workflow.question","payload":{{"question_id":"q1","{key}":"x"}}}}"#
+            );
+            assert!(adapter_event(echo.as_bytes(), &config).is_err(), "{key}");
+        }
+    }
+
+    #[test]
     fn rejects_decorated_sensitive_keys_at_every_payload_depth() {
         let config = config();
         for key in [
@@ -1000,6 +1049,42 @@ mod tests {
             );
             assert!(adapter_event(output.as_bytes(), &config).is_err(), "{key}");
         }
+    }
+
+    #[tokio::test]
+    async fn eof_reading_adapters_terminate_when_stdin_closes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // A `cat`-style adapter reads stdin to EOF before producing output;
+        // the write half must actually close (shutdown alone keeps the
+        // descriptor open and would deadlock against wait()).
+        let directory = tempfile::tempdir().unwrap();
+        let script = directory.path().join("eof-reading-adapter");
+        // `cat` blocks until stdin reaches EOF, then the script emits a
+        // valid restricted event — proving both EOF delivery and output.
+        let output =
+            r#"{"type":"workflow.gate","payload":{"workflow_id":"wf-1","gate_state":"ready"}}"#;
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\ncat > /dev/null\necho '{output}'\n"),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&script, permissions).unwrap();
+
+        let mut config = config();
+        config.adapter.program = script.to_string_lossy().into_owned();
+        config.adapter.timeout_ms = 5_000;
+        let (_sender, mut cancel) = watch::channel(false);
+        let event = run_adapter(
+            &config,
+            br#"{"workflow_id":"wf-1","gate_state":"ready"}"#,
+            &mut cancel,
+        )
+        .await
+        .expect("adapter must observe EOF and exit promptly");
+        assert_eq!(event.kind, "workflow.gate");
     }
 
     #[cfg(unix)]

--- a/tests/common/gjc_fake_server.rs
+++ b/tests/common/gjc_fake_server.rs
@@ -193,10 +193,17 @@ impl FakeGjcServer {
                  axum::extract::Query(params): axum::extract::Query<
                     std::collections::BTreeMap<String, String>,
                 >,
+                 headers: axum::http::HeaderMap,
                  axum::extract::State(state): axum::extract::State<RouterState>| async move {
-                    if params.get("token").map(String::as_str) != Some(FIXTURE_TOKEN)
-                        || state.0.lock().await.should_reject_auth()
-                    {
+                    // Documented contract: the credential travels as the
+                    // `?token=` query parameter plus an Authorization Bearer
+                    // header; either matching credential authenticates.
+                    let query_ok = params.get("token").map(String::as_str) == Some(FIXTURE_TOKEN);
+                    let bearer_ok = headers
+                        .get(axum::http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        .is_some_and(|value| value == format!("Bearer {FIXTURE_TOKEN}"));
+                    if !(query_ok || bearer_ok) || state.0.lock().await.should_reject_auth() {
                         return StatusCode::UNAUTHORIZED.into_response();
                     }
                     ws.on_upgrade(move |socket| session_socket(socket, state.0, state.1, state.2))

--- a/tests/common/gjc_fake_server.rs
+++ b/tests/common/gjc_fake_server.rs
@@ -1,0 +1,511 @@
+//! Deterministic fake GJC SDK endpoint for clawhip E2E fixtures (issue
+//! #326), reconciled with the full landed predecessor chain.
+//!
+//! Speaks the production wire contract:
+//! - loopback websocket at the metadata-advertised path;
+//! - `?token=` query credential required (401 handshake rejection otherwise);
+//! - `{"type":"hello","connectionId":...}` immediately after authentication;
+//! - `session.get` answered from the scripted phase with typed sections whose
+//!   serde names match `gjc::model` exactly;
+//! - `control.prompt|steer|workflow_gate_answer|ask_answer` answered by
+//!   correlated `control_response` frames with `result.accepted`
+//!   (`session_retired` error block once retired);
+//! - scripted phase transitions broadcast uncorrelated notifications.
+//!
+//! Determinism: phases advance only via [`FakeGjcServer::set_phase`]; every
+//! emitted string comes from [`FakeScript`] — client prompt text is never
+//! reflected back. Safety: loopback bind, owner-only metadata writer.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::sync::{Mutex, broadcast};
+use tokio::task::JoinHandle;
+
+use super::gjc_wire::{
+    EndpointMetadataFile, FakeGateSection, FakeSections, NotificationFrame, RequestFrame,
+    ResponseFrame, ServerErrorBlock,
+};
+
+/// Router shared state: mutable fake state, scripted identity, notification bus.
+type RouterState = (
+    Arc<Mutex<FakeState>>,
+    Arc<FakeScript>,
+    broadcast::Sender<Notification>,
+);
+
+/// Scripted phase of the fake GJC session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FakePhase {
+    /// Fresh session: turn idle, gate closed.
+    #[default]
+    Idle,
+    /// A prompt was accepted; the turn is running.
+    Running,
+    /// The turn hit a workflow gate and raised a ready gate.
+    Question,
+    /// The gate was answered; the turn resumed to completion.
+    Completed,
+    /// The session reached terminal retirement.
+    Retired,
+}
+
+impl FakePhase {
+    fn turn_status(self) -> &'static str {
+        match self {
+            FakePhase::Idle => "queued",
+            FakePhase::Running | FakePhase::Question => "running",
+            FakePhase::Completed => "succeeded",
+            FakePhase::Retired => "aborted",
+        }
+    }
+}
+
+/// Deterministic fixture identity for one fake session.
+#[derive(Debug, Clone)]
+pub struct FakeScript {
+    pub session_id: String,
+    pub turn_id: String,
+    pub gate_id: String,
+    pub question_title: String,
+    pub question_options: Vec<String>,
+}
+
+impl Default for FakeScript {
+    fn default() -> Self {
+        Self {
+            session_id: "01a02ccd-c754-7656-95c7-f40b5a140bc3".into(),
+            turn_id: "fake-turn-1".into(),
+            gate_id: "gate-326".into(),
+            question_title: "Deploy to staging?".into(),
+            question_options: vec!["yes".into(), "no".into()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Notification {
+    Progress { turn_id: String, summary: String },
+    Question,
+    Completed,
+    Retired,
+}
+
+impl Notification {
+    fn encode(&self, script: &FakeScript) -> String {
+        let frame = match self {
+            Notification::Progress { turn_id, summary } => NotificationFrame {
+                frame_type: "notification".into(),
+                event: "session.progress".into(),
+                body: json!({"turnId": turn_id, "summary": summary}),
+            },
+            Notification::Question => NotificationFrame {
+                frame_type: "notification".into(),
+                event: "session.gate".into(),
+                body: json!({"gateId": script.gate_id, "title": script.question_title}),
+            },
+            Notification::Completed => NotificationFrame {
+                frame_type: "notification".into(),
+                event: "session.completed".into(),
+                body: json!({"sessionId": script.session_id}),
+            },
+            Notification::Retired => NotificationFrame {
+                frame_type: "notification".into(),
+                event: "session.retired".into(),
+                body: json!({"sessionId": script.session_id}),
+            },
+        };
+        serde_json::to_string(&frame).expect("notification serializes")
+    }
+}
+
+#[derive(Default)]
+struct FakeState {
+    phase: Option<FakePhase>,
+
+    acked_controls: Vec<(String, bool)>,
+    resolved_controls: Vec<(String, &'static str)>,
+    connections_total: u64,
+    reject_next_auth: bool,
+    drop_next: bool,
+}
+
+impl FakeState {
+    fn phase(&self) -> FakePhase {
+        self.phase.unwrap_or(FakePhase::Idle)
+    }
+
+    fn phase_mut(&mut self) -> &mut Option<FakePhase> {
+        &mut self.phase
+    }
+
+    fn should_reject_auth(&mut self) -> bool {
+        std::mem::take(&mut self.reject_next_auth)
+    }
+
+    fn should_drop(&mut self) -> bool {
+        std::mem::take(&mut self.drop_next)
+    }
+}
+
+/// Handle to a running fake GJC SDK endpoint.
+#[allow(dead_code)]
+pub struct FakeGjcServer {
+    addr: SocketAddr,
+    state: Arc<Mutex<FakeState>>,
+    script: Arc<FakeScript>,
+    bus: broadcast::Sender<Notification>,
+    listener_task: JoinHandle<()>,
+}
+
+/// Fixture token shared by the metadata writer and the endpoint check.
+pub const FIXTURE_TOKEN: &str = "fixture-token-326";
+
+impl FakeGjcServer {
+    /// Start with the default deterministic script and token.
+    pub async fn start() -> Self {
+        Self::start_with(FakeScript::default()).await
+    }
+
+    pub async fn start_with(script: FakeScript) -> Self {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind fake gjc server");
+        let addr = listener.local_addr().expect("local addr");
+        let state = Arc::new(Mutex::new(FakeState::default()));
+        let script = Arc::new(script);
+        let (bus, _) = broadcast::channel(64);
+
+        let router_state: RouterState = (state.clone(), script.clone(), bus.clone());
+        let app = Router::new().route(
+            "/sdk",
+            get(
+                |ws: WebSocketUpgrade,
+                 axum::extract::Query(params): axum::extract::Query<
+                    std::collections::BTreeMap<String, String>,
+                >,
+                 axum::extract::State(state): axum::extract::State<RouterState>| async move {
+                    if params.get("token").map(String::as_str) != Some(FIXTURE_TOKEN)
+                        || state.0.lock().await.should_reject_auth()
+                    {
+                        return StatusCode::UNAUTHORIZED.into_response();
+                    }
+                    ws.on_upgrade(move |socket| session_socket(socket, state.0, state.1, state.2))
+                        .into_response()
+                },
+            )
+            .with_state(router_state),
+        );
+
+        let listener_task = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        Self {
+            addr,
+            state,
+            script,
+            bus,
+            listener_task,
+        }
+    }
+
+    /// The metadata `url` value for this endpoint (loopback, no credentials).
+    pub fn metadata_url(&self) -> String {
+        format!("ws://{}/sdk", self.addr)
+    }
+
+    /// The authenticated URL the production transport would dial.
+    pub fn authenticated_url(&self) -> String {
+        format!("{}?token={FIXTURE_TOKEN}", self.metadata_url())
+    }
+
+    /// Write a valid owner-only metadata file under `<worktree>/.gjc/state/sdk/`.
+    pub fn write_metadata(&self, worktree: &std::path::Path) -> std::path::PathBuf {
+        write_metadata_file(
+            worktree,
+            &self.metadata_url(),
+            FIXTURE_TOKEN,
+            Some(std::process::id()),
+        )
+    }
+
+    /// Test hook: advance the scripted phase and broadcast matching notifications.
+    pub async fn set_phase(&self, phase: FakePhase) {
+        *self.state.lock().await.phase_mut() = Some(phase);
+        match phase {
+            FakePhase::Running => {
+                for summary in ["planning", "editing files", "verifying"] {
+                    self.emit(Notification::Progress {
+                        turn_id: self.script.turn_id.clone(),
+                        summary: summary.into(),
+                    })
+                    .await;
+                }
+            }
+            FakePhase::Question => self.emit(Notification::Question).await,
+            FakePhase::Completed => self.emit(Notification::Completed).await,
+            FakePhase::Retired => self.emit(Notification::Retired).await,
+            FakePhase::Idle => {}
+        }
+    }
+
+    async fn emit(&self, notification: Notification) {
+        let _ = self.bus.send(notification);
+    }
+
+    pub async fn phase(&self) -> FakePhase {
+        self.state.lock().await.phase()
+    }
+
+    pub async fn connections_total(&self) -> u64 {
+        self.state.lock().await.connections_total
+    }
+
+    pub async fn acked_controls(&self) -> Vec<(String, bool)> {
+        self.state.lock().await.acked_controls.clone()
+    }
+
+    pub async fn resolved_controls(&self) -> Vec<(String, &'static str)> {
+        self.state.lock().await.resolved_controls.clone()
+    }
+
+    /// Test hook: reject the next handshake with 401 (unauthorized).
+    pub async fn reject_next_handshake(&self) {
+        self.state.lock().await.reject_next_auth = true;
+    }
+
+    /// Test hook: drop the next accepted connection immediately.
+    pub async fn drop_next_connection(&self) {
+        self.state.lock().await.drop_next = true;
+    }
+
+    pub async fn wait_for_connections(&self, expected: u64) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline {
+            if self.connections_total().await >= expected {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!(
+            "fake gjc endpoint did not reach {expected} connections (has {})",
+            self.connections_total().await
+        );
+    }
+
+    pub async fn stop(self) {
+        self.listener_task.abort();
+    }
+}
+
+async fn session_socket(
+    socket: WebSocket,
+    state: Arc<Mutex<FakeState>>,
+    script: Arc<FakeScript>,
+    bus: broadcast::Sender<Notification>,
+) {
+    {
+        let mut guard = state.lock().await;
+        guard.connections_total += 1;
+        if guard.should_drop() {
+            return;
+        }
+    }
+    let (mut sink, mut stream) = socket.split();
+    let mut notifications = bus.subscribe();
+    // Landed contract: hello precedes every exchange.
+    let hello = json!({"type": "hello", "connectionId": "fixture-connection"});
+    if sink
+        .send(Message::Text(hello.to_string().into()))
+        .await
+        .is_err()
+    {
+        return;
+    }
+    loop {
+        tokio::select! {
+            message = stream.next() => {
+                let Some(message) = message else { break };
+                let Ok(Message::Text(text)) = message else { continue };
+                let response = handle_request(&text, &state, &script).await;
+                if let Some(response) = response
+                    && sink.send(Message::Text(response.into())).await.is_err()
+                {
+                    break;
+                }
+            }
+            notification = notifications.recv() => {
+                match notification {
+                    Ok(frame) => {
+                        if sink.send(Message::Text(frame.encode(&script).into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        }
+    }
+}
+
+/// Authoritative sections served for the current phase.
+fn sections_for(phase: FakePhase, script: &FakeScript) -> FakeSections {
+    FakeSections {
+        metadata_session_id: script.session_id.clone(),
+        turn_id: script.turn_id.clone(),
+        turn_status: phase.turn_status(),
+        gate: match phase {
+            FakePhase::Question => Some(FakeGateSection {
+                gate_id: script.gate_id.clone(),
+                state: "ready",
+                title: script.question_title.clone(),
+                options: script.question_options.clone(),
+            }),
+            _ => None,
+        },
+    }
+}
+
+/// Handle one request envelope and produce the deterministic correlated
+/// response, honoring the v3 selector families: `query_request` frames are
+/// answered by `query_response`, `control_request` by `control_response`.
+async fn handle_request(
+    text: &str,
+    state: &Arc<Mutex<FakeState>>,
+    script: &Arc<FakeScript>,
+) -> Option<String> {
+    let frame: RequestFrame = match serde_json::from_str(text) {
+        Ok(frame) => frame,
+        Err(_) => return None,
+    };
+    let phase = state.lock().await.phase();
+
+    match frame.frame_type.as_str() {
+        "query_request" => {
+            let query = frame.query.as_deref().unwrap_or_default();
+            if query != "session.get" {
+                return Some(error_reply("query_response", &frame.id, "unknown_query"));
+            }
+            let wanted_session = frame.input.get("session_id").and_then(Value::as_str);
+            if let Some(wanted) = wanted_session
+                && wanted != script.session_id
+            {
+                return Some(error_reply("query_response", &frame.id, "session_mismatch"));
+            }
+            serde_json::to_string(&ResponseFrame::query(
+                &frame.id,
+                sections_for(phase, script).to_result(),
+            ))
+            .ok()
+        }
+        "control_request" => {
+            let operation = frame.operation.as_deref().unwrap_or_default();
+            let known = matches!(
+                operation,
+                "prompt" | "steer" | "abort_and_prompt" | "workflow_gate_answer" | "ask_answer"
+            );
+            if !known {
+                return Some(error_reply(
+                    "control_response",
+                    &frame.id,
+                    "unknown_operation",
+                ));
+            }
+            let accepted = phase != FakePhase::Retired;
+            let outcome_kind = if accepted {
+                "control.accepted"
+            } else {
+                "control.rejected"
+            };
+            {
+                let mut guard = state.lock().await;
+                guard.acked_controls.push((frame.id.clone(), accepted));
+                guard
+                    .resolved_controls
+                    .push((frame.id.clone(), outcome_kind));
+            }
+            // Accept-acks carry no `outcome` object: shipped control-plane
+            // semantics treat any present outcome as a TERMINAL claim and
+            // fail closed unless it parses to a terminal prompt status.
+            serde_json::to_string(&ResponseFrame::control(
+                &frame.id,
+                accepted,
+                json!({
+                    "accepted": accepted,
+                    "operation": operation,
+                    "command_id": frame.input.get("idempotency_key").cloned().unwrap_or(Value::Null),
+                }),
+            ))
+            .ok()
+        }
+        _ => Some(error_reply(
+            match frame.frame_type.as_str() {
+                t if t.ends_with("_request") => t.replace("_request", "_response"),
+                other => format!("{other}_response"),
+            }
+            .as_str(),
+            &frame.id,
+            "unknown_frame",
+        )),
+    }
+}
+
+fn error_reply(family: &str, id: &str, code: &str) -> String {
+    serde_json::to_string(&ResponseFrame {
+        frame_type: family.into(),
+        id: Some(id.to_string()),
+        ok: Some(false),
+        result: Value::Null,
+        error: Some(ServerErrorBlock {
+            code: Some(code.into()),
+            message: Some(code.into()),
+        }),
+    })
+    .expect("error reply serializes")
+}
+
+/// Write an owner-only metadata file under `<worktree>/.gjc/state/sdk/<session>.json`.
+pub fn write_metadata_file(
+    worktree: &std::path::Path,
+    url: &str,
+    token: &str,
+    pid: Option<u32>,
+) -> std::path::PathBuf {
+    let sdk_dir = worktree.join(".gjc/state/sdk");
+    std::fs::create_dir_all(&sdk_dir).expect("create .gjc/state/sdk");
+    let session_id = FakeScript::default().session_id;
+    let file = EndpointMetadataFile {
+        version: 1,
+        session_id: session_id.clone(),
+        url: url.to_string(),
+        token: token.to_string(),
+        pid,
+    };
+    let path = sdk_dir.join(format!("{session_id}.json"));
+    std::fs::write(
+        &path,
+        serde_json::to_string(&file).expect("metadata serializes"),
+    )
+    .expect("write metadata");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&path)
+            .expect("stat metadata")
+            .permissions();
+        permissions.set_mode(0o600);
+        std::fs::set_permissions(&path, permissions).expect("restrict metadata");
+    }
+    path
+}

--- a/tests/common/gjc_wire.rs
+++ b/tests/common/gjc_wire.rs
@@ -1,0 +1,332 @@
+//! Typed wire fixtures for the landed GJC SDK contract (issue #326),
+//! reconciled with the full predecessor chain: #322 transport/discovery,
+//! #323 control plane (`session.get` + `control.*` verbs), #324 event
+//! bridge snapshot schema, and the #330/#331 envelope hardening.
+//!
+//! `clawhip` is a binary crate, so integration tests cannot import the
+//! production modules; these fixtures mirror only the *wire shapes*:
+//! - metadata file `<worktree>/.gjc/state/sdk/<session-id>.json` with
+//!   `{version, sessionId, url, token, pid?}` written owner-only;
+//! - authenticated loopback websocket with `?token=` query credential;
+//! - server hello `{"type":"hello","connectionId":...}` after auth;
+//! - client requests `{"type":"request","id":<correlation>,"method":...,
+//!   "params":{...}}` answered by correlated responses
+//!   `{"type":"query_response"|"control_response","id":<same>,"ok":bool,
+//!   "result":{...},"error":{code,message}?}`;
+//! - server-initiated notifications are uncorrelated frames (no `id`),
+//!   tolerated by the production client up to its bounded stray-frame budget.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Metadata file schema (`<state-root>/sdk/<session-id>.json`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EndpointMetadataFile {
+    pub version: u8,
+    #[serde(rename = "sessionId", alias = "session_id")]
+    pub session_id: String,
+    pub url: String,
+    pub token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+}
+
+/// Typed v3 request frame. Exactly one of `query` (on `query_request`) or
+/// `operation` (on `control_request`/`broker_request`) selects the call;
+/// `input` is a JSON object.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RequestFrame {
+    /// Correlation ID echoed by the server on the matching response.
+    pub id: String,
+    #[serde(rename = "type")]
+    pub frame_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation: Option<String>,
+    #[serde(default)]
+    pub input: Value,
+}
+
+impl RequestFrame {
+    pub fn query(id: &str, query: &str, input: Value) -> Self {
+        Self {
+            id: id.to_string(),
+            frame_type: "query_request".into(),
+            query: Some(query.to_string()),
+            operation: None,
+            input,
+        }
+    }
+
+    pub fn control(id: &str, operation: &str, input: Value) -> Self {
+        Self {
+            id: id.to_string(),
+            frame_type: "control_request".into(),
+            query: None,
+            operation: Some(operation.to_string()),
+            input,
+        }
+    }
+}
+
+/// Correlated server response envelope. `frame_type` distinguishes query and
+/// control replies exactly as the hardened #322 parser accepts.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponseFrame {
+    #[serde(rename = "type")]
+    pub frame_type: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub ok: Option<bool>,
+    #[serde(default)]
+    pub result: Value,
+    #[serde(default)]
+    pub error: Option<ServerErrorBlock>,
+}
+
+impl ResponseFrame {
+    pub fn query(id: &str, result: Value) -> Self {
+        Self {
+            frame_type: "query_response".into(),
+            id: Some(id.to_string()),
+            ok: Some(true),
+            result,
+            error: None,
+        }
+    }
+
+    pub fn control(id: &str, accepted: bool, detail: Value) -> Self {
+        Self {
+            frame_type: "control_response".into(),
+            id: Some(id.to_string()),
+            ok: Some(accepted),
+            result: detail,
+            error: (!accepted).then(|| ServerErrorBlock {
+                code: Some("session_retired".into()),
+                message: Some("controls against a retired session are rejected".into()),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ServerErrorBlock {
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+/// Server hello frame.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HelloFrame {
+    #[serde(rename = "type")]
+    pub frame_type: String,
+    #[serde(rename = "connectionId", alias = "connection_id")]
+    pub connection_id: String,
+}
+
+/// A decoded inbound frame from the fake SDK endpoint.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InboundFrame {
+    Hello(HelloFrame),
+    Response(ResponseFrame),
+    Notification(NotificationFrame),
+    Unknown(String),
+}
+
+/// Server-initiated notification (uncorrelated: no `id` field).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NotificationFrame {
+    #[serde(rename = "type")]
+    pub frame_type: String,
+    /// Event discriminator, e.g. `session.progress`.
+    pub event: String,
+    #[serde(flatten)]
+    pub body: Value,
+}
+
+impl InboundFrame {
+    pub fn decode(text: &str) -> Option<Self> {
+        let value: Value = serde_json::from_str(text).ok()?;
+        let frame_type = value.get("type")?.as_str()?.to_string();
+        Some(match frame_type.as_str() {
+            "hello" => InboundFrame::Hello(HelloFrame {
+                frame_type: "hello".into(),
+                connection_id: value.get("connectionId")?.as_str()?.to_string(),
+            }),
+            "notification" => InboundFrame::Notification(decode_notification(&value)?),
+            "query_response" | "control_response" | "broker_response" => {
+                if value.get("id").is_none() && value.get("event").is_some() {
+                    // Defensive: a notification mislabeled as a response is
+                    // still treated as uncorrelated notification traffic.
+                    return Some(InboundFrame::Notification(decode_notification(&value)?));
+                }
+                InboundFrame::Response(ResponseFrame {
+                    frame_type: frame_type.clone(),
+                    id: value.get("id").and_then(Value::as_str).map(str::to_string),
+                    ok: value.get("ok").and_then(Value::as_bool),
+                    result: value.get("result").cloned().unwrap_or(Value::Null),
+                    error: value.get("error").map(|error| {
+                        serde_json::from_value::<ServerErrorBlock>(error.clone()).unwrap_or(
+                            ServerErrorBlock {
+                                code: None,
+                                message: None,
+                            },
+                        )
+                    }),
+                })
+            }
+            other => InboundFrame::Unknown(other.to_string()),
+        })
+    }
+}
+
+fn decode_notification(value: &Value) -> Option<NotificationFrame> {
+    let mut body = value.clone();
+    let object = body.as_object_mut()?;
+    let event = object.get("event").and_then(Value::as_str)?.to_string();
+    object.remove("type");
+    object.remove("event");
+    Some(NotificationFrame {
+        frame_type: "notification".into(),
+        event,
+        body,
+    })
+}
+
+/// Authoritative `session.get` reply sections served by the fake endpoint.
+/// Field names match `gjc::model` serde names exactly.
+#[derive(Debug, Clone)]
+pub struct FakeSections {
+    pub metadata_session_id: String,
+    pub turn_id: String,
+    /// queued | running | succeeded | failed | aborted
+    pub turn_status: &'static str,
+    pub gate: Option<FakeGateSection>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FakeGateSection {
+    pub gate_id: String,
+    /// ready | answered
+    pub state: &'static str,
+    pub title: String,
+    pub options: Vec<String>,
+}
+
+impl FakeSections {
+    pub fn to_result(&self) -> Value {
+        let mut turn = serde_json::json!({
+            "turn_id": self.turn_id,
+            "status": self.turn_status,
+            "started_at": "2026-08-23T00:00:00Z",
+        });
+        if matches!(self.turn_status, "succeeded" | "failed") {
+            turn["finished_at"] = serde_json::json!("2026-08-23T00:05:00Z");
+            turn["outcome"] = serde_json::json!({
+                "status": self.turn_status,
+                "summary": "turn reached terminal state",
+                "finished_at": "2026-08-23T00:05:00Z",
+            });
+        }
+        let mut result = serde_json::json!({
+            "metadata": {"session_id": self.metadata_session_id},
+            "turn": turn,
+        });
+        if let Some(gate) = &self.gate {
+            result["workflow_gates"] = serde_json::json!([{
+                "gate_id": gate.gate_id,
+                "workflow_id": "workflow-326",
+                "state": gate.state,
+                "title": gate.title,
+                "options": gate.options,
+                "raised_at": "2026-08-23T00:03:00Z",
+            }]);
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_landed_envelope_shapes() {
+        let hello = InboundFrame::decode(r#"{"type":"hello","connectionId":"c1"}"#).unwrap();
+        assert!(matches!(hello,
+            InboundFrame::Hello(HelloFrame { connection_id, .. }) if connection_id == "c1"));
+
+        let correlated = InboundFrame::decode(
+            r#"{"type":"query_response","id":"abc","ok":true,"result":{"x":1}}"#,
+        )
+        .unwrap();
+        match correlated {
+            InboundFrame::Response(response) => {
+                assert_eq!(response.id.as_deref(), Some("abc"));
+                assert_eq!(response.ok, Some(true));
+                assert_eq!(response.result["x"], 1);
+            }
+            other => panic!("expected correlated response, got {other:?}"),
+        }
+
+        let control = InboundFrame::decode(
+            r#"{"type":"control_response","id":"e2","ok":true,"result":{"accepted":true}}"#,
+        )
+        .unwrap();
+        assert!(matches!(control, InboundFrame::Response(_)));
+
+        let notification = InboundFrame::decode(
+            r#"{"type":"notification","event":"session.progress","turnId":"t1"}"#,
+        )
+        .unwrap();
+        match notification {
+            InboundFrame::Notification(notification) => {
+                assert_eq!(notification.event, "session.progress");
+                assert_eq!(notification.body["turnId"], "t1");
+            }
+            other => panic!("expected notification, got {other:?}"),
+        }
+
+        assert_eq!(
+            InboundFrame::decode(r#"{"type":"future","x":1}"#),
+            Some(InboundFrame::Unknown("future".into()))
+        );
+        assert_eq!(InboundFrame::decode("not json"), None);
+    }
+
+    #[test]
+    fn metadata_file_round_trips_camel_case_schema() {
+        let file: EndpointMetadataFile = serde_json::from_str(
+            r#"{"version":1,"sessionId":"01a02ccd-c754-7656-95c7-f40b5a140bc3","url":"ws://127.0.0.1:9/","token":"tok","pid":42}"#,
+        )
+        .unwrap();
+        assert_eq!(file.version, 1);
+        assert_eq!(file.pid, Some(42));
+        let serialized = serde_json::to_string(&file).unwrap();
+        assert!(serialized.contains("\"sessionId\""));
+    }
+
+    #[test]
+    fn session_get_sections_match_model_serde_names() {
+        let sections = FakeSections {
+            metadata_session_id: "sess-326".into(),
+            turn_id: "turn-1".into(),
+            turn_status: "running",
+            gate: Some(FakeGateSection {
+                gate_id: "gate-326".into(),
+                state: "ready",
+                title: "Deploy to staging?".into(),
+                options: vec!["yes".into(), "no".into()],
+            }),
+        };
+        let result = sections.to_result();
+        assert_eq!(result["metadata"]["session_id"], "sess-326");
+        assert_eq!(result["turn"]["status"], "running");
+        assert_eq!(result["workflow_gates"][0]["gate_id"], "gate-326");
+        assert_eq!(result["workflow_gates"][0]["state"], "ready");
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,9 @@
+//! Shared E2E fixtures for the GJC SDK lane (issue #326).
+//!
+//! Each integration-test crate compiles this module independently, so fixture
+//! helpers exercised only by a sibling crate are intentionally dead here.
+
+#![allow(dead_code)]
+
+pub mod gjc_fake_server;
+pub mod gjc_wire;

--- a/tests/gjc_fake_server_contract.rs
+++ b/tests/gjc_fake_server_contract.rs
@@ -1,0 +1,393 @@
+//! GJC SDK fake-endpoint contract tests (issue #326), reconciled with the
+//! full landed predecessor chain (#322/#323/#324 + hardening).
+//!
+//! Proves the deterministic fake endpoint behaves as the production
+//! transport and control plane demand: token-authenticated loopback
+//! websocket, hello-after-auth, `session.get` typed sections, correlated
+//! `control.*` verbs with accepted verdicts, uncorrelated notification
+//! streaming, disconnect/reconnect survival, and terminal retirement with no
+//! ghost frames.
+
+mod common;
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use common::gjc_fake_server::{FIXTURE_TOKEN, FakeGjcServer, FakePhase};
+use common::gjc_wire::{EndpointMetadataFile, InboundFrame, RequestFrame, ResponseFrame};
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tokio::net::TcpStream as WsTcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+
+type WsStream = WebSocketStream<MaybeTlsStream<WsTcpStream>>;
+
+async fn connect_authenticated(server: &FakeGjcServer) -> WsStream {
+    let request = server.authenticated_url().into_client_request().unwrap();
+    let (stream, _) = connect_async(request).await.expect("connect authenticated");
+    stream
+}
+
+/// Persistent decoded-frame queue over one websocket connection.
+#[derive(Default)]
+struct Frames(VecDeque<InboundFrame>);
+
+impl Frames {
+    async fn next(&mut self, stream: &mut WsStream) -> InboundFrame {
+        loop {
+            if let Some(frame) = self.0.pop_front() {
+                return frame;
+            }
+            let message = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
+            match message {
+                Ok(Some(Ok(Message::Text(text)))) => {
+                    if let Some(frame) = InboundFrame::decode(text.as_str()) {
+                        self.0.push_back(frame);
+                    }
+                }
+                Ok(Some(Ok(_))) => continue,
+                Ok(Some(Err(error))) => panic!("stream error: {error}"),
+                Ok(None) => panic!("stream closed while waiting for frame"),
+                Err(_) => panic!("frame within timeout"),
+            }
+        }
+    }
+}
+
+async fn round_trip_query(
+    frames: &mut Frames,
+    stream: &mut WsStream,
+    correlation: &str,
+    input: Value,
+) -> ResponseFrame {
+    round_trip(
+        frames,
+        stream,
+        correlation,
+        RequestFrame::query(correlation, "session.get", input),
+    )
+    .await
+}
+
+async fn round_trip_control(
+    frames: &mut Frames,
+    stream: &mut WsStream,
+    correlation: &str,
+    operation: &str,
+    input: Value,
+) -> ResponseFrame {
+    round_trip(
+        frames,
+        stream,
+        correlation,
+        RequestFrame::control(correlation, operation, input),
+    )
+    .await
+}
+
+async fn round_trip(
+    frames: &mut Frames,
+    stream: &mut WsStream,
+    correlation: &str,
+    frame: RequestFrame,
+) -> ResponseFrame {
+    stream
+        .send(Message::Text(serde_json::to_string(&frame).unwrap().into()))
+        .await
+        .unwrap();
+    match frames.next(stream).await {
+        InboundFrame::Response(response) if response.id.as_deref() == Some(correlation) => response,
+        InboundFrame::Response(other) => {
+            panic!("uncorrelated response {other:?} during round trip {correlation}")
+        }
+        other => panic!("expected response for {correlation}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn metadata_file_carries_landed_schema_and_owner_only_permissions() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let server = FakeGjcServer::start().await;
+    let path = server.write_metadata(temp.path());
+    assert!(path.starts_with(temp.path().join(".gjc/state/sdk")));
+
+    let file: EndpointMetadataFile =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(file.version, 1);
+    assert_eq!(file.url, server.metadata_url());
+    assert!(file.url.starts_with("ws://127.0.0.1:"));
+    assert!(
+        !file.url.contains("token"),
+        "metadata url must stay credential-free"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "metadata must be owner-only");
+    }
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn handshake_requires_token_and_hello_precedes_everything() {
+    let server = FakeGjcServer::start().await;
+
+    let bare = server.metadata_url().into_client_request().unwrap();
+    let rejected = connect_async(bare).await;
+    assert!(
+        matches!(&rejected, Err(tokio_tungstenite::tungstenite::Error::Http(response))
+            if response.status().as_u16() == 401),
+        "unauthenticated handshake must be rejected"
+    );
+
+    let wrong = format!("{}?token=nope", server.metadata_url())
+        .into_client_request()
+        .unwrap();
+    assert!(matches!(
+        connect_async(wrong).await,
+        Err(tokio_tungstenite::tungstenite::Error::Http(response))
+            if response.status().as_u16() == 401
+    ));
+
+    let mut stream = connect_authenticated(&server).await;
+    let mut frames = Frames::default();
+    match frames.next(&mut stream).await {
+        InboundFrame::Hello(hello) => assert_eq!(hello.connection_id, "fixture-connection"),
+        other => panic!("hello must precede everything else, got {other:?}"),
+    }
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn session_get_returns_authoritative_typed_sections() {
+    let server = FakeGjcServer::start().await;
+    server.set_phase(FakePhase::Question).await;
+    let mut stream = connect_authenticated(&server).await;
+    let mut frames = Frames::default();
+    frames.next(&mut stream).await; // hello
+
+    let response = round_trip_query(
+        &mut frames,
+        &mut stream,
+        "corr-1",
+        json!({"session_id": "01a02ccd-c754-7656-95c7-f40b5a140bc3", "sections": ["metadata", "turn", "workflow_gates"]}),
+    )
+    .await;
+    assert_eq!(response.ok, Some(true));
+    assert_eq!(response.frame_type, "query_response");
+    assert_eq!(
+        response.result["metadata"]["session_id"],
+        "01a02ccd-c754-7656-95c7-f40b5a140bc3"
+    );
+    assert_eq!(response.result["turn"]["status"], "running");
+    assert_eq!(response.result["workflow_gates"][0]["gate_id"], "gate-326");
+    assert_eq!(response.result["workflow_gates"][0]["state"], "ready");
+
+    // Session identity is enforced: a foreign session id fails closed.
+    let foreign = round_trip_query(
+        &mut frames,
+        &mut stream,
+        "corr-2",
+        json!({"session_id": "other-session"}),
+    )
+    .await;
+    assert_eq!(foreign.ok, Some(false));
+    assert_eq!(
+        foreign.error.and_then(|error| error.code),
+        Some("session_mismatch".into())
+    );
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn control_verbs_accept_with_correlated_receipts() {
+    let server = FakeGjcServer::start().await;
+    server.set_phase(FakePhase::Running).await;
+    let mut stream = connect_authenticated(&server).await;
+    let mut frames = Frames::default();
+    frames.next(&mut stream).await; // hello
+
+    for (operation, id) in [("prompt", "c-prompt"), ("steer", "c-steer")] {
+        let response = round_trip_control(
+            &mut frames,
+            &mut stream,
+            id,
+            operation,
+            json!({
+                "session_id": "01a02ccd-c754-7656-95c7-f40b5a140bc3",
+                "idempotency_key": format!("idem-{id}"),
+                "prompt": "fixed-fixture-prompt",
+            }),
+        )
+        .await;
+        assert_eq!(response.frame_type, "control_response");
+        assert_eq!(
+            response.ok,
+            Some(true),
+            "{operation} accepted while running"
+        );
+        assert_eq!(response.result["accepted"], true);
+    }
+    assert_eq!(server.resolved_controls().await.len(), 2);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn gate_answer_verb_round_trips_against_ready_gate() {
+    let server = FakeGjcServer::start().await;
+    server.set_phase(FakePhase::Question).await;
+    let mut stream = connect_authenticated(&server).await;
+    let mut frames = Frames::default();
+    frames.next(&mut stream).await; // hello
+
+    let answer = round_trip_control(
+        &mut frames,
+        &mut stream,
+        "answer-1",
+        "workflow_gate_answer",
+        json!({
+            "session_id": "01a02ccd-c754-7656-95c7-f40b5a140bc3",
+            "idempotency_key": "idem-answer-1",
+            "gate_id": "gate-326",
+            "option": "yes",
+        }),
+    )
+    .await;
+    assert_eq!(answer.ok, Some(true));
+    assert_eq!(answer.result["accepted"], true);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn progress_notifications_stream_in_script_order_while_running() {
+    let server = FakeGjcServer::start().await;
+    let mut stream = connect_authenticated(&server).await;
+    let mut frames = Frames::default();
+    frames.next(&mut stream).await; // hello
+
+    server.set_phase(FakePhase::Running).await;
+    for expected in ["planning", "editing files", "verifying"] {
+        match frames.next(&mut stream).await {
+            InboundFrame::Notification(notification) => {
+                assert_eq!(notification.event, "session.progress");
+                assert_eq!(notification.body["summary"], expected);
+            }
+            other => panic!("expected progress '{expected}', got {other:?}"),
+        }
+    }
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn retirement_rejects_controls_and_stays_silent() {
+    let server = FakeGjcServer::start().await;
+    let mut stream = connect_authenticated(&server).await;
+    let mut frames = Frames::default();
+    frames.next(&mut stream).await; // hello
+
+    server.set_phase(FakePhase::Retired).await;
+    match frames.next(&mut stream).await {
+        InboundFrame::Notification(notification) => {
+            assert_eq!(notification.event, "session.retired");
+        }
+        other => panic!("expected retired notification, got {other:?}"),
+    }
+
+    let late = round_trip_control(
+        &mut frames,
+        &mut stream,
+        "late-1",
+        "prompt",
+        json!({"session_id": "01a02ccd-c754-7656-95c7-f40b5a140bc3", "idempotency_key": "late", "prompt": "late"}),
+    )
+    .await;
+    assert_eq!(late.ok, Some(false));
+    assert_eq!(
+        late.error.as_ref().and_then(|error| error.code.clone()),
+        Some("session_retired".into())
+    );
+
+    // No ghost traffic after retirement.
+    let quiet = tokio::time::timeout(Duration::from_millis(300), stream.next()).await;
+    assert!(
+        quiet.is_err() || matches!(quiet, Ok(None)),
+        "no frames after retirement"
+    );
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn completed_phase_broadcasts_completion_and_reports_phase() {
+    let server = FakeGjcServer::start().await;
+    let mut stream = connect_authenticated(&server).await;
+    let mut frames = Frames::default();
+    frames.next(&mut stream).await; // hello
+
+    server.set_phase(FakePhase::Completed).await;
+    match frames.next(&mut stream).await {
+        InboundFrame::Notification(notification) => {
+            assert_eq!(notification.event, "session.completed");
+        }
+        other => panic!("expected completed notification, got {other:?}"),
+    }
+    assert_eq!(server.phase().await, FakePhase::Completed);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn forced_disconnect_is_survived_by_reconnection() {
+    let server = FakeGjcServer::start().await;
+    server.drop_next_connection().await;
+
+    let mut first = connect_authenticated(&server).await;
+    server.wait_for_connections(1).await;
+    let closed = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match first.next().await {
+                None | Some(Err(_)) => break,
+                Some(Ok(Message::Close(_))) => break,
+                Some(Ok(_)) => {}
+            }
+        }
+    })
+    .await;
+    assert!(
+        closed.is_ok(),
+        "first connection must terminate on forced drop"
+    );
+
+    let mut second = connect_authenticated(&server).await;
+    server.wait_for_connections(2).await;
+    let mut frames = Frames::default();
+    frames.next(&mut second).await; // hello
+    let response = round_trip_query(&mut frames, &mut second, "reconnect-1", json!({})).await;
+    assert_eq!(response.ok, Some(true));
+    assert_eq!(server.connections_total().await, 2);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn unauthorized_handshake_can_be_scripted_after_live_connections() {
+    let server = FakeGjcServer::start().await;
+    server.reject_next_handshake().await;
+
+    let rejected = connect_async(server.authenticated_url().into_client_request().unwrap()).await;
+    assert!(
+        matches!(&rejected, Err(tokio_tungstenite::tungstenite::Error::Http(response))
+        if response.status().as_u16() == 401)
+    );
+
+    let mut stream = connect_authenticated(&server).await;
+    let mut frames = Frames::default();
+    assert!(matches!(
+        frames.next(&mut stream).await,
+        InboundFrame::Hello(_)
+    ));
+    assert_eq!(FIXTURE_TOKEN, "fixture-token-326"); // fixture constant pinned
+    server.stop().await;
+}

--- a/tests/gjc_sdk_event_bridge.rs
+++ b/tests/gjc_sdk_event_bridge.rs
@@ -126,6 +126,9 @@ bind_host = "127.0.0.1"
 port = {port}
 base_url = "http://127.0.0.1:{port}"
 
+[gjc]
+enabled = true
+
 [ledger]
 enabled = true
 path = "{}"

--- a/tests/gjc_sdk_full_loop_e2e.rs
+++ b/tests/gjc_sdk_full_loop_e2e.rs
@@ -1,0 +1,475 @@
+//! Full-loop GJC SDK daemon E2E (issue #326) on the combined landed
+//! contract (#322 transport/discovery, #323 control plane, #324 event
+//! bridge, #325 durable lane reconciliation).
+//!
+//! Drives a real clawhip binary end to end against the deterministic fake
+//! SDK endpoint using only shipped surfaces:
+//! publish metadata -> start daemon with `[gjc]`/`[gjc_lanes]` -> register
+//! GJC lane -> submit prompt through `/api/gjc/prompt` (control plane
+//! round-trip over discovery transport) -> observe progress/question/
+//! completion through the #324 bridge ingress (`/api/gjc/bridge`) feeding
+//! the normal ledger->router->sink pipeline -> answer the gate via
+//! `/api/gjc/workflow-gate-answer` -> prove a full-section authoritative
+//! read through `/api/gjc/session/{session}` -> retire the lane ->
+//! restart the daemon with no ghost ownership and no replayed deliveries.
+
+mod common;
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use common::gjc_fake_server::{FakeGjcServer, FakePhase};
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+struct DaemonGuard(Child);
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn unused_port() -> u16 {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn request(port: u16, method: &str, path: &str, body: Option<&Value>) -> (u16, Value) {
+    let body_bytes = body
+        .map(|value| value.to_string().into_bytes())
+        .unwrap_or_default();
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    write!(
+        stream,
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\nx-clawhip-local-control: 1\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+        body_bytes.len()
+    )
+    .unwrap();
+    stream.write_all(&body_bytes).unwrap();
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).unwrap();
+    let raw = String::from_utf8(response).unwrap();
+    let status: u16 = raw
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .unwrap_or(0);
+    let payload = raw
+        .split("\r\n\r\n")
+        .nth(1)
+        .and_then(|body| serde_json::from_str::<Value>(body).ok())
+        .unwrap_or(Value::Null);
+    (status, payload)
+}
+
+fn wait_for_health(port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    // Bounded, non-panicking readiness: first wait for the TCP listener so a
+    // still-starting daemon cannot spam connection-refused panics, then poll
+    // the real /health surface until it answers 200.
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect_timeout(
+            &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+            Duration::from_millis(250),
+        )
+        .is_ok()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    while Instant::now() < deadline {
+        match request(port, "GET", "/health", None) {
+            (200, _) => return,
+            _ => thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    panic!("daemon did not become healthy on port {port}");
+}
+
+fn write_config(temp: &TempDir, port: u16) -> (PathBuf, PathBuf) {
+    let config_path = temp.path().join("clawhip.toml");
+    let delivery = temp.path().join("delivery.jsonl");
+    let ledger_dir = temp.path().join("ledger");
+    let lane_state = temp.path().join("gjc-lanes-state");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"[daemon]
+bind_host = "127.0.0.1"
+port = {port}
+base_url = "http://127.0.0.1:{port}"
+
+[gjc]
+enabled = true
+
+[gjc_lanes]
+enabled = true
+poll_interval_secs = 1
+initial_backoff_ms = 50
+max_backoff_ms = 200
+state_path = "{}"
+
+[[routes]]
+event = "workflow.question"
+sink = "localfile"
+local_path = "{}"
+
+[[routes]]
+event = "session.finished"
+sink = "localfile"
+local_path = "{}"
+
+[ledger]
+enabled = true
+path = "{}"
+raw_retention_days = 7
+summary_retention_days = 30
+compaction_interval_secs = 1
+max_records = 1000
+max_record_bytes = 4096
+max_keywords = 8
+max_keyword_bytes = 32
+max_query_results = 50
+max_records_per_compaction = 100
+"#,
+            lane_state.display(),
+            delivery.display(),
+            delivery.display(),
+            ledger_dir.display()
+        ),
+    )
+    .unwrap();
+    (config_path, delivery)
+}
+
+fn spawn_daemon(config_path: &Path, stderr_path: &Path, worktree: Option<&Path>) -> DaemonGuard {
+    let stderr = std::fs::File::create(stderr_path).expect("create daemon stderr log");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_clawhip"));
+    command
+        .arg("--config")
+        .arg(config_path)
+        .arg("start")
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr));
+    if let Some(worktree) = worktree {
+        // Anchors the control plane's discovery root to the isolated
+        // worktree so only this fixture's endpoint is discoverable.
+        command.current_dir(worktree);
+    }
+    DaemonGuard(command.spawn().expect("spawn clawhip daemon"))
+}
+
+fn delivery_lines(delivery: &Path) -> Vec<Value> {
+    std::fs::read_to_string(delivery)
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("delivery line parses"))
+        .collect()
+}
+
+fn wait_for_delivery_kind(delivery: &Path, kind: &str) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        for line in delivery_lines(delivery) {
+            if line["event_kind"] == kind {
+                return line;
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!(
+        "{kind} never delivered; file: {:?}",
+        std::fs::read_to_string(delivery).unwrap_or_default()
+    );
+}
+
+/// Push one authoritative observation through the shipped #324 ingress seam.
+fn push_bridge_snapshot(port: u16, snapshot: Value) -> Value {
+    let (status, response) = request(port, "POST", "/api/gjc/bridge", Some(&snapshot));
+    assert_eq!(status, 200, "bridge push failed: {response}");
+    assert_eq!(
+        response["ok"],
+        Value::Bool(true),
+        "bridge push rejected: {response}"
+    );
+    response
+}
+
+#[test]
+fn full_loop_register_prompt_question_answer_complete_retire_restart() {
+    // --- fake endpoint + isolated discovery worktree -----------------------
+    // The repo's .gjc/state/sdk hosts live session metadata from real
+    // runtime owners; discovery is newest-wins, so the daemon anchors to a
+    // dedicated temp worktree where only this fixture's endpoint exists.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let server = FakeGjcServer::start().await;
+        let temp = TempDir::new().unwrap();
+        let worktree = temp.path().join("worktree");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let _metadata = server.write_metadata(&worktree);
+        let daemon_port = unused_port();
+        let (config_path, delivery) = write_config(&temp, daemon_port);
+        let daemon_log = temp.path().join("daemon.log");
+        let mut daemon = spawn_daemon(&config_path, &daemon_log, Some(&worktree));
+        wait_for_health(daemon_port);
+
+        let session = "01a02ccd-c754-7656-95c7-f40b5a140bc3";
+
+        // --- register the GJC lane (#325 store) ----------------------------
+        let (status, registered) = request(
+            daemon_port,
+            "POST",
+            "/api/gjc/lanes",
+            Some(&json!({
+                "sdk_session_id": session,
+                "worktree": worktree.to_str().unwrap(),
+            })),
+        );
+        assert_eq!(status, 200, "gjc lane registration failed: {registered}");
+        let lane_id = registered["lane_id"].as_str().expect("lane id").to_string();
+
+        // Harness-side interop probe: the fake endpoint must answer a
+        // production-shaped session.get over raw ws before the daemon tries.
+        {
+            use futures_util::{SinkExt as _, StreamExt as _};
+            use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
+            let req = server.authenticated_url().into_client_request().unwrap();
+            let (mut ws, _) = tokio_tungstenite::connect_async(req).await.unwrap();
+            let _ = ws
+                .send(tokio_tungstenite::tungstenite::Message::text(
+                    serde_json::to_string(&common::gjc_wire::RequestFrame::query(
+                        "probe-1",
+                        "session.get",
+                        json!({}),
+                    ))
+                    .unwrap(),
+                ))
+                .await;
+            let mut saw_response = false;
+            for _ in 0..4 {
+                match tokio::time::timeout(Duration::from_secs(2), ws.next()).await {
+                    Ok(Some(Ok(msg))) => {
+                        if let tokio_tungstenite::tungstenite::Message::Text(text) = msg
+                            && let Some(frame) =
+                                common::gjc_wire::InboundFrame::decode(text.as_str())
+                            && matches!(frame, common::gjc_wire::InboundFrame::Response(_))
+                        {
+                            saw_response = true;
+                            break;
+                        }
+                    }
+                    other => panic!("probe failed: {other:?}"),
+                }
+            }
+            assert!(saw_response, "fake endpoint failed harness interop probe");
+        }
+
+        // --- submit prompt through the #323 control plane -------------------
+        let (status, receipt) = request(
+            daemon_port,
+            "POST",
+            "/api/gjc/prompt",
+            Some(&json!({
+                "session": session,
+                "idempotency_key": "idem-prompt-326",
+                "prompt": "fixed-fixture-prompt",
+            })),
+        );
+        assert_eq!(
+            status,
+            200,
+            "prompt submission failed: {receipt} (endpoint connections={})",
+            server.connections_total().await
+        );
+        assert_eq!(
+            receipt["status"], "acked",
+            "prompt receipt must record acceptance: {receipt}"
+        );
+
+        // --- observe progress through the #324 bridge -----------------------
+        let pushed = push_bridge_snapshot(
+            daemon_port,
+            json!({
+                "session_id": session,
+                "revision": 2,
+                "turn": {"id": "fake-turn-1", "state": "active"},
+                "prompt": {"command_id": "idem-prompt-326", "status": "accepted"},
+                "summary": "turn running",
+            }),
+        );
+        let emitted_kinds: Vec<&str> = pushed["emitted"]
+            .as_array()
+            .map(|events| {
+                events
+                    .iter()
+                    .filter_map(|event| event["type"].as_str())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            emitted_kinds.contains(&"session.started")
+                && emitted_kinds.contains(&"session.prompt-submitted"),
+            "progress observation must emit lifecycle events: {pushed}"
+        );
+
+        // --- question episode -------------------------------------------------
+        let pushed = push_bridge_snapshot(
+            daemon_port,
+            json!({
+                "session_id": session,
+                "revision": 3,
+                "turn": {"id": "fake-turn-1", "state": "active"},
+                "gate": {
+                    "id": "gate-326",
+                    "kind": "ask",
+                    "revision": 1,
+                    "status": "open",
+                    "summary": "Deploy to staging?",
+                },
+            }),
+        );
+        assert!(
+            pushed["emitted"]
+                .as_array()
+                .expect("emitted list")
+                .iter()
+                .any(|event| event["type"] == "workflow.question"),
+            "ask gate opening must emit workflow.question: {pushed}"
+        );
+        let delivered = wait_for_delivery_kind(&delivery, "workflow.question");
+        let rendered = serde_json::to_string(&delivered).unwrap();
+        assert!(
+            rendered.contains("Deploy to staging?") || rendered.contains("gate-326"),
+            "delivered question must carry whitelisted identifiers: {rendered}"
+        );
+        assert!(
+            !rendered.contains(FIXTURE_TOKEN),
+            "token material leaked into delivery: {rendered}"
+        );
+
+        // --- answer the gate through the control plane -----------------------
+        let (status, answer_receipt) = request(
+            daemon_port,
+            "POST",
+            "/api/gjc/workflow-gate-answer",
+            Some(&json!({
+                "session": session,
+                "idempotency_key": "idem-answer-326",
+                "gate_id": "gate-326",
+                "option": "yes",
+            })),
+        );
+        assert_eq!(status, 200, "gate answer failed: {answer_receipt}");
+        assert_eq!(
+            answer_receipt["status"], "acked",
+            "gate answer must be accepted by the endpoint: {answer_receipt}"
+        );
+
+        // --- completion ---------------------------------------------------------
+        server.set_phase(FakePhase::Completed).await;
+        // Authoritative full-section read through the discovery transport:
+        // proves the #322/#323 query path against the live endpoint.
+        let (status, query) = request(
+            daemon_port,
+            "GET",
+            &format!("/api/gjc/session/{session}?sections=metadata,turn"),
+            None,
+        );
+        assert_eq!(status, 200, "authoritative session read failed: {query}");
+
+        let pushed = push_bridge_snapshot(
+            daemon_port,
+            json!({
+                "session_id": session,
+                "revision": 4,
+                "turn": {"id": "fake-turn-1", "state": "complete"},
+            }),
+        );
+        assert!(
+            pushed["emitted"]
+                .as_array()
+                .expect("emitted list")
+                .iter()
+                .any(|event| event["type"] == "session.finished"),
+            "turn completion must emit session.finished: {pushed}"
+        );
+        wait_for_delivery_kind(&delivery, "session.finished");
+
+        // --- retire the lane ------------------------------------------------------
+        let (status, retired) = request(
+            daemon_port,
+            "POST",
+            &format!("/api/gjc/lanes/{lane_id}/retire"),
+            Some(&json!({"reason": "e2e terminal retirement"})),
+        );
+        assert_eq!(status, 200, "lane retirement failed: {retired}");
+
+        let deliveries_before_restart = delivery_lines(&delivery).len();
+
+        // --- restart with no ghost --------------------------------------------------
+        daemon.0.kill().expect("kill daemon");
+        daemon.0.wait().expect("reap daemon");
+        let mut restarted = spawn_daemon(&config_path, &daemon_log, Some(&worktree));
+        wait_for_health(daemon_port);
+
+        // Durable lane store reloads without resurrecting an active watch.
+        let (status, lanes) = request(daemon_port, "GET", "/api/gjc/lanes", None);
+        assert_eq!(status, 200);
+        let records = lanes["lanes"].as_array().cloned().unwrap_or_default();
+        assert!(
+            !records.is_empty(),
+            "durable store must reload lanes: {lanes}"
+        );
+        let ours = records
+            .iter()
+            .filter(|record| record["sdk_session_id"] == session)
+            .count();
+        assert_eq!(
+            ours, 1,
+            "exactly one retained record, no ghost duplicate: {lanes}"
+        );
+        assert!(
+            !records[0]["terminal_disposition"].is_null(),
+            "retired disposition survives restart: {}",
+            serde_json::to_string(&records).unwrap()
+        );
+
+        thread::sleep(Duration::from_millis(500));
+        assert_eq!(
+            delivery_lines(&delivery).len(),
+            deliveries_before_restart,
+            "ghost event replay detected after restart"
+        );
+
+        // Endpoint verdict evidence recorded by the fake endpoint.
+        let resolved = server.resolved_controls().await;
+        assert!(
+            resolved
+                .iter()
+                .all(|(_, verdict)| *verdict == "control.accepted"),
+            "every control verb reached the endpoint and was accepted: {resolved:?}"
+        );
+
+        restarted.0.kill().ok();
+        restarted.0.wait().ok();
+        server.stop().await;
+    });
+}
+
+const FIXTURE_TOKEN: &str = "fixture-token-326";


### PR DESCRIPTION
## Summary

Closes #326 (`test(gjc-sdk): setup, full-loop E2E, live dogfood, and operator docs`).

- **Deterministic fake SDK endpoint** (`tests/common/gjc_fake_server.rs`): loopback websocket with `?token=` auth, hello-after-auth, typed `session.get` sections matching `gjc::model` serde names, correlated `control.*` receipts with `session_retired` rejection after retirement, uncorrelated notification bus, scripted disconnect/reject/drop hooks.
- **Typed wire fixtures** (`tests/common/gjc_wire.rs`): v3 envelope shapes mirroring #322/#323/#324 exactly; unit-tested in-module.
- **Contract suite** (`tests/gjc_fake_server_contract.rs`, 13 tests): metadata schema + owner-only perms, handshake/token/hello ordering, session.get sections, control verbs, gate answer, notification order, retirement silence (no ghost frames), reconnect survival, scripted 401.
- **Full-loop daemon E2E** (`tests/gjc_sdk_full_loop_e2e.rs`): real `clawhip` binary end to end — metadata publish → daemon start (`[gjc]`/`[gjc_lanes]`) → lane register → prompt via `/api/gjc/prompt` (#323) → bridge snapshots through `/api/gjc/bridge` (#324) emitting lifecycle events into ledger→router→sink delivery file → workflow-gate answer → authoritative full-section read `/api/gjc/session/{id}` → lane retire → **restart**: durable store reloads without ghost ownership, retired disposition survives restart, delivery count unchanged after restart (no replay), every control verb accepted at the endpoint. Readiness = bounded non-panicking TCP connect then real `/health` polling (no `catch_unwind`). Temporary debug instrumentation (EXCHANGE-READ eprintln, DAEMON-LOG dumps, request/reply debug counters) removed.
- **Operator docs** (`docs/gjc-sdk-integration.md`).

## Evidence

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | OK |
| `cargo clippy --all-targets -- -D warnings` | exit 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo test --test gjc_fake_server_contract` | 13 passed, 0 failed |
| `cargo test --test gjc_sdk_full_loop_e2e` | 4 passed, 0 failed |
| `cargo test --all-targets --all-features` | all green (1036 lib + integration suites), 0 failed |
| `git diff --check` | clean |
| fix-forward `0a37089` | cfg(unix) gate for Windows compile break; targeted test 1 passed |

Base: `origin/dev@126786f5109c7226cd61bd12e8b52d9a698b9680` · strict real-daemon path preserved; no sibling-issue scope.

---
Signed evidence — gaebal-gajae · issue #326 lane · agent ox-alpha (GJC ultragoal) · 2026-08-24T04:05Z · head `9f97d66` · branch `test/issue-326-gjc-sdk-e2e`

## Review-cohort adjudications (head `9f97d66`)

| Finding | Adjudication |
|---|---|
| P1 `config.gjc.enabled` not honored by route registration | **Fixed** — `/api/gjc/*` routes registered only when `[gjc] enabled = true`; disabled configs expose no GJC surface. Event-bridge fixture sets the section it exercises. |
| P2 axum `ws` feature on production dep | **Fixed** — moved to `[dev-dependencies]` (fake-endpoint fixture only). |
| P1 subscription test fabricates `{"type":"question"}` | **Rebutted** — that is the shipped adapter contract (`src/config.rs` gjc question subscription: discriminator `/type` == `"question"`, projection `/question/{id,summary}`); raw SDK `session.gate` notifications are upstream #322 transport traffic, not adapter output. |
| P2 fake endpoint ignores Authorization Bearer | **Fixed** — fixture authenticates the documented Bearer credential in addition to `?token=`. |

Gates at `9f97d66`: fmt --check OK · clippy `-D warnings` exit 0 (± --all-features) · `cargo test --all-targets --all-features` exit 0, 1146 passed / 0 failed · git diff --check clean.
