### PR TITLE
fix(gjc): authenticate bridge ingress against local-control (#339)

### DIFF
--- a/docs/gjc-sdk-event-bridge.md
+++ b/docs/gjc-sdk-event-bridge.md
@@ -15,9 +15,18 @@ scraping, key injection, or credentials**:
 ```
 POST /api/gjc/bridge
 Content-Type: application/json
+x-clawhip-local-control: 1
+Host: 127.0.0.1:<port>
 
 { ...one authoritative state snapshot... }
 ```
+
+The route is registered only when `[gjc] enabled = true`. Live ingress uses
+the same local-control contract as other GJC control handlers: loopback peer,
+loopback `Host`, loopback `Origin` when present, and `x-clawhip-local-control:
+1`. Missing or invalid credentials, and non-loopback Host/Origin, are rejected
+with `403` (`local_control_rejected`). Unauthenticated remote snapshot
+forgery is not accepted even when the daemon binds `0.0.0.0`.
 
 The body is one SDK response payload (the `payload` value of the #322 typed
 websocket response envelope). It is mapped through

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1414,7 +1414,14 @@ async fn post_native_hook(
 /// snapshot per observation; the process-wide bridge reduces transitions and
 /// the emitted events flow through `accept_event` (ledger, router, sinks).
 /// No polling loop or durable lane ownership lives here.
+///
+/// Fail-closed like the rest of the GJC control plane: the route is absent
+/// when `[gjc] enabled = false`, and live ingress requires the local-control
+/// header plus a loopback peer/Host/Origin (`SubscriptionControlRequest` and
+/// `LoopbackLanePeer`). Unauthenticated or remote snapshot forgery is rejected.
 async fn post_gjc_bridge(
+    _control: SubscriptionControlRequest,
+    _peer: LoopbackLanePeer,
     State(state): State<AppState>,
     Json(payload): Json<Value>,
 ) -> axum::response::Response {

--- a/tests/common/gjc_fake_server.rs
+++ b/tests/common/gjc_fake_server.rs
@@ -3,7 +3,8 @@
 //!
 //! Speaks the production wire contract:
 //! - loopback websocket at the metadata-advertised path;
-//! - `?token=` query credential required (401 handshake rejection otherwise);
+//! - `?token=` query or matching `Authorization: Bearer` authenticates
+//!   (401 when neither credential matches);
 //! - `{"type":"hello","connectionId":...}` immediately after authentication;
 //! - `session.get` answered from the scripted phase with typed sections whose
 //!   serde names match `gjc::model` exactly;

--- a/tests/gjc_fake_server_contract.rs
+++ b/tests/gjc_fake_server_contract.rs
@@ -3,7 +3,7 @@
 //!
 //! Proves the deterministic fake endpoint behaves as the production
 //! transport and control plane demand: token-authenticated loopback
-//! websocket, hello-after-auth, `session.get` typed sections, correlated
+//! websocket (query token and/or Bearer), hello-after-auth, `session.get` typed sections, correlated
 //! `control.*` verbs with accepted verdicts, uncorrelated notification
 //! streaming, disconnect/reconnect survival, and terminal retirement with no
 //! ghost frames.
@@ -29,6 +29,38 @@ async fn connect_authenticated(server: &FakeGjcServer) -> WsStream {
     let request = server.authenticated_url().into_client_request().unwrap();
     let (stream, _) = connect_async(request).await.expect("connect authenticated");
     stream
+}
+
+async fn connect_with(
+    url: &str,
+    bearer: Option<&str>,
+) -> Result<WsStream, tokio_tungstenite::tungstenite::Error> {
+    let mut request = url.into_client_request().unwrap();
+    if let Some(token) = bearer {
+        request
+            .headers_mut()
+            .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    }
+    connect_async(request).await.map(|(stream, _)| stream)
+}
+
+fn assert_unauthorized(result: Result<WsStream, tokio_tungstenite::tungstenite::Error>) {
+    assert!(
+        matches!(
+            &result,
+            Err(tokio_tungstenite::tungstenite::Error::Http(response))
+                if response.status().as_u16() == 401
+        ),
+        "expected 401 unauthorized handshake, got {result:?}"
+    );
+}
+
+async fn assert_hello(stream: &mut WsStream) {
+    let mut frames = Frames::default();
+    match frames.next(stream).await {
+        InboundFrame::Hello(hello) => assert_eq!(hello.connection_id, "fixture-connection"),
+        other => panic!("hello must follow authenticated handshake, got {other:?}"),
+    }
 }
 
 /// Persistent decoded-frame queue over one websocket connection.
@@ -160,6 +192,45 @@ async fn handshake_requires_token_and_hello_precedes_everything() {
         InboundFrame::Hello(hello) => assert_eq!(hello.connection_id, "fixture-connection"),
         other => panic!("hello must precede everything else, got {other:?}"),
     }
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn handshake_accepts_query_and_bearer_credential_combinations() {
+    let server = FakeGjcServer::start().await;
+    let query = server.authenticated_url();
+    let bare = server.metadata_url();
+    let wrong_query = format!("{bare}?token=nope");
+
+    let mut query_only = connect_with(&query, None)
+        .await
+        .expect("query-only credential must authenticate");
+    assert_hello(&mut query_only).await;
+
+    let mut bearer_only = connect_with(&bare, Some(FIXTURE_TOKEN))
+        .await
+        .expect("bearer-only credential must authenticate");
+    assert_hello(&mut bearer_only).await;
+
+    let mut query_and_bearer = connect_with(&query, Some(FIXTURE_TOKEN))
+        .await
+        .expect("matching query plus bearer must authenticate");
+    assert_hello(&mut query_and_bearer).await;
+
+    let mut query_wins = connect_with(&query, Some("nope"))
+        .await
+        .expect("matching query must authenticate even with a wrong bearer");
+    assert_hello(&mut query_wins).await;
+
+    let mut bearer_wins = connect_with(&wrong_query, Some(FIXTURE_TOKEN))
+        .await
+        .expect("matching bearer must authenticate even with a wrong query token");
+    assert_hello(&mut bearer_wins).await;
+
+    assert_unauthorized(connect_with(&bare, Some("nope")).await);
+    assert_unauthorized(connect_with(&wrong_query, Some("nope")).await);
+    assert_unauthorized(connect_with(&bare, None).await);
+
     server.stop().await;
 }
 

--- a/tests/gjc_sdk_event_bridge.rs
+++ b/tests/gjc_sdk_event_bridge.rs
@@ -30,11 +30,36 @@ fn unused_port() -> u16 {
 }
 
 fn request(port: u16, method: &str, path: &str, body: Option<&[u8]>) -> (u16, Vec<u8>) {
+    request_with(
+        port,
+        method,
+        path,
+        body,
+        &format!("127.0.0.1:{port}"),
+        &[("x-clawhip-local-control", "1")],
+    )
+}
+
+fn request_with(
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&[u8]>,
+    host: &str,
+    extra_headers: &[(&str, &str)],
+) -> (u16, Vec<u8>) {
     let body = body.unwrap_or_default();
     let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    let mut extra = String::new();
+    for (name, value) in extra_headers {
+        extra.push_str(name);
+        extra.push_str(": ");
+        extra.push_str(value);
+        extra.push_str("\r\n");
+    }
     write!(
         stream,
-        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+        "{method} {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n{extra}Content-Type: application/json\r\nContent-Length: {}\r\n\r\n",
         body.len()
     )
     .unwrap();
@@ -115,19 +140,41 @@ fn wait_for_ledger_and_delivery(
 }
 
 fn write_config(temp: &TempDir, port: u16) -> std::path::PathBuf {
-    let config = temp.path().join("clawhip.toml");
-    let ledger = temp.path().join("ledger");
-    let delivery = temp.path().join("delivery.jsonl");
+    write_config_with(temp, port, "127.0.0.1", true, None)
+}
+
+fn write_config_with(
+    temp: &TempDir,
+    port: u16,
+    bind_host: &str,
+    gjc_enabled: bool,
+    tag: Option<&str>,
+) -> std::path::PathBuf {
+    let (config_name, ledger_name, delivery_name) = match tag {
+        Some(tag) => (
+            format!("clawhip-{tag}.toml"),
+            format!("ledger-{tag}"),
+            format!("delivery-{tag}.jsonl"),
+        ),
+        None => (
+            "clawhip.toml".into(),
+            "ledger".into(),
+            "delivery.jsonl".into(),
+        ),
+    };
+    let config = temp.path().join(config_name);
+    let ledger = temp.path().join(ledger_name);
+    let delivery = temp.path().join(delivery_name);
     std::fs::write(
         &config,
         format!(
             r#"[daemon]
-bind_host = "127.0.0.1"
+bind_host = "{bind_host}"
 port = {port}
 base_url = "http://127.0.0.1:{port}"
 
 [gjc]
-enabled = true
+enabled = {gjc_enabled}
 
 [ledger]
 enabled = true
@@ -379,4 +426,114 @@ fn gjc_bridge_ingest_dedupes_replay_stale_and_restart_boundaries() {
     assert!(totals["snapshots"].as_u64().unwrap() >= 6, "{totals}");
     assert!(totals["duplicates"].as_u64().unwrap() >= 2, "{totals}");
     assert!(totals["stale"].as_u64().unwrap() >= 1, "{totals}");
+}
+
+#[test]
+fn gjc_bridge_requires_local_control_and_is_absent_when_disabled() {
+    let temp = TempDir::new().unwrap();
+    let payload = serde_json::to_vec(&snapshot(1)).unwrap();
+
+    let disabled_port = unused_port();
+    let disabled_config =
+        write_config_with(&temp, disabled_port, "127.0.0.1", false, Some("disabled"));
+    let _disabled = spawn_daemon(&disabled_config, &temp, disabled_port, "disabled");
+    wait_for_health(disabled_port);
+    let (status, body) = request(
+        disabled_port,
+        "POST",
+        "/api/gjc/bridge",
+        Some(payload.as_slice()),
+    );
+    assert_eq!(
+        status,
+        404,
+        "disabled [gjc] must hide /api/gjc/bridge: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let port = unused_port();
+    let config = write_config_with(&temp, port, "0.0.0.0", true, Some("open"));
+    let _daemon = spawn_daemon(&config, &temp, port, "open");
+    wait_for_health(port);
+    let loopback_host = format!("127.0.0.1:{port}");
+
+    let (status, body) = request_with(
+        port,
+        "POST",
+        "/api/gjc/bridge",
+        Some(payload.as_slice()),
+        &loopback_host,
+        &[],
+    );
+    assert_local_control_rejected(status, &body);
+
+    let (status, body) = request_with(
+        port,
+        "POST",
+        "/api/gjc/bridge",
+        Some(payload.as_slice()),
+        &loopback_host,
+        &[("x-clawhip-local-control", "0")],
+    );
+    assert_local_control_rejected(status, &body);
+
+    let (status, body) = request_with(
+        port,
+        "POST",
+        "/api/gjc/bridge",
+        Some(payload.as_slice()),
+        &format!("8.8.8.8:{port}"),
+        &[("x-clawhip-local-control", "1")],
+    );
+    assert_local_control_rejected(status, &body);
+
+    let (status, body) = request_with(
+        port,
+        "POST",
+        "/api/gjc/bridge",
+        Some(payload.as_slice()),
+        &loopback_host,
+        &[
+            ("x-clawhip-local-control", "1"),
+            ("Origin", "http://evil.example"),
+        ],
+    );
+    assert_local_control_rejected(status, &body);
+
+    let (status, body) = request(
+        port,
+        "GET",
+        "/api/ledger/query?session_id=sess-324&limit=50",
+        None,
+    );
+    assert_eq!(status, 200, "{}", String::from_utf8_lossy(&body));
+    let query: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        query["records"].as_array().map(Vec::len).unwrap_or(0),
+        0,
+        "rejected snapshots must not reach the ledger: {query}"
+    );
+
+    let response = post_snapshot(port, &snapshot(1));
+    let emitted: Vec<String> = response["emitted"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["type"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        emitted.contains(&"session.started".to_string()),
+        "{response}"
+    );
+    assert!(
+        emitted.contains(&"session.prompt-submitted".to_string()),
+        "{response}"
+    );
+}
+
+fn assert_local_control_rejected(status: u16, body: &[u8]) {
+    assert_eq!(status, 403, "{}", String::from_utf8_lossy(body));
+    let value: Value = serde_json::from_slice(body).expect("local-control JSON body");
+    assert_eq!(value["ok"], json!(false), "{value}");
+    assert_eq!(value["reason"], json!("local_control_rejected"), "{value}");
 }


### PR DESCRIPTION
## Summary

Fixes #339 (`fix(gjc): authenticate bridge ingress and reject remote snapshot forgery`).

`POST /api/gjc/bridge` now uses the same local-control/loopback authorization contract as the rest of the GJC control plane (`SubscriptionControlRequest` + `LoopbackLanePeer`). Unauthenticated or remote snapshot forgery is rejected even when the daemon binds `0.0.0.0`. The route remains unregistered when `[gjc] enabled = false`.

## Acceptance

1. `[gjc] enabled = false` → `/api/gjc/bridge` is absent (`404`)
2. enabled bridge without `x-clawhip-local-control: 1` → `403 local_control_rejected`
3. invalid control credential → `403 local_control_rejected`
4. non-loopback `Host` / `Origin` → `403 local_control_rejected`
5. authenticated loopback request on `bind_host = 0.0.0.0` succeeds and emits `session.started` / `session.prompt-submitted`
6. rejected snapshots never reach the ledger
7. fake endpoint handshake covers query-only, bearer-only, matching query+bearer, mixed valid/invalid combinations, and dual-invalid 401 without weakening production dual-credential auth

## Evidence

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | OK |
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo test --test gjc_fake_server_contract` | 14 passed |
| `cargo test --test gjc_sdk_event_bridge` | 2 passed |
| `cargo test --test gjc_sdk_full_loop_e2e` | 4 passed |
| `cargo test --all-targets --all-features` | 1148 passed, 0 failed |
| `cargo build --release` | OK |
| `git diff --check` | clean |

Base: `origin/dev@aac9c1f11be72f0b8fbb4b5a622ac5d8f94f540a`
Head: `3f0122df5b949d3297c1a24e16741c6ddacb459c`
Branch: `fix/issue-339-gjc-bridge-auth`

Parent evidence: PR #338 post-merge `REQUEST_CHANGES` on unauthenticated bridge ingress.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*