### PR TITLE
fix(tmux): reconcile persisted ghost watches out of active runtime registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .clawhip/state/
 .gjc/
 tmux-watch-registry.json
+tmux-watch-registry.audit.json

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -51,8 +51,8 @@ use crate::source::{
     SubscriptionState, SubscriptionWorker, TmuxSource, WorkspaceSource,
     default_github_ci_baseline_path, default_registry_state_path, inspect_tmux_registry_state,
     list_active_tmux_registrations, load_tmux_registry_state, new_shared_git_monitor_diagnostics,
-    register_runtime_tmux_registration, snapshot_git_monitor_diagnostics,
-    tmux_registry_diagnostics,
+    reconcile_restored_tmux_registry, register_runtime_tmux_registration,
+    snapshot_git_monitor_diagnostics, tmux_registry_diagnostics,
 };
 use crate::telemetry;
 use crate::update::{self, SharedPendingUpdate};
@@ -186,6 +186,15 @@ pub async fn run(
     let tmux_registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
     let tmux_registry_state_path = default_registry_state_path(&cron_state_path);
     load_tmux_registry_state(&tmux_registry_state_path, &tmux_registry).await;
+    // #341: reconcile runtime-gone dynamic registrations out of the restored
+    // active set before the daemon serves or polls, so a restart cannot
+    // resurrect persisted ghost watches. Reconciled entries leave bounded
+    // tombstone evidence in the audit trail beside the registry state.
+    if let Err(error) =
+        reconcile_restored_tmux_registry(&tmux_registry, &tmux_registry_state_path).await
+    {
+        eprintln!("clawhip tmux restart reconcile failed: {error}");
+    }
     let (tx, rx) = mpsc::channel(EVENT_QUEUE_CAPACITY);
     let native_observability = new_shared_native_hook_observability();
     let subscriptions = new_subscription_registry(config.as_ref(), tx.clone()).await;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -20,7 +20,8 @@ pub use subscription::{SubscriptionSnapshot, SubscriptionState, SubscriptionWork
 pub use tmux::{
     RegisteredTmuxSession, SharedTmuxRegistry, TmuxSource, default_registry_state_path,
     inspect_tmux_registry_state, list_active_tmux_registrations, load_tmux_registry_state,
-    register_runtime_tmux_registration, tmux_registry_diagnostics,
+    reconcile_restored_tmux_registry, register_runtime_tmux_registration,
+    tmux_registry_diagnostics,
 };
 pub use workspace::WorkspaceSource;
 

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -1009,6 +1009,80 @@ async fn save_durable_tmux_registry(
     Ok(durable.len())
 }
 
+/// Tombstone schema for reconciled-away tmux watch registrations (#341).
+pub const TMUX_WATCH_AUDIT_SCHEMA: &str = "clawhip.tmux-watch-audit.v1";
+
+/// Bounded tombstone audit: oldest entries are dropped once this many exist,
+/// mirroring the gjc lane audit policy. Audit evidence is kept separate from
+/// the active registry so it can never resurrect as a ghost registration.
+const MAX_TMUX_WATCH_AUDIT_ENTRIES: usize = 256;
+
+/// Bounded, public-safe tombstone for a watch registration reconciled out of
+/// the active registry. Records who owned the watch and when it was retired
+/// without persisting pane text or routing payloads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TmuxWatchAuditEntry {
+    at: String,
+    session: String,
+    reason: String,
+    registration_source: String,
+    registered_at: String,
+    wrapper_owned: bool,
+    parent_pid: Option<u32>,
+    parent_name: Option<String>,
+    registration_generation: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TmuxWatchAuditFile {
+    schema: String,
+    entries: Vec<TmuxWatchAuditEntry>,
+    dropped: u64,
+}
+
+impl Default for TmuxWatchAuditFile {
+    fn default() -> Self {
+        Self {
+            schema: TMUX_WATCH_AUDIT_SCHEMA.to_string(),
+            entries: Vec::new(),
+            dropped: 0,
+        }
+    }
+}
+
+/// Tombstone file kept beside the durable registry state.
+fn tmux_watch_audit_path(registry_state_path: &Path) -> PathBuf {
+    registry_state_path.with_extension("audit.json")
+}
+
+/// Append tombstones to the bounded audit file. Best-effort: a corrupt or
+/// unreadable file restarts the trail instead of blocking reconciliation,
+/// and the durable registry save has already happened by the time this runs.
+async fn record_tmux_watch_audit(path: &Path, appended: Vec<TmuxWatchAuditEntry>) -> Result<()> {
+    let mut audit = match tokio::fs::read(path).await {
+        Ok(content) => serde_json::from_slice::<TmuxWatchAuditFile>(&content).unwrap_or_default(),
+        Err(_) => TmuxWatchAuditFile::default(),
+    };
+    audit.schema = TMUX_WATCH_AUDIT_SCHEMA.to_string();
+    audit.entries.extend(appended);
+    if audit.entries.len() > MAX_TMUX_WATCH_AUDIT_ENTRIES {
+        let overflow = audit.entries.len() - MAX_TMUX_WATCH_AUDIT_ENTRIES;
+        audit.entries.drain(0..overflow);
+        audit.dropped += overflow as u64;
+    }
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let content = serde_json::to_vec_pretty(&audit)?;
+    let tmp_path = path.with_extension("json.tmp");
+    tokio::fs::write(&tmp_path, content).await?;
+    tokio::fs::rename(&tmp_path, path).await?;
+    Ok(())
+}
+
 pub async fn load_tmux_registry_state(
     path: &Path,
     registry: &SharedTmuxRegistry,
@@ -1075,6 +1149,54 @@ pub async fn load_tmux_registry_state(
             last_error: Some(error.to_string()),
         },
     }
+}
+
+/// Restart reconciliation (#341): after the durable registry is restored,
+/// reconcile runtime-gone dynamic registrations out of the active set so a
+/// daemon restart cannot resurrect ghost watches. The authoritative tmux
+/// session inventory is the lifecycle authority — never pane text. Only a
+/// definitive `Sessions` observation is acted on: with no server or a probe
+/// failure the source poll loop performs the identical reconciliation once
+/// evidence is available. Live registrations, config-monitor entries, and
+/// in-flight lane evidence are untouched.
+pub async fn reconcile_restored_tmux_registry(
+    registry: &SharedTmuxRegistry,
+    registry_state_path: &Path,
+) -> Result<usize> {
+    let sessions = match list_tmux_sessions().await {
+        Ok(TmuxSessionInventory::Sessions(sessions)) => sessions,
+        Ok(TmuxSessionInventory::NoServer) => return Ok(0),
+        Err(error) => {
+            telemetry::emit(source_record(
+                telemetry::event_name::SOURCE_DEGRADED,
+                "source_poll_failed",
+                None,
+                Some(error.to_string()),
+            ));
+            eprintln!("clawhip source tmux restart reconcile skipped: {error}");
+            return Ok(0);
+        }
+    };
+    let snapshot = registry.read().await;
+    let mut candidates: Vec<AbsentRegistrationCandidate> = snapshot
+        .iter()
+        .filter(|(session, registration)| {
+            !sessions.contains(*session) && registration_is_reconcilable(registration)
+        })
+        .map(|(session, registration)| AbsentRegistrationCandidate {
+            session: session.clone(),
+            registration_generation: registration.registration_generation,
+        })
+        .collect();
+    drop(snapshot);
+    candidates.sort_by(|a, b| a.session.cmp(&b.session));
+    prune_absent_dynamic_registrations_with_reason(
+        registry,
+        registry_state_path,
+        &candidates,
+        "tmux session absent at daemon restart reconcile",
+    )
+    .await
 }
 
 pub async fn inspect_tmux_registry_state(path: &Path) -> TmuxRegistryStateDiagnostics {
@@ -1154,7 +1276,6 @@ pub async fn remove_tmux_registrations(
                     .lane
                     .as_ref()
                     .is_some_and(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced)
-                || (registration.lane.is_none() && registration_is_ownerless(registration))
         });
 
         if removable && next.remove(session).is_some() {
@@ -1179,15 +1300,28 @@ pub struct AbsentRegistrationCandidate {
     pub registration_generation: u64,
 }
 
-fn registration_is_ownerless(registration: &RegisteredTmuxSession) -> bool {
-    !registration.active_wrapper_monitor && registration.parent_process.is_none()
+/// Prune rule (#341): a dynamic watch registration is reconciled out of the
+/// active registry when its tmux session is definitively absent — session
+/// absence is the lifecycle authority, never pane text. Recorded wrapper
+/// ownership (`active_wrapper_monitor`, `parent_process`) does not retain a
+/// watch whose session no longer exists: wrapper processes exit without
+/// deregistering (kill, crash, closed lane), and a persisted parent pid is
+/// only the pid of the process that launched `clawhip tmux watch`, not proof
+/// of a live watch. Bounded tombstone evidence is written to the audit trail
+/// beside the registry so removal is auditable and reversible in review.
+fn registration_is_reconcilable(registration: &RegisteredTmuxSession) -> bool {
+    registration.registration_source != RegistrationSource::ConfigMonitor
+        && registration
+            .lane
+            .as_ref()
+            .is_none_or(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced)
 }
 
-/// Prune daemon-owned dynamic registrations and explicitly retired/quiesced
-/// lane registrations whose tmux session has been observed absent. Active and
-/// handoff lane evidence is preserved regardless of liveness to avoid
-/// destroying in-flight R0/R1/R2 lane evidence that is expected to exist
-/// before the tmux session is created.
+/// Prune dynamic (non-config-monitor) registrations and explicitly
+/// retired/quiesced lane registrations whose tmux session has been observed
+/// absent. Active and handoff lane evidence is preserved regardless of
+/// liveness to avoid destroying in-flight R0/R1/R2 lane evidence that is
+/// expected to exist before the tmux session is created.
 ///
 /// Config-monitor registrations are never selected or removed by this
 /// function — they are reconciled declaratively via
@@ -1197,6 +1331,21 @@ pub async fn prune_absent_dynamic_registrations(
     path: &Path,
     candidates: &[AbsentRegistrationCandidate],
 ) -> Result<usize> {
+    prune_absent_dynamic_registrations_with_reason(
+        registry,
+        path,
+        candidates,
+        "tmux session absent",
+    )
+    .await
+}
+
+pub async fn prune_absent_dynamic_registrations_with_reason(
+    registry: &SharedTmuxRegistry,
+    path: &Path,
+    candidates: &[AbsentRegistrationCandidate],
+    reason: &str,
+) -> Result<usize> {
     if candidates.is_empty() {
         return Ok(0);
     }
@@ -1204,27 +1353,45 @@ pub async fn prune_absent_dynamic_registrations(
     let mut next = registry.read().await.clone();
     let mut removed = 0;
     let mut first_removed: Option<&str> = None;
+    let mut tombstones: Vec<TmuxWatchAuditEntry> = Vec::new();
+    let removed_at = current_timestamp_rfc3339();
     for candidate in candidates {
         let removable = next.get(&candidate.session).is_some_and(|registration| {
             registration.registration_generation == candidate.registration_generation
-                && registration.registration_source != RegistrationSource::ConfigMonitor
-                && registration
-                    .lane
-                    .as_ref()
-                    .is_none_or(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced)
-                && (registration.lane.is_some() || registration_is_ownerless(registration))
+                && registration_is_reconcilable(registration)
         });
 
-        if removable && next.remove(&candidate.session).is_some() {
+        if removable && let Some(registration) = next.remove(&candidate.session) {
             if first_removed.is_none() {
                 first_removed = Some(candidate.session.as_str());
             }
             removed += 1;
+            tombstones.push(TmuxWatchAuditEntry {
+                at: removed_at.clone(),
+                session: registration.session.clone(),
+                reason: reason.to_string(),
+                registration_source: registration.registration_source.as_str().to_string(),
+                registered_at: registration.registered_at.clone(),
+                wrapper_owned: registration.active_wrapper_monitor,
+                parent_pid: registration
+                    .parent_process
+                    .as_ref()
+                    .map(|parent| parent.pid),
+                parent_name: registration
+                    .parent_process
+                    .as_ref()
+                    .and_then(|parent| parent.name.clone()),
+                registration_generation: registration.registration_generation,
+            });
         }
     }
     if removed > 0 {
         save_durable_tmux_registry(path, &next).await?;
         *registry.write().await = next;
+        if let Err(error) = record_tmux_watch_audit(&tmux_watch_audit_path(path), tombstones).await
+        {
+            eprintln!("clawhip tmux watch audit append failed: {error}");
+        }
         let mut record = source_record(
             telemetry::event_name::SOURCE_INVENTORY,
             "dynamic_registration_pruned_absent",
@@ -1820,36 +1987,31 @@ pub async fn list_active_tmux_registrations(
             // reconciliation so the generation captured for each candidate
             // matches the liveness observation.
             let snapshot = registry.read().await;
-            let retired_lane_candidates: Vec<AbsentRegistrationCandidate> = snapshot
+            // Absent dynamic registrations (wrapper-owned or ownerless) and
+            // retired/quiesced lanes are reconciled out of the active
+            // registry (#341): the tmux session inventory is the lifecycle
+            // authority, never pane text. Config-monitor entries are excluded
+            // — they are reconciled declaratively above.
+            let mut absent_candidates: Vec<AbsentRegistrationCandidate> = snapshot
                 .iter()
                 .filter(|(session, registration)| {
                     !available_sessions.contains(*session)
-                        && registration.lane.as_ref().is_some_and(|lane| {
-                            lane.workflow == LaneWorkflow::Retired && lane.quiesced
-                        })
+                        && registration_is_reconcilable(registration)
                 })
                 .map(|(session, registration)| AbsentRegistrationCandidate {
                     session: session.clone(),
                     registration_generation: registration.registration_generation,
                 })
                 .collect();
-            let mut orphaned_candidates: Vec<AbsentRegistrationCandidate> = snapshot
-                .iter()
-                .filter(|(session, registration)| {
-                    !available_sessions.contains(*session)
-                        && registration.registration_source != RegistrationSource::ConfigMonitor
-                        && registration.lane.is_none()
-                        && registration_is_ownerless(registration)
-                })
-                .map(|(session, registration)| AbsentRegistrationCandidate {
-                    session: session.clone(),
-                    registration_generation: registration.registration_generation,
-                })
-                .collect();
-            orphaned_candidates.extend(retired_lane_candidates);
+            absent_candidates.sort_by(|a, b| a.session.cmp(&b.session));
             drop(snapshot);
-            prune_absent_dynamic_registrations(registry, registry_state_path, &orphaned_candidates)
-                .await?;
+            prune_absent_dynamic_registrations_with_reason(
+                registry,
+                registry_state_path,
+                &absent_candidates,
+                "tmux session absent from list-sessions inventory",
+            )
+            .await?;
         }
         Err(error) => {
             telemetry::emit(source_record(
@@ -1928,14 +2090,12 @@ async fn poll_tmux(
                     Some(session_name),
                     None,
                 ));
-                let retired_lane = registration
-                    .lane
-                    .as_ref()
-                    .is_some_and(|lane| lane.workflow == LaneWorkflow::Retired && lane.quiesced);
-                if registration.registration_source != RegistrationSource::ConfigMonitor
-                    && ((registration.lane.is_none() && registration_is_ownerless(registration))
-                        || retired_lane)
-                {
+                // Session absence is definitive (#341): reconcile dynamic
+                // registrations — including wrapper-owned ones — out of the
+                // active registry. Only config monitors keep a durable
+                // session-less registration; they are reconciled
+                // declaratively and never pruned here.
+                if registration_is_reconcilable(registration) {
                     dynamic_prune_candidates.push(AbsentRegistrationCandidate {
                         session: session_name.clone(),
                         registration_generation: registration.registration_generation,
@@ -2084,10 +2244,11 @@ async fn poll_tmux(
         remove_tmux_registrations(registry, registry_state_path, &sessions_to_unregister).await?;
     }
     if !dynamic_prune_candidates.is_empty() {
-        prune_absent_dynamic_registrations(
+        prune_absent_dynamic_registrations_with_reason(
             registry,
             registry_state_path,
             &dynamic_prune_candidates,
+            "tmux session absent from has-session probe",
         )
         .await?;
     }
@@ -4427,13 +4588,10 @@ error: failed";
     }
 
     #[tokio::test]
-    async fn prune_absent_dynamic_preserves_live_owner_then_removes_ownerless_registration() {
+    async fn prune_absent_dynamic_removes_wrapper_owned_ghost_and_writes_tombstone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("registry.json");
         let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
-        let path = std::env::temp_dir().join(format!(
-            "clawhip-test-prune-cliwatch-{}.json",
-            std::process::id()
-        ));
-        let _ = tokio::fs::remove_file(&path).await;
         let registration = RegisteredTmuxSession {
             session: "dead-watch".into(),
             channel: Some("alerts".into()),
@@ -4447,11 +4605,10 @@ error: failed";
             registration_source: RegistrationSource::CliWatch,
             parent_process: Some(ParentProcessInfo {
                 pid: 42,
-                name: Some("clawhip-wrapper".into()),
+                name: Some("create.sh".into()),
             }),
-            registration_generation: 0,
+            registration_generation: 7,
             active_wrapper_monitor: true,
-
             lane: None,
         };
         registry
@@ -4460,35 +4617,30 @@ error: failed";
             .insert("dead-watch".into(), registration);
         let candidates = vec![AbsentRegistrationCandidate {
             session: "dead-watch".into(),
-            registration_generation: 0,
+            registration_generation: 7,
         }];
-        let removed = prune_absent_dynamic_registrations(&registry, &path, &candidates)
-            .await
-            .unwrap();
-        assert_eq!(removed, 0);
-        assert!(registry.read().await.contains_key("dead-watch"));
-        registry
-            .write()
-            .await
-            .get_mut("dead-watch")
-            .unwrap()
-            .active_wrapper_monitor = false;
-        let removed = prune_absent_dynamic_registrations(&registry, &path, &candidates)
-            .await
-            .unwrap();
-        assert_eq!(removed, 0);
-        registry
-            .write()
-            .await
-            .get_mut("dead-watch")
-            .unwrap()
-            .parent_process = None;
         let removed = prune_absent_dynamic_registrations(&registry, &path, &candidates)
             .await
             .unwrap();
         assert_eq!(removed, 1);
         assert!(registry.read().await.get("dead-watch").is_none());
-        let _ = tokio::fs::remove_file(&path).await;
+        // Durable registry no longer carries the ghost.
+        let persisted: BTreeMap<String, StoredTmuxRegistration> =
+            serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
+        assert!(!persisted.contains_key("dead-watch"));
+        // Bounded tombstone evidence is retained separately.
+        let audit_path = tmux_watch_audit_path(&path);
+        let audit: TmuxWatchAuditFile =
+            serde_json::from_slice(&tokio::fs::read(&audit_path).await.unwrap()).unwrap();
+        assert_eq!(audit.schema, TMUX_WATCH_AUDIT_SCHEMA);
+        assert_eq!(audit.entries.len(), 1);
+        let entry = &audit.entries[0];
+        assert_eq!(entry.session, "dead-watch");
+        assert_eq!(entry.registration_source, "cli-watch");
+        assert_eq!(entry.registration_generation, 7);
+        assert!(entry.wrapper_owned);
+        assert_eq!(entry.parent_pid, Some(42));
+        assert_eq!(entry.reason, "tmux session absent");
     }
 
     #[tokio::test]
@@ -4529,6 +4681,229 @@ error: failed";
         assert_eq!(removed, 0);
         assert!(registry.read().await.get("config-mon").is_some());
         let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[cfg(unix)]
+    #[serial]
+    #[tokio::test]
+    async fn restart_reconcile_removes_absent_dynamics_and_keeps_live_and_config() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("registry.json");
+        let stub = dir.path().join("tmux-restart-stub.sh");
+        std::fs::write(
+            &stub,
+            "#!/bin/sh\nif [ \"$1\" = \"list-sessions\" ]; then printf 'live-watch\\n'; exit 0; fi\nexit 1\n",
+        )
+        .expect("write tmux restart stub");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod tmux restart stub");
+
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let mut ghost = registration(Vec::new());
+        ghost.session = "ghost-watch".into();
+        ghost.registration_source = RegistrationSource::CliWatch;
+        ghost.parent_process = Some(ParentProcessInfo {
+            pid: 905215,
+            name: Some("create.sh".into()),
+        });
+        ghost.active_wrapper_monitor = true;
+        ghost.registration_generation = 7;
+        let mut live = registration(Vec::new());
+        live.session = "live-watch".into();
+        live.registration_source = RegistrationSource::CliWatch;
+        live.registration_generation = 8;
+        let mut config_monitor = registration(Vec::new());
+        config_monitor.session = "config-mon".into();
+        config_monitor.registration_source = RegistrationSource::ConfigMonitor;
+        config_monitor.registration_generation = 9;
+        {
+            let mut write = registry.write().await;
+            write.insert(ghost.session.clone(), ghost);
+            write.insert(live.session.clone(), live);
+            write.insert(config_monitor.session.clone(), config_monitor);
+        }
+
+        let prior_tmux_bin = std::env::var("CLAWHIP_TMUX_BIN").ok();
+        unsafe {
+            std::env::set_var("CLAWHIP_TMUX_BIN", &stub);
+        }
+        let removed = reconcile_restored_tmux_registry(&registry, &path)
+            .await
+            .unwrap();
+        unsafe {
+            match prior_tmux_bin {
+                Some(value) => std::env::set_var("CLAWHIP_TMUX_BIN", value),
+                None => std::env::remove_var("CLAWHIP_TMUX_BIN"),
+            }
+        }
+
+        assert_eq!(removed, 1);
+        let snapshot = registry.read().await;
+        assert!(snapshot.get("ghost-watch").is_none());
+        assert!(snapshot.get("live-watch").is_some());
+        assert!(snapshot.get("config-mon").is_some());
+        // Tombstone evidence survives the restart reconcile.
+        let audit: TmuxWatchAuditFile =
+            serde_json::from_slice(&tokio::fs::read(tmux_watch_audit_path(&path)).await.unwrap())
+                .unwrap();
+        assert_eq!(audit.entries.len(), 1);
+        assert_eq!(audit.entries[0].session, "ghost-watch");
+        assert!(audit.entries[0].wrapper_owned);
+        assert_eq!(
+            audit.entries[0].reason,
+            "tmux session absent at daemon restart reconcile"
+        );
+    }
+
+    #[cfg(unix)]
+    #[serial]
+    #[tokio::test]
+    async fn restart_reconcile_is_noop_on_probe_failure_and_no_server() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("registry.json");
+        let failing = dir.path().join("tmux-fail-stub.sh");
+        std::fs::write(&failing, "#!/bin/sh\nexit 3\n").expect("write failing stub");
+        let no_server = dir.path().join("tmux-noserver-stub.sh");
+        std::fs::write(
+            &no_server,
+            "#!/bin/sh\nif [ \"$1\" = \"list-sessions\" ]; then echo 'no server running on /tmp/tmux-1000/default' >&2; exit 1; fi\nexit 1\n",
+        )
+        .expect("write no-server stub");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&failing, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod failing stub");
+        std::fs::set_permissions(&no_server, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod no-server stub");
+
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let mut ghost = registration(Vec::new());
+        ghost.session = "ghost-watch".into();
+        ghost.registration_source = RegistrationSource::CliWatch;
+        ghost.active_wrapper_monitor = true;
+        ghost.registration_generation = 7;
+        registry.write().await.insert("ghost-watch".into(), ghost);
+
+        for stub in [&failing, &no_server] {
+            let prior_tmux_bin = std::env::var("CLAWHIP_TMUX_BIN").ok();
+            unsafe {
+                std::env::set_var("CLAWHIP_TMUX_BIN", stub);
+            }
+            let removed = reconcile_restored_tmux_registry(&registry, &path)
+                .await
+                .unwrap();
+            unsafe {
+                match prior_tmux_bin {
+                    Some(value) => std::env::set_var("CLAWHIP_TMUX_BIN", value),
+                    None => std::env::remove_var("CLAWHIP_TMUX_BIN"),
+                }
+            }
+            assert_eq!(removed, 0, "no definitive inventory, nothing removed");
+        }
+        assert!(registry.read().await.contains_key("ghost-watch"));
+    }
+
+    #[tokio::test]
+    async fn watch_audit_trail_is_bounded() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("audit.json");
+        let entries: Vec<TmuxWatchAuditEntry> = (0..(MAX_TMUX_WATCH_AUDIT_ENTRIES + 50))
+            .map(|index| TmuxWatchAuditEntry {
+                at: format!("2026-08-25T00:00:{index:02}Z"),
+                session: format!("sess-{index}"),
+                reason: "tmux session absent".into(),
+                registration_source: "cli-watch".into(),
+                registered_at: "2026-08-01T00:00:00Z".into(),
+                wrapper_owned: true,
+                parent_pid: Some(index as u32),
+                parent_name: None,
+                registration_generation: index as u64,
+            })
+            .collect();
+        record_tmux_watch_audit(&path, entries).await.unwrap();
+        let audit: TmuxWatchAuditFile =
+            serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
+        assert_eq!(audit.entries.len(), MAX_TMUX_WATCH_AUDIT_ENTRIES);
+        assert!(audit.dropped > 0);
+        // Oldest entries were dropped, newest retained.
+        assert_eq!(audit.entries[0].session, "sess-50");
+        assert_eq!(
+            audit.entries.last().unwrap().session,
+            format!("sess-{}", MAX_TMUX_WATCH_AUDIT_ENTRIES + 49)
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_skips_registration_that_arrives_after_observation() {
+        // Race: the absent-session observation was taken at generation 7, but
+        // a wrapper re-registered (generation 42) before the prune ran. The
+        // stale candidate must not remove the fresh registration.
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let mut fresh = registration(Vec::new());
+        fresh.session = "raced-watch".into();
+        fresh.registration_source = RegistrationSource::CliWatch;
+        fresh.registration_generation = 42;
+        registry.write().await.insert("raced-watch".into(), fresh);
+
+        let removed = prune_absent_dynamic_registrations_with_reason(
+            &registry,
+            &path,
+            &[AbsentRegistrationCandidate {
+                session: "raced-watch".into(),
+                registration_generation: 7,
+            }],
+            "tmux session absent",
+        )
+        .await
+        .unwrap();
+        assert_eq!(removed, 0);
+        assert!(registry.read().await.contains_key("raced-watch"));
+        // No durable save or tombstone happened.
+        assert!(tokio::fs::read(&path).await.is_err());
+        assert!(tokio::fs::read(tmux_watch_audit_path(&path)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn re_registration_after_ghost_removal_succeeds() {
+        // A wrapper may legitimately re-register the same session name after
+        // the ghost was reconciled away (e.g. tmux session recreated).
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("registry.json");
+        let registry: SharedTmuxRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let mut removed_ghost = registration(Vec::new());
+        removed_ghost.session = "rebind-watch".into();
+        removed_ghost.registration_source = RegistrationSource::CliWatch;
+        removed_ghost.registration_generation = 7;
+        registry
+            .write()
+            .await
+            .insert("rebind-watch".into(), removed_ghost);
+        prune_absent_dynamic_registrations(
+            &registry,
+            &path,
+            &[AbsentRegistrationCandidate {
+                session: "rebind-watch".into(),
+                registration_generation: 7,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let mut fresh = registration(Vec::new());
+        fresh.session = "rebind-watch".into();
+        fresh.registration_source = RegistrationSource::CliWatch;
+        fresh.active_wrapper_monitor = true;
+        fresh.parent_process = Some(ParentProcessInfo {
+            pid: 4242,
+            name: Some("create.sh".into()),
+        });
+        let durable = register_runtime_tmux_registration(&registry, &path, fresh)
+            .await
+            .unwrap();
+        assert_eq!(durable, 1);
+        assert!(registry.read().await.contains_key("rebind-watch"));
     }
 
     #[tokio::test]

--- a/tests/lane_thread_verification.rs
+++ b/tests/lane_thread_verification.rs
@@ -299,7 +299,7 @@ case "$1" in
   attach-session) expected="$(cat "$S/session")"; if test -f "$S/prefix_collision" && test "$3" != "=$expected"; then echo 'fixture-prefix-collision' >&2; exit 1; fi; if test -f "$S/require_attach_tty"; then test -t 0 && test -t 1 && test -t 2 || {{ echo 'fixture-attach-not-a-tty' >&2; exit 1; }}; printf '0 1 2\n' >> "$S/attach_ttys"; fi; echo 'fixture-attach-stdio' >&2; printf '%s\n' "$3" >> "$S/attach_targets"; if test -f "$S/fail_attach_session"; then echo 'fixture-attach-failed' >&2; exit 1; fi ;;
   display-message) printf 'lane\t%%1\t1\tcodex\t/tmp\n' ;;
   kill-session) rm -f "$S/live" ;;
-  list-sessions) test -f "$S/live" && test -f "$S/session" && cat "$S/session" ;;
+  list-sessions) if test -f "$S/sessions_list"; then test -f "$S/live" && cat "$S/sessions_list"; else test -f "$S/live" && test -f "$S/session" && cat "$S/session"; fi ;;
   *) : ;;
 esac
 "#
@@ -542,6 +542,33 @@ fn http_json_value(port: u16, method: &str, path: &str, body: Value) -> Value {
         .expect("HTTP response body")
         .1;
     serde_json::from_str(payload).expect("daemon JSON response")
+}
+
+/// POST a runtime tmux registration the way the wrapper client does (with the
+/// local-control header) and return the parsed JSON response.
+fn register_runtime_watch(port: u16, body: Value) -> Value {
+    let payload = serde_json::to_string(&body).expect("request json");
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect daemon");
+    let request = format!(
+        "POST /api/tmux/register HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nx-clawhip-local-control: 1\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .expect("write daemon request");
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("read daemon response");
+    assert!(
+        response.starts_with("HTTP/1.1 202"),
+        "daemon rejected registration fixture: {response}"
+    );
+    let body = response
+        .split_once("\r\n\r\n")
+        .expect("HTTP response body")
+        .1;
+    serde_json::from_str(body).expect("daemon JSON response")
 }
 
 fn calls_after(state: &Path, baseline: &str) -> String {
@@ -1129,6 +1156,170 @@ fn restart_reconciles_stale_terminal_watch_registry_without_duplicate_live_watch
     let public_again = String::from_utf8_lossy(&listed_again.stdout);
     assert!(public_again.contains("live-watch"));
     assert!(!public_again.contains("stale-watch"));
+}
+
+/// #341: wrapper-owned registrations whose tmux session no longer exists are
+/// ghost watches. Daemon restart must reconcile them out of the active
+/// registry (status/list stay truthful), keep live wrapper watches, and
+/// retain bounded tombstone evidence in the audit file beside the registry.
+#[test]
+#[serial]
+fn restart_reconciles_persisted_wrapper_owned_ghost_watches() {
+    let temp = TempDir::new().expect("temp");
+    let home = temp.path().join("home");
+    let config_path = temp.path().join("config.toml");
+    let state = temp.path().join("tmux");
+    let tmux = temp.path().join("tmux.sh");
+    fs::create_dir_all(&home).expect("home");
+    fake_tmux(&tmux, &state);
+    // Live inventory: exactly one live session plus an active config monitor
+    // projection target is not needed here; two ghosts come from the durable
+    // registry (both wrapper-owned like real `create.sh`-launched watches).
+    write_file(&state.join("live"), "1");
+    write_file(&state.join("session"), "live-watch");
+    write_file(&state.join("sessions_list"), "live-watch\n");
+    write_file(&state.join("strict_has_session"), "1");
+    config(&config_path, free_port());
+
+    let ghost = |session: &str, generation: u64| {
+        json!({
+            "session": session,
+            "channel": "alerts",
+            "mention": null,
+            "keywords": ["owner-endpoint-unreachable"],
+            "keyword_window_secs": 30,
+            "stale_minutes": 60,
+            "format": "compact",
+            "registered_at": "2026-08-01T00:00:00Z",
+            "registration_source": "cli-watch",
+            "parent_process": {"pid": 905215, "name": "create.sh"},
+            "registration_generation": generation,
+            "active_wrapper_monitor": true
+        })
+    };
+    write_file(
+        &registry_path(&config_path),
+        &json!({
+            "clawhip-issue-339-gjc-bridge-auth": ghost("clawhip-issue-339-gjc-bridge-auth", 7),
+            "gajae-code-issue-4844-unlazy-evaluation": ghost(
+                "gajae-code-issue-4844-unlazy-evaluation",
+                8
+            ),
+            "live-watch": {
+                "session": "live-watch",
+                "channel": "alerts",
+                "mention": null,
+                "keywords": ["owner-endpoint-unreachable"],
+                "keyword_window_secs": 30,
+                "stale_minutes": 60,
+                "format": "compact",
+                "registered_at": "2026-08-01T00:00:01Z",
+                "registration_source": "cli-watch",
+                "parent_process": {"pid": 252806, "name": "clawhip"},
+                "registration_generation": 9,
+                "active_wrapper_monitor": true
+            }
+        })
+        .to_string(),
+    );
+
+    let discord = MockDiscord::start("success");
+    let port = free_port();
+    config(&config_path, port);
+    let mut config_contents = fs::read_to_string(&config_path).expect("read config");
+    config_contents.push_str("\n[monitors]\npoll_interval_secs = 1\n");
+    write_file(&config_path, &config_contents);
+
+    let _daemon = start(&config_path, &home, &tmux, &discord, port);
+
+    // Restart reconcile happens during daemon startup: ghosts must already be
+    // gone from the durable registry once the daemon is healthy.
+    let reconciled = registry(&config_path);
+    assert!(
+        reconciled
+            .get("clawhip-issue-339-gjc-bridge-auth")
+            .is_none()
+    );
+    assert!(
+        reconciled
+            .get("gajae-code-issue-4844-unlazy-evaluation")
+            .is_none()
+    );
+    assert!(reconciled.get("live-watch").is_some());
+
+    // Status and list report active ownership truthfully.
+    let health = http_json_value(port, "GET", "/health", json!({}));
+    assert_eq!(health["registered_tmux_sessions"], 1);
+    assert_eq!(health["tmux"]["registry_registration_count"], 1);
+    assert_eq!(health["tmux"]["registered_count"], 1);
+    assert_eq!(health["tmux"]["durable_runtime_count"], 1);
+    assert_eq!(health["tmux"]["live_probe"]["count"], 1);
+
+    let listed = lane_command(&config_path, &home, &tmux, &discord, &["tmux", "list"]);
+    successful(&listed);
+    let public = String::from_utf8_lossy(&listed.stdout);
+    assert!(public.contains("live-watch"));
+    assert!(!public.contains("clawhip-issue-339-gjc-bridge-auth"));
+    assert!(!public.contains("gajae-code-issue-4844-unlazy-evaluation"));
+
+    // Bounded tombstone evidence is retained beside the registry state.
+    let audit_path = registry_path(&config_path).with_file_name("tmux-watch-registry.audit.json");
+    let audit: Value =
+        serde_json::from_slice(&fs::read(&audit_path).expect("audit file")).expect("audit json");
+    assert_eq!(audit["schema"], "clawhip.tmux-watch-audit.v1");
+    let sessions: Vec<&str> = audit["entries"]
+        .as_array()
+        .expect("entries")
+        .iter()
+        .map(|entry| entry["session"].as_str().expect("session"))
+        .collect();
+    assert_eq!(sessions.len(), 2);
+    assert!(sessions.contains(&"clawhip-issue-339-gjc-bridge-auth"));
+    assert!(sessions.contains(&"gajae-code-issue-4844-unlazy-evaluation"));
+    for entry in audit["entries"].as_array().expect("entries") {
+        assert_eq!(entry["wrapper_owned"], json!(true));
+        assert_eq!(entry["parent_pid"], json!(905215));
+        assert_eq!(
+            entry["reason"],
+            json!("tmux session absent at daemon restart reconcile")
+        );
+    }
+    // A wrapper may legitimately re-register the same session name right
+    // after the ghost was reconciled away (session recreated, then
+    // re-watched): the registry must accept it as a fresh live registration
+    // and `tmux list` must keep it because the session is live again.
+    write_file(
+        &state.join("sessions_list"),
+        "live-watch\nclawhip-issue-339-gjc-bridge-auth\n",
+    );
+    let reregister = register_runtime_watch(
+        port,
+        json!({
+            "session": "clawhip-issue-339-gjc-bridge-auth",
+            "channel": "alerts",
+            "keywords": ["owner-endpoint-unreachable"],
+            "keyword_window_secs": 30,
+            "stale_minutes": 60,
+            "format": "compact",
+            "registered_at": "2026-08-25T00:00:00Z",
+            "registration_source": "cli-watch",
+            "parent_process": {"pid": 424242, "name": "clawhip"},
+            "registration_generation": 0,
+            "active_wrapper_monitor": true
+        }),
+    );
+    assert_eq!(reregister["ok"], json!(true));
+    assert!(
+        registry(&config_path)
+            .get("clawhip-issue-339-gjc-bridge-auth")
+            .is_some()
+    );
+    let listed_again = lane_command(&config_path, &home, &tmux, &discord, &["tmux", "list"]);
+    successful(&listed_again);
+    let public_again = String::from_utf8_lossy(&listed_again.stdout);
+    assert!(public_again.contains("live-watch"));
+    assert!(public_again.contains("clawhip-issue-339-gjc-bridge-auth"));
+    assert!(!public_again.contains("gajae-code-issue-4844-unlazy-evaluation"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #341

## Summary
- **Root cause (proven, live):** the operator registry held 331 durable entries — every one wrapper-owned (`cli-watch`, `active_wrapper_monitor=true`, `parent_process` set) — against 5 live tmux sessions. The prune gate `registration_is_ownerless` (`!active_wrapper_monitor && parent_process.is_none()`) is false for every wrapper-registered watch, so the poll loop, `tmux list`, and daemon restart could never remove them. Wrappers exit without deregistering, and the recorded parent pid is the launcher's pid (often a long-lived `create.sh`), not watch liveness.
- **Lifecycle authority is the tmux session inventory** (never pane text, never parent-pid liveness): `registration_is_reconcilable` retires dynamic registrations whose session is definitively absent. Config-monitor entries remain declarative; active/handoff lane evidence remains preserved until explicit quiesced retirement.
- **Restart cannot resurrect ghosts:** `reconcile_restored_tmux_registry` runs at daemon startup after the durable registry is restored. Only a definitive `Sessions` inventory acts; no-server and probe failures defer to the poll loop's identical reconciliation.
- **Audit separated from ownership truth:** reconciled watches leave bounded tombstones (256 entries, oldest dropped with accounting) in `tmux-watch-registry.audit.json` beside the registry — never reloaded as registrations.
- **Races preserved:** generation CAS fencing unchanged — a re-registration arriving after an absent observation is never removed; re-registering a removed session name succeeds normally.
- `clawhip status` and `clawhip tmux list` now report the true active set.

## Verification (exact head ab09ae169aedc31faf90547c94ae910d2898096a, base dev@1a0599bc12879876c8d91055109947c4efa67c7e)
- `cargo test` — full suite green (bin 1041 + 15 suites)
- `cargo clippy --tests -- -D warnings` — clean
- `cargo fmt --check` — clean
- focused: `cargo test --bin clawhip tmux` (115), `cargo test --test lane_thread_verification` (24) including new restart/ghost/tombstone/rebind/no-server e2e coverage
- live dogfood (reversible, fixture daemon with real binary): restart against a mixed durable registry reconciled ghosts out, kept the live watch, wrote tombstones, and `tmux list` reported only the live session

Closes #341

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*