### PR TITLE
feat: alert on authoritative GJC failures and idle sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # clawhip
 
+Clawhip is a GJC-first event router. It automatically discovers and binds live
+native GJC SDK sessions, routes authoritative lifecycle, question, gate, and
+failure events through the normal ledger/router/sink pipeline, and preserves
+loopback-only credentials and public-safe projections. GJC remains the process
+owner; Clawhip observes and controls only through the SDK contract.
+
 <p align="center">
   <img src="assets/clawhip-mascot.jpg" width="400" alt="clawhip mascot" />
 </p>

--- a/docs/gjc-sdk-event-bridge.md
+++ b/docs/gjc-sdk-event-bridge.md
@@ -63,8 +63,25 @@ router → sinks (Discord/Slack/local-file). The response reports what happened:
 | `prompt` | object? | `{command_id, status: accepted\|progressing}` — acceptance evidence for the submitted control command. |
 | `gate` | object? | `{id, kind: ask\|workflow, revision, status: open\|resolved, summary}` — question/gate episode with the identifiers #323 answers against. |
 | `model`, `profile` | string? | Public-safe identifiers; changes are announced once per transition. |
+
+Query section presence is significant for reconciliation. An omitted `turn` or
+`workflow_gates` member means that surface was not observed and does not clear
+durable state; a present `turn: null` is an authoritative no-current-turn
+observation, and a present `workflow_gates: []` resolves retained gate state.
+Full adapter queries fail closed when the required `turn` member is omitted.
+Turn-level `succeeded` and `failed` results do not retire a lane: without an
+authoritative session-level terminal field, the session remains reusable for
+later turns. Retirement requires explicit watch/process lifecycle evidence or
+operator action.
 | `endpoint` | object? | `{health: ok\|degraded\|failed, detail}` — no URLs, no credentials. |
 | `repo_name`, `repo_path`, `worktree_path`, `branch` | string? | Routing identity copied onto every emitted event. |
+
+Gate metadata remains intentionally bounded to the fields present in the
+authoritative SDK wire contract (`id`, `kind`, `revision`, `status`, and
+summary). `workflow_id`, option lists, and answer metadata are not synthesized
+from local state; they require an additive native SDK contract before they can
+be exposed safely. Until then, multiple simultaneous ready gates are rejected
+as invalid state rather than projected ambiguously.
 | `observed_at` | RFC3339 string? | Preserved as `event_timestamp`. |
 | `summary` | string? | Optional public-safe lane summary. |
 
@@ -92,12 +109,11 @@ tracked but deliberately emit no event: they would be noise on Discord.
   higher gate revision; a different gate id starts a new episode.
 - Every event carries a deterministic `event_id` (FNV-1a over
   `kind|session|revision|turn|gate|transition`) plus `idempotency_key`.
-  The event ledger dedupes on this identity, so replaying the same
-  authoritative feed after a daemon restart produces ledger-level duplicates:
-  no second Discord delivery.
-- Known limitation: an endpoint-failure episode that spans a daemon restart
-  can re-notify once, because the bridge keeps its alert flag in memory.
-  #325's durable reconciler closes this gap by seeding last observed state.
+  The event ledger dedupes on this identity. Native pending alerts additionally
+  persist per-destination `claimed`, `delivered`, and `failed` state, so a
+  replay retries only failed destinations and does not resend destinations
+  already delivered before a restart. Ledger-disabled replay uses the same
+  durable pending-alert journal.
 
 ## Sibling integration (landed surfaces)
 

--- a/docs/gjc-sdk-integration.md
+++ b/docs/gjc-sdk-integration.md
@@ -1,11 +1,9 @@
 # Clawhip ↔ GJC SDK Integration — Operator Guide
 
-Status: staged on lane `test/issue-326-gjc-sdk-e2e` (issue #326, parent epic #321).
-The endpoint discovery/transport layer itself landed with #322
-(`src/gjc_sdk.rs`); control-plane (#323), event bridge (#324), and durable
-reconciliation (#325) are sibling-owned. **Open regression #328 tracks the
-transport against the real GJC SDK v3 endpoint** — the live-session steps in
-the dogfood checklist below stay gated until #328's repaired dev merge.
+Status: supported. Clawhip is the GJC-first event router: native SDK endpoint
+discovery, authoritative control, event projection, and durable reconciliation
+are one daemon path. The individual #322-#325 surfaces remain documented by
+their module ownership, but are no longer staged or manually wired.
 
 ## 1. What this integration is
 
@@ -48,6 +46,30 @@ enabled = true
 ```
 
 Legacy configs without `[gjc]` keep parsing byte-stable; absent means off.
+
+### Session enrollment for external creators (#349)
+
+Session creators remain process owners. The daemon automatically discovers and
+enrolls live metadata in its trusted worktree on startup and on each poll. For
+an external creator that needs an immediate explicit enrollment, the same
+stable local API (or equivalent CLI) is available:
+
+```sh
+clawhip gjc register \
+  --session "$GJC_SESSION_ID" \
+  --worktree "$PWD"
+```
+
+The same contract is available as an authenticated local `POST /api/gjc/lanes`
+with JSON fields `sdk_session_id` and `worktree` (plus optional `owner_id`,
+Registration is idempotent at the daemon API for the session identity. The daemon queries the authoritative SDK control plane during
+durable reconciliation; it does not scrape tmux panes or take ownership of the
+creator's process. Endpoint outages produce one deduped
+`session.endpoint-failed` alert with a bounded public-safe summary.
+
+For a daemon serving several repositories, add trusted roots under
+`[gjc_lanes].discovery_worktrees`; the daemon scans the current worktree and
+those roots on every reconciliation pass.
 
 ### Question delivery (existing surface)
 
@@ -105,7 +127,7 @@ names, or token values. For endpoint-level diagnostics use
 | `stale` | `kill -0 <pid>` | Session process exited without cleanup; retire the stale metadata file. |
 | `malformed` | validate JSON schema | Metadata edited by hand or truncated; republish from the SDK CLI. |
 | Probe `endpoint_unauthorized` | token mismatch | The `?token=` credential does not match the metadata file; republish. |
-| Probe `timeout` / `connection_closed` | endpoint liveness | Endpoint died mid-exchange; see #328 for the open v3 regression. |
+| Probe `timeout` / `connection_closed` | endpoint liveness | Endpoint died mid-exchange; Clawhip emits a deduped endpoint-failed alert. |
 | Subscription `retry_exhausted` | `GET /api/subscriptions/<name>` | Endpoint unreachable for the full reconnect budget; restart the daemon after the endpoint returns. |
 | Question delivered without summary | projection keys | Projection must select `/questionId` and `/summary` from notification frames. |
 
@@ -119,8 +141,9 @@ names, or token values. For endpoint-level diagnostics use
 
 ## 8. Live dogfood checklist (bounded)
 
-Preconditions: real GJC session in this worktree; dev head with #328's
-transport repair merged; `[gjc] enabled = true`; question route configured.
+Preconditions: real GJC session in this worktree; `[gjc] enabled = true` and
+`[gjc_lanes] enabled = true` (the official setup enables both); question route
+configured when testing bidirectional gates.
 
 1. `clawhip gjc inspect --probe --json` → expect `"status":"live"` with
    correlated probe results.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -844,6 +844,8 @@ pub enum GjcCommands {
     },
     /// Replay the receipt of an accepted command by idempotency key.
     Receipt {
+        /// GJC session id bound to the receipt.
+        session: String,
         /// Idempotency key used when the command was accepted.
         #[arg(long)]
         idempotency_key: String,

--- a/src/client.rs
+++ b/src/client.rs
@@ -151,6 +151,7 @@ impl DaemonClient {
             .http
             .post(format!("{}{}", self.base_url, path))
             .header(LOCAL_CONTROL_HEADER, "1")
+            .header(reqwest::header::ORIGIN, &self.base_url)
             .json(payload)
             .send()
             .await?;
@@ -180,8 +181,11 @@ impl DaemonClient {
     }
 
     pub async fn gjc_reconcile(&self) -> Result<Value> {
-        self.private_post_json("/api/gjc/lane/reconcile", &serde_json::json!({}))
-            .await
+        self.private_post_json(
+            "/api/gjc/lane/reconcile?force_resume=true",
+            &serde_json::json!({}),
+        )
+        .await
     }
 
     pub async fn gjc_retire(&self, lane: &str, reason: Option<&str>) -> Result<Value> {
@@ -265,6 +269,8 @@ impl DaemonClient {
         let response = self
             .http
             .get(format!("{}/api/ledger/query", self.base_url))
+            .header(crate::daemon::LOCAL_CONTROL_HEADER, "1")
+            .header(reqwest::header::ORIGIN, &self.base_url)
             .query(params)
             .send()
             .await?;
@@ -332,10 +338,14 @@ impl DaemonClient {
         .await
     }
 
-    pub async fn gjc_command_receipt(&self, key: &str) -> Result<Value> {
+    pub async fn gjc_command_receipt(&self, session: &str, key: &str) -> Result<Value> {
         self.gjc_private_request(
             reqwest::Method::GET,
-            &format!("/api/gjc/command/{}", urlencoding_lite(key)),
+            &format!(
+                "/api/gjc/command/{}?session={}",
+                urlencoding_lite(key),
+                urlencoding_lite(session)
+            ),
             None,
         )
         .await
@@ -379,6 +389,8 @@ impl DaemonClient {
         let response = self
             .http
             .get(format!("{}{}", self.base_url, path))
+            .header(crate::daemon::LOCAL_CONTROL_HEADER, "1")
+            .header(reqwest::header::ORIGIN, &self.base_url)
             .send()
             .await?;
         if response.status().is_success() {
@@ -410,6 +422,7 @@ impl DaemonClient {
             .http
             .post(format!("{}{}", self.base_url, path))
             .header(LOCAL_CONTROL_HEADER, "1")
+            .header(reqwest::header::ORIGIN, &self.base_url)
             .json(payload)
             .send()
             .await?;
@@ -583,6 +596,7 @@ mod tests {
             let request = String::from_utf8_lossy(&request[..size]);
             assert!(request.starts_with("POST /api/subscriptions/safe/start HTTP/1.1"));
             assert!(request.contains("x-clawhip-local-control: 1\r\n"));
+            assert!(request.contains("origin: http://127.0.0.1:"));
             stream
                 .write_all(
                     b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 44\r\nConnection: close\r\n\r\n{\"ok\":true,\"name\":\"safe\",\"reason\":\"started\"}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -2061,6 +2061,7 @@ impl AppConfig {
     /// so no endpoint or secret is ever written into the config file.
     pub fn apply_gjc_sdk_setup(&mut self) {
         self.gjc.enabled = true;
+        self.gjc_lanes.enabled = true;
     }
 
     pub fn scaffold_webhook_quickstart(&mut self, webhook: String) -> Result<()> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,8 +30,8 @@ use crate::render::{DefaultRenderer, Renderer};
 use crate::router::Router;
 
 use crate::gjc_lane::{
-    GjcLaneRegistrationRequest, GjcLaneStore, GjcReconciler, SharedGjcLaneStore,
-    SharedGjcReconciler,
+    GjcControlPlaneAdapter, GjcLaneRegistrationRequest, GjcLaneStore, GjcReconciler,
+    SharedGjcLaneStore, SharedGjcReconciler,
 };
 use crate::gjc_lane::{default_gjc_lane_state_path, health_json as gjc_health_json};
 use crate::sink::{DiscordSink, HttpSink, LocalFileSink, Sink, SlackSink};
@@ -89,9 +89,14 @@ fn shared_event_ledger() -> Option<SharedEventLedger> {
 /// sibling tracks reduce here into lifecycle/question/notification events that
 /// flow through the normal accept pipeline (ledger -> router -> sinks).
 static GJC_SDK_BRIDGE: OnceLock<std::sync::Mutex<GjcEventBridge>> = OnceLock::new();
+static GJC_BRIDGE_INGRESS: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 
 fn gjc_bridge_slot() -> &'static std::sync::Mutex<GjcEventBridge> {
     GJC_SDK_BRIDGE.get_or_init(|| std::sync::Mutex::new(GjcEventBridge::new()))
+}
+
+fn gjc_bridge_ingress() -> &'static tokio::sync::Mutex<()> {
+    GJC_BRIDGE_INGRESS.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
 const STALE_NATIVE_REPLAY_GRACE: Duration = Duration::from_secs(5 * 60);
@@ -269,6 +274,23 @@ pub async fn run(
             update::run_checker(config, tx, pending).await;
         });
     }
+    let gjc_registry = crate::gjc::control::new_shared_command_registry();
+    let gjc_control = match std::env::current_dir() {
+        Ok(cwd) => Arc::new(crate::gjc::control::GjcControlPlane::for_worktree(
+            &cwd,
+            gjc_registry.clone(),
+        )),
+        // Without a resolvable worktree anchor the plane stays explicitly
+        // unavailable instead of silently re-scoping the trust boundary.
+        Err(_) => Arc::new(crate::gjc::control::GjcControlPlane::unavailable(
+            gjc_registry.clone(),
+        )),
+    };
+    if config.gjc.enabled && config.gjc_lanes.enabled {
+        let _ = crate::gjc_lane::register_gjc_control_plane(Arc::new(GjcControlPlaneAdapter::new(
+            gjc_registry.clone(),
+        )));
+    }
     let (gjc_store, gjc_reconciler) =
         spawn_gjc_lane_reconciler(config.clone(), cron_state_path.clone(), tx.clone()).await?;
 
@@ -351,18 +373,7 @@ pub async fn run(
         discord_watch_lock: Arc::new(Mutex::new(())),
         subscriptions: subscriptions.clone(),
         git_monitor_diagnostics,
-        gjc: match std::env::current_dir() {
-            Ok(cwd) => crate::gjc::control::GjcControlPlane::for_worktree(
-                &cwd,
-                crate::gjc::control::new_shared_command_registry(),
-            ),
-            // Without a resolvable worktree anchor the plane stays
-            // explicitly unavailable instead of silently re-scoping the
-            // trust boundary to ".".
-            Err(_) => crate::gjc::control::GjcControlPlane::unavailable(
-                crate::gjc::control::new_shared_command_registry(),
-            ),
-        },
+        gjc: (*gjc_control).clone(),
         gjc_store,
         gjc_reconciler,
     });
@@ -488,13 +499,20 @@ async fn spawn_gjc_lane_reconciler(
     let pr_resolver: Option<std::sync::Arc<dyn crate::gjc_lane::GjcLanePrResolver>> =
         crate::gjc_lane::GithubApiPrResolver::from_config(&config.gjc_lanes.pr)?
             .map(|resolver| resolver as _);
-    let reconciler = Arc::new(GjcReconciler::new(
-        plane,
-        pr_resolver,
-        store.clone(),
-        tx,
-        config.gjc_lanes.polling_policy(),
-    ));
+    let reconciler = Arc::new(
+        GjcReconciler::new(
+            plane,
+            pr_resolver,
+            store.clone(),
+            tx,
+            config.gjc_lanes.polling_policy(),
+        )
+        .with_auto_enrollment({
+            let mut worktrees = vec![std::env::current_dir().unwrap_or_default()];
+            worktrees.extend(config.gjc_lanes.discovery_worktrees.iter().cloned());
+            worktrees
+        }),
+    );
     {
         let runner = reconciler.clone();
         tokio::spawn(async move {
@@ -585,6 +603,35 @@ async fn register_gjc_lane_handler(
     };
     match store.register_lane(&request, &crate::gjc_lane::now_rfc3339()) {
         Ok(record) => Json(record).into_response(),
+        Err(error) if error.to_string().contains("registration conflict") => {
+            let Some(record) = store.record_for_session(&request.sdk_session_id) else {
+                return gjc_lane_error(error).into_response();
+            };
+            let same_owner = record.ownership.owner_id == request.owner_id;
+            let same_endpoint = request
+                .endpoint_generation
+                .is_none_or(|generation| record.endpoint_generation == generation);
+            let same_worktree = record.worktree == request.worktree;
+            let same_pr = record
+                .pr
+                .as_ref()
+                .map(|pr| {
+                    request.pr.as_ref().is_some_and(|input| {
+                        pr.repo == input.repo
+                            && pr.number == input.number
+                            && pr.head_sha == input.head_sha.to_ascii_lowercase()
+                            && pr.base_branch == input.base_branch
+                    })
+                })
+                .unwrap_or(request.pr.is_none());
+            if record.watch_removed_at.is_some() || record.terminal_disposition.is_some() {
+                gjc_lane_error("lane registration conflict: session is retired").into_response()
+            } else if same_owner && same_endpoint && same_worktree && same_pr {
+                Json(record).into_response()
+            } else {
+                gjc_lane_error(error).into_response()
+            }
+        }
         Err(error) => gjc_lane_error(error).into_response(),
     }
 }
@@ -624,6 +671,7 @@ async fn retire_gjc_lane_handler(
 async fn reconcile_gjc_lanes_handler(
     _peer: LoopbackLanePeer,
     State(state): State<AppState>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> impl IntoResponse {
     let Some(reconciler) = &state.gjc_reconciler else {
         return (
@@ -632,6 +680,13 @@ async fn reconcile_gjc_lanes_handler(
         )
             .into_response();
     };
+    if params
+        .get("force_resume")
+        .is_some_and(|value| value == "true")
+        && let Some(store) = &state.gjc_store
+    {
+        store.resume_suspended(&crate::gjc_lane::now_rfc3339());
+    }
     match reconciler.poll_once(OffsetDateTime::now_utc()).await {
         Ok(outcome) => Json(json!({"ok": true, "outcome": outcome})).into_response(),
         Err(_) => (
@@ -1054,11 +1109,82 @@ fn gjc_error_response(error: &crate::gjc::model::GjcError) -> axum::response::Re
         .into_response()
 }
 
+/// Resolve the authoritative control plane for an enrolled SDK session.
+///
+/// The daemon's startup control plane is anchored to its own current working
+/// directory, which is not necessarily the worktree owning a requested lane.
+/// Public session handlers must first consult the durable lane store, reject
+/// sessions that are not enrolled (or whose watch has been retired), then
+/// scope transport discovery to the stored worktree. Missing worktree
+/// identity is treated as an invisible session rather than falling back to
+/// the daemon CWD.
+fn gjc_control_for_session(
+    state: &AppState,
+    session: &crate::gjc::model::SessionId,
+) -> crate::gjc::model::GjcResult<crate::gjc::control::GjcControlPlane> {
+    gjc_control_for_session_with_policy(state, session, true)
+}
+
+fn gjc_read_control_for_session(
+    state: &AppState,
+    session: &crate::gjc::model::SessionId,
+) -> crate::gjc::model::GjcResult<crate::gjc::control::GjcControlPlane> {
+    gjc_control_for_session_with_policy(state, session, false)
+}
+
+fn gjc_control_for_session_with_policy(
+    state: &AppState,
+    session: &crate::gjc::model::SessionId,
+    reject_terminal: bool,
+) -> crate::gjc::model::GjcResult<crate::gjc::control::GjcControlPlane> {
+    let not_found = || crate::gjc::model::GjcError::SessionNotFound {
+        session_id: session.as_str().to_string(),
+    };
+    let Some(store) = state.gjc_store.as_ref() else {
+        if state.config.gjc_lanes.enabled {
+            return Err(not_found());
+        }
+        // Preserve pre-#349 configurations where [gjc] was enabled without
+        // [gjc_lanes]. The lane-scoped store is unavailable there, so the
+        // existing daemon-CWD control plane remains the explicit legacy
+        // boundary instead of silently disabling established controls.
+        return Ok(state.gjc.clone());
+    };
+    let Some(record) = store.record_for_session(session.as_str()) else {
+        return Err(not_found());
+    };
+    if record.watch_removed_at.is_some()
+        || (reject_terminal && record.terminal_disposition.is_some())
+    {
+        return Err(not_found());
+    }
+    let Some(worktree) = record
+        .worktree
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+    else {
+        return Err(not_found());
+    };
+    Ok(state.gjc.scoped_to_worktree(std::path::Path::new(worktree)))
+}
+
 async fn gjc_capabilities(
     _control: SubscriptionControlRequest,
     State(state): State<AppState>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> axum::response::Response {
-    let caps = state.gjc.capabilities().await;
+    let caps = if let Some(session) = params.get("session") {
+        let session_id = match crate::gjc::model::SessionId::new(session) {
+            Ok(session_id) => session_id,
+            Err(error) => return gjc_error_response(&error),
+        };
+        match gjc_control_for_session(&state, &session_id) {
+            Ok(control) => control.capabilities_for_session(&session_id).await,
+            Err(error) => return gjc_error_response(&error),
+        }
+    } else {
+        state.gjc.capabilities().await
+    };
     Json(crate::gjc::api::capabilities_body(&caps)).into_response()
 }
 
@@ -1068,30 +1194,43 @@ async fn gjc_session_query(
     axum::extract::Path(session): axum::extract::Path<String>,
     Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> axum::response::Response {
+    let session_id = match crate::gjc::model::SessionId::new(&session) {
+        Ok(session) => session,
+        Err(error) => return gjc_error_response(&error),
+    };
+    let sections = match crate::gjc::api::parse_sections(params.get("sections").map(String::as_str))
+    {
+        Ok(sections) => sections,
+        Err(error) => return gjc_error_response(&error),
+    };
+    let control = match gjc_read_control_for_session(&state, &session_id) {
+        Ok(control) => control,
+        Err(error) => return gjc_error_response(&error),
+    };
+    let refs = sections.iter().map(String::as_str).collect::<Vec<_>>();
     // Full-section reads feed the #324 event bridge from the same authoritative
     // evidence they return; partial `sections` reads skip the bridge because a
     // reducer fed partial state could derive wrong transitions.
     if !params.contains_key("sections") {
-        match state
-            .gjc
-            .query_session(
-                &match crate::gjc::model::SessionId::new(&session) {
-                    Ok(session) => session,
-                    Err(error) => return gjc_error_response(&error),
-                },
-                crate::gjc::api::SESSION_SECTIONS,
-            )
-            .await
-        {
+        match control.query_session(&session_id, &refs).await {
             Ok(query) => {
-                feed_gjc_bridge_from_query(&state, &session, &query).await;
+                if state.gjc_store.is_none() {
+                    return Json(crate::gjc::api::session_query_body(&query)).into_response();
+                }
+                if !feed_gjc_bridge_from_query(&state, &session, &query).await {
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        Json(json!({"ok": false, "error": "gjc bridge delivery unavailable"})),
+                    )
+                        .into_response();
+                }
                 return Json(crate::gjc::api::session_query_body(&query)).into_response();
             }
             Err(error) => return gjc_error_response(&error),
         }
     }
     match crate::gjc::api::run_session_query(
-        &state.gjc,
+        &control,
         &session,
         params.get("sections").map(String::as_str),
     )
@@ -1110,38 +1249,69 @@ async fn feed_gjc_bridge_from_query(
     state: &AppState,
     sdk_session_id: &str,
     query: &crate::gjc::model::SessionQuery,
-) {
+) -> bool {
     let Some(store) = state.gjc_store.as_ref() else {
-        return;
+        return false;
     };
     let lane_id = crate::gjc_lane::gjc_lane_id(sdk_session_id);
     let Some(record) = store.record(&lane_id) else {
-        return;
+        return false;
     };
     let identity = GjcSnapshotIdentity {
         repo_name: record.pr.as_ref().map(|pr| pr.repo.clone()),
+        repo_path: record.worktree.clone(),
         worktree_path: record.worktree.clone(),
-        ..GjcSnapshotIdentity::default()
+        branch: record.branch.clone(),
     };
-    // sdk_revision (the SDK's own monotonic counter) keeps the query feed in
-    // the same revision space as push-ingress payloads so interleaved seams
-    // cannot suppress each other's transitions.
-    let snapshot =
-        snapshot_from_session_query(sdk_session_id, record.sdk_revision, query, &identity);
-    let outcome = {
-        let Ok(mut bridge) = gjc_bridge_slot().lock() else {
-            return;
+    let _ingress_guard = gjc_bridge_ingress().lock().await;
+    let Some(query_revision) = query.revision else {
+        return false;
+    };
+    let (candidate, events) = {
+        let Ok(bridge) = gjc_bridge_slot().lock() else {
+            return false;
         };
-        bridge.observe(&snapshot)
+        let Some(record) = store.record(&lane_id) else {
+            return false;
+        };
+        if query_revision <= record.sdk_revision {
+            return true;
+        }
+        let snapshot =
+            snapshot_from_session_query(sdk_session_id, query_revision, query, &identity);
+        let mut candidate = bridge.clone();
+        let Ok(outcome) = candidate.observe(&snapshot) else {
+            return false;
+        };
+        (candidate, outcome.events)
     };
-    let Ok(outcome) = outcome else {
-        return;
-    };
-    for event in outcome.events {
-        // Awaited send like every other ingress: bridge dedupe state has
-        // already advanced, so a silently dropped event would never re-emit.
-        let _ = enqueue_event(&state.tx, normalize_event(event)).await;
+    for event in &events {
+        if enqueue_event(&state.tx, normalize_event(event.clone()))
+            .await
+            .is_err()
+        {
+            return false;
+        }
     }
+    let Some(current) = store.record(&lane_id) else {
+        return false;
+    };
+    if store
+        .set_sdk_revision_if(
+            &lane_id,
+            current.sdk_revision,
+            query_revision,
+            &crate::gjc_lane::now_rfc3339(),
+        )
+        .is_err()
+    {
+        return false;
+    }
+    let Ok(mut bridge) = gjc_bridge_slot().lock() else {
+        return false;
+    };
+    *bridge = candidate;
+    true
 }
 
 async fn gjc_turn_outcome(
@@ -1159,7 +1329,11 @@ async fn gjc_turn_outcome(
             reason: "must be 1..=128 bytes".into(),
         });
     }
-    match state.gjc.turn_outcome(&session, &turn).await {
+    let control = match gjc_read_control_for_session(&state, &session) {
+        Ok(control) => control,
+        Err(error) => return gjc_error_response(&error),
+    };
+    match control.turn_outcome(&session, &turn).await {
         Ok(outcome) => Json(crate::gjc::api::outcome_body(&outcome)).into_response(),
         Err(error) => gjc_error_response(&error),
     }
@@ -1171,10 +1345,18 @@ async fn gjc_prompt(
     Json(dto): Json<crate::gjc::api::PromptDto>,
 ) -> axum::response::Response {
     match dto.into_request() {
-        Ok(request) => match state.gjc.prompt(request).await {
-            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
-            Err(error) => gjc_error_response(&error),
-        },
+        Ok(request) => {
+            let control = match gjc_control_for_session(&state, &request.envelope.session) {
+                Ok(control) => control,
+                Err(error) => return gjc_error_response(&error),
+            };
+            match control.prompt(request).await {
+                Ok(receipt) => {
+                    Json(crate::gjc::api::command_receipt_body(&receipt)).into_response()
+                }
+                Err(error) => gjc_error_response(&error),
+            }
+        }
         Err(error) => gjc_error_response(&error),
     }
 }
@@ -1185,10 +1367,18 @@ async fn gjc_steer(
     Json(dto): Json<crate::gjc::api::SteerDto>,
 ) -> axum::response::Response {
     match dto.into_request() {
-        Ok(request) => match state.gjc.steer(request).await {
-            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
-            Err(error) => gjc_error_response(&error),
-        },
+        Ok(request) => {
+            let control = match gjc_control_for_session(&state, &request.envelope.session) {
+                Ok(control) => control,
+                Err(error) => return gjc_error_response(&error),
+            };
+            match control.steer(request).await {
+                Ok(receipt) => {
+                    Json(crate::gjc::api::command_receipt_body(&receipt)).into_response()
+                }
+                Err(error) => gjc_error_response(&error),
+            }
+        }
         Err(error) => gjc_error_response(&error),
     }
 }
@@ -1199,10 +1389,18 @@ async fn gjc_abort_and_prompt(
     Json(dto): Json<crate::gjc::api::AbortAndPromptDto>,
 ) -> axum::response::Response {
     match dto.into_request() {
-        Ok(request) => match state.gjc.abort_and_prompt(request).await {
-            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
-            Err(error) => gjc_error_response(&error),
-        },
+        Ok(request) => {
+            let control = match gjc_control_for_session(&state, &request.envelope.session) {
+                Ok(control) => control,
+                Err(error) => return gjc_error_response(&error),
+            };
+            match control.abort_and_prompt(request).await {
+                Ok(receipt) => {
+                    Json(crate::gjc::api::command_receipt_body(&receipt)).into_response()
+                }
+                Err(error) => gjc_error_response(&error),
+            }
+        }
         Err(error) => gjc_error_response(&error),
     }
 }
@@ -1213,10 +1411,18 @@ async fn gjc_workflow_gate_answer(
     Json(dto): Json<crate::gjc::api::WorkflowGateAnswerDto>,
 ) -> axum::response::Response {
     match dto.into_request() {
-        Ok(request) => match state.gjc.answer_workflow_gate(request).await {
-            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
-            Err(error) => gjc_error_response(&error),
-        },
+        Ok(request) => {
+            let control = match gjc_control_for_session(&state, &request.envelope.session) {
+                Ok(control) => control,
+                Err(error) => return gjc_error_response(&error),
+            };
+            match control.answer_workflow_gate(request).await {
+                Ok(receipt) => {
+                    Json(crate::gjc::api::command_receipt_body(&receipt)).into_response()
+                }
+                Err(error) => gjc_error_response(&error),
+            }
+        }
         Err(error) => gjc_error_response(&error),
     }
 }
@@ -1227,10 +1433,18 @@ async fn gjc_ask_answer(
     Json(dto): Json<crate::gjc::api::AskAnswerDto>,
 ) -> axum::response::Response {
     match dto.into_request() {
-        Ok(request) => match state.gjc.answer_ask(request).await {
-            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
-            Err(error) => gjc_error_response(&error),
-        },
+        Ok(request) => {
+            let control = match gjc_control_for_session(&state, &request.envelope.session) {
+                Ok(control) => control,
+                Err(error) => return gjc_error_response(&error),
+            };
+            match control.answer_ask(request).await {
+                Ok(receipt) => {
+                    Json(crate::gjc::api::command_receipt_body(&receipt)).into_response()
+                }
+                Err(error) => gjc_error_response(&error),
+            }
+        }
         Err(error) => gjc_error_response(&error),
     }
 }
@@ -1241,10 +1455,24 @@ async fn gjc_model_selection(
     Json(dto): Json<crate::gjc::api::ModelSelectionDto>,
 ) -> axum::response::Response {
     match dto.into_request() {
-        Ok(request) => match state.gjc.select_model(request).await {
-            Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
-            Err(error) => gjc_error_response(&error),
-        },
+        Ok(request) => {
+            if request.model.is_none() == request.profile.is_none() {
+                return gjc_error_response(&crate::gjc::model::GjcError::InvalidRequest {
+                    field: "model",
+                    reason: "exactly one of model or profile must be provided".into(),
+                });
+            }
+            let control = match gjc_control_for_session(&state, &request.envelope.session) {
+                Ok(control) => control,
+                Err(error) => return gjc_error_response(&error),
+            };
+            match control.select_model(request).await {
+                Ok(receipt) => {
+                    Json(crate::gjc::api::command_receipt_body(&receipt)).into_response()
+                }
+                Err(error) => gjc_error_response(&error),
+            }
+        }
         Err(error) => gjc_error_response(&error),
     }
 }
@@ -1253,13 +1481,37 @@ async fn gjc_command_receipt(
     _control: SubscriptionControlRequest,
     State(state): State<AppState>,
     axum::extract::Path(key): axum::extract::Path<String>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> axum::response::Response {
+    let Some(session) = params.get("session") else {
+        return gjc_error_response(&crate::gjc::model::GjcError::InvalidRequest {
+            field: "session",
+            reason: "receipt lookup requires a session".into(),
+        });
+    };
     let key = match crate::gjc::model::IdempotencyKey::new(key) {
         Ok(key) => key,
         Err(error) => return gjc_error_response(&error),
     };
+    if let Some(store) = &state.gjc_store
+        && store
+            .record_for_session(session)
+            .is_none_or(|record| record.watch_removed_at.is_some())
+    {
+        return gjc_error_response(&crate::gjc::model::GjcError::SessionNotFound {
+            session_id: session.clone(),
+        });
+    }
     match state.gjc.command_receipt(&key).await {
-        Ok(receipt) => Json(crate::gjc::api::command_receipt_body(&receipt)).into_response(),
+        Ok(receipt) => {
+            if receipt.session_id != *session {
+                return gjc_error_response(&crate::gjc::model::GjcError::InvalidRequest {
+                    field: "session",
+                    reason: "receipt is bound to another session".into(),
+                });
+            }
+            Json(crate::gjc::api::command_receipt_body(&receipt)).into_response()
+        }
         Err(error) => gjc_error_response(&error),
     }
 }
@@ -1451,7 +1703,10 @@ async fn post_gjc_bridge(
     State(state): State<AppState>,
     Json(payload): Json<Value>,
 ) -> axum::response::Response {
-    let snapshot = match snapshot_from_response_payload(&payload) {
+    if !state.config.gjc.enabled {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let mut snapshot = match snapshot_from_response_payload(&payload) {
         Ok(snapshot) => snapshot,
         Err(error) => {
             return (
@@ -1462,19 +1717,62 @@ async fn post_gjc_bridge(
         }
     };
     let session_id = snapshot.session_id.trim().to_string();
+    let _ingress_guard = gjc_bridge_ingress().lock().await;
+    let mut push_lane_id = None;
+    if state.config.gjc_lanes.enabled {
+        let Some(store) = &state.gjc_store else {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"ok": false, "error": "gjc lane reconciliation is disabled"})),
+            )
+                .into_response();
+        };
+        if store.record_for_session(&session_id).is_none_or(|record| {
+            record.watch_removed_at.is_some()
+                || record.terminal_disposition.is_some()
+                || record
+                    .worktree
+                    .as_deref()
+                    .is_none_or(|worktree| worktree.trim().is_empty())
+        }) {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"ok": false, "error": "gjc session is not enrolled"})),
+            )
+                .into_response();
+        }
+        let record = store
+            .record_for_session(&session_id)
+            .expect("membership checked");
+        push_lane_id = Some(record.lane_id.clone());
+        if snapshot.revision <= record.sdk_revision {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({"ok": false, "error": "stale or non-authoritative bridge revision"})),
+            )
+                .into_response();
+        }
+        snapshot.repo_name = record.pr.as_ref().map(|pr| pr.repo.clone());
+        snapshot.repo_path = record.worktree.clone();
+        snapshot.worktree_path = record.worktree.clone();
+        snapshot.branch = record.branch.clone();
+    }
     let revision = snapshot.revision;
     let outcome = {
-        let Ok(mut bridge) = gjc_bridge_slot().lock() else {
+        let Ok(bridge) = gjc_bridge_slot().lock() else {
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(json!({"ok": false, "error": "gjc_bridge_unavailable"})),
             )
                 .into_response();
         };
-        bridge.observe(&snapshot)
+        let mut candidate = bridge.clone();
+        candidate
+            .observe(&snapshot)
+            .map(|outcome| (candidate, outcome))
     };
-    let outcome = match outcome {
-        Ok(outcome) => outcome,
+    let (candidate, outcome) = match outcome {
+        Ok(result) => result,
         Err(error) => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -1501,11 +1799,6 @@ async fn post_gjc_bridge(
             rejected.push(json!({"type": kind, "event_id": event_id}));
         }
     }
-    let totals = gjc_bridge_slot()
-        .lock()
-        .map(|bridge| bridge.stats())
-        .unwrap_or_default();
-
     let mut record = telemetry::record(
         "gjc_bridge_snapshot",
         if rejected.is_empty() {
@@ -1528,10 +1821,46 @@ async fn post_gjc_bridge(
     );
     telemetry::emit(record);
 
+    let response_status = if rejected.is_empty() {
+        if let Some(lane_id) = push_lane_id.as_deref()
+            && let Some(store) = &state.gjc_store
+            && let Some(current) = store.record(lane_id)
+            && store
+                .set_sdk_revision_if(
+                    lane_id,
+                    current.sdk_revision,
+                    revision,
+                    &crate::gjc_lane::now_rfc3339(),
+                )
+                .is_err()
+        {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"ok": false, "error": "gjc bridge watermark conflict"})),
+            )
+                .into_response();
+        }
+        if let Ok(mut bridge) = gjc_bridge_slot().lock() {
+            *bridge = candidate;
+        } else {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"ok": false, "error": "gjc_bridge_unavailable"})),
+            )
+                .into_response();
+        }
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    let totals = gjc_bridge_slot()
+        .lock()
+        .map(|bridge| bridge.stats())
+        .unwrap_or_default();
     (
-        StatusCode::OK,
+        response_status,
         Json(json!({
-            "ok": true,
+            "ok": rejected.is_empty(),
             "session_id": session_id,
             "revision": revision,
             "duplicate": outcome.duplicate,
@@ -2164,6 +2493,9 @@ fn local_control_error() -> (StatusCode, Json<Value>) {
 
 fn is_loopback_host(host: &str) -> bool {
     let host = host.trim_matches(['[', ']']);
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
     host.parse::<std::net::IpAddr>().is_ok_and(|ip| {
         ip.is_loopback()
             || matches!(ip, std::net::IpAddr::V6(ip) if ip.to_ipv4().is_some_and(|ip| ip.is_loopback()))
@@ -2235,6 +2567,11 @@ impl<S: Send + Sync> FromRequestParts<S> for LoopbackLanePeer {
         parts: &mut axum::http::request::Parts,
         _state: &S,
     ) -> std::result::Result<Self, Self::Rejection> {
+        if parts.uri.path().starts_with("/api/gjc/") {
+            return SubscriptionControlRequest::from_request_parts(parts, _state)
+                .await
+                .map(|_| Self);
+        }
         let peer = parts
             .extensions
             .get::<ConnectInfo<SocketAddr>>()
@@ -2804,6 +3141,7 @@ mod tests {
     use crate::sink::SinkTarget;
     use crate::source::tmux::{ParentProcessInfo, RegistrationSource};
     use axum::body::to_bytes;
+    use futures_util::{SinkExt, StreamExt};
     use serial_test::serial;
 
     use std::fs;
@@ -2840,6 +3178,16 @@ mod tests {
             parts
                 .extensions
                 .insert(ConnectInfo(address.parse::<SocketAddr>().unwrap()));
+            parts
+                .headers
+                .insert(axum::http::header::HOST, "127.0.0.1:25294".parse().unwrap());
+            parts.headers.insert(
+                axum::http::header::ORIGIN,
+                "http://127.0.0.1:25294".parse().unwrap(),
+            );
+            parts
+                .headers
+                .insert(LOCAL_CONTROL_HEADER, "1".parse().unwrap());
             assert!(
                 LoopbackLanePeer::from_request_parts(&mut parts, &())
                     .await
@@ -5053,9 +5401,13 @@ mod tests {
         let (state, _rx) = native_hook_test_state();
 
         // Capabilities surface is honest about the missing transport.
-        let response = gjc_capabilities(SubscriptionControlRequest, State(state.clone()))
-            .await
-            .into_response();
+        let response = gjc_capabilities(
+            SubscriptionControlRequest,
+            State(state.clone()),
+            Query(std::collections::HashMap::new()),
+        )
+        .await
+        .into_response();
         assert_eq!(response.status(), StatusCode::OK);
         let body: Value =
             serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
@@ -5063,7 +5415,8 @@ mod tests {
         assert_eq!(body["transport_implemented"], Value::Bool(false));
         assert_eq!(body["capabilities"], json!([]));
 
-        // Session queries require a transport and fail closed with 503.
+        // Legacy configurations without lane reconciliation retain the
+        // daemon-CWD control boundary; this test plane has no transport.
         let response = gjc_session_query(
             SubscriptionControlRequest,
             State(state.clone()),
@@ -5101,7 +5454,8 @@ mod tests {
                 .unwrap();
         assert_eq!(body["error_code"], "invalid_request");
 
-        // Well-formed mutations still fail closed without a transport.
+        // Well-formed mutations still fail closed when the session is not
+        // enrolled; no daemon-CWD transport is consulted.
         let valid = crate::gjc::api::PromptDto {
             base: crate::gjc::api::MutationDto {
                 session: "sess-1".into(),
@@ -5118,26 +5472,185 @@ mod tests {
         )
         .await
         .into_response();
-        // Capability gate fires before the transport check: with no
-        // transport nothing is exercisable, so mutations are 501.
         assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 
-        // Unknown receipts are 404; malformed keys are 400.
+        // Receipt lookups require a session before key resolution.
         let response = gjc_command_receipt(
             SubscriptionControlRequest,
             State(state.clone()),
             axum::extract::Path("idem-key-missing".into()),
-        )
-        .await
-        .into_response();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        let response = gjc_command_receipt(
-            SubscriptionControlRequest,
-            State(state),
-            axum::extract::Path("bad key!".into()),
+            Query(std::collections::HashMap::new()),
         )
         .await
         .into_response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let response = gjc_command_receipt(
+            SubscriptionControlRequest,
+            State(state),
+            axum::extract::Path("bad key!".into()),
+            Query(std::collections::HashMap::new()),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn gjc_session_query_uses_enrolled_external_worktree() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let websocket = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let (mut sink, mut stream) = websocket.split();
+            sink.send(tokio_tungstenite::tungstenite::Message::text(
+                r#"{"type":"hello","connectionId":"external-query"}"#,
+            ))
+            .await
+            .unwrap();
+            let Some(Ok(tokio_tungstenite::tungstenite::Message::Text(request))) =
+                stream.next().await
+            else {
+                return;
+            };
+            let request: Value = serde_json::from_str(request.as_ref()).unwrap();
+            sink.send(tokio_tungstenite::tungstenite::Message::text(
+                json!({
+                    "type": "query_response",
+                    "id": request["id"],
+                    "ok": true,
+                    "result": {
+                        "metadata": {
+                            "session_id": "external-session",
+                            "title": "external lane"
+                        }
+                    }
+                })
+                .to_string(),
+            ))
+            .await
+            .unwrap();
+        });
+
+        let worktree = tempdir().unwrap();
+        let sdk_dir = worktree.path().join(".gjc").join("state").join("sdk");
+        fs::create_dir_all(&sdk_dir).unwrap();
+        let metadata = sdk_dir.join("external-session.json");
+        fs::write(
+            &metadata,
+            json!({
+                "version": 1,
+                "sessionId": "external-session",
+                "url": format!("ws://{address}/"),
+                "token": "external-token"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&metadata, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+
+        let lane_state = tempdir().unwrap();
+        let store = Arc::new(GjcLaneStore::open(&lane_state.path().join("lanes.json")).unwrap());
+        store
+            .register_lane(
+                &GjcLaneRegistrationRequest {
+                    sdk_session_id: "external-session".into(),
+                    worktree: Some(worktree.path().display().to_string()),
+                    endpoint_generation: None,
+                    owner_id: None,
+                    pr: None,
+                },
+                "2026-08-29T00:00:00Z",
+            )
+            .unwrap();
+        let (mut state, _rx) = native_hook_test_state();
+        state.gjc_store = Some(store);
+
+        let response = gjc_session_query(
+            SubscriptionControlRequest,
+            State(state),
+            axum::extract::Path("external-session".into()),
+            Query(std::collections::HashMap::from([(
+                "sections".into(),
+                "metadata".into(),
+            )])),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(body["metadata"]["title"], "external lane");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn gjc_handlers_reject_unbound_and_retired_sessions() {
+        let lane_state = tempdir().unwrap();
+        let store = Arc::new(GjcLaneStore::open(&lane_state.path().join("lanes.json")).unwrap());
+        store
+            .register_lane(
+                &GjcLaneRegistrationRequest {
+                    sdk_session_id: "unbound-session".into(),
+                    worktree: None,
+                    endpoint_generation: None,
+                    owner_id: None,
+                    pr: None,
+                },
+                "2026-08-29T00:00:00Z",
+            )
+            .unwrap();
+        let retired = store
+            .register_lane(
+                &GjcLaneRegistrationRequest {
+                    sdk_session_id: "retired-session".into(),
+                    worktree: Some("/tmp/retired-worktree".into()),
+                    endpoint_generation: None,
+                    owner_id: None,
+                    pr: None,
+                },
+                "2026-08-29T00:00:00Z",
+            )
+            .unwrap();
+        store
+            .retire_lane(
+                &retired.lane_id,
+                retired.revision,
+                "test retirement",
+                "2026-08-29T00:00:01Z",
+            )
+            .unwrap();
+
+        let (mut state, _rx) = native_hook_test_state();
+        state.gjc_store = Some(store);
+        for session in ["unbound-session", "retired-session"] {
+            let response = gjc_prompt(
+                SubscriptionControlRequest,
+                State(state.clone()),
+                Json(crate::gjc::api::PromptDto {
+                    base: crate::gjc::api::MutationDto {
+                        session: session.into(),
+                        idempotency_key: format!("idem-{session}-0001"),
+                        expected_session: None,
+                        timeout_ms: None,
+                    },
+                    prompt: "hello".into(),
+                }),
+            )
+            .await
+            .into_response();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            let body: Value =
+                serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                    .unwrap();
+            assert_eq!(body["error_code"], "session_not_found");
+        }
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::Result;
 use crate::core::timer_wheel::{DelayedEntry, TimerWheel};
@@ -20,6 +21,7 @@ use crate::sink::{Sink, SinkMessage, SinkTarget, SinkTelemetry};
 use crate::telemetry;
 
 const DEFAULT_BATCH_TICK: Duration = Duration::from_secs(1);
+const MAX_ALERT_DESTINATION_KEY: usize = 512;
 
 pub struct Dispatcher {
     rx: mpsc::Receiver<IncomingEvent>,
@@ -31,6 +33,113 @@ pub struct Dispatcher {
     batch_tick: Duration,
     native_observability: SharedNativeHookObservability,
     ledger: Option<SharedEventLedger>,
+}
+
+static ALERT_ACCEPTANCE: OnceLock<Mutex<HashMap<String, Vec<oneshot::Sender<bool>>>>> =
+    OnceLock::new();
+
+/// Durable delivery ownership for a native pending alert. A destination is
+/// claimed before the sink call and transitions to one terminal outcome
+/// afterwards. Claimed destinations are intentionally not replayed: this
+/// preserves at-most-once delivery across a crash between the sink call and
+/// the durable outcome update, while explicit failures remain retryable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AlertDeliveryState {
+    Claimed,
+    Delivered,
+    Failed,
+}
+
+pub(crate) trait AlertDeliveryJournal: Send + Sync {
+    fn state(&self, destination: &str) -> Option<AlertDeliveryState>;
+    fn claim(&self, destination: &str) -> bool;
+    fn record(&self, destination: &str, delivered: bool) -> bool;
+}
+
+type AlertDeliveryJournalMap = Mutex<HashMap<String, std::sync::Arc<dyn AlertDeliveryJournal>>>;
+
+static ALERT_DELIVERY_JOURNALS: OnceLock<AlertDeliveryJournalMap> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LedgerAcceptance {
+    Accepted,
+    Duplicate,
+    Failed,
+    Unavailable,
+}
+
+pub(crate) fn register_alert_acceptance(event_id: &str) -> oneshot::Receiver<bool> {
+    let (sender, receiver) = oneshot::channel();
+    if let Ok(mut pending) = ALERT_ACCEPTANCE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+    {
+        pending
+            .entry(event_id.to_string())
+            .or_default()
+            .push(sender);
+    }
+    receiver
+}
+
+pub(crate) fn register_alert_delivery_journal(
+    event_id: &str,
+    journal: std::sync::Arc<dyn AlertDeliveryJournal>,
+) {
+    if let Ok(mut pending) = ALERT_DELIVERY_JOURNALS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+    {
+        pending.insert(event_id.to_string(), journal);
+    }
+}
+
+pub(crate) fn clear_alert_delivery_journal(event_id: &str) {
+    if let Ok(mut pending) = ALERT_DELIVERY_JOURNALS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+    {
+        pending.remove(event_id);
+    }
+}
+
+fn alert_delivery_journal(
+    event: &IncomingEvent,
+) -> Option<std::sync::Arc<dyn AlertDeliveryJournal>> {
+    let event_id = event.payload.get("event_id").and_then(Value::as_str)?;
+    ALERT_DELIVERY_JOURNALS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .ok()
+        .and_then(|pending| pending.get(event_id).cloned())
+}
+
+fn resolve_alert_acceptance(event: &IncomingEvent, accepted: bool) {
+    let Some(event_id) = event.payload.get("event_id").and_then(Value::as_str) else {
+        return;
+    };
+    resolve_alert_acceptance_id(event_id, accepted);
+}
+
+pub(crate) fn resolve_alert_acceptance_id(event_id: &str, accepted: bool) {
+    if let Ok(mut pending) = ALERT_ACCEPTANCE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        && let Some(senders) = pending.remove(event_id)
+    {
+        for sender in senders {
+            let _ = sender.send(accepted);
+        }
+    }
+}
+
+pub(crate) fn cancel_alert_acceptance(event_id: &str) {
+    if let Ok(mut pending) = ALERT_ACCEPTANCE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+    {
+        pending.remove(event_id);
+    }
 }
 
 impl Dispatcher {
@@ -87,18 +196,61 @@ impl Dispatcher {
                     match maybe_event {
                         Some(event) => {
                             let event = normalize_event(event);
-                            if !self.record_event(&event) {
-                                continue;
+                            let ledger_result = self.record_event_result(&event);
+                            match ledger_result {
+                                LedgerAcceptance::Duplicate => {
+                                    // A pending native alert owns its
+                                    // per-destination retry state outside the
+                                    // event ledger. Re-enter dispatch so a
+                                    // failed destination can retry while
+                                    // delivered destinations are skipped.
+                                    if alert_delivery_journal(&event).is_none() {
+                                        resolve_alert_acceptance(&event, true);
+                                        continue;
+                                    }
+                                }
+                                LedgerAcceptance::Failed => {
+                                    resolve_alert_acceptance(&event, false);
+                                    continue;
+                                }
+                                LedgerAcceptance::Accepted => {}
+                                LedgerAcceptance::Unavailable => {
+                                    // Delivery remains the acceptance boundary
+                                    // when the optional ledger is disabled.
+                                }
                             }
-
+                            let acceptance_event = event.clone();
                             let now_ms = now_ms();
                             self.flush_due_batches(now_ms).await?;
                             if self.is_ci_event(&event) {
                                 for flushed in self.ci_batcher.observe(event, now_ms) {
                                     self.deliver_event(flushed).await;
                                 }
+                                if matches!(
+                                    ledger_result,
+                                    LedgerAcceptance::Accepted
+                                        | LedgerAcceptance::Duplicate
+                                        | LedgerAcceptance::Unavailable
+                                ) {
+                                    resolve_alert_acceptance(&acceptance_event, true);
+                                }
                             } else {
-                                self.resolve_and_dispatch(event, now_ms).await;
+                                let routed = self.resolve_and_dispatch(event, now_ms).await;
+                                if let Some(event_id) = acceptance_event
+                                    .payload
+                                    .get("event_id")
+                                    .and_then(Value::as_str)
+                                {
+                                    clear_alert_delivery_journal(event_id);
+                                }
+                                if matches!(
+                                    ledger_result,
+                                    LedgerAcceptance::Accepted
+                                        | LedgerAcceptance::Duplicate
+                                        | LedgerAcceptance::Unavailable
+                                ) {
+                                    resolve_alert_acceptance(&acceptance_event, routed);
+                                }
                             }
                         }
                         None => {
@@ -117,23 +269,23 @@ impl Dispatcher {
         Ok(())
     }
 
-    fn record_event(&self, event: &IncomingEvent) -> bool {
+    fn record_event_result(&self, event: &IncomingEvent) -> LedgerAcceptance {
         let Some(ledger) = &self.ledger else {
-            return true;
+            return LedgerAcceptance::Unavailable;
         };
         let mut ledger = match ledger.lock() {
             Ok(ledger) => ledger,
             Err(_) => {
                 eprintln!("clawhip ledger rejected event: lock_poisoned");
-                return false;
+                return LedgerAcceptance::Failed;
             }
         };
         match ledger.append(event) {
-            Ok(AppendOutcome::Appended) => true,
-            Ok(AppendOutcome::Duplicate) => false,
+            Ok(AppendOutcome::Appended) => LedgerAcceptance::Accepted,
+            Ok(AppendOutcome::Duplicate) => LedgerAcceptance::Duplicate,
             Err(error) => {
                 eprintln!("clawhip ledger rejected event: {error}");
-                false
+                LedgerAcceptance::Failed
             }
         }
     }
@@ -210,7 +362,7 @@ impl Dispatcher {
         }
     }
 
-    async fn resolve_and_dispatch(&mut self, event: IncomingEvent, now_ms: u64) {
+    async fn resolve_and_dispatch(&mut self, event: IncomingEvent, now_ms: u64) -> bool {
         let provenance = is_native_hook_event(&event).then(|| self.router.explain(&event));
         let deliveries = match self.router.resolve(&event).await {
             Ok(deliveries) => {
@@ -240,16 +392,20 @@ impl Dispatcher {
                     "clawhip dispatcher failed to resolve {}: {error}",
                     event.canonical_kind()
                 );
-                return;
+                return false;
             }
         };
+        if deliveries.is_empty() {
+            return false;
+        }
 
+        let mut accepted = true;
         for delivery in deliveries {
             self.emit_route_trace(&event, &delivery);
             if self.should_batch_routine_delivery(&event, &delivery) {
                 self.emit_routine_deferred(&event, &delivery);
                 let Some(routine_batcher) = self.routine_batcher.as_mut() else {
-                    self.send_delivery(&event, &delivery).await;
+                    accepted &= self.send_delivery(&event, &delivery).await;
                     continue;
                 };
                 routine_batcher.observe(
@@ -262,8 +418,9 @@ impl Dispatcher {
                 continue;
             }
 
-            self.send_delivery(&event, &delivery).await;
+            accepted &= self.send_delivery(&event, &delivery).await;
         }
+        accepted
     }
 
     fn observe_native_route_outcome(
@@ -304,7 +461,35 @@ impl Dispatcher {
         );
     }
 
-    async fn send_delivery(&self, event: &IncomingEvent, delivery: &ResolvedDelivery) {
+    async fn send_delivery(&self, event: &IncomingEvent, delivery: &ResolvedDelivery) -> bool {
+        let journal = alert_delivery_journal(event);
+        let destination = journal.as_ref().map(|_| alert_destination_key(delivery));
+        if let (Some(journal), Some(destination)) = (journal.as_ref(), destination.as_deref()) {
+            if matches!(
+                journal.state(destination),
+                Some(AlertDeliveryState::Claimed | AlertDeliveryState::Delivered)
+            ) {
+                return true;
+            }
+            if !journal.claim(destination) {
+                self.emit_dispatch_failure(
+                    event,
+                    telemetry::reason::SINK_SEND_FAILED,
+                    Some(delivery),
+                    "durable alert delivery ownership unavailable".to_string(),
+                );
+                return false;
+            }
+        }
+
+        let finish = |delivered: bool| {
+            if let (Some(journal), Some(destination)) = (journal.as_ref(), destination.as_deref()) {
+                let persisted = journal.record(destination, delivered);
+                return delivered && persisted;
+            }
+            delivered
+        };
+
         let Some(sink) = self.sinks.get(delivery.sink.as_str()) else {
             self.emit_dispatch_failure(
                 event,
@@ -317,7 +502,7 @@ impl Dispatcher {
                 delivery.sink,
                 safe_target_for_log(&delivery.target)
             );
-            return;
+            return finish(false);
         };
 
         let content = match self
@@ -339,22 +524,24 @@ impl Dispatcher {
                     delivery.sink,
                     safe_target_for_log(&delivery.target)
                 );
-                return;
+                return finish(false);
             }
         };
 
-        self.send_sink_message(
-            sink.as_ref(),
-            &delivery.target,
-            SinkMessage {
-                event_kind: event.canonical_kind().to_string(),
-                format: delivery.format.clone(),
-                content,
-                payload: event.payload.clone(),
-                telemetry: Some(sink_telemetry_for(event, delivery, None)),
-            },
+        finish(
+            self.send_sink_message(
+                sink.as_ref(),
+                &delivery.target,
+                SinkMessage {
+                    event_kind: event.canonical_kind().to_string(),
+                    format: delivery.format.clone(),
+                    content,
+                    payload: event.payload.clone(),
+                    telemetry: Some(sink_telemetry_for(event, delivery, None)),
+                },
+            )
+            .await,
         )
-        .await;
     }
 
     async fn send_routine_batch(&self, batch: FlushedRoutineDeliveryBatch) {
@@ -487,7 +674,12 @@ impl Dispatcher {
         }
     }
 
-    async fn send_sink_message(&self, sink: &dyn Sink, target: &SinkTarget, message: SinkMessage) {
+    async fn send_sink_message(
+        &self,
+        sink: &dyn Sink,
+        target: &SinkTarget,
+        message: SinkMessage,
+    ) -> bool {
         if let Err(error) = sink.send(target, &message).await {
             let mut record = telemetry::record(
                 telemetry::event_name::DISPATCH_FAILURE,
@@ -500,7 +692,9 @@ impl Dispatcher {
             record.insert("error".to_string(), json!(error.to_string()));
             telemetry::emit(record);
             eprintln!("clawhip dispatcher delivery failed to {safe_target}: {error}");
+            return false;
         }
+        true
     }
 
     fn emit_route_trace(&self, event: &IncomingEvent, delivery: &ResolvedDelivery) {
@@ -597,6 +791,7 @@ impl Dispatcher {
         self.routine_batcher.is_some()
             && delivery.sink == "discord"
             && !self.is_ci_event(event)
+            && alert_delivery_journal(event).is_none()
             && !should_bypass_routine_batch(event)
     }
 }
@@ -994,7 +1189,11 @@ fn ci_run_job_count(payload: &Value) -> usize {
 fn should_bypass_routine_batch(event: &IncomingEvent) -> bool {
     let kind = event.canonical_kind();
     kind.ends_with(".failed")
+        || kind.ends_with("-failed")
         || kind.ends_with(".blocked")
+        || kind.ends_with(".stalled")
+        || kind.ends_with(".retry-needed")
+        || kind.starts_with("session.")
         || kind == "tmux.stale"
         || kind.starts_with("github.ci-")
         // GJC SDK question/gate notifications (#324) are operator-facing
@@ -1146,6 +1345,25 @@ fn sink_target_key(target: &SinkTarget) -> String {
         SinkTarget::HttpEndpoint(endpoint) => format!("http-endpoint:{endpoint}"),
         SinkTarget::LocalFile(path) => format!("localfile:{path}"),
     }
+}
+
+fn alert_destination_key(delivery: &ResolvedDelivery) -> String {
+    let safe_target = telemetry::safe_target_id(&delivery.target);
+    // A route index distinguishes two fanout entries that intentionally use
+    // the same sink target but different templates/mentions. The target is
+    // still redacted before it crosses the durable boundary.
+    let key = format!(
+        "route:{}:{safe_target}",
+        delivery
+            .trace
+            .matched_route_index
+            .map(|index| index.to_string())
+            .unwrap_or_else(|| "fallback".to_string())
+    );
+    if key.len() <= MAX_ALERT_DESTINATION_KEY {
+        return key;
+    }
+    telemetry::stable_correlation_id("gjc.alert.destination", &json!({"key": key}))
 }
 
 fn now_ms() -> u64 {
@@ -2189,8 +2407,14 @@ mod tests {
             template: None,
             payload: json!({"event_id":"one","repo":"owner/repo","summary":"private text"}),
         };
-        assert!(dispatcher.record_event(&first));
-        assert!(!dispatcher.record_event(&first));
+        assert_eq!(
+            dispatcher.record_event_result(&first),
+            LedgerAcceptance::Accepted
+        );
+        assert_eq!(
+            dispatcher.record_event_result(&first),
+            LedgerAcceptance::Duplicate
+        );
         let second = IncomingEvent {
             kind: "agent.failed".into(),
             channel: None,
@@ -2199,13 +2423,160 @@ mod tests {
             template: None,
             payload: json!({"event_id":"two","repo":"owner/repo"}),
         };
-        assert!(!dispatcher.record_event(&second));
+        assert_eq!(
+            dispatcher.record_event_result(&second),
+            LedgerAcceptance::Failed
+        );
         assert_eq!(ledger.lock().unwrap().status().records, 1);
         let persisted = std::fs::read_dir(dir.path().join("raw"))
             .unwrap()
             .map(|entry| std::fs::read_to_string(entry.unwrap().path()).unwrap())
             .collect::<String>();
         assert!(!persisted.contains("private text"));
+    }
+
+    #[tokio::test]
+    async fn native_alert_fanout_retries_only_failed_destinations() {
+        use async_trait::async_trait;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct TestJournal {
+            states: Mutex<HashMap<String, AlertDeliveryState>>,
+        }
+
+        impl AlertDeliveryJournal for TestJournal {
+            fn state(&self, destination: &str) -> Option<AlertDeliveryState> {
+                self.states
+                    .lock()
+                    .expect("journal")
+                    .get(destination)
+                    .copied()
+            }
+
+            fn claim(&self, destination: &str) -> bool {
+                let mut states = self.states.lock().expect("journal");
+                match states.get(destination) {
+                    Some(AlertDeliveryState::Claimed | AlertDeliveryState::Delivered) => true,
+                    _ => {
+                        states.insert(destination.to_string(), AlertDeliveryState::Claimed);
+                        true
+                    }
+                }
+            }
+
+            fn record(&self, destination: &str, delivered: bool) -> bool {
+                self.states.lock().expect("journal").insert(
+                    destination.to_string(),
+                    if delivered {
+                        AlertDeliveryState::Delivered
+                    } else {
+                        AlertDeliveryState::Failed
+                    },
+                );
+                true
+            }
+        }
+
+        struct TestSink {
+            calls: Arc<Mutex<Vec<String>>>,
+            failed_once: AtomicUsize,
+        }
+
+        #[async_trait]
+        impl Sink for TestSink {
+            async fn send(&self, target: &SinkTarget, _message: &SinkMessage) -> crate::Result<()> {
+                let target = safe_target_for_log(target);
+                self.calls.lock().expect("calls").push(target.clone());
+                if target.contains("channel:b")
+                    && self.failed_once.fetch_add(1, Ordering::SeqCst) == 0
+                {
+                    return Err("deterministic sink failure".into());
+                }
+                Ok(())
+            }
+        }
+
+        let config = AppConfig {
+            routes: vec![
+                RouteRule {
+                    event: "session.failed".into(),
+                    sink: "discord".into(),
+                    channel: Some("a".into()),
+                    ..RouteRule::default()
+                },
+                RouteRule {
+                    event: "session.failed".into(),
+                    sink: "discord".into(),
+                    channel: Some("b".into()),
+                    ..RouteRule::default()
+                },
+            ],
+            ..AppConfig::default()
+        };
+        let (_tx, rx) = mpsc::channel(1);
+        let mut sinks: HashMap<String, Box<dyn Sink>> = HashMap::new();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        sinks.insert(
+            "discord".into(),
+            Box::new(TestSink {
+                calls: calls.clone(),
+                failed_once: AtomicUsize::new(0),
+            }),
+        );
+        let mut dispatcher = Dispatcher::new(
+            rx,
+            Router::new(Arc::new(config)),
+            Box::new(DefaultRenderer),
+            sinks,
+            Duration::from_secs(30),
+            None,
+            new_shared_native_hook_observability(),
+        );
+        let journal = Arc::new(TestJournal {
+            states: Mutex::new(HashMap::new()),
+        });
+        let event = IncomingEvent {
+            kind: "session.failed".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({"event_id": "fanout-retry", "provider": "codex"}),
+        };
+
+        register_alert_delivery_journal(
+            event.payload["event_id"].as_str().unwrap(),
+            journal.clone(),
+        );
+        assert!(
+            !dispatcher
+                .resolve_and_dispatch(event.clone(), now_ms())
+                .await
+        );
+        let first_calls = calls.lock().expect("calls").clone();
+        assert_eq!(first_calls.len(), 2);
+        assert_eq!(
+            journal.state("route:0:discord:channel:a"),
+            Some(AlertDeliveryState::Delivered)
+        );
+        assert_eq!(
+            journal.state("route:1:discord:channel:b"),
+            Some(AlertDeliveryState::Failed)
+        );
+
+        clear_alert_delivery_journal("fanout-retry");
+        register_alert_delivery_journal("fanout-retry", journal.clone());
+        assert!(dispatcher.resolve_and_dispatch(event, now_ms()).await);
+        assert_eq!(calls.lock().expect("calls").len(), 3);
+        assert_eq!(
+            journal.state("route:0:discord:channel:a"),
+            Some(AlertDeliveryState::Delivered)
+        );
+        assert_eq!(
+            journal.state("route:1:discord:channel:b"),
+            Some(AlertDeliveryState::Delivered)
+        );
+        clear_alert_delivery_journal("fanout-retry");
     }
 
     #[tokio::test]

--- a/src/gjc/api.rs
+++ b/src/gjc/api.rs
@@ -174,13 +174,19 @@ pub struct WorkflowGateAnswerDto {
 
 impl WorkflowGateAnswerDto {
     pub fn into_request(self) -> GjcResult<WorkflowGateAnswerRequest> {
-        if self.gate_id.is_empty() || self.gate_id.len() > 128 {
+        if self.gate_id.is_empty()
+            || self.gate_id.len() > 128
+            || self.gate_id.chars().any(|ch| ch.is_control())
+        {
             return Err(GjcError::InvalidRequest {
                 field: "gate_id",
                 reason: "must be 1..=128 bytes".into(),
             });
         }
-        if self.option.is_empty() || self.option.len() > 256 {
+        if self.option.is_empty()
+            || self.option.len() > 128
+            || self.option.chars().any(|ch| ch.is_control())
+        {
             return Err(GjcError::InvalidRequest {
                 field: "option",
                 reason: "must be 1..=256 bytes".into(),
@@ -207,7 +213,10 @@ pub struct AskAnswerDto {
 
 impl AskAnswerDto {
     pub fn into_request(self) -> GjcResult<AskAnswerRequest> {
-        if self.ask_id.is_empty() || self.ask_id.len() > 128 {
+        if self.ask_id.is_empty()
+            || self.ask_id.len() > 128
+            || self.ask_id.chars().any(|ch| ch.is_control())
+        {
             return Err(GjcError::InvalidRequest {
                 field: "ask_id",
                 reason: "must be 1..=128 bytes".into(),
@@ -226,7 +235,10 @@ impl AskAnswerDto {
                 .choices
                 .into_iter()
                 .map(|option| {
-                    if option.is_empty() || option.len() > 256 {
+                    if option.is_empty()
+                        || option.len() > 256
+                        || option.chars().any(|ch| ch.is_control())
+                    {
                         Err(GjcError::InvalidRequest {
                             field: "choices",
                             reason: "each choice must be 1..=256 bytes".into(),
@@ -252,7 +264,9 @@ impl ModelSelectionDto {
     pub fn into_request(self) -> GjcResult<ModelSelectionRequest> {
         for (field, value) in [("model", &self.model), ("profile", &self.profile)] {
             if let Some(value) = value.as_deref()
-                && (value.is_empty() || value.len() > 128)
+                && (value.is_empty()
+                    || value.len() > 128
+                    || value.chars().any(|ch| ch.is_control()))
             {
                 return Err(GjcError::InvalidRequest {
                     field: "model",
@@ -287,8 +301,14 @@ pub fn session_query_body(query: &SessionQuery) -> Value {
         metadata.provider_metadata = metadata
             .provider_metadata
             .iter()
-            .filter(|(_, value)| {
-                value.is_string() || value.is_number() || value.is_boolean() || value.is_null()
+            .filter(|(key, value)| {
+                matches!(
+                    key.as_str(),
+                    "provider" | "model" | "profile" | "status" | "region"
+                ) && (value.is_string()
+                    || value.is_number()
+                    || value.is_boolean()
+                    || value.is_null())
             })
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
@@ -298,26 +318,94 @@ pub fn session_query_body(query: &SessionQuery) -> Value {
         body["stats"] = serde_json::to_value(stats).unwrap_or(Value::Null);
     }
     if let Some(model_profile) = query.model_profile.as_ref() {
-        body["model_profile"] = serde_json::to_value(model_profile).unwrap_or(Value::Null);
+        body["model_profile"] = json!({
+            "model": if model_profile.model.len() <= 128
+                && !model_profile.model.chars().any(|ch| ch.is_control())
+            {
+                model_profile.model.clone()
+            } else {
+                "redacted".to_string()
+            },
+            "profile": model_profile.profile.as_deref().filter(|profile| {
+                profile.len() <= 128 && !profile.chars().any(|ch| ch.is_control())
+            }),
+        });
     }
     if let Some(turn) = query.turn.as_ref() {
-        body["turn"] = serde_json::to_value(turn).unwrap_or(Value::Null);
+        let mut turn_body = serde_json::to_value(turn).unwrap_or(Value::Null);
+        if let Some(outcome) = turn_body.get("outcome").cloned() {
+            turn_body["outcome"] = crate::gjc::control::public_outcome(&outcome);
+        }
+        body["turn"] = turn_body;
+    } else if query.turn_present {
+        body["turn"] = Value::Null;
     }
     if let Some(queue) = query.queue.as_ref() {
-        body["queue"] = serde_json::to_value(queue).unwrap_or(Value::Null);
+        body["queue"] = json!({
+            "depth": queue.depth,
+            "entries": queue
+                .entries
+                .iter()
+                .take(64)
+                .map(|entry| json!({
+                    "position": entry.position,
+                    "kind": if entry.kind.len() <= 128
+                        && !entry.kind.chars().any(|ch| ch.is_control())
+                    {
+                        entry.kind.clone()
+                    } else {
+                        "redacted".to_string()
+                    },
+                    "summary": entry.summary.as_deref().filter(|summary| {
+                        summary.len() <= 256 && !summary.chars().any(|ch| ch.is_control())
+                    }),
+                }))
+                .collect::<Vec<_>>(),
+        });
     }
     if let Some(gates) = query.workflow_gates.as_ref() {
-        body["workflow_gates"] = serde_json::to_value(gates).unwrap_or(Value::Null);
+        body["workflow_gates"] = Value::Array(
+            gates
+                .iter()
+                .map(|gate| {
+                    let title = gate.title.as_deref().filter(|value| {
+                        value.len() <= 256 && !value.chars().any(|ch| ch.is_control())
+                    });
+                    let options = gate
+                        .options
+                        .iter()
+                        .filter(|value| {
+                            !value.is_empty()
+                                && value.len() <= 256
+                                && !value.chars().any(|ch| ch.is_control())
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    json!({
+                        "gate_id": gate.gate_id,
+                        "state": gate.state,
+                        "title": title,
+                        "options": options,
+                    })
+                })
+                .collect(),
+        );
     }
     if let Some(goal_todo) = query.goal_todo.as_ref() {
-        body["goal_todo"] = serde_json::to_value(goal_todo).unwrap_or(Value::Null);
+        body["goal_todo"] = serde_json::json!({
+            "todo_count": goal_todo.todos.len(),
+        });
     }
     body
 }
 
 /// Command receipt response body.
 pub fn command_receipt_body(receipt: &CommandReceipt) -> Value {
-    serde_json::to_value(receipt).unwrap_or(Value::Null)
+    let mut body = serde_json::to_value(receipt).unwrap_or(Value::Null);
+    if let Some(outcome) = body.get("outcome").cloned() {
+        body["outcome"] = crate::gjc::control::public_outcome(&outcome);
+    }
+    body
 }
 
 /// Terminal outcome response body.
@@ -373,6 +461,19 @@ mod tests {
         .into_request()
         .unwrap_err();
         assert_eq!(error.error_code(), "invalid_request");
+
+        let invalid_id = AskAnswerDto {
+            base: base_dto(),
+            ask_id: "ask-\n1".into(),
+            choices: vec!["yes".into()],
+        };
+        assert!(invalid_id.into_request().is_err());
+        let invalid_choice = AskAnswerDto {
+            base: base_dto(),
+            ask_id: "ask-1".into(),
+            choices: vec!["yes\u{7f}".into()],
+        };
+        assert!(invalid_choice.into_request().is_err());
     }
 
     #[test]
@@ -398,6 +499,15 @@ mod tests {
         .into_request()
         .unwrap_err();
         assert_eq!(error.error_code(), "invalid_request");
+        let mut bad_control = WorkflowGateAnswerDto {
+            base: base_dto(),
+            gate_id: "gate-\n1".into(),
+            option: "ok".into(),
+        };
+        assert!(bad_control.clone().into_request().is_err());
+        bad_control.gate_id = "gate-1".into();
+        bad_control.option = "ok\u{7f}".into();
+        assert!(bad_control.into_request().is_err());
     }
 
     #[test]
@@ -422,6 +532,12 @@ mod tests {
         // DTO-level validation passes; exactly-one is enforced by the
         // control plane (and surfaced as invalid_request there).
         assert!(dto.clone().into_request().is_ok());
+        let invalid = ModelSelectionDto {
+            base: base_dto(),
+            model: Some("model\nname".into()),
+            profile: None,
+        };
+        assert!(invalid.into_request().is_err());
     }
 
     #[test]
@@ -435,7 +551,7 @@ mod tests {
                 last_active_at: None,
                 lane: None,
                 provider_metadata: [
-                    ("safe".to_string(), Value::String("v".into())),
+                    ("provider".to_string(), Value::String("v".into())),
                     ("nested".to_string(), json!({"secret": true})),
                 ]
                 .into_iter()
@@ -444,11 +560,35 @@ mod tests {
             ..SessionQuery::default()
         };
         let body = session_query_body(&query);
-        assert_eq!(body["metadata"]["provider_metadata"]["safe"], "v");
+        assert_eq!(body["metadata"]["provider_metadata"]["provider"], "v");
         assert!(
             body["metadata"]["provider_metadata"]
                 .get("nested")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn session_query_body_preserves_present_null_turn() {
+        let query = SessionQuery {
+            turn_present: true,
+            ..SessionQuery::default()
+        };
+        assert_eq!(session_query_body(&query)["turn"], Value::Null);
+    }
+
+    #[test]
+    fn session_query_body_never_exposes_raw_goal_or_todo_values() {
+        let query = SessionQuery {
+            goal_todo: Some(crate::gjc::model::GoalTodoSnapshot {
+                goal: Some(serde_json::json!("prompt=secret")),
+                todos: vec![serde_json::json!("token=secret")],
+            }),
+            ..SessionQuery::default()
+        };
+        assert_eq!(
+            session_query_body(&query)["goal_todo"],
+            serde_json::json!({"todo_count": 1})
         );
     }
 

--- a/src/gjc/cli.rs
+++ b/src/gjc/cli.rs
@@ -239,10 +239,13 @@ pub async fn run(config: Arc<AppConfig>, command: GjcCommands) -> Result<()> {
             render_receipt(&body, mutation.json)
         }
         GjcCommands::Receipt {
+            session,
             idempotency_key,
             json,
         } => {
-            let body = client.gjc_command_receipt(&idempotency_key).await?;
+            let body = client
+                .gjc_command_receipt(&session, &idempotency_key)
+                .await?;
             render_receipt(&body, json)
         }
     }

--- a/src/gjc/control.rs
+++ b/src/gjc/control.rs
@@ -1,24 +1,370 @@
 //! Control plane over the typed GJC contract: idempotent command registry,
 //! capability gating, session-mismatch guards, and the mutation verbs.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use serde_json::{Value, json};
-use tokio::sync::RwLock;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use super::model::{
     AbortAndPromptRequest, AskAnswerRequest, CommandId, CommandReceipt, ControlRequestEnvelope,
     GJC_CONTROL_SCHEMA, GjcCommandKind, GjcCommandStatus, GjcError, GjcPromptStatus, GjcRequest,
     GjcResponse, GjcResult, GjcTransport, IdempotencyKey, ModelSelectionRequest, PromptRequest,
-    SessionId, SessionQuery, SteerRequest, WorkflowGateAnswerRequest,
+    SessionId, SessionQuery, SteerRequest, TurnId, WorkflowGateAnswerRequest,
 };
 
 pub type SharedGjcCommandRegistry = Arc<RwLock<HashMap<String, CommandReceipt>>>;
+const MAX_COMMAND_RECEIPTS: usize = 4096;
+const RECEIPT_JOURNAL_FILENAME: &str = "gjc-command-receipts.json";
+const RECEIPT_JOURNAL_SCHEMA: &str = "clawhip.gjc-command-receipts.v1";
+const MAX_RECEIPT_JOURNAL_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_RECEIPT_BYTES: usize = 16 * 1024;
 
 pub fn new_shared_command_registry() -> SharedGjcCommandRegistry {
     Arc::new(RwLock::new(HashMap::new()))
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct ReceiptJournalFile {
+    schema: String,
+    receipts: BTreeMap<String, CommandReceipt>,
+}
+
+struct ReceiptJournalState {
+    pending: Option<GjcResult<BTreeMap<String, CommandReceipt>>>,
+    loaded: bool,
+    error: Option<GjcError>,
+}
+
+/// Durable receipt state is only attached to production worktree-scoped
+/// planes. Static transports intentionally remain memory-only test seams.
+struct ReceiptJournal {
+    path: PathBuf,
+    state: Mutex<ReceiptJournalState>,
+    persist_lock: std::sync::Mutex<()>,
+}
+
+impl ReceiptJournal {
+    fn for_worktree(worktree: &Path) -> Self {
+        let state_dir = worktree.join(".gjc").join("state");
+        let path = state_dir.join(RECEIPT_JOURNAL_FILENAME);
+        let pending = load_receipt_journal(worktree, &path);
+        Self {
+            path,
+            state: Mutex::new(ReceiptJournalState {
+                pending: Some(pending),
+                loaded: false,
+                error: None,
+            }),
+            persist_lock: std::sync::Mutex::new(()),
+        }
+    }
+
+    fn initialize(&self, registry: &SharedGjcCommandRegistry) {
+        let Ok(mut state) = self.state.try_lock() else {
+            return;
+        };
+        if state.loaded || state.error.is_some() {
+            return;
+        }
+        let Some(pending) = state.pending.take() else {
+            return;
+        };
+        let receipts = match pending {
+            Ok(receipts) => receipts,
+            Err(error) => {
+                state.error = Some(error);
+                return;
+            }
+        };
+        let Ok(mut write) = registry.try_write() else {
+            state.pending = Some(Ok(receipts));
+            return;
+        };
+        if let Err(error) = merge_loaded_receipts(&mut write, receipts) {
+            state.error = Some(error);
+            return;
+        }
+        state.loaded = true;
+    }
+
+    async fn ensure_loaded(&self, registry: &SharedGjcCommandRegistry) -> GjcResult<()> {
+        let mut state = self.state.lock().await;
+        if let Some(error) = state.error.clone() {
+            return Err(error);
+        }
+        if state.loaded {
+            return Ok(());
+        }
+        let pending = state
+            .pending
+            .take()
+            .expect("receipt journal initialization state must be present");
+        let receipts = match pending {
+            Ok(receipts) => receipts,
+            Err(error) => {
+                state.error = Some(error.clone());
+                return Err(error);
+            }
+        };
+        let mut write = registry.write().await;
+        if let Err(error) = merge_loaded_receipts(&mut write, receipts) {
+            state.error = Some(error.clone());
+            return Err(error);
+        }
+        state.loaded = true;
+        Ok(())
+    }
+
+    fn persist(&self, registry: &HashMap<String, CommandReceipt>) -> GjcResult<()> {
+        let _guard = self
+            .persist_lock
+            .lock()
+            .map_err(|_| receipt_journal_error("receipt journal lock failed"))?;
+        let mut receipts = BTreeMap::new();
+        for (key, receipt) in registry {
+            validate_loaded_receipt(key, receipt)?;
+            receipts.insert(key.clone(), receipt.clone());
+        }
+        if receipts.len() > MAX_COMMAND_RECEIPTS {
+            return Err(receipt_journal_error("receipt journal exceeds capacity"));
+        }
+        let journal = ReceiptJournalFile {
+            schema: RECEIPT_JOURNAL_SCHEMA.into(),
+            receipts,
+        };
+        let bytes = serde_json::to_vec_pretty(&journal)
+            .map_err(|_| receipt_journal_error("receipt journal serialization failed"))?;
+        if bytes.len() as u64 > MAX_RECEIPT_JOURNAL_BYTES {
+            return Err(receipt_journal_error("receipt journal exceeds size limit"));
+        }
+        let parent = self
+            .path
+            .parent()
+            .ok_or_else(|| receipt_journal_error("receipt journal path is invalid"))?;
+        validate_state_directory(parent)?;
+        let temp_path = parent.join(format!(
+            ".{}.{}.tmp",
+            RECEIPT_JOURNAL_FILENAME,
+            Uuid::new_v4()
+        ));
+        let result = (|| {
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            let mut file = options
+                .open(&temp_path)
+                .map_err(|_| receipt_journal_error("receipt journal write failed"))?;
+            file.write_all(&bytes)
+                .and_then(|_| file.flush())
+                .and_then(|_| file.sync_all())
+                .map_err(|_| receipt_journal_error("receipt journal write failed"))?;
+            drop(file);
+            fs::rename(&temp_path, &self.path)
+                .map_err(|_| receipt_journal_error("receipt journal replace failed"))?;
+            File::open(parent)
+                .and_then(|directory| directory.sync_all())
+                .map_err(|_| receipt_journal_error("receipt journal directory sync failed"))?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temp_path);
+        }
+        result
+    }
+}
+
+fn merge_loaded_receipts(
+    registry: &mut HashMap<String, CommandReceipt>,
+    receipts: BTreeMap<String, CommandReceipt>,
+) -> GjcResult<()> {
+    if receipts.len() > MAX_COMMAND_RECEIPTS {
+        return Err(receipt_journal_error("receipt journal exceeds capacity"));
+    }
+    let additions = receipts
+        .keys()
+        .filter(|key| !registry.contains_key(*key))
+        .count();
+    if registry.len().saturating_add(additions) > MAX_COMMAND_RECEIPTS {
+        return Err(receipt_journal_error("receipt journal exceeds capacity"));
+    }
+    for (key, receipt) in &receipts {
+        if let Some(existing) = registry.get(key)
+            && serde_json::to_value(existing).ok() != serde_json::to_value(receipt).ok()
+        {
+            return Err(receipt_journal_error(
+                "receipt journal conflicts with live state",
+            ));
+        }
+    }
+    for (key, receipt) in receipts {
+        registry.entry(key).or_insert(receipt);
+    }
+    Ok(())
+}
+
+fn receipt_journal_error(reason: &str) -> GjcError {
+    GjcError::InvalidRequest {
+        field: "receipt_journal",
+        reason: reason.into(),
+    }
+}
+
+fn load_receipt_journal(
+    worktree: &Path,
+    path: &Path,
+) -> GjcResult<BTreeMap<String, CommandReceipt>> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| receipt_journal_error("receipt journal path is invalid"))?;
+    ensure_state_directory(worktree, parent)?;
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(_) => return Err(receipt_journal_error("receipt journal cannot be inspected")),
+    };
+    if metadata.is_symlink() || !metadata.is_file() {
+        return Err(receipt_journal_error(
+            "receipt journal is not a regular file",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let owner = metadata.uid();
+        let current = unsafe { libc::getuid() };
+        if owner != 0 && current != 0 && owner != current {
+            return Err(receipt_journal_error(
+                "receipt journal owner is not trusted",
+            ));
+        }
+        if metadata.permissions().mode() & 0o077 != 0 {
+            return Err(receipt_journal_error(
+                "receipt journal permissions are not trusted",
+            ));
+        }
+    }
+    if metadata.len() > MAX_RECEIPT_JOURNAL_BYTES {
+        return Err(receipt_journal_error("receipt journal exceeds size limit"));
+    }
+    let bytes =
+        fs::read(path).map_err(|_| receipt_journal_error("receipt journal cannot be read"))?;
+    if bytes.len() as u64 > MAX_RECEIPT_JOURNAL_BYTES {
+        return Err(receipt_journal_error("receipt journal exceeds size limit"));
+    }
+    let journal: ReceiptJournalFile = serde_json::from_slice(&bytes)
+        .map_err(|_| receipt_journal_error("receipt journal is malformed"))?;
+    if journal.schema != RECEIPT_JOURNAL_SCHEMA {
+        return Err(receipt_journal_error(
+            "receipt journal schema is unsupported",
+        ));
+    }
+    if journal.receipts.len() > MAX_COMMAND_RECEIPTS {
+        return Err(receipt_journal_error("receipt journal exceeds capacity"));
+    }
+    for (key, receipt) in &journal.receipts {
+        validate_loaded_receipt(key, receipt)?;
+    }
+    Ok(journal.receipts)
+}
+
+fn ensure_state_directory(worktree: &Path, state_dir: &Path) -> GjcResult<()> {
+    let gjc_dir = worktree.join(".gjc");
+    for directory in [&gjc_dir, state_dir] {
+        match fs::symlink_metadata(directory) {
+            Ok(metadata) if metadata.is_symlink() || !metadata.is_dir() => {
+                return Err(receipt_journal_error(
+                    "receipt state directory is not trusted",
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir(directory).map_err(|_| {
+                    receipt_journal_error("receipt state directory cannot be created")
+                })?;
+            }
+            Err(_) => {
+                return Err(receipt_journal_error(
+                    "receipt state directory cannot be inspected",
+                ));
+            }
+        }
+    }
+    validate_state_directory(state_dir)
+}
+
+fn validate_state_directory(state_dir: &Path) -> GjcResult<()> {
+    let metadata = fs::symlink_metadata(state_dir)
+        .map_err(|_| receipt_journal_error("receipt state directory cannot be inspected"))?;
+    if metadata.is_symlink() || !metadata.is_dir() {
+        return Err(receipt_journal_error(
+            "receipt state directory is not trusted",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o002 != 0 {
+            return Err(receipt_journal_error(
+                "receipt state directory is writable by others",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_loaded_receipt(key: &str, receipt: &CommandReceipt) -> GjcResult<()> {
+    IdempotencyKey::new(key.to_string())
+        .map_err(|_| receipt_journal_error("receipt idempotency key is invalid"))?;
+    if receipt.schema != GJC_CONTROL_SCHEMA || receipt.idempotency_key != key {
+        return Err(receipt_journal_error("receipt identity is invalid"));
+    }
+    CommandId::new(receipt.command_id.clone())
+        .map_err(|_| receipt_journal_error("receipt command id is invalid"))?;
+    SessionId::new(receipt.session_id.clone())
+        .map_err(|_| receipt_journal_error("receipt session id is invalid"))?;
+    if !matches!(
+        receipt.kind.as_str(),
+        "prompt"
+            | "steer"
+            | "abort_and_prompt"
+            | "workflow_gate_answer"
+            | "ask_answer"
+            | "model_selection"
+    ) {
+        return Err(receipt_journal_error("receipt command kind is invalid"));
+    }
+    if let Some(turn_id) = receipt.turn_id.as_ref() {
+        TurnId::new(turn_id.clone())
+            .map_err(|_| receipt_journal_error("receipt turn id is invalid"))?;
+    }
+    OffsetDateTime::parse(&receipt.created_at, &Rfc3339)
+        .map_err(|_| receipt_journal_error("receipt timestamp is invalid"))?;
+    if receipt.status.is_terminal() != receipt.outcome.is_some() {
+        return Err(receipt_journal_error("receipt outcome state is invalid"));
+    }
+    if let Some(outcome) = receipt.outcome.as_ref()
+        && public_outcome(outcome) != *outcome
+    {
+        return Err(receipt_journal_error("receipt outcome is not public-safe"));
+    }
+    let bytes = serde_json::to_vec(receipt)
+        .map_err(|_| receipt_journal_error("receipt cannot be serialized"))?;
+    if bytes.len() > MAX_RECEIPT_BYTES {
+        return Err(receipt_journal_error("receipt exceeds size limit"));
+    }
+    Ok(())
 }
 
 fn now_rfc3339() -> String {
@@ -41,8 +387,9 @@ enum TransportSource {
 /// A live transport binding: the resolved endpoint and the session it serves.
 #[derive(Clone)]
 struct BoundTransport {
-    session_id: Option<String>,
     transport: Arc<dyn GjcTransport>,
+    session_id: Option<String>,
+    worktree: Option<PathBuf>,
 }
 
 /// The authoritative control plane. One instance per daemon; CLI paths go
@@ -52,6 +399,7 @@ pub struct GjcControlPlane {
     source: TransportSource,
     bound: Arc<RwLock<Option<BoundTransport>>>,
     registry: SharedGjcCommandRegistry,
+    journal: Option<Arc<ReceiptJournal>>,
 }
 
 impl GjcControlPlane {
@@ -62,6 +410,7 @@ impl GjcControlPlane {
             source: TransportSource::Static(transport),
             bound: Arc::new(RwLock::new(None)),
             registry,
+            journal: None,
         }
     }
 
@@ -72,17 +421,51 @@ impl GjcControlPlane {
             source: TransportSource::Unavailable,
             bound: Arc::new(RwLock::new(None)),
             registry,
+            journal: None,
         }
     }
 
     /// Production constructor: resolve the lane endpoint under `worktree`
     /// through the #322 discovery surface on demand.
     pub fn for_worktree(worktree: &std::path::Path, registry: SharedGjcCommandRegistry) -> Self {
+        let journal = Arc::new(ReceiptJournal::for_worktree(worktree));
+        journal.initialize(&registry);
         Self {
             source: TransportSource::Discovery(worktree.to_path_buf()),
             bound: Arc::new(RwLock::new(None)),
             registry,
+            journal: Some(journal),
         }
+    }
+
+    /// Scope a control plane to an enrolled lane's worktree while retaining
+    /// the shared command registry used for idempotent receipts. Public
+    /// daemon handlers use this after resolving the session through the
+    /// durable lane store; callers must not derive the worktree from the
+    /// daemon's current directory.
+    pub fn scoped_to_worktree(&self, worktree: &std::path::Path) -> Self {
+        let journal = Arc::new(ReceiptJournal::for_worktree(worktree));
+        journal.initialize(&self.registry);
+        Self {
+            source: TransportSource::Discovery(worktree.to_path_buf()),
+            bound: Arc::new(RwLock::new(None)),
+            registry: self.registry.clone(),
+            journal: Some(journal),
+        }
+    }
+
+    async fn ensure_receipt_journal(&self) -> GjcResult<()> {
+        if let Some(journal) = self.journal.as_ref() {
+            journal.ensure_loaded(&self.registry).await?;
+        }
+        Ok(())
+    }
+
+    fn persist_receipts(&self, registry: &HashMap<String, CommandReceipt>) -> GjcResult<()> {
+        if let Some(journal) = self.journal.as_ref() {
+            journal.persist(registry)?;
+        }
+        Ok(())
     }
 
     /// Resolve a usable transport, enforcing session binding for
@@ -94,23 +477,18 @@ impl GjcControlPlane {
     ) -> GjcResult<Option<BoundTransport>> {
         match &self.source {
             TransportSource::Static(transport) => Ok(Some(BoundTransport {
-                session_id: None,
                 transport: transport.clone(),
+                session_id: None,
+                worktree: None,
             })),
             TransportSource::Unavailable => Ok(None),
             TransportSource::Discovery(root) => {
-                let cached = self.bound.read().await.clone();
-                if let Some(bound) = cached {
-                    let matches = match (bound.session_id.as_deref(), wanted) {
-                        (_, None) => true,
-                        (None, _) => true,
-                        (Some(bound_session), Some(wanted)) => bound_session == wanted.as_str(),
-                    };
-                    if matches {
-                        return Ok(Some(bound));
-                    }
-                }
-                match super::transport::discover_endpoint(root) {
+                let discovered = if let Some(wanted) = wanted {
+                    super::transport::discover_endpoint_for_session(root, wanted.as_str())
+                } else {
+                    super::transport::discover_endpoint(root)
+                };
+                match discovered {
                     Ok(endpoint) => {
                         if let Some(wanted) = wanted {
                             let endpoint_session = endpoint.session_id().to_string();
@@ -121,8 +499,9 @@ impl GjcControlPlane {
                             }
                         }
                         let bound = BoundTransport {
-                            session_id: Some(endpoint.session_id().to_string()),
                             transport: Arc::new(endpoint),
+                            session_id: wanted.map(|session| session.as_str().to_string()),
+                            worktree: Some(root.clone()),
                         };
                         *self.bound.write().await = Some(bound.clone());
                         Ok(Some(bound))
@@ -140,6 +519,14 @@ impl GjcControlPlane {
             self.resolve_transport(None).await,
             Ok(Some(_)) | Err(GjcError::SessionMismatch { .. })
         );
+        super::model::Capabilities::for_transport(implemented)
+    }
+
+    pub async fn capabilities_for_session(
+        &self,
+        session: &SessionId,
+    ) -> super::model::Capabilities {
+        let implemented = matches!(self.resolve_transport(Some(session)).await, Ok(Some(_)));
         super::model::Capabilities::for_transport(implemented)
     }
     // -----------------------------------------------------------------
@@ -171,8 +558,32 @@ impl GjcControlPlane {
             )
             .await?;
         let result = reply.result;
-        let mut query = SessionQuery::default();
-        if let Some(value) = result.get("metadata") {
+        let Some(result) = result.as_object() else {
+            return Err(GjcError::InvalidPeerReply {
+                method: "session.get".into(),
+                reason: "result must be an object".into(),
+            });
+        };
+        if sections.contains(&"metadata")
+            && !result
+                .get("metadata")
+                .is_some_and(|value| value.is_object())
+        {
+            return Err(GjcError::InvalidPeerReply {
+                method: "session.get".into(),
+                reason: "metadata identity section is required".into(),
+            });
+        }
+        let mut query = SessionQuery {
+            revision: result.get("revision").and_then(Value::as_u64),
+            workflow_gates_present: sections.contains(&"workflow_gates")
+                && result.contains_key("workflow_gates"),
+            turn_present: sections.contains(&"turn") && result.contains_key("turn"),
+            ..SessionQuery::default()
+        };
+        if sections.contains(&"metadata")
+            && let Some(value) = result.get("metadata")
+        {
             query.metadata = serde_json::from_value(value.clone()).map_err(|error| {
                 GjcError::InvalidPeerReply {
                     method: "session.get".into(),
@@ -180,7 +591,9 @@ impl GjcControlPlane {
                 }
             })?;
         }
-        if let Some(value) = result.get("stats") {
+        if sections.contains(&"stats")
+            && let Some(value) = result.get("stats")
+        {
             query.stats = serde_json::from_value(value.clone()).map_err(|error| {
                 GjcError::InvalidPeerReply {
                     method: "session.get".into(),
@@ -188,7 +601,9 @@ impl GjcControlPlane {
                 }
             })?;
         }
-        if let Some(value) = result.get("model_profile") {
+        if sections.contains(&"model_profile")
+            && let Some(value) = result.get("model_profile")
+        {
             query.model_profile = serde_json::from_value(value.clone()).map_err(|error| {
                 GjcError::InvalidPeerReply {
                     method: "session.get".into(),
@@ -196,7 +611,9 @@ impl GjcControlPlane {
                 }
             })?;
         }
-        if let Some(value) = result.get("turn") {
+        if sections.contains(&"turn")
+            && let Some(value) = result.get("turn")
+        {
             query.turn = serde_json::from_value(value.clone()).map_err(|error| {
                 GjcError::InvalidPeerReply {
                     method: "session.get".into(),
@@ -204,7 +621,9 @@ impl GjcControlPlane {
                 }
             })?;
         }
-        if let Some(value) = result.get("queue") {
+        if sections.contains(&"queue")
+            && let Some(value) = result.get("queue")
+        {
             query.queue = serde_json::from_value(value.clone()).map_err(|error| {
                 GjcError::InvalidPeerReply {
                     method: "session.get".into(),
@@ -212,7 +631,15 @@ impl GjcControlPlane {
                 }
             })?;
         }
-        if let Some(value) = result.get("workflow_gates") {
+        if sections.contains(&"workflow_gates")
+            && let Some(value) = result.get("workflow_gates")
+        {
+            if value.is_null() {
+                return Err(GjcError::InvalidPeerReply {
+                    method: "session.get".into(),
+                    reason: "workflow_gates section must be an array when present".into(),
+                });
+            }
             query.workflow_gates = serde_json::from_value(value.clone()).map_err(|error| {
                 GjcError::InvalidPeerReply {
                     method: "session.get".into(),
@@ -220,7 +647,9 @@ impl GjcControlPlane {
                 }
             })?;
         }
-        if let Some(value) = result.get("goal_todo") {
+        if sections.contains(&"goal_todo")
+            && let Some(value) = result.get("goal_todo")
+        {
             query.goal_todo = serde_json::from_value(value.clone()).map_err(|error| {
                 GjcError::InvalidPeerReply {
                     method: "session.get".into(),
@@ -234,6 +663,7 @@ impl GjcControlPlane {
 
     /// Terminal outcome receipt for one turn.
     pub async fn turn_outcome(&self, session: &SessionId, turn_id: &str) -> GjcResult<Value> {
+        let requested_turn = TurnId::new(turn_id.to_string())?;
         let transport = self
             .resolve_transport(Some(session))
             .await?
@@ -259,7 +689,33 @@ impl GjcControlPlane {
                     method: "turn.outcome".into(),
                     reason: "outcome missing".into(),
                 })?;
-        Ok(outcome)
+        let status = outcome
+            .get("status")
+            .and_then(Value::as_str)
+            .ok_or_else(|| GjcError::InvalidPeerReply {
+                method: "turn.outcome".into(),
+                reason: "outcome status missing".into(),
+            })?;
+        if !matches!(status, "succeeded" | "failed" | "aborted") {
+            return Err(GjcError::InvalidPeerReply {
+                method: "turn.outcome".into(),
+                reason: "outcome is not terminal".into(),
+            });
+        }
+        if let Some(echoed) = outcome.get("turn_id").and_then(Value::as_str) {
+            let echoed_turn =
+                TurnId::new(echoed.to_string()).map_err(|_| GjcError::InvalidPeerReply {
+                    method: "turn.outcome".into(),
+                    reason: "outcome turn identity is malformed".into(),
+                })?;
+            if echoed_turn != requested_turn {
+                return Err(GjcError::InvalidPeerReply {
+                    method: "turn.outcome".into(),
+                    reason: "outcome turn identity mismatch".into(),
+                });
+            }
+        }
+        Ok(public_outcome(&outcome))
     }
 
     // -----------------------------------------------------------------
@@ -359,6 +815,7 @@ impl GjcControlPlane {
 
     /// Replay an accepted command by idempotency key.
     pub async fn command_receipt(&self, key: &IdempotencyKey) -> GjcResult<CommandReceipt> {
+        self.ensure_receipt_journal().await?;
         self.registry
             .read()
             .await
@@ -366,16 +823,6 @@ impl GjcControlPlane {
             .cloned()
             .ok_or(GjcError::SessionNotFound {
                 session_id: key.as_str().to_string(),
-            })
-            .and_then(|receipt| {
-                if receipt.status.is_terminal() {
-                    Ok(receipt)
-                } else {
-                    Err(GjcError::InvalidRequest {
-                        field: "idempotency_key",
-                        reason: "command has not reached a terminal state".into(),
-                    })
-                }
             })
     }
 
@@ -401,6 +848,41 @@ impl GjcControlPlane {
         Ok(reply)
     }
 
+    /// Re-read the discovery record for a mutating exchange and compare it to
+    /// the endpoint captured during resolution. This is deliberately called
+    /// after the durable reservation and both immediately before dispatch and
+    /// immediately before trusting an acknowledgement; any ambiguity leaves
+    /// the non-terminal reservation intact and never triggers a replay.
+    async fn validate_mutation_lease(
+        &self,
+        transport: &BoundTransport,
+        session: &SessionId,
+    ) -> GjcResult<()> {
+        let TransportSource::Discovery(root) = &self.source else {
+            return Ok(());
+        };
+        if transport.session_id.as_deref() != Some(session.as_str())
+            || transport.worktree.as_deref() != Some(root.as_path())
+        {
+            return Err(GjcError::SessionMismatch {
+                expected: session.as_str().to_string(),
+            });
+        }
+        let current = super::transport::discover_endpoint_for_session(root, session.as_str())
+            .map_err(|error| match error {
+                GjcError::SessionNotFound { .. } => GjcError::StaleEndpoint {
+                    capability: super::model::CAP_ENDPOINT.into(),
+                },
+                other => other,
+            })?;
+        if transport.transport.endpoint_generation() != Some(current.endpoint_generation()) {
+            return Err(GjcError::StaleEndpoint {
+                capability: super::model::CAP_ENDPOINT.into(),
+            });
+        }
+        Ok(())
+    }
+
     /// Shared mutation path: capability gate, session guard, idempotent
     /// replay, bounded exchange, receipt recording with forward-only
     /// status progression.
@@ -410,7 +892,35 @@ impl GjcControlPlane {
         kind: GjcCommandKind,
         params: Value,
     ) -> GjcResult<CommandReceipt> {
+        self.ensure_receipt_journal().await?;
         envelope.validate()?;
+        if let Some(expected) = envelope.expected_session.as_ref()
+            && expected.as_str() != envelope.session.as_str()
+        {
+            return Err(GjcError::SessionMismatch {
+                expected: envelope.session.as_str().to_string(),
+            });
+        }
+        if let Some(existing) = self
+            .registry
+            .read()
+            .await
+            .get(envelope.idempotency_key.as_str())
+        {
+            if existing.session_id != envelope.session.as_str() || existing.kind != kind.as_str() {
+                return Err(GjcError::InvalidRequest {
+                    field: "idempotency_key",
+                    reason: "key is bound to another session or command kind".into(),
+                });
+            }
+            if existing.status.is_terminal() {
+                return Ok(existing.clone());
+            }
+            return Err(GjcError::InvalidRequest {
+                field: "idempotency_key",
+                reason: "command is already in flight".into(),
+            });
+        }
         // Capability gate: mutations fail closed on missing capability
         // before any session or transport work happens.
         self.capabilities()
@@ -420,27 +930,6 @@ impl GjcControlPlane {
             .resolve_transport(Some(&envelope.session))
             .await?
             .ok_or(GjcError::TransportUnavailable)?;
-
-        // Idempotent replay: the identical key returns the recorded receipt.
-        if let Some(existing) = self
-            .registry
-            .read()
-            .await
-            .get(envelope.idempotency_key.as_str())
-            && existing.status.is_terminal()
-        {
-            return Ok(existing.clone());
-        }
-
-        // Expected-session guard: fail closed before any dispatch when the
-        // caller's belief disagrees with the addressed session.
-        if let Some(expected) = envelope.expected_session.as_ref()
-            && expected.as_str() != envelope.session.as_str()
-        {
-            return Err(GjcError::SessionMismatch {
-                expected: envelope.session.as_str().to_string(),
-            });
-        }
 
         let mut request_params = json!({
             "session_id": envelope.session.as_str(),
@@ -468,22 +957,86 @@ impl GjcControlPlane {
             outcome: None,
             created_at: now_rfc3339(),
         };
-        self.registry.write().await.insert(
-            envelope.idempotency_key.as_str().to_string(),
-            receipt.clone(),
-        );
+        // Replay checking and reservation share one write lock so concurrent
+        // callers cannot both claim the same key.
+        let mut registry = self.registry.write().await;
+        if let Some(existing) = registry.get(envelope.idempotency_key.as_str()) {
+            if existing.session_id != envelope.session.as_str() || existing.kind != kind.as_str() {
+                return Err(GjcError::InvalidRequest {
+                    field: "idempotency_key",
+                    reason: "key is bound to another session or command kind".into(),
+                });
+            }
+            if existing.status.is_terminal() {
+                return Ok(existing.clone());
+            }
+            return Err(GjcError::InvalidRequest {
+                field: "idempotency_key",
+                reason: "command is already in flight".into(),
+            });
+        }
+        if registry.len() >= MAX_COMMAND_RECEIPTS {
+            let evictable = registry
+                .iter()
+                .find(|(_, receipt)| receipt.status.is_terminal())
+                .map(|(key, _)| key.clone());
+            let Some(evictable) = evictable else {
+                return Err(GjcError::InvalidRequest {
+                    field: "idempotency_key",
+                    reason: "command receipt capacity is exhausted by active commands".into(),
+                });
+            };
+            let evicted = registry
+                .remove(&evictable)
+                .expect("receipt eviction key must still exist");
+            registry.insert(
+                envelope.idempotency_key.as_str().to_string(),
+                receipt.clone(),
+            );
+            if let Err(error) = self.persist_receipts(&registry) {
+                registry.remove(envelope.idempotency_key.as_str());
+                registry.insert(evictable, evicted);
+                return Err(error);
+            }
+        } else {
+            registry.insert(
+                envelope.idempotency_key.as_str().to_string(),
+                receipt.clone(),
+            );
+            if let Err(error) = self.persist_receipts(&registry) {
+                registry.remove(envelope.idempotency_key.as_str());
+                return Err(error);
+            }
+        }
+        drop(registry);
+        // The reservation is durable before any peer exchange begins.
+
+        // Revalidate the enrolled worktree/session/generation at the final
+        // dispatch boundary. Rotation is stale rather than retryable: this
+        // command remains reserved and is never sent to a replacement peer.
+        self.validate_mutation_lease(&transport, &envelope.session)
+            .await?;
 
         // Transport exchange with bounded timeout semantics owned by the
         // transport implementation (#322). Ambiguous or malformed acks fail
         // closed; the recorded receipt stays non-terminal so a replay does
         // not fabricate an outcome.
-        let reply = self
+        let reply = match self
             .round_trip(
                 &transport,
                 &format!("control.{}", kind.as_str()),
                 request_params,
                 envelope.timeout_ms,
             )
+            .await
+        {
+            Ok(reply) => reply,
+            Err(error) => return Err(error),
+        };
+        // Revalidate again before accepting the acknowledgement. If metadata
+        // rotated while the exchange was in flight, the reservation remains
+        // Accepted and the control is never replayed automatically.
+        self.validate_mutation_lease(&transport, &envelope.session)
             .await?;
 
         let acked = reply
@@ -499,9 +1052,12 @@ impl GjcControlPlane {
 
         // Ack-side session guard: an ack naming a different session is
         // treated as a mismatch and fails closed.
-        if let Some(echoed) = reply.result.get("session_id").and_then(Value::as_str)
-            && echoed != envelope.session.as_str()
-        {
+        let Some(echoed) = reply.result.get("session_id").and_then(Value::as_str) else {
+            return Err(GjcError::AmbiguousAck {
+                method: kind.as_str().into(),
+            });
+        };
+        if echoed != envelope.session.as_str() {
             return Err(GjcError::SessionMismatch {
                 expected: envelope.session.as_str().to_string(),
             });
@@ -513,26 +1069,37 @@ impl GjcControlPlane {
             .get("turn_id")
             .and_then(Value::as_str)
             .map(str::to_string);
-        let outcome = reply.result.get("outcome").cloned();
+        let outcome = reply.result.get("outcome").map(public_outcome);
 
         let mut write = self.registry.write().await;
-        let entry =
-            write
-                .get_mut(envelope.idempotency_key.as_str())
-                .ok_or(GjcError::InvalidRequest {
+        let previous;
+        let acked_entry = {
+            let entry = write.get_mut(envelope.idempotency_key.as_str()).ok_or(
+                GjcError::InvalidRequest {
                     field: "idempotency_key",
                     reason: "command registry entry vanished mid-flight".into(),
-                })?;
-        if !entry.status.can_transition_to(GjcCommandStatus::Acked) {
-            return Err(GjcError::AmbiguousAck {
-                method: kind.as_str().into(),
-            });
+                },
+            )?;
+            if !entry.status.can_transition_to(GjcCommandStatus::Acked) {
+                return Err(GjcError::AmbiguousAck {
+                    method: kind.as_str().into(),
+                });
+            }
+            previous = entry.clone();
+            entry.status = GjcCommandStatus::Acked;
+            if let Some(turn_id) = turn_id.clone() {
+                entry.turn_id = Some(turn_id);
+            }
+            entry.clone()
+        };
+        let snapshot = write.clone();
+        if let Err(error) = self.persist_receipts(&snapshot) {
+            if let Some(entry) = write.get_mut(envelope.idempotency_key.as_str()) {
+                *entry = previous;
+            }
+            return Err(error);
         }
-        entry.status = GjcCommandStatus::Acked;
-        if let Some(turn_id) = turn_id.clone() {
-            entry.turn_id = Some(turn_id);
-        }
-        let mut updated = entry.clone();
+        let mut updated = acked_entry;
         drop(write);
 
         // Terminal receipt: a peer outcome is only trusted when it carries
@@ -558,12 +1125,26 @@ impl GjcControlPlane {
                 }
             };
             let mut write = self.registry.write().await;
-            if let Some(entry) = write.get_mut(envelope.idempotency_key.as_str())
+            let previous_and_updated = if let Some(entry) =
+                write.get_mut(envelope.idempotency_key.as_str())
                 && entry.status.can_transition_to(terminal)
             {
+                let previous = entry.clone();
                 entry.status = terminal;
                 entry.outcome = Some(outcome);
-                updated = entry.clone();
+                Some((previous, entry.clone()))
+            } else {
+                None
+            };
+            if let Some((previous, terminal_entry)) = previous_and_updated {
+                let snapshot = write.clone();
+                if let Err(error) = self.persist_receipts(&snapshot) {
+                    if let Some(entry) = write.get_mut(envelope.idempotency_key.as_str()) {
+                        *entry = previous;
+                    }
+                    return Err(error);
+                }
+                updated = terminal_entry;
             }
         }
 
@@ -583,6 +1164,70 @@ impl GjcControlPlane {
         }
         Ok(())
     }
+}
+
+pub(crate) fn public_outcome(value: &Value) -> Value {
+    let Some(object) = value.as_object() else {
+        return json!({"status": "unknown", "summary": "details redacted"});
+    };
+    let mut safe = serde_json::Map::new();
+    let status = object
+        .get("status")
+        .and_then(Value::as_str)
+        .filter(|status| {
+            matches!(
+                *status,
+                "queued" | "running" | "succeeded" | "failed" | "aborted"
+            )
+        })
+        .unwrap_or("unknown");
+    safe.insert("status".into(), Value::String(status.into()));
+    if let Some(Value::String(text)) = object.get("turn_id")
+        && text.len() <= 128
+        && !text.is_empty()
+        && text
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        safe.insert("turn_id".into(), Value::String(text.clone()));
+    }
+    if let Some(Value::String(text)) = object.get("finished_at")
+        && let Ok(parsed) = OffsetDateTime::parse(text, &Rfc3339)
+        && let Ok(canonical) = parsed.format(&Rfc3339)
+    {
+        safe.insert("finished_at".into(), Value::String(canonical));
+    }
+    if let Some(Value::String(summary)) = object.get("summary") {
+        let lower = summary.to_ascii_lowercase();
+        let compact: String = lower.chars().filter(char::is_ascii_alphanumeric).collect();
+        let safe_summary = if summary.len() <= 128
+            && !lower.contains("token")
+            && !lower.contains("secret")
+            && !lower.contains("password")
+            && !lower.contains("api_key")
+            && !lower.contains("api-key")
+            && !lower.contains("private_key")
+            && !lower.contains("authorization")
+            && !lower.contains("apikey")
+            && !lower.contains("credential")
+            && !lower.contains("passwd")
+            && !lower.contains("auth:")
+            && !compact.contains("privatekey")
+            && !lower.contains("auth=")
+            && !lower.contains("bearer")
+            && !lower.contains("://")
+            && summary.is_ascii()
+        {
+            summary
+                .chars()
+                .filter(|character| !character.is_control())
+                .collect()
+        } else {
+            "details redacted".to_string()
+        };
+        safe.insert("summary".into(), Value::String(safe_summary));
+    }
+    Value::Object(safe)
 }
 
 fn parse_prompt_status(raw: &str) -> Option<GjcPromptStatus> {
@@ -652,7 +1297,7 @@ mod tests {
     fn ack_reply(turn_id: &str) -> GjcResult<GjcResponse> {
         Ok(GjcResponse {
             correlation_id: String::new(),
-            result: json!({"accepted": true, "turn_id": turn_id}),
+            result: json!({"accepted": true, "session_id": "sess-1", "turn_id": turn_id}),
         })
     }
 
@@ -661,6 +1306,7 @@ mod tests {
             correlation_id: String::new(),
             result: json!({
                 "accepted": true,
+                "session_id": "sess-1",
                 "turn_id": turn_id,
                 "outcome": {"status": status, "summary": summary},
             }),
@@ -709,6 +1355,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_session_allows_omitted_optional_surfaces() {
+        let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({
+                "metadata": {"session_id": "sess-1"}
+            }),
+        })])
+        .await;
+        let query = plane
+            .query_session(
+                &SessionId::new("sess-1").unwrap(),
+                &["metadata", "stats", "turn", "workflow_gates"],
+            )
+            .await
+            .unwrap();
+        assert!(query.stats.is_none());
+        assert!(query.turn.is_none());
+        assert!(query.workflow_gates.is_none());
+        assert!(!query.turn_present);
+    }
+
+    #[tokio::test]
+    async fn query_session_preserves_explicit_null_turn_presence() {
+        let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({
+                "metadata": {"session_id": "sess-1"},
+                "turn": null
+            }),
+        })])
+        .await;
+        let query = plane
+            .query_session(&SessionId::new("sess-1").unwrap(), &["metadata", "turn"])
+            .await
+            .unwrap();
+        assert!(query.turn_present);
+        assert!(query.turn.is_none());
+    }
+
+    #[tokio::test]
+    async fn query_session_ignores_unrequested_sections() {
+        let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
+            correlation_id: String::new(),
+            result: json!({
+                "metadata": {"session_id": "sess-1"},
+                "turn": {"id": "not-returned", "state": "invalid"},
+                "goal_todo": {"raw": "not-returned"}
+            }),
+        })])
+        .await;
+        let query = plane
+            .query_session(&SessionId::new("sess-1").unwrap(), &["metadata"])
+            .await
+            .unwrap();
+        assert!(query.turn.is_none());
+        assert!(query.goal_todo.is_none());
+    }
+
+    #[tokio::test]
     async fn prompt_accepts_and_records_acked_receipt() {
         let key = IdempotencyKey::new("idem-key-0100").unwrap();
         let (plane, _transport) = implemented_plane_with(vec![ack_reply("turn-100")]).await;
@@ -722,9 +1427,8 @@ mod tests {
         assert_eq!(receipt.status, GjcCommandStatus::Acked);
         assert_eq!(receipt.turn_id.as_deref(), Some("turn-100"));
         assert!(!receipt.status.is_terminal());
-        // Non-terminal receipts are not replayable as outcomes.
-        let error = plane.command_receipt(&key).await.unwrap_err();
-        assert_eq!(error.error_code(), "invalid_request");
+        let recorded = plane.command_receipt(&key).await.unwrap();
+        assert_eq!(recorded.status, GjcCommandStatus::Acked);
     }
 
     #[tokio::test]
@@ -760,6 +1464,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn idempotency_key_cannot_replay_across_sessions() {
+        let (plane, _transport) =
+            implemented_plane_with(vec![terminal_ack_reply("turn-102", "succeeded", "done")]).await;
+        plane
+            .prompt(PromptRequest {
+                envelope: envelope("idem-key-cross-session"),
+                prompt: "once".into(),
+            })
+            .await
+            .unwrap();
+        let mut cross_session = envelope("idem-key-cross-session");
+        cross_session.session = SessionId::new("sess-2").unwrap();
+        let error = plane
+            .prompt(PromptRequest {
+                envelope: cross_session,
+                prompt: "replay".into(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "session_mismatch");
+    }
+
+    #[tokio::test]
     async fn ambiguous_ack_fails_closed_without_fabricating_outcome() {
         let (plane, _transport) = implemented_plane_with(vec![Ok(GjcResponse {
             correlation_id: String::new(),
@@ -774,15 +1501,15 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(error.error_code(), "ambiguous_ack");
-        let receipt = plane
-            .registry
-            .read()
-            .await
-            .get("idem-key-0102")
-            .cloned()
-            .expect("record kept");
-        // The record stays non-terminal so a replay cannot fake success.
-        assert_eq!(receipt.status, GjcCommandStatus::Accepted);
+        assert_eq!(
+            plane
+                .registry
+                .read()
+                .await
+                .get("idem-key-0102")
+                .map(|receipt| receipt.status),
+            Some(GjcCommandStatus::Accepted)
+        );
     }
 
     #[tokio::test]
@@ -1018,5 +1745,255 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(transport.timeouts.lock().unwrap()[0], 4_321);
+    }
+
+    #[tokio::test]
+    async fn endpoint_rotation_after_resolution_rejects_lease_and_keeps_reservation() {
+        let worktree = tempfile::tempdir().unwrap();
+        let sdk_dir = worktree.path().join(".gjc").join("state").join("sdk");
+        std::fs::create_dir_all(&sdk_dir).unwrap();
+        let metadata = sdk_dir.join("sess-1.json");
+        std::fs::write(
+            &metadata,
+            json!({
+                "version": 1,
+                "sessionId": "sess-1",
+                "url": "ws://127.0.0.1:1/",
+                "token": "lease-before",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&metadata, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+
+        let plane = GjcControlPlane::for_worktree(worktree.path(), new_shared_command_registry());
+        let session = SessionId::new("sess-1").unwrap();
+        let bound = plane
+            .resolve_transport(Some(&session))
+            .await
+            .unwrap()
+            .unwrap();
+        plane.registry.write().await.insert(
+            "idem-lease-001".into(),
+            stored_receipt("idem-lease-001", GjcCommandStatus::Accepted),
+        );
+
+        std::fs::write(
+            &metadata,
+            json!({
+                "version": 1,
+                "sessionId": "sess-1",
+                "url": "ws://127.0.0.1:2/",
+                "token": "lease-after",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&metadata, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+
+        let error = plane
+            .validate_mutation_lease(&bound, &session)
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "stale_endpoint");
+        assert_eq!(
+            plane
+                .registry
+                .read()
+                .await
+                .get("idem-lease-001")
+                .map(|receipt| receipt.status),
+            Some(GjcCommandStatus::Accepted)
+        );
+    }
+
+    #[tokio::test]
+    async fn bound_mutation_lease_rejects_worktree_mismatch() {
+        let worktree = tempfile::tempdir().unwrap();
+        let sdk_dir = worktree.path().join(".gjc").join("state").join("sdk");
+        std::fs::create_dir_all(&sdk_dir).unwrap();
+        let metadata = sdk_dir.join("sess-1.json");
+        std::fs::write(
+            &metadata,
+            json!({
+                "version": 1,
+                "sessionId": "sess-1",
+                "url": "ws://127.0.0.1:1/",
+                "token": "worktree-bound",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&metadata, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+
+        let plane = GjcControlPlane::for_worktree(worktree.path(), new_shared_command_registry());
+        let session = SessionId::new("sess-1").unwrap();
+        let bound = plane
+            .resolve_transport(Some(&session))
+            .await
+            .unwrap()
+            .unwrap();
+        let foreign_worktree = tempfile::tempdir().unwrap();
+        let foreign_plane = plane.scoped_to_worktree(foreign_worktree.path());
+        let error = foreign_plane
+            .validate_mutation_lease(&bound, &session)
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "session_mismatch");
+    }
+
+    fn stored_receipt(key: &str, status: GjcCommandStatus) -> CommandReceipt {
+        CommandReceipt {
+            schema: GJC_CONTROL_SCHEMA.into(),
+            command_id: format!("cmd-{key}"),
+            idempotency_key: key.into(),
+            kind: "prompt".into(),
+            session_id: "sess-1".into(),
+            status,
+            turn_id: (!matches!(status, GjcCommandStatus::Accepted)).then(|| format!("turn-{key}")),
+            outcome: status.is_terminal().then(|| {
+                json!({
+                    "status": if status == GjcCommandStatus::Completed {
+                        "succeeded"
+                    } else {
+                        "failed"
+                    },
+                    "summary": "stored",
+                })
+            }),
+            created_at: "2026-01-01T00:00:00Z".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn production_receipt_journal_reloads_reserved_receipt() {
+        let worktree = tempfile::tempdir().unwrap();
+        let registry = new_shared_command_registry();
+        let plane = GjcControlPlane::for_worktree(worktree.path(), registry.clone());
+        plane.ensure_receipt_journal().await.unwrap();
+        let receipt = stored_receipt("reload-key-0001", GjcCommandStatus::Accepted);
+        registry
+            .write()
+            .await
+            .insert(receipt.idempotency_key.clone(), receipt.clone());
+        let snapshot = registry.read().await.clone();
+        plane.persist_receipts(&snapshot).unwrap();
+        drop(plane);
+
+        let reloaded =
+            GjcControlPlane::for_worktree(worktree.path(), new_shared_command_registry());
+        assert_eq!(
+            reloaded
+                .command_receipt(&IdempotencyKey::new("reload-key-0001").unwrap())
+                .await
+                .unwrap()
+                .command_id,
+            receipt.command_id
+        );
+    }
+
+    #[tokio::test]
+    async fn production_receipt_journal_retains_active_and_ambiguous_entries() {
+        let worktree = tempfile::tempdir().unwrap();
+        let registry = new_shared_command_registry();
+        let plane = GjcControlPlane::for_worktree(worktree.path(), registry.clone());
+        plane.ensure_receipt_journal().await.unwrap();
+        let accepted = stored_receipt("active-key-0001", GjcCommandStatus::Accepted);
+        let acked = stored_receipt("ambiguous-key-001", GjcCommandStatus::Acked);
+        {
+            let mut write = registry.write().await;
+            write.insert(accepted.idempotency_key.clone(), accepted.clone());
+            write.insert(acked.idempotency_key.clone(), acked.clone());
+        }
+        let snapshot = registry.read().await.clone();
+        plane.persist_receipts(&snapshot).unwrap();
+        drop(plane);
+
+        let reloaded =
+            GjcControlPlane::for_worktree(worktree.path(), new_shared_command_registry());
+        reloaded.ensure_receipt_journal().await.unwrap();
+        let write = reloaded.registry.read().await;
+        assert_eq!(
+            write.get("active-key-0001").unwrap().status,
+            GjcCommandStatus::Accepted
+        );
+        assert_eq!(
+            write.get("ambiguous-key-001").unwrap().status,
+            GjcCommandStatus::Acked
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_production_receipt_journal_fails_closed() {
+        let worktree = tempfile::tempdir().unwrap();
+        let state = worktree.path().join(".gjc").join("state");
+        std::fs::create_dir_all(&state).unwrap();
+        let path = state.join(RECEIPT_JOURNAL_FILENAME);
+        std::fs::write(&path, b"not-json").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        let plane = GjcControlPlane::for_worktree(worktree.path(), new_shared_command_registry());
+        let error = plane
+            .command_receipt(&IdempotencyKey::new("malformed-key-001").unwrap())
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn receipt_capacity_evicts_terminal_entries_only() {
+        let worktree = tempfile::tempdir().unwrap();
+        let (mut plane, _transport) =
+            implemented_plane_with(vec![ack_reply("turn-capacity")]).await;
+        plane.journal = Some(Arc::new(ReceiptJournal::for_worktree(worktree.path())));
+        plane.ensure_receipt_journal().await.unwrap();
+        {
+            let mut write = plane.registry.write().await;
+            write.insert(
+                "active-key-0002".into(),
+                stored_receipt("active-key-0002", GjcCommandStatus::Accepted),
+            );
+            for index in 0..(MAX_COMMAND_RECEIPTS - 1) {
+                let key = format!("terminal-{index:04}");
+                write.insert(
+                    key.clone(),
+                    stored_receipt(&key, GjcCommandStatus::Completed),
+                );
+            }
+        }
+        let result = plane
+            .prompt(PromptRequest {
+                envelope: envelope("capacity-key-001"),
+                prompt: "bounded".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(result.status, GjcCommandStatus::Acked);
+        let write = plane.registry.read().await;
+        assert_eq!(write.len(), MAX_COMMAND_RECEIPTS);
+        assert!(write.contains_key("active-key-0002"));
+        assert!(write.contains_key("capacity-key-001"));
+        assert_eq!(
+            write
+                .values()
+                .filter(|receipt| receipt.status.is_terminal())
+                .count(),
+            MAX_COMMAND_RECEIPTS - 2
+        );
     }
 }

--- a/src/gjc/model.rs
+++ b/src/gjc/model.rs
@@ -254,6 +254,10 @@ pub struct GjcResponse {
 #[async_trait]
 pub trait GjcTransport: Send + Sync {
     async fn round_trip(&self, request: GjcRequest) -> std::result::Result<GjcResponse, GjcError>;
+
+    fn endpoint_generation(&self) -> Option<u64> {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -345,7 +349,8 @@ impl GjcError {
                 format!("gjc reply correlation failed for {method}")
             }
             GjcError::InvalidPeerReply { method, reason } => {
-                format!("gjc reply rejected for {method}: {reason}")
+                let _ = reason;
+                format!("gjc reply rejected for {method}")
             }
             GjcError::MissingCapability { capability } => {
                 format!("required gjc capability is missing: {capability}")
@@ -517,6 +522,8 @@ impl GjcPromptStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkflowGate {
     pub gate_id: String,
+    #[serde(default)]
+    pub kind: Option<String>,
     pub workflow_id: Option<String>,
     pub state: WorkflowGateState,
     pub title: Option<String>,
@@ -545,6 +552,8 @@ pub struct GoalTodoSnapshot {
 pub struct SessionTurn {
     pub turn_id: String,
     pub status: GjcPromptStatus,
+    #[serde(default)]
+    pub prompt_accepted: bool,
     pub started_at: Option<String>,
     pub finished_at: Option<String>,
     /// Terminal outcome payload; present only on terminal statuses.
@@ -562,12 +571,18 @@ pub struct SessionTurnOutcome {
 /// is requested by name; missing surfaces stay `None` instead of guessed.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SessionQuery {
+    #[serde(default)]
+    pub revision: Option<u64>,
     pub metadata: Option<SessionMetadata>,
     pub stats: Option<SessionStats>,
     pub model_profile: Option<SessionModelProfile>,
     pub turn: Option<SessionTurn>,
+    #[serde(skip)]
+    pub turn_present: bool,
     pub queue: Option<QueueSnapshot>,
     pub workflow_gates: Option<Vec<WorkflowGate>>,
+    #[serde(skip)]
+    pub workflow_gates_present: bool,
     pub goal_todo: Option<GoalTodoSnapshot>,
 }
 

--- a/src/gjc/transport.rs
+++ b/src/gjc/transport.rs
@@ -5,6 +5,7 @@
 use std::path::Path;
 
 use async_trait::async_trait;
+use serde_json::Value;
 
 use super::model::{GjcError, GjcRequest, GjcResponse, GjcResult, GjcTransport};
 use crate::gjc_sdk::{
@@ -20,16 +21,75 @@ use crate::gjc_sdk::{
 #[derive(Debug)]
 pub struct SdkEndpointTransport {
     metadata: EndpointMetadata,
+    /// Discovery root used to revalidate the endpoint lease around mutating
+    /// exchanges. Static construction remains available for unit-test seams;
+    /// production discovery always supplies this root.
+    state_root: Option<StateRoot>,
 }
 
 impl SdkEndpointTransport {
+    #[allow(dead_code)]
     pub fn new(metadata: EndpointMetadata) -> Self {
-        Self { metadata }
+        Self {
+            metadata,
+            state_root: None,
+        }
+    }
+
+    fn from_discovery(state_root: &StateRoot, metadata: EndpointMetadata) -> Self {
+        Self {
+            metadata,
+            state_root: Some(state_root.clone()),
+        }
     }
 
     /// Public-safe session identifier this endpoint is bound to.
     pub fn session_id(&self) -> &str {
         self.metadata.session_id()
+    }
+
+    pub fn endpoint_generation(&self) -> u64 {
+        self.metadata.generation()
+    }
+
+    /// Re-read the enrolled endpoint metadata and reject any rotation or
+    /// identity change before trusting a mutating exchange. The metadata
+    /// itself is the lease: a changed generation means the old transport is
+    /// no longer an unambiguous peer for this command.
+    fn validate_lease(&self) -> GjcResult<()> {
+        let Some(state_root) = self.state_root.as_ref() else {
+            return Ok(());
+        };
+        let current = gjc_sdk::discover_all(state_root)
+            .map_err(|error| map_transport_error("endpoint.validate", &error))?
+            .into_iter()
+            .find(|metadata| metadata.session_id() == self.session_id());
+        let Some(current) = current else {
+            return Err(GjcError::StaleEndpoint {
+                capability: crate::gjc::model::CAP_ENDPOINT.into(),
+            });
+        };
+        if current.generation() != self.endpoint_generation() {
+            return Err(GjcError::StaleEndpoint {
+                capability: crate::gjc::model::CAP_ENDPOINT.into(),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_request_session(&self, request: &GjcRequest) -> GjcResult<()> {
+        let Some(requested) = request.params.get("session_id").and_then(Value::as_str) else {
+            return Err(GjcError::InvalidPeerReply {
+                method: request.method.clone(),
+                reason: "mutating request session identity is missing".into(),
+            });
+        };
+        if requested != self.session_id() {
+            return Err(GjcError::SessionMismatch {
+                expected: self.session_id().to_string(),
+            });
+        }
+        Ok(())
     }
 }
 
@@ -65,7 +125,19 @@ fn map_transport_error(method: &str, error: &crate::DynError) -> GjcError {
 
 #[async_trait]
 impl GjcTransport for SdkEndpointTransport {
+    fn endpoint_generation(&self) -> Option<u64> {
+        Some(self.endpoint_generation())
+    }
+
     async fn round_trip(&self, request: GjcRequest) -> std::result::Result<GjcResponse, GjcError> {
+        let mutating = request.method.starts_with("control.");
+        // The lease must still describe the enrolled session immediately
+        // before opening the authenticated connection. A stale command stays
+        // reserved and is never replayed against a replacement endpoint.
+        if mutating {
+            self.validate_request_session(&request)?;
+            self.validate_lease()?;
+        }
         // v3 wire mapping: `control.*` methods become control_request
         // frames; every other method is a query_request. The correlation ID
         // is minted inside the typed frame and echoed by the peer.
@@ -93,6 +165,13 @@ impl GjcTransport for SdkEndpointTransport {
             .await
             .map_err(|error| map_transport_error(&request.method, &error))?;
 
+        // A peer may rotate its metadata while the exchange is in flight. Do
+        // not accept an otherwise valid ack from an endpoint whose identity
+        // changed during this non-idempotent operation.
+        if mutating {
+            self.validate_lease()?;
+        }
+
         // Defense in depth: the transport already enforces correlation;
         // re-check before trusting the payload.
         if reply.id.as_deref() != Some(correlation_id.as_str()) {
@@ -105,6 +184,16 @@ impl GjcTransport for SdkEndpointTransport {
                 .error
                 .and_then(|error| error.code)
                 .unwrap_or_else(|| "unknown".into());
+            if reason == "session_not_found" {
+                return Err(GjcError::SessionNotFound {
+                    session_id: request
+                        .params
+                        .get("session_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown")
+                        .to_string(),
+                });
+            }
             return Err(GjcError::InvalidPeerReply {
                 method: request.method.clone(),
                 reason: format!("peer rejected request: {reason}"),
@@ -121,15 +210,33 @@ impl GjcTransport for SdkEndpointTransport {
 /// unrelated root. Outcomes map directly onto control-plane failures so the
 /// daemon never guesses.
 pub fn discover_endpoint(worktree: &Path) -> GjcResult<SdkEndpointTransport> {
-    let discovery = gjc_sdk::discover(&StateRoot::for_worktree(worktree))
+    let state_root = StateRoot::for_worktree(worktree);
+    let discovery = gjc_sdk::discover(&state_root)
         .map_err(|error| map_transport_error("endpoint.discover", &error))?;
     match discovery {
-        Discovery::Live(metadata) => Ok(SdkEndpointTransport::new(metadata)),
+        Discovery::Live(metadata) => {
+            Ok(SdkEndpointTransport::from_discovery(&state_root, metadata))
+        }
         Discovery::Stale { .. } => Err(GjcError::StaleEndpoint {
             capability: super::model::CAP_ENDPOINT.into(),
         }),
         Discovery::Malformed | Discovery::NoMetadata => Err(GjcError::TransportUnavailable),
     }
+}
+
+pub fn discover_endpoint_for_session(
+    worktree: &Path,
+    session_id: &str,
+) -> GjcResult<SdkEndpointTransport> {
+    let state_root = StateRoot::for_worktree(worktree);
+    let metadata = gjc_sdk::discover_all(&state_root)
+        .map_err(|error| map_transport_error("endpoint.discover", &error))?
+        .into_iter()
+        .find(|metadata| metadata.session_id() == session_id)
+        .ok_or_else(|| GjcError::SessionNotFound {
+            session_id: session_id.to_string(),
+        })?;
+    Ok(SdkEndpointTransport::from_discovery(&state_root, metadata))
 }
 
 #[cfg(test)]
@@ -275,5 +382,146 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(error.error_code(), "transport_unavailable");
+    }
+
+    #[tokio::test]
+    async fn mutating_exchange_rejects_rotation_before_dispatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = write_metadata(
+            temp.path(),
+            "sess-lane-1",
+            "ws://127.0.0.1:1/",
+            "tok-before",
+        );
+        let transport = discover_endpoint_for_session(temp.path(), "sess-lane-1").unwrap();
+
+        // Resolve the endpoint first, then rotate its metadata before the
+        // mutation reaches the websocket. The lease check must fail closed
+        // without attempting a connection to either endpoint.
+        std::fs::write(
+            &path,
+            json!({
+                "version": 1,
+                "sessionId": "sess-lane-1",
+                "url": "ws://127.0.0.1:2/",
+                "token": "tok-after",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+
+        let error = transport
+            .round_trip(GjcRequest::new(
+                "rotation-corr",
+                "control.prompt",
+                json!({"session_id": "sess-lane-1"}),
+                1_000,
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "stale_endpoint");
+    }
+
+    #[tokio::test]
+    async fn mutating_exchange_rejects_foreign_session_before_dispatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let _ = write_metadata(
+            temp.path(),
+            "sess-lane-1",
+            "ws://127.0.0.1:1/",
+            "tok-session",
+        );
+        let transport = discover_endpoint_for_session(temp.path(), "sess-lane-1").unwrap();
+        let error = transport
+            .round_trip(GjcRequest::new(
+                "identity-corr",
+                "control.prompt",
+                json!({"session_id": "sess-foreign"}),
+                1_000,
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "session_mismatch");
+    }
+
+    #[tokio::test]
+    async fn mutating_exchange_rejects_rotation_before_acknowledgement() {
+        use futures_util::{SinkExt, StreamExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let metadata = write_metadata(
+            temp.path(),
+            "sess-lane-1",
+            &format!("ws://{addr}/"),
+            "tok-before-ack",
+        );
+        let server_metadata = metadata.clone();
+        let server = tokio::spawn(async move {
+            use tokio_tungstenite::tungstenite::Message;
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let (mut sink, mut stream) = ws.split();
+            sink.send(Message::text(
+                r#"{"type":"hello","connectionId":"ack-rotation"}"#,
+            ))
+            .await
+            .unwrap();
+            let Some(Ok(Message::Text(text))) = stream.next().await else {
+                return;
+            };
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            std::fs::write(
+                &server_metadata,
+                json!({
+                    "version": 1,
+                    "sessionId": "sess-lane-1",
+                    "url": format!("ws://{addr}/"),
+                    "token": "tok-after-ack",
+                })
+                .to_string(),
+            )
+            .unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&server_metadata, std::fs::Permissions::from_mode(0o600))
+                    .unwrap();
+            }
+            sink.send(Message::text(
+                json!({
+                    "type": "control_response",
+                    "id": value["id"],
+                    "ok": true,
+                    "result": {
+                        "accepted": true,
+                        "session_id": "sess-lane-1"
+                    }
+                })
+                .to_string(),
+            ))
+            .await
+            .unwrap();
+        });
+
+        let transport = discover_endpoint_for_session(temp.path(), "sess-lane-1").unwrap();
+        let error = transport
+            .round_trip(GjcRequest::new(
+                "ack-rotation-corr",
+                "control.prompt",
+                json!({"session_id": "sess-lane-1"}),
+                1_000,
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(error.error_code(), "stale_endpoint");
+        server.await.unwrap();
     }
 }

--- a/src/gjc_lane.rs
+++ b/src/gjc_lane.rs
@@ -29,7 +29,16 @@ use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use tokio::sync::mpsc;
 
+use crate::dispatch::{
+    AlertDeliveryJournal, AlertDeliveryState, cancel_alert_acceptance,
+    clear_alert_delivery_journal, register_alert_acceptance, register_alert_delivery_journal,
+};
 use crate::events::IncomingEvent;
+use crate::gjc_sdk_events::{
+    GjcEventBridge, GjcSdkEndpoint, GjcSdkEndpointHealth, GjcSdkGate, GjcSdkGateKind,
+    GjcSdkGateStatus, GjcSdkStateSnapshot, GjcSdkTurn, GjcSdkTurnPhase, gate_revision,
+    valid_gate_id,
+};
 
 pub const GJC_LANE_STATE_SCHEMA: &str = "clawhip.gjc-lane-state.v1";
 pub const GJC_LANE_STATUS_EVENT: &str = "gjc.lane.status";
@@ -38,6 +47,12 @@ pub const GJC_LANE_HEALTH_SCHEMA: &str = "clawhip.gjc-health.v1";
 
 /// Audit trail is bounded: oldest entries are dropped once this many exist.
 pub const MAX_AUDIT_ENTRIES: usize = 512;
+/// Pending alerts are retained until the reconciler's send succeeds. Refuse
+/// to grow beyond this bound rather than dropping an operator-visible alert.
+const MAX_PENDING_ALERTS: usize = 64;
+const MAX_PENDING_ALERT_DELIVERIES: usize = 64;
+const MAX_LANES: usize = 1024;
+const ALERT_ACCEPTANCE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_SESSION_LEN: usize = 128;
 const MAX_WORKTREE_LEN: usize = 4096;
 const MAX_OWNER_LEN: usize = 64;
@@ -96,6 +111,7 @@ pub enum GjcTurnState {
     AwaitingInput,
     Complete,
     Failed,
+    Aborted,
 }
 
 /// Workflow-gate state reported by the SDK.
@@ -122,13 +138,23 @@ pub enum GjcSessionDisposition {
 pub struct GjcSdkObservation {
     pub session_id: String,
     pub worktree: Option<String>,
+    pub branch: Option<String>,
+    pub branch_observed: bool,
     pub endpoint_generation: u64,
     pub revision: u64,
     pub turn_state: GjcTurnState,
     pub turn_id: Option<String>,
+    pub prompt_accepted: bool,
     pub gate_state: Option<GjcGateState>,
+    pub gate_section_present: bool,
     pub gate_id: Option<String>,
+    pub gate_revision: u64,
+    pub gate_kind: Option<GjcSdkGateKind>,
+    pub gate_workflow_id: Option<String>,
+    pub gate_title: Option<String>,
+    pub gate_options: Vec<String>,
     pub disposition: GjcSessionDisposition,
+    pub error_summary: Option<String>,
 }
 
 /// Query failure kinds. Only `SessionNotFound` is authoritative about the
@@ -148,6 +174,7 @@ pub enum GjcSdkQueryError {
         observed: u64,
     },
     Ambiguous(String),
+    InvalidState(String),
 }
 
 impl fmt::Display for GjcSdkQueryError {
@@ -160,6 +187,7 @@ impl fmt::Display for GjcSdkQueryError {
                 write!(f, "stale endpoint generation; observed {observed}")
             }
             Self::Ambiguous(detail) => write!(f, "ambiguous response: {detail}"),
+            Self::InvalidState(detail) => write!(f, "invalid control-plane state: {detail}"),
         }
     }
 }
@@ -175,6 +203,216 @@ pub trait GjcSdkControlPlane: Send + Sync {
         &self,
         query: &GjcLaneQuery,
     ) -> std::result::Result<GjcSdkObservation, GjcSdkQueryError>;
+}
+
+/// Adapter that makes the authoritative #323 control plane usable by the
+/// durable #325 reconciler. Keeping this adapter at the seam prevents the
+/// reconciler from learning transport or websocket details.
+pub struct GjcControlPlaneAdapter {
+    registry: crate::gjc::control::SharedGjcCommandRegistry,
+}
+
+impl GjcControlPlaneAdapter {
+    pub fn new(registry: crate::gjc::control::SharedGjcCommandRegistry) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl GjcSdkControlPlane for GjcControlPlaneAdapter {
+    async fn query_lane(
+        &self,
+        query: &GjcLaneQuery,
+    ) -> std::result::Result<GjcSdkObservation, GjcSdkQueryError> {
+        let session = crate::gjc::model::SessionId::new(query.sdk_session_id.clone())
+            .map_err(|_| GjcSdkQueryError::SessionNotFound("invalid session identity".into()))?;
+        let worktree =
+            query.worktree.as_deref().map(Path::new).ok_or_else(|| {
+                GjcSdkQueryError::EndpointUnavailable("worktree unavailable".into())
+            })?;
+        let endpoint_generation =
+            crate::gjc::transport::discover_endpoint_for_session(worktree, &query.sdk_session_id)
+                .map_err(map_control_error)?
+                .endpoint_generation();
+        if query.known_endpoint_generation != 0
+            && query.known_endpoint_generation != endpoint_generation
+        {
+            return Err(GjcSdkQueryError::StaleEndpointGeneration {
+                observed: endpoint_generation,
+            });
+        }
+        let control =
+            crate::gjc::control::GjcControlPlane::for_worktree(worktree, self.registry.clone());
+        let session_query = control
+            .query_session(&session, &["metadata", "stats", "turn", "workflow_gates"])
+            .await
+            .map_err(map_control_error)?;
+        let confirmed_generation =
+            crate::gjc::transport::discover_endpoint_for_session(worktree, &query.sdk_session_id)
+                .map_err(map_control_error)?
+                .endpoint_generation();
+        if confirmed_generation != endpoint_generation {
+            return Err(GjcSdkQueryError::StaleEndpointGeneration {
+                observed: confirmed_generation,
+            });
+        }
+        if !session_query.turn_present {
+            return Err(GjcSdkQueryError::InvalidState(
+                "authoritative session query omitted turn".to_string(),
+            ));
+        }
+        let turn = session_query.turn.as_ref();
+        let (turn_state, turn_id, disposition, error_summary, prompt_accepted) = match turn {
+            Some(turn) => match turn.status {
+                crate::gjc::model::GjcPromptStatus::Queued => (
+                    GjcTurnState::Running,
+                    Some(turn.turn_id.clone()),
+                    GjcSessionDisposition::Live,
+                    None,
+                    turn.prompt_accepted,
+                ),
+                crate::gjc::model::GjcPromptStatus::Running => (
+                    GjcTurnState::Running,
+                    Some(turn.turn_id.clone()),
+                    GjcSessionDisposition::Live,
+                    None,
+                    turn.prompt_accepted,
+                ),
+                crate::gjc::model::GjcPromptStatus::Succeeded => (
+                    GjcTurnState::Complete,
+                    Some(turn.turn_id.clone()),
+                    GjcSessionDisposition::Live,
+                    turn.outcome
+                        .as_ref()
+                        .and_then(|outcome| outcome.summary.clone()),
+                    turn.prompt_accepted,
+                ),
+                crate::gjc::model::GjcPromptStatus::Failed => (
+                    GjcTurnState::Failed,
+                    Some(turn.turn_id.clone()),
+                    GjcSessionDisposition::Live,
+                    turn.outcome
+                        .as_ref()
+                        .and_then(|outcome| outcome.summary.clone()),
+                    turn.prompt_accepted,
+                ),
+                crate::gjc::model::GjcPromptStatus::Aborted => (
+                    GjcTurnState::Aborted,
+                    Some(turn.turn_id.clone()),
+                    GjcSessionDisposition::Live,
+                    turn.outcome
+                        .as_ref()
+                        .and_then(|outcome| outcome.summary.clone()),
+                    turn.prompt_accepted,
+                ),
+            },
+            None => (
+                GjcTurnState::Idle,
+                None,
+                GjcSessionDisposition::Live,
+                None,
+                false,
+            ),
+        };
+        let gates = session_query.workflow_gates.as_deref().unwrap_or_default();
+        if gates
+            .iter()
+            .filter(|gate| gate.state == crate::gjc::model::WorkflowGateState::Ready)
+            .count()
+            > 1
+        {
+            return Err(GjcSdkQueryError::InvalidState(
+                "multiple ready workflow gates".to_string(),
+            ));
+        }
+        if gates
+            .iter()
+            .any(|gate| !valid_gate_id(&gate.gate_id) || gate_revision(gate) == 0)
+        {
+            return Err(GjcSdkQueryError::InvalidState(
+                "workflow gate identity or revision is malformed".to_string(),
+            ));
+        }
+        let gate = gates
+            .iter()
+            .find(|gate| gate.state == crate::gjc::model::WorkflowGateState::Ready)
+            .or_else(|| {
+                session_query
+                    .workflow_gates
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .max_by_key(|gate| crate::gjc_sdk_events::gate_revision(gate))
+            });
+        let (branch_observed, branch) = match query.worktree.as_deref() {
+            Some(worktree) => match current_git_branch(worktree) {
+                Ok(branch) => (true, branch),
+                Err(_) => (false, None),
+            },
+            None => (false, None),
+        };
+        Ok(GjcSdkObservation {
+            session_id: query.sdk_session_id.clone(),
+            worktree: query.worktree.clone(),
+            branch_observed,
+            branch,
+            endpoint_generation,
+            revision: session_query.revision.ok_or_else(|| {
+                GjcSdkQueryError::InvalidState(
+                    "authoritative session query omitted revision".to_string(),
+                )
+            })?,
+            turn_state: if gate
+                .is_some_and(|gate| gate.state == crate::gjc::model::WorkflowGateState::Ready)
+            {
+                GjcTurnState::AwaitingInput
+            } else {
+                turn_state
+            },
+            turn_id,
+            gate_state: gate.map(|gate| {
+                if gate.state == crate::gjc::model::WorkflowGateState::Ready {
+                    GjcGateState::Ready
+                } else {
+                    GjcGateState::Answered
+                }
+            }),
+            gate_section_present: session_query.workflow_gates_present,
+            gate_id: gate.map(|gate| gate.gate_id.clone()),
+            gate_revision: gate.map(crate::gjc_sdk_events::gate_revision).unwrap_or(0),
+            gate_kind: gate.and_then(|gate| match gate.kind.as_deref() {
+                Some("ask") => Some(GjcSdkGateKind::Ask),
+                Some("workflow") => Some(GjcSdkGateKind::Workflow),
+                _ => None,
+            }),
+            gate_workflow_id: gate.and_then(|gate| gate.workflow_id.clone()),
+            gate_title: gate.and_then(|gate| gate.title.clone()),
+            gate_options: gate.map(|gate| gate.options.clone()).unwrap_or_default(),
+            disposition,
+            error_summary,
+            prompt_accepted,
+        })
+    }
+}
+
+fn map_control_error(error: crate::gjc::model::GjcError) -> GjcSdkQueryError {
+    use crate::gjc::model::GjcError;
+    match error {
+        GjcError::SessionNotFound { .. } => {
+            GjcSdkQueryError::SessionNotFound("session not found".into())
+        }
+        GjcError::Timeout { .. } => GjcSdkQueryError::Timeout("control-plane timeout".into()),
+        GjcError::TransportUnavailable | GjcError::StaleEndpoint { .. } => {
+            GjcSdkQueryError::EndpointUnavailable("sdk endpoint unavailable".into())
+        }
+        GjcError::AmbiguousAck { .. }
+        | GjcError::InvalidPeerReply { .. }
+        | GjcError::MissingCapability { .. }
+        | GjcError::SessionMismatch { .. }
+        | GjcError::InvalidRequest { .. } => {
+            GjcSdkQueryError::Ambiguous("control-plane response was not authoritative".into())
+        }
+    }
 }
 
 /// Inputs the control plane needs to locate one SDK session.
@@ -247,6 +485,8 @@ pub struct GjcPrBinding {
 pub struct GjcTurnSnapshot {
     pub state: GjcTurnState,
     pub turn_id: Option<String>,
+    #[serde(default)]
+    pub prompt_accepted: bool,
     pub observed_at: String,
 }
 
@@ -254,6 +494,8 @@ pub struct GjcTurnSnapshot {
 pub struct GjcGateSnapshot {
     pub state: GjcGateState,
     pub gate_id: Option<String>,
+    #[serde(default)]
+    pub revision: u64,
     pub observed_at: String,
 }
 
@@ -283,15 +525,74 @@ pub struct GjcReconcileAuditEntry {
     pub detail: String,
 }
 
+/// One alert durably staged before attempting delivery. The event payload is
+/// already public-safe and carries its deterministic `event_id`; keeping the
+/// complete payload here makes crash recovery independent of a fresh SDK
+/// observation or bridge process-local reducer state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GjcPendingAlert {
+    pub event_id: String,
+    pub kind: String,
+    pub payload: Value,
+    #[serde(default)]
+    pub queued_at: String,
+    #[serde(default)]
+    pub attempts: u32,
+    /// Per-destination ownership and terminal outcome. The map is durable so
+    /// a replay can skip destinations already claimed or delivered while
+    /// independently retrying destinations whose sink returned an error.
+    #[serde(default)]
+    pub deliveries: BTreeMap<String, GjcPendingAlertDelivery>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GjcPendingAlertDeliveryState {
+    Claimed,
+    Delivered,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GjcPendingAlertDelivery {
+    pub state: GjcPendingAlertDeliveryState,
+    #[serde(default)]
+    pub attempts: u32,
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+impl GjcPendingAlert {
+    fn incoming_event(&self) -> IncomingEvent {
+        IncomingEvent {
+            kind: self.kind.clone(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: self.payload.clone(),
+        }
+    }
+}
+
 /// Durable record for one GJC SDK-backed lane watch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GjcLaneRecord {
     pub lane_id: String,
     pub sdk_session_id: String,
     pub worktree: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
     /// Last observed SDK endpoint generation; a bump invalidates stale
     /// review/owner evidence captured under the previous generation.
     pub endpoint_generation: u64,
+    /// Monotonic durable endpoint failure episode. It changes only after a
+    /// successful endpoint observation followed by a new failure, never on a
+    /// local CAS mutation.
+    #[serde(default)]
+    pub endpoint_episode: u64,
+    #[serde(default)]
+    pub endpoint_alerted: bool,
     /// Local durable-record revision for optimistic concurrency (CAS).
     pub revision: u64,
     /// Last observed SDK-side session revision.
@@ -313,6 +614,9 @@ pub struct GjcLaneRecord {
     pub watch_removed_at: Option<String>,
     pub registered_at: String,
     pub updated_at: String,
+    /// Alerts staged before delivery; bounded and replayed until acknowledged.
+    #[serde(default)]
+    pub pending_alerts: Vec<GjcPendingAlert>,
 }
 
 /// Registration input accepted by the store and daemon API.
@@ -353,6 +657,8 @@ struct GjcLaneStateFile {
     schema: String,
     generation: u64,
     lanes: BTreeMap<String, GjcLaneRecord>,
+    #[serde(default)]
+    lane_id_aliases: BTreeMap<String, String>,
     audit: Vec<GjcReconcileAuditEntry>,
     audit_entries_dropped: u64,
 }
@@ -382,7 +688,13 @@ pub fn now_rfc3339() -> String {
 
 /// Stable, filesystem-safe lane id derived from the SDK session identity.
 pub fn gjc_lane_id(sdk_session_id: &str) -> String {
-    format!("gjc-{:016x}", Sha256::digest(sdk_session_id.as_bytes())[0])
+    let digest = Sha256::digest(sdk_session_id.as_bytes());
+    let hex: String = digest
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    format!("gjc-{hex}")
 }
 
 fn fingerprint(value: &str) -> String {
@@ -405,16 +717,24 @@ fn valid_id(value: &str) -> bool {
 }
 
 fn valid_session_id(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= MAX_SESSION_LEN
-        && value.is_ascii()
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+    value.len() <= MAX_SESSION_LEN && crate::gjc::model::SessionId::new(value).is_ok()
 }
 
 fn valid_worktree(value: &str) -> bool {
-    !value.is_empty() && value.len() <= MAX_WORKTREE_LEN && !value.chars().any(char::is_control)
+    if value.is_empty() || value.len() > MAX_WORKTREE_LEN || value.chars().any(char::is_control) {
+        return false;
+    }
+    let path = std::path::Path::new(value);
+    if !path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return false;
+    }
+    path.canonicalize()
+        .map(|canonical| canonical == path)
+        .unwrap_or(true)
 }
 
 fn valid_hex_sha(value: &str) -> bool {
@@ -429,16 +749,251 @@ fn default_true() -> bool {
     true
 }
 
+fn migrate_lane_ids(state: &mut GjcLaneStateFile) -> Result<bool> {
+    for (alias, target) in &state.lane_id_aliases {
+        if alias == target || state.lanes.contains_key(alias) {
+            bail!("lane id migration alias collides with canonical lane");
+        }
+        if state.lane_id_aliases.contains_key(target) {
+            bail!("lane id migration alias chain is not supported");
+        }
+        if !state.lanes.contains_key(target) {
+            bail!("lane id migration alias target is missing");
+        }
+    }
+    let canonical_ids = state
+        .lanes
+        .values()
+        .map(|record| gjc_lane_id(&record.sdk_session_id))
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut migrated = false;
+    let mut lanes = BTreeMap::new();
+    for (old_id, mut record) in std::mem::take(&mut state.lanes) {
+        let new_id = gjc_lane_id(&record.sdk_session_id);
+        if old_id != new_id && canonical_ids.contains(&old_id) {
+            bail!("lane id migration alias collision for canonical lane");
+        }
+        if old_id != new_id || record.lane_id != new_id {
+            migrated = true;
+            record.lane_id = new_id.clone();
+        }
+        if lanes.insert(new_id.clone(), record).is_some() {
+            bail!("lane id migration collision for session identity");
+        }
+        if old_id != new_id {
+            state.lane_id_aliases.insert(old_id, new_id);
+        }
+    }
+    state.lanes = lanes;
+    for target in state.lane_id_aliases.values() {
+        if state.lane_id_aliases.contains_key(target) {
+            bail!("lane id migration alias chain is not supported");
+        }
+        if !state.lanes.contains_key(target) {
+            bail!("lane id migration alias target is missing");
+        }
+    }
+    Ok(migrated)
+}
+
+fn current_git_branch(worktree: &str) -> Result<Option<String>> {
+    let output = std::process::Command::new("git")
+        .args(["-C", worktree, "branch", "--show-current"])
+        .output()
+        .context("git branch probe failed")?;
+    if !output.status.success() {
+        bail!("git branch probe returned non-success");
+    }
+    let branch = String::from_utf8(output.stdout)
+        .context("git branch probe returned invalid output")?
+        .trim()
+        .to_string();
+    Ok((!branch.is_empty() && branch.len() <= 128).then_some(branch))
+}
+
+fn canonical_lane_id(state: &GjcLaneStateFile, lane_id: &str) -> String {
+    state
+        .lane_id_aliases
+        .get(lane_id)
+        .cloned()
+        .unwrap_or_else(|| lane_id.to_string())
+}
+
+fn observation_snapshot(
+    record: &GjcLaneRecord,
+    previous: Option<&GjcLaneRecord>,
+    observation: &GjcSdkObservation,
+    now: &str,
+    endpoint: Option<GjcSdkEndpoint>,
+) -> GjcSdkStateSnapshot {
+    let turn_id = observation.turn_id.clone().or_else(|| {
+        previous
+            .and_then(|record| record.last_turn.as_ref())
+            .and_then(|turn| turn.turn_id.clone())
+    });
+    let turn = turn_id.map(|id| GjcSdkTurn {
+        id,
+        state: match observation.turn_state {
+            GjcTurnState::Running => {
+                if observation.prompt_accepted {
+                    GjcSdkTurnPhase::Active
+                } else {
+                    GjcSdkTurnPhase::Idle
+                }
+            }
+            GjcTurnState::AwaitingInput => GjcSdkTurnPhase::WaitingInput,
+            GjcTurnState::Complete => GjcSdkTurnPhase::Complete,
+            GjcTurnState::Failed => GjcSdkTurnPhase::Failed,
+            GjcTurnState::Idle => GjcSdkTurnPhase::Idle,
+            GjcTurnState::Aborted => GjcSdkTurnPhase::Aborted,
+        },
+        prompt_accepted: observation.prompt_accepted,
+        attempt: 0,
+        error_summary: observation.error_summary.clone(),
+    });
+    let gate = observation.gate_id.as_ref().map(|gate_id| GjcSdkGate {
+        id: gate_id.clone(),
+        kind: observation.gate_kind.unwrap_or(GjcSdkGateKind::Workflow),
+        revision: observation.gate_revision,
+        status: if observation.gate_state == Some(GjcGateState::Ready) {
+            GjcSdkGateStatus::Open
+        } else {
+            GjcSdkGateStatus::Resolved
+        },
+        summary: observation.gate_title.clone(),
+        workflow_id: observation.gate_workflow_id.clone(),
+        title: observation.gate_title.clone(),
+        options: observation.gate_options.clone(),
+    });
+    GjcSdkStateSnapshot {
+        session_id: observation.session_id.clone(),
+        revision: observation.revision,
+        endpoint_episode: record.endpoint_episode,
+        turn,
+        gate,
+        endpoint,
+        repo_name: record.pr.as_ref().map(|pr| pr.repo.clone()),
+        worktree_path: record.worktree.clone(),
+        branch: record.branch.clone(),
+        observed_at: Some(now.to_string()),
+        summary: observation.error_summary.clone(),
+        ..GjcSdkStateSnapshot::default()
+    }
+}
+
+fn pending_from_event(event: IncomingEvent, now: &str) -> Result<GjcPendingAlert> {
+    let event_id = event
+        .payload
+        .get("event_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("gjc alert missing deterministic event id"))?
+        .to_string();
+    Ok(GjcPendingAlert {
+        event_id,
+        kind: event.kind,
+        payload: event.payload,
+        queued_at: now.to_string(),
+        attempts: 0,
+        deliveries: BTreeMap::new(),
+    })
+}
+
+fn queue_pending_alert(record: &mut GjcLaneRecord, alert: GjcPendingAlert) -> Result<()> {
+    if record
+        .pending_alerts
+        .iter()
+        .any(|existing| existing.event_id == alert.event_id)
+    {
+        return Ok(());
+    }
+    if record.pending_alerts.len() >= MAX_PENDING_ALERTS {
+        bail!("gjc pending alert queue is full");
+    }
+    record.pending_alerts.push(alert);
+    Ok(())
+}
+
+struct GjcPendingAlertJournal {
+    store: SharedGjcLaneStore,
+    lane_id: String,
+    event_id: String,
+}
+
+impl AlertDeliveryJournal for GjcPendingAlertJournal {
+    fn state(&self, destination: &str) -> Option<AlertDeliveryState> {
+        self.store
+            .pending_alert_delivery_state(&self.lane_id, &self.event_id, destination)
+            .map(|state| match state {
+                GjcPendingAlertDeliveryState::Claimed => AlertDeliveryState::Claimed,
+                GjcPendingAlertDeliveryState::Delivered => AlertDeliveryState::Delivered,
+                GjcPendingAlertDeliveryState::Failed => AlertDeliveryState::Failed,
+            })
+    }
+
+    fn claim(&self, destination: &str) -> bool {
+        self.store
+            .claim_pending_alert_delivery(&self.lane_id, &self.event_id, destination)
+            .unwrap_or(false)
+    }
+
+    fn record(&self, destination: &str, delivered: bool) -> bool {
+        self.store
+            .record_pending_alert_delivery(&self.lane_id, &self.event_id, destination, delivered)
+            .unwrap_or(false)
+    }
+}
+
+fn bridge_alerts(
+    previous: Option<&GjcSdkStateSnapshot>,
+    snapshot: &GjcSdkStateSnapshot,
+) -> Result<Vec<IncomingEvent>> {
+    let mut bridge = GjcEventBridge::new();
+    if let Some(previous) = previous {
+        bridge
+            .observe(previous)
+            .map_err(|error| anyhow!("build prior sdk alert state: {error}"))?;
+    }
+    Ok(bridge
+        .observe(snapshot)
+        .map_err(|error| anyhow!("build sdk alert: {error}"))?
+        .events
+        .into_iter()
+        .filter(|event| {
+            matches!(
+                event.kind.as_str(),
+                "session.failed"
+                    | "session.stalled"
+                    | "session.endpoint-failed"
+                    | "workflow.gate"
+                    | "workflow.question"
+            )
+        })
+        .collect())
+}
+
 impl GjcLaneStore {
     /// Open (or initialize) the durable lane-state file. Invalid content fails
     /// open as `IgnoredInvalid` rather than blocking the daemon, mirroring the
     /// tmux watch registry contract.
     pub fn open(path: &Path) -> Result<Self> {
-        let (state, status) = match std::fs::read(path) {
+        let (mut state, status) = match std::fs::read(path) {
             Ok(content) => match serde_json::from_slice::<GjcLaneStateFile>(&content) {
                 Ok(parsed) if parsed.schema == GJC_LANE_STATE_SCHEMA => {
-                    let lanes = parsed.lanes.len();
-                    (parsed, GjcLaneStoreStatus::Loaded { lanes })
+                    match validate_loaded_state(&parsed) {
+                        Ok(()) => {
+                            let lanes = parsed.lanes.len();
+                            (parsed, GjcLaneStoreStatus::Loaded { lanes })
+                        }
+                        Err(error) => (
+                            GjcLaneStateFile {
+                                schema: GJC_LANE_STATE_SCHEMA.to_string(),
+                                ..Default::default()
+                            },
+                            GjcLaneStoreStatus::IgnoredInvalid {
+                                error: error.to_string(),
+                            },
+                        ),
+                    }
                 }
                 Ok(parsed) => (
                     GjcLaneStateFile {
@@ -470,11 +1025,20 @@ impl GjcLaneStore {
                 return Err(error).context(format!("failed to read {}", path.display()));
             }
         };
-        Ok(Self {
+        let migrated = migrate_lane_ids(&mut state)?;
+        let store = Self {
             path: path.to_path_buf(),
             state: Mutex::new(state),
             status,
-        })
+        };
+        if migrated {
+            let mut state = store
+                .state
+                .lock()
+                .map_err(|_| anyhow!("lane store poisoned"))?;
+            store.persist_locked(&mut state)?;
+        }
+        Ok(store)
     }
 
     pub fn status(&self) -> &GjcLaneStoreStatus {
@@ -501,7 +1065,62 @@ impl GjcLaneStore {
     }
 
     pub fn record(&self, lane_id: &str) -> Option<GjcLaneRecord> {
-        self.state.lock().ok()?.lanes.get(lane_id).cloned()
+        let state = self.state.lock().ok()?;
+        let canonical = state
+            .lane_id_aliases
+            .get(lane_id)
+            .map(String::as_str)
+            .unwrap_or(lane_id);
+        state.lanes.get(canonical).cloned()
+    }
+
+    pub fn record_for_session(&self, session_id: &str) -> Option<GjcLaneRecord> {
+        let state = self.state.lock().ok()?;
+        state
+            .lanes
+            .values()
+            .find(|record| record.sdk_session_id == session_id)
+            .cloned()
+    }
+
+    pub fn set_sdk_revision_if(
+        &self,
+        lane_id: &str,
+        expected_sdk_revision: u64,
+        new_sdk_revision: u64,
+        now: &str,
+    ) -> Result<GjcLaneRecord> {
+        let current = self
+            .record(lane_id)
+            .ok_or_else(|| anyhow!("lane not found"))?;
+        self.mutate(lane_id, current.revision, now, |mut record| {
+            if record.sdk_revision != expected_sdk_revision
+                || new_sdk_revision <= record.sdk_revision
+            {
+                bail!("sdk revision watermark conflict");
+            }
+            record.sdk_revision = new_sdk_revision;
+            Ok(multi_audit(record, vec![]))
+        })
+    }
+
+    pub fn resume_suspended(&self, now: &str) -> usize {
+        let records = self.snapshot_watches(true);
+        records
+            .into_iter()
+            .filter(|record| record.polling_suspended)
+            .filter_map(|record| {
+                self.mutate(&record.lane_id, record.revision, now, |mut updated| {
+                    updated.polling_suspended = false;
+                    updated.consecutive_unavailable_polls = 0;
+                    Ok(multi_audit(
+                        updated,
+                        vec![(GjcAuditKind::PollingResumed, "manual force-resume".into())],
+                    ))
+                })
+                .ok()
+            })
+            .count()
     }
 
     pub fn audit(&self) -> Vec<GjcReconcileAuditEntry> {
@@ -539,6 +1158,9 @@ impl GjcLaneStore {
         request: &GjcLaneRegistrationRequest,
         now: &str,
     ) -> Result<GjcLaneRecord> {
+        if let GjcLaneStoreStatus::IgnoredInvalid { .. } = self.status() {
+            bail!("lane store is quarantined after invalid persisted state");
+        }
         let lane_id = gjc_lane_id(&request.sdk_session_id);
         validate_registration(request)?;
         let mut state = self
@@ -574,7 +1196,13 @@ impl GjcLaneStore {
             lane_id: lane_id.clone(),
             sdk_session_id: request.sdk_session_id.clone(),
             worktree: request.worktree.clone(),
+            branch: request
+                .worktree
+                .as_deref()
+                .and_then(|worktree| current_git_branch(worktree).ok().flatten()),
             endpoint_generation: request.endpoint_generation.unwrap_or(0),
+            endpoint_episode: 0,
+            endpoint_alerted: false,
             revision: 1,
             sdk_revision: 0,
             last_turn: None,
@@ -592,6 +1220,7 @@ impl GjcLaneStore {
             watch_removed_at: None,
             registered_at: now.to_string(),
             updated_at: now.to_string(),
+            pending_alerts: Vec::new(),
         };
         state.push_audit(GjcReconcileAuditEntry {
             at: now.to_string(),
@@ -666,12 +1295,58 @@ impl GjcLaneStore {
             evidence_invalidated: false,
         };
         let record = self.mutate(lane_id, expected_revision, now, |mut record| {
-            if observation.endpoint_generation < record.endpoint_generation {
-                // Never regress generation; treat as ambiguous upstream state.
-                bail!("lane revision conflict: endpoint generation regressed");
+            let previous_record = record.clone();
+            let observation = observation.clone();
+            #[cfg(not(test))]
+            {
+                if observation.session_id != record.sdk_session_id {
+                    bail!("sdk observation session identity mismatch");
+                }
+                if let Some(turn_id) = observation.turn_id.as_deref() {
+                    crate::gjc::model::TurnId::new(turn_id.to_string()).map_err(|_| {
+                        anyhow::anyhow!("sdk observation turn identity malformed")
+                    })?;
+                }
+                if let (Some(observed), Some(enrolled)) =
+                    (observation.worktree.as_deref(), record.worktree.as_deref())
+                    && observed != enrolled
+                {
+                    bail!("sdk observation worktree identity mismatch");
+                }
             }
+            if observation.revision < record.sdk_revision {
+                bail!("stale sdk observation revision");
+            }
+            if matches!(
+                (observation.disposition, observation.turn_state),
+                (GjcSessionDisposition::Complete, state)
+                    if state != GjcTurnState::Complete
+            ) || matches!(
+                (observation.disposition, observation.turn_state),
+                (GjcSessionDisposition::Failed, state) if state != GjcTurnState::Failed
+            ) {
+                bail!("sdk observation disposition conflicts with turn state");
+            }
+            match observation.gate_state {
+                Some(_) => {
+                    if observation
+                        .gate_id
+                        .as_deref()
+                        .is_none_or(|gate_id| !valid_gate_id(gate_id))
+                        || observation.gate_revision == 0
+                    {
+                        bail!("gate observation lacks canonical identity or revision");
+                    }
+                }
+                None => {
+                    if observation.gate_id.is_some() || observation.gate_revision != 0 {
+                        bail!("gate observation has identity without state");
+                    }
+                }
+            }
+            let mut generation_audit = Vec::new();
             let previous_generation = record.endpoint_generation;
-            if observation.endpoint_generation > previous_generation
+            if observation.endpoint_generation != previous_generation
                 && (record.review_evidence_valid || record.owner_evidence_valid)
             {
                 record.review_evidence_valid = false;
@@ -679,34 +1354,69 @@ impl GjcLaneStore {
                 record.evidence_revision += 1;
                 outcome.evidence_invalidated = true;
                 record.endpoint_generation = observation.endpoint_generation;
-                return Ok(multi_audit(
-                    record,
-                    vec![(
-                        GjcAuditKind::EvidenceInvalidated,
-                        format!(
-                            "endpoint generation {previous_generation} -> {}; stale review/owner evidence invalidated",
-                            observation.endpoint_generation
-                        ),
-                    )],
+                generation_audit.push((
+                    GjcAuditKind::EvidenceInvalidated,
+                    format!(
+                        "endpoint generation {previous_generation} -> {}; stale review/owner evidence invalidated",
+                        observation.endpoint_generation
+                    ),
                 ));
             }
             record.sdk_revision = observation.revision;
-            record.endpoint_generation = record.endpoint_generation.max(observation.endpoint_generation);
+            record.endpoint_generation = observation.endpoint_generation;
+            // A successful authoritative observation closes the current
+            // endpoint-failure episode. The next transport failure receives a
+            // fresh durable episode identity.
+            record.endpoint_alerted = false;
             record.consecutive_unavailable_polls = 0;
             record.last_query_at = Some(now.to_string());
+            if observation.branch_observed {
+                record.branch = observation.branch.clone();
+            }
             let resumed = record.polling_suspended;
             record.polling_suspended = false;
 
             record.last_turn = Some(GjcTurnSnapshot {
                 state: observation.turn_state,
                 turn_id: observation.turn_id.clone(),
+                prompt_accepted: observation.prompt_accepted,
                 observed_at: now.to_string(),
             });
-            record.last_gate = observation.gate_state.map(|gate_state| GjcGateSnapshot {
-                state: gate_state,
-                gate_id: observation.gate_id.clone(),
-                observed_at: now.to_string(),
-            });
+            if let Some(gate_state) = observation.gate_state {
+                let update_gate = match record.last_gate.as_ref() {
+                    None => true,
+                    Some(previous) if previous.gate_id != observation.gate_id => true,
+                    Some(previous) if observation.gate_revision < previous.revision => false,
+                    Some(previous) if observation.gate_revision == previous.revision => {
+                        if previous.state != gate_state
+                            && !(previous.state == GjcGateState::Ready
+                                && gate_state == GjcGateState::Answered)
+                        {
+                            bail!("conflicting equal gate revision");
+                        }
+                        previous.state != gate_state
+                    }
+                    Some(_) => true,
+                };
+                if update_gate {
+                    record.last_gate = Some(GjcGateSnapshot {
+                        state: gate_state,
+                        gate_id: observation.gate_id.clone(),
+                        revision: observation.gate_revision,
+                        observed_at: now.to_string(),
+                    });
+                }
+            } else if observation.gate_section_present
+                && record.last_gate.as_ref().is_some_and(|gate| {
+                    gate.state == GjcGateState::Ready
+                        && (observation.gate_id.is_none()
+                            || gate.gate_id == observation.gate_id)
+                })
+                && let Some(gate) = record.last_gate.as_mut()
+            {
+                gate.state = GjcGateState::Answered;
+                gate.observed_at = now.to_string();
+            }
 
             let previous_phase = record.phase;
             let previous_terminal = record.terminal_disposition.as_ref().map(|d| d.kind);
@@ -726,12 +1436,12 @@ impl GjcLaneStore {
                 }
             }
 
-            record.phase = Some(classify_lane(&record, Some(observation)));
+            record.phase = Some(classify_lane(&record, Some(&observation)));
             if record.phase != previous_phase {
                 outcome.phase_changed = record.phase;
             }
 
-            let mut audit = Vec::new();
+            let mut audit = generation_audit;
             if resumed {
                 audit.push((
                     GjcAuditKind::PollingResumed,
@@ -756,6 +1466,115 @@ impl GjcLaneStore {
                         outcome.terminal_set, observation.revision
                     ),
                 ));
+            }
+
+            // Stage alert transitions in the same atomic write as the
+            // observation. This closes the crash window between durable state
+            // update and the reconciler's send attempt.
+            let current_snapshot = observation_snapshot(
+                &record,
+                Some(&previous_record),
+                &observation,
+                now,
+                None,
+            );
+            let new_failed_turn = observation.prompt_accepted
+                && observation.turn_state == GjcTurnState::Failed
+                && previous_record
+                    .last_turn
+                    .as_ref()
+                    .map(|turn| {
+                        turn.state != GjcTurnState::Failed
+                            || turn.turn_id.as_deref() != observation.turn_id.as_deref()
+                    })
+                    .unwrap_or(true);
+            if outcome.terminal_set.is_some() || new_failed_turn {
+                for event in bridge_alerts(None, &current_snapshot)? {
+                    queue_pending_alert(&mut record, pending_from_event(event, now)?)?;
+                }
+            }
+            let previous_turn_active = previous_record
+                .last_turn
+                .as_ref()
+                .map(|turn| {
+                    turn.prompt_accepted
+                        && matches!(turn.state, GjcTurnState::Running | GjcTurnState::AwaitingInput)
+                })
+                .unwrap_or(false);
+            let same_turn = previous_record
+                .last_turn
+                .as_ref()
+                .and_then(|turn| turn.turn_id.as_deref())
+                .zip(observation.turn_id.as_deref())
+                .map(|(left, right)| left == right)
+                .unwrap_or_else(|| {
+                    previous_record
+                        .last_turn
+                        .as_ref()
+                        .and_then(|turn| turn.turn_id.as_deref())
+                        == current_snapshot.turn.as_ref().map(|turn| turn.id.as_str())
+                });
+            if previous_turn_active
+                && same_turn
+                && matches!(observation.turn_state, GjcTurnState::Idle | GjcTurnState::Aborted)
+            {
+                let previous_snapshot = observation_snapshot(
+                    &previous_record,
+                    None,
+                    &GjcSdkObservation {
+                        session_id: previous_record.sdk_session_id.clone(),
+                        worktree: previous_record.worktree.clone(),
+                        branch: previous_record.branch.clone(),
+                        branch_observed: false,
+                        endpoint_generation: previous_record.endpoint_generation,
+                        revision: previous_record.sdk_revision,
+                        turn_state: previous_record
+                            .last_turn
+                            .as_ref()
+                            .map(|turn| turn.state)
+                            .unwrap_or(GjcTurnState::Running),
+                        turn_id: previous_record
+                            .last_turn
+                            .as_ref()
+                            .and_then(|turn| turn.turn_id.clone()),
+                        prompt_accepted: true,
+                        gate_revision: previous_record
+                            .last_gate
+                            .as_ref()
+                            .map(|gate| gate.revision)
+                            .unwrap_or(0),
+                        gate_state: previous_record.last_gate.as_ref().map(|gate| gate.state),
+                        gate_section_present: true,
+                        gate_id: previous_record
+                            .last_gate
+                            .as_ref()
+                            .and_then(|gate| gate.gate_id.clone()),
+                        gate_kind: None,
+                        gate_workflow_id: None,
+                        gate_title: None,
+                        gate_options: Vec::new(),
+                        disposition: GjcSessionDisposition::Live,
+                        error_summary: None,
+                    },
+                    now,
+                    None,
+                );
+                for event in bridge_alerts(Some(&previous_snapshot), &current_snapshot)? {
+                    queue_pending_alert(&mut record, pending_from_event(event, now)?)?;
+                }
+            }
+            let new_gate_episode = observation.gate_state == Some(GjcGateState::Ready)
+                && match previous_record.last_gate.as_ref() {
+                    Some(previous) => {
+                        previous.gate_id != observation.gate_id
+                            || observation.gate_revision > previous.revision
+                    }
+                    None => true,
+                };
+            if new_gate_episode {
+                for event in bridge_alerts(None, &current_snapshot)? {
+                    queue_pending_alert(&mut record, pending_from_event(event, now)?)?;
+                }
             }
             audit.push((
                 GjcAuditKind::ObservationApplied,
@@ -791,6 +1610,27 @@ impl GjcLaneStore {
             record.last_query_at = Some(now.to_string());
             record.consecutive_unavailable_polls =
                 record.consecutive_unavailable_polls.saturating_add(1);
+            if !record.endpoint_alerted {
+                record.endpoint_episode = record.endpoint_episode.saturating_add(1);
+                let snapshot = GjcSdkStateSnapshot {
+                    session_id: record.sdk_session_id.clone(),
+                    revision: record.sdk_revision,
+                    endpoint_episode: record.endpoint_episode,
+                    endpoint: Some(GjcSdkEndpoint {
+                        health: GjcSdkEndpointHealth::Failed,
+                        detail: Some(reason.to_string()),
+                    }),
+                    repo_name: record.pr.as_ref().map(|pr| pr.repo.clone()),
+                    worktree_path: record.worktree.clone(),
+                    branch: record.branch.clone(),
+                    observed_at: Some(now.to_string()),
+                    ..GjcSdkStateSnapshot::default()
+                };
+                for event in bridge_alerts(None, &snapshot)? {
+                    queue_pending_alert(&mut record, pending_from_event(event, now)?)?;
+                }
+                record.endpoint_alerted = true;
+            }
             if !record.polling_suspended && record.consecutive_unavailable_polls >= suspend_after {
                 record.polling_suspended = true;
                 newly_suspended = true;
@@ -812,13 +1652,221 @@ impl GjcLaneStore {
                 GjcAuditKind::ObservationApplied,
                 format!(
                     "unavailable (attempt {}): {}",
-                    record.consecutive_unavailable_polls,
-                    bounded_text(reason)
+                    record.consecutive_unavailable_polls, "sdk endpoint unavailable"
                 ),
             ));
             Ok(multi_audit(record, audit))
         })?;
         Ok((record, newly_suspended))
+    }
+
+    /// Durably stage an endpoint failure without changing lane classification.
+    /// Ambiguous control-plane replies use this fail-closed path.
+    pub fn enqueue_endpoint_failure(
+        &self,
+        lane_id: &str,
+        expected_revision: u64,
+        reason: &str,
+        now: &str,
+    ) -> Result<GjcLaneRecord> {
+        self.mutate(lane_id, expected_revision, now, |mut record| {
+            if !record.endpoint_alerted {
+                record.endpoint_episode = record.endpoint_episode.saturating_add(1);
+                let snapshot = GjcSdkStateSnapshot {
+                    session_id: record.sdk_session_id.clone(),
+                    revision: record.sdk_revision,
+                    endpoint_episode: record.endpoint_episode,
+                    endpoint: Some(GjcSdkEndpoint {
+                        health: GjcSdkEndpointHealth::Failed,
+                        detail: Some(reason.to_string()),
+                    }),
+                    repo_name: record.pr.as_ref().map(|pr| pr.repo.clone()),
+                    worktree_path: record.worktree.clone(),
+                    branch: record.branch.clone(),
+                    observed_at: Some(now.to_string()),
+                    ..GjcSdkStateSnapshot::default()
+                };
+                for event in bridge_alerts(None, &snapshot)? {
+                    queue_pending_alert(&mut record, pending_from_event(event, now)?)?;
+                }
+                record.endpoint_alerted = true;
+            }
+            Ok(multi_audit(record, vec![]))
+        })
+    }
+
+    /// Acknowledge one pending alert only after the reconciler's channel send
+    /// succeeds. A repeated acknowledgement is an idempotent no-op.
+    pub fn acknowledge_pending_alert(
+        &self,
+        lane_id: &str,
+        expected_revision: u64,
+        event_id: &str,
+        now: &str,
+    ) -> Result<GjcLaneRecord> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow!("lane store poisoned"))?;
+        let canonical_id = canonical_lane_id(&state, lane_id);
+        let mut record = state
+            .lanes
+            .get(&canonical_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("lane not found: {lane_id}"))?;
+        if record.revision != expected_revision {
+            bail!(
+                "lane revision conflict: expected {expected_revision}, current {}",
+                record.revision
+            );
+        }
+        let original_len = record.pending_alerts.len();
+        record
+            .pending_alerts
+            .retain(|alert| alert.event_id != event_id);
+        if record.pending_alerts.len() == original_len {
+            return Ok(record);
+        }
+        record.revision = record
+            .revision
+            .checked_add(1)
+            .context("revision overflow")?;
+        record.updated_at = now.to_string();
+        state.lanes.insert(canonical_id, record.clone());
+        self.persist_locked(&mut state)?;
+        Ok(record)
+    }
+
+    pub(crate) fn pending_alert_delivery_state(
+        &self,
+        lane_id: &str,
+        event_id: &str,
+        destination: &str,
+    ) -> Option<GjcPendingAlertDeliveryState> {
+        let state = self.state.lock().ok()?;
+        let canonical_id = canonical_lane_id(&state, lane_id);
+        state
+            .lanes
+            .get(&canonical_id)?
+            .pending_alerts
+            .iter()
+            .find(|alert| alert.event_id == event_id)
+            .and_then(|alert| alert.deliveries.get(destination))
+            .map(|delivery| delivery.state)
+    }
+
+    pub(crate) fn claim_pending_alert_delivery(
+        &self,
+        lane_id: &str,
+        event_id: &str,
+        destination: &str,
+    ) -> Result<bool> {
+        self.update_pending_alert_delivery(
+            lane_id,
+            event_id,
+            destination,
+            GjcPendingAlertDeliveryState::Claimed,
+        )
+    }
+
+    pub(crate) fn record_pending_alert_delivery(
+        &self,
+        lane_id: &str,
+        event_id: &str,
+        destination: &str,
+        delivered: bool,
+    ) -> Result<bool> {
+        self.update_pending_alert_delivery(
+            lane_id,
+            event_id,
+            destination,
+            if delivered {
+                GjcPendingAlertDeliveryState::Delivered
+            } else {
+                GjcPendingAlertDeliveryState::Failed
+            },
+        )
+    }
+
+    fn update_pending_alert_delivery(
+        &self,
+        lane_id: &str,
+        event_id: &str,
+        destination: &str,
+        next_state: GjcPendingAlertDeliveryState,
+    ) -> Result<bool> {
+        if destination.is_empty()
+            || destination.len() > 512
+            || destination.chars().any(char::is_control)
+        {
+            bail!("invalid pending alert destination");
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow!("lane store poisoned"))?;
+        let canonical_id = canonical_lane_id(&state, lane_id);
+        let record = state
+            .lanes
+            .get(&canonical_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("lane not found: {lane_id}"))?;
+        let mut updated = record.clone();
+        let alert = updated
+            .pending_alerts
+            .iter_mut()
+            .find(|alert| alert.event_id == event_id)
+            .ok_or_else(|| anyhow!("pending alert not found: {event_id}"))?;
+        if let Some(existing) = alert.deliveries.get(destination) {
+            if existing.state == GjcPendingAlertDeliveryState::Delivered
+                || (existing.state == GjcPendingAlertDeliveryState::Claimed
+                    && next_state == GjcPendingAlertDeliveryState::Claimed)
+            {
+                return Ok(true);
+            }
+        } else if alert.deliveries.len() >= MAX_PENDING_ALERT_DELIVERIES {
+            bail!("pending alert delivery map is full");
+        }
+        let attempts = alert
+            .deliveries
+            .get(destination)
+            .map(|delivery| delivery.attempts)
+            .unwrap_or_default()
+            .saturating_add((next_state == GjcPendingAlertDeliveryState::Claimed) as u32);
+        alert.deliveries.insert(
+            destination.to_string(),
+            GjcPendingAlertDelivery {
+                state: next_state,
+                attempts,
+                updated_at: now_rfc3339(),
+            },
+        );
+        updated.revision = updated
+            .revision
+            .checked_add(1)
+            .context("revision overflow")?;
+        updated.updated_at = now_rfc3339();
+        state.lanes.insert(canonical_id, updated);
+        self.persist_locked(&mut state)?;
+        Ok(true)
+    }
+
+    pub fn note_pending_alert_attempt(
+        &self,
+        lane_id: &str,
+        expected_revision: u64,
+        event_id: &str,
+        now: &str,
+    ) -> Result<GjcLaneRecord> {
+        self.mutate(lane_id, expected_revision, now, |mut record| {
+            let alert = record
+                .pending_alerts
+                .iter_mut()
+                .find(|alert| alert.event_id == event_id)
+                .ok_or_else(|| anyhow!("pending alert not found: {event_id}"))?;
+            alert.attempts = alert.attempts.saturating_add(1);
+            Ok(multi_audit(record, vec![]))
+        })
     }
 
     /// Mark a lane whose SDK session authoritatively no longer exists while
@@ -882,6 +1930,9 @@ impl GjcLaneStore {
             if record.terminal_disposition.is_none() {
                 bail!("only terminal lanes qualify for ghost watch removal");
             }
+            if !record.pending_alerts.is_empty() {
+                bail!("pending alerts must be acknowledged before ghost removal");
+            }
             record.watch_removed_at = Some(now.to_string());
             record.phase = Some(match record.terminal_disposition.as_ref() {
                 Some(disposition) => match disposition.kind {
@@ -894,6 +1945,71 @@ impl GjcLaneStore {
             Ok(multi_audit(
                 record,
                 vec![(GjcAuditKind::GhostWatchRemoved, bounded_text(reason))],
+            ))
+        })
+    }
+
+    pub fn reclaim_tombstone(
+        &self,
+        lane_id: &str,
+        expected_revision: u64,
+        endpoint_generation: u64,
+        worktree: Option<String>,
+        now: &str,
+    ) -> Result<GjcLaneRecord> {
+        self.mutate(lane_id, expected_revision, now, |mut record| {
+            if record.watch_removed_at.is_none() {
+                bail!("lane is not a removed tombstone");
+            }
+            record.watch_removed_at = None;
+            record.terminal_disposition = None;
+            record.phase = None;
+            record.worktree = worktree;
+            record.branch = None;
+            record.pr = None;
+            record.endpoint_generation = endpoint_generation;
+            record.endpoint_episode = 0;
+            record.sdk_revision = 0;
+            record.last_turn = None;
+            record.last_gate = None;
+            record.evidence_revision = 0;
+            record.review_evidence_valid = true;
+            record.owner_evidence_valid = true;
+            record.ownership = GjcLaneOwnership::default();
+            record.consecutive_unavailable_polls = 0;
+            record.endpoint_alerted = false;
+            Ok(multi_audit(
+                record,
+                vec![(
+                    GjcAuditKind::LaneRegistered,
+                    "removed tombstone reclaimed for native session re-enrollment".into(),
+                )],
+            ))
+        })
+    }
+
+    pub fn note_endpoint_rotation(
+        &self,
+        lane_id: &str,
+        expected_revision: u64,
+        endpoint_generation: u64,
+        now: &str,
+    ) -> Result<GjcLaneRecord> {
+        self.mutate(lane_id, expected_revision, now, |mut record| {
+            if endpoint_generation == record.endpoint_generation {
+                return Ok((record, vec![]));
+            }
+            record.endpoint_generation = endpoint_generation;
+            record.endpoint_episode = record.endpoint_episode.saturating_add(1);
+            record.endpoint_alerted = false;
+            record.review_evidence_valid = false;
+            record.owner_evidence_valid = false;
+            Ok(multi_audit(
+                record,
+                vec![(
+                    GjcAuditKind::EvidenceInvalidated,
+                    "endpoint generation changed; awaiting authoritative query".into(),
+                )],
             ))
         })
     }
@@ -1054,9 +2170,10 @@ impl GjcLaneStore {
             .state
             .lock()
             .map_err(|_| anyhow!("lane store poisoned"))?;
+        let canonical_id = canonical_lane_id(&state, lane_id);
         let record = state
             .lanes
-            .get(lane_id)
+            .get(&canonical_id)
             .cloned()
             .ok_or_else(|| anyhow!("lane not found: {lane_id}"))?;
         if record.revision != expected_revision {
@@ -1074,12 +2191,12 @@ impl GjcLaneStore {
         for (kind, detail) in audit {
             state.push_audit(GjcReconcileAuditEntry {
                 at: now.to_string(),
-                lane_id: lane_id.to_string(),
+                lane_id: canonical_id.clone(),
                 kind,
                 detail,
             });
         }
-        state.lanes.insert(lane_id.to_string(), updated.clone());
+        state.lanes.insert(canonical_id, updated.clone());
         self.persist_locked(&mut state)?;
         Ok(updated)
     }
@@ -1094,8 +2211,17 @@ impl GjcLaneStore {
         let tmp_path = self.path.with_extension("json.tmp");
         std::fs::write(&tmp_path, &serialized)
             .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+        std::fs::File::open(&tmp_path)
+            .and_then(|file| file.sync_all())
+            .with_context(|| format!("failed to sync {}", tmp_path.display()))?;
         std::fs::rename(&tmp_path, &self.path)
             .with_context(|| format!("failed to persist {}", self.path.display()))?;
+        #[cfg(unix)]
+        if let Some(parent) = self.path.parent() {
+            std::fs::File::open(parent)
+                .and_then(|file| file.sync_all())
+                .with_context(|| format!("failed to sync {}", parent.display()))?;
+        }
         Ok(())
     }
 }
@@ -1154,10 +2280,12 @@ pub fn classify_lane(
         GjcSessionDisposition::Complete => GjcLanePhase::Complete,
         GjcSessionDisposition::Live => {
             if observation.gate_state == Some(GjcGateState::Ready)
-                || observation.turn_state == GjcTurnState::AwaitingInput
+                || (observation.turn_state == GjcTurnState::AwaitingInput
+                    && observation.prompt_accepted)
             {
                 GjcLanePhase::Blocked
-            } else if observation.turn_state == GjcTurnState::Running {
+            } else if observation.turn_state == GjcTurnState::Running && observation.prompt_accepted
+            {
                 GjcLanePhase::Active
             } else {
                 GjcLanePhase::Idle
@@ -1256,6 +2384,9 @@ pub struct GjcLanesConfig {
     /// Optional state-file override; defaults beside the cron state file.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state_path: Option<PathBuf>,
+    /// Additional trusted worktrees whose native SDK endpoints are enrolled.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub discovery_worktrees: Vec<PathBuf>,
     /// PR head/base reconciliation settings.
     #[serde(default)]
     pub pr: GjcLanesPrConfig,
@@ -1271,6 +2402,7 @@ impl Default for GjcLanesConfig {
             max_consecutive_attempts: default_gjc_max_consecutive_attempts(),
             ghost_grace_polls: default_gjc_ghost_grace_polls(),
             state_path: None,
+            discovery_worktrees: Vec::new(),
             pr: GjcLanesPrConfig::default(),
         }
     }
@@ -1278,7 +2410,10 @@ impl Default for GjcLanesConfig {
 
 impl GjcLanesConfig {
     pub fn is_empty(&self) -> bool {
-        !self.enabled && self.state_path.is_none() && self.pr.is_empty()
+        !self.enabled
+            && self.state_path.is_none()
+            && self.discovery_worktrees.is_empty()
+            && self.pr.is_empty()
     }
 
     pub fn polling_policy(&self) -> GjcPollingPolicy {
@@ -1376,6 +2511,8 @@ pub struct GjcReconciler {
     store: SharedGjcLaneStore,
     tx: mpsc::Sender<IncomingEvent>,
     policy: GjcPollingPolicy,
+    auto_enrollment: bool,
+    discovery_worktrees: Vec<PathBuf>,
 }
 
 pub type SharedGjcReconciler = Arc<GjcReconciler>;
@@ -1394,7 +2531,15 @@ impl GjcReconciler {
             store,
             tx,
             policy,
+            auto_enrollment: false,
+            discovery_worktrees: Vec::new(),
         }
+    }
+
+    pub fn with_auto_enrollment(mut self, worktrees: Vec<PathBuf>) -> Self {
+        self.auto_enrollment = true;
+        self.discovery_worktrees = worktrees;
+        self
     }
 
     /// Long-running loop: one bounded pass per interval. Runs until the task
@@ -1417,10 +2562,34 @@ impl GjcReconciler {
         let now_text = now
             .format(&Rfc3339)
             .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+        if self.auto_enrollment {
+            self.auto_enroll_native_sessions(&now_text);
+        }
         let mut outcome = GjcReconcileOutcome::default();
-        let records = self.store.snapshot_watches(false);
+        let records = self
+            .store
+            .snapshot_watches(true)
+            .into_iter()
+            .filter(|record| record.watch_removed_at.is_none())
+            .collect::<Vec<_>>();
         for snapshot in records {
-            if snapshot.polling_suspended {
+            let snapshot = self.replay_pending_alerts(&snapshot, &now_text).await;
+            if snapshot.terminal_disposition.as_ref().map(|d| d.kind)
+                == Some(GjcTerminalKind::Retired)
+                && snapshot.pending_alerts.is_empty()
+            {
+                if let Ok(updated) = self.store.remove_ghost_watch(
+                    &snapshot.lane_id,
+                    snapshot.revision,
+                    "retired watch cleanup",
+                    &now_text,
+                ) {
+                    outcome.ghost_watches_removed += 1;
+                    self.emit_status(&updated, &now_text);
+                }
+                continue;
+            }
+            if snapshot.polling_suspended && self.suspension_defers(&snapshot, now) {
                 continue;
             }
             if self.backoff_defers(&snapshot, now) {
@@ -1435,38 +2604,49 @@ impl GjcReconciler {
             };
             let expected = snapshot.revision;
             match self.plane.query_lane(&query).await {
-                Ok(observation) => match self.store.apply_observation(
-                    &snapshot.lane_id,
-                    expected,
-                    &observation,
-                    &now_text,
-                ) {
-                    Ok((record, applied)) => {
+                Ok(observation) => {
+                    if observation.revision <= snapshot.sdk_revision {
                         outcome.retained += 1;
-                        if applied.terminal_set.is_some() {
-                            outcome.terminal_set += 1;
+                        continue;
+                    }
+                    match self.store.apply_observation(
+                        &snapshot.lane_id,
+                        expected,
+                        &observation,
+                        &now_text,
+                    ) {
+                        Ok((record, applied)) => {
+                            outcome.retained += 1;
+                            let record = self.replay_pending_alerts(&record, &now_text).await;
+                            if applied.terminal_set.is_some() {
+                                outcome.terminal_set += 1;
+                                self.emit_status(&record, &now_text);
+                                continue;
+                            }
+                            if applied.evidence_invalidated {
+                                outcome.evidence_invalidations += 1;
+                            }
                             self.emit_status(&record, &now_text);
-                            continue;
+                            self.reconcile_pr(&record, &now_text, &mut outcome).await;
                         }
-                        if applied.evidence_invalidated {
-                            outcome.evidence_invalidations += 1;
+                        Err(error) => {
+                            if error.to_string().contains("revision conflict") {
+                                outcome.skipped_conflicts += 1;
+                                self.store.note_revision_conflict(
+                                    &snapshot.lane_id,
+                                    expected,
+                                    &now_text,
+                                );
+                            } else {
+                                outcome.retained += 1;
+                                eprintln!(
+                                    "clawhip gjc lane observation retained after validation failure: {}",
+                                    bounded_text(&error.to_string())
+                                );
+                            }
                         }
-                        self.emit_status(&record, &now_text);
-                        self.reconcile_pr(&record, &now_text, &mut outcome).await;
                     }
-                    Err(error) => {
-                        if error.to_string().contains("revision conflict") {
-                            outcome.skipped_conflicts += 1;
-                            self.store.note_revision_conflict(
-                                &snapshot.lane_id,
-                                expected,
-                                &now_text,
-                            );
-                        } else {
-                            return Err(error);
-                        }
-                    }
-                },
+                }
                 Err(GjcSdkQueryError::SessionNotFound(detail)) => {
                     if snapshot.terminal_disposition.is_some() {
                         // Definitive evidence the terminal session is gone:
@@ -1489,6 +2669,12 @@ impl GjcReconciler {
                                         expected,
                                         &now_text,
                                     );
+                                } else if !snapshot.pending_alerts.is_empty() {
+                                    outcome.retained += 1;
+                                    eprintln!(
+                                        "clawhip gjc terminal watch retained with pending alerts: {}",
+                                        bounded_text(&error.to_string())
+                                    );
                                 } else {
                                     return Err(error);
                                 }
@@ -1505,6 +2691,7 @@ impl GjcReconciler {
                                 outcome.runtime_gone += 1;
                                 outcome.terminal_set += 1;
                                 outcome.evidence_invalidations += 1;
+                                let _ = self.replay_pending_alerts(&record, &now_text).await;
                                 self.emit_status(&record, &now_text);
                             }
                             Err(error) => {
@@ -1523,30 +2710,15 @@ impl GjcReconciler {
                     }
                 }
                 Err(GjcSdkQueryError::StaleEndpointGeneration { observed }) => {
-                    match self.store.apply_observation(
+                    match self.store.note_endpoint_rotation(
                         &snapshot.lane_id,
                         expected,
-                        &GjcSdkObservation {
-                            session_id: snapshot.sdk_session_id.clone(),
-                            worktree: snapshot.worktree.clone(),
-                            endpoint_generation: observed,
-                            revision: snapshot.sdk_revision,
-                            turn_state: snapshot
-                                .last_turn
-                                .as_ref()
-                                .map(|turn| turn.state)
-                                .unwrap_or(GjcTurnState::Idle),
-                            turn_id: None,
-                            gate_state: snapshot.last_gate.as_ref().map(|gate| gate.state),
-                            gate_id: None,
-                            disposition: GjcSessionDisposition::Live,
-                        },
+                        observed,
                         &now_text,
                     ) {
-                        Ok((_, applied)) => {
-                            if applied.evidence_invalidated {
-                                outcome.evidence_invalidations += 1;
-                            }
+                        Ok(record) => {
+                            outcome.evidence_invalidations += 1;
+                            self.emit_status(&record, &now_text);
                         }
                         Err(error) => {
                             if error.to_string().contains("revision conflict") {
@@ -1568,10 +2740,39 @@ impl GjcReconciler {
                         // Ghost-watch grace: terminal watches survive only a
                         // bounded number of consecutive transport failures.
                         let misses = snapshot.consecutive_unavailable_polls + 1;
+                        let (record, _) = match self.store.mark_unavailable(
+                            &snapshot.lane_id,
+                            expected,
+                            &detail,
+                            u32::MAX,
+                            &now_text,
+                        ) {
+                            Ok(result) => result,
+                            Err(error) => {
+                                if error.to_string().contains("revision conflict") {
+                                    outcome.skipped_conflicts += 1;
+                                    self.store.note_revision_conflict(
+                                        &snapshot.lane_id,
+                                        expected,
+                                        &now_text,
+                                    );
+                                    continue;
+                                }
+                                return Err(error);
+                            }
+                        };
+                        let record = self.replay_pending_alerts(&record, &now_text).await;
                         if misses >= self.policy.ghost_grace_polls {
+                            if !record.pending_alerts.is_empty() {
+                                // Never tombstone a watch while an alert is
+                                // still waiting for delivery; the pending
+                                // payload is the durable replay source.
+                                outcome.retained += 1;
+                                continue;
+                            }
                             match self.store.remove_ghost_watch(
                                 &snapshot.lane_id,
-                                expected,
+                                record.revision,
                                 &format!(
                                     "terminal watch exceeded ghost grace after {misses} unavailable polls: {detail}"
                                 ),
@@ -1586,7 +2787,7 @@ impl GjcReconciler {
                                         outcome.skipped_conflicts += 1;
                                         self.store.note_revision_conflict(
                                             &snapshot.lane_id,
-                                            expected,
+                                            record.revision,
                                             &now_text,
                                         );
                                     } else {
@@ -1595,27 +2796,7 @@ impl GjcReconciler {
                                 }
                             }
                         } else {
-                            match self.store.mark_unavailable(
-                                &snapshot.lane_id,
-                                expected,
-                                &detail,
-                                u32::MAX,
-                                &now_text,
-                            ) {
-                                Ok(_) => outcome.retained += 1,
-                                Err(error) => {
-                                    if error.to_string().contains("revision conflict") {
-                                        outcome.skipped_conflicts += 1;
-                                        self.store.note_revision_conflict(
-                                            &snapshot.lane_id,
-                                            expected,
-                                            &now_text,
-                                        );
-                                    } else {
-                                        return Err(error);
-                                    }
-                                }
-                            }
+                            outcome.retained += 1;
                         }
                     } else {
                         match self.store.mark_unavailable(
@@ -1625,7 +2806,8 @@ impl GjcReconciler {
                             self.policy.max_consecutive_attempts,
                             &now_text,
                         ) {
-                            Ok((_, suspended)) => {
+                            Ok((record, suspended)) => {
+                                let _ = self.replay_pending_alerts(&record, &now_text).await;
                                 if suspended {
                                     outcome.suspended += 1;
                                 }
@@ -1646,12 +2828,35 @@ impl GjcReconciler {
                         }
                     }
                 }
+                Err(GjcSdkQueryError::InvalidState(_)) => {
+                    outcome.retained += 1;
+                }
                 Err(GjcSdkQueryError::Ambiguous(detail)) => {
                     // Fail closed: no classification change without
                     // authoritative evidence.
-                    self.store
-                        .note_revision_conflict(&snapshot.lane_id, expected, &now_text);
-                    let _ = detail;
+                    if detail == "multiple ready workflow gates" {
+                        outcome.retained += 1;
+                        continue;
+                    }
+                    match self.store.enqueue_endpoint_failure(
+                        &snapshot.lane_id,
+                        expected,
+                        &detail,
+                        &now_text,
+                    ) {
+                        Ok(record) => {
+                            let _ = self.replay_pending_alerts(&record, &now_text).await;
+                        }
+                        Err(error) if error.to_string().contains("revision conflict") => {
+                            outcome.skipped_conflicts += 1;
+                            self.store.note_revision_conflict(
+                                &snapshot.lane_id,
+                                expected,
+                                &now_text,
+                            );
+                        }
+                        Err(error) => return Err(error),
+                    }
                     outcome.retained += 1;
                 }
             }
@@ -1672,6 +2877,80 @@ impl GjcReconciler {
                 .policy
                 .backoff_after(record.consecutive_unavailable_polls)
                 .as_millis() as u64
+    }
+
+    fn suspension_defers(&self, record: &GjcLaneRecord, now: OffsetDateTime) -> bool {
+        let Some(last_query) = &record.last_query_at else {
+            return false;
+        };
+        let Ok(parsed) = OffsetDateTime::parse(last_query, &Rfc3339) else {
+            return false;
+        };
+        (now - parsed).whole_seconds() < self.policy.poll_interval_secs.saturating_mul(60) as i64
+    }
+
+    fn auto_enroll_native_sessions(&self, now_text: &str) {
+        let known = self.store.snapshot_watches(true);
+        for worktree in &self.discovery_worktrees {
+            let endpoints = match crate::gjc_sdk::discover_all(
+                &crate::gjc_sdk::StateRoot::for_worktree(worktree),
+            ) {
+                Ok(endpoints) => endpoints,
+                Err(_) => {
+                    eprintln!(
+                        "clawhip GJC auto-enrollment skipped unreadable worktree metadata: {}",
+                        worktree.display()
+                    );
+                    continue;
+                }
+            };
+            for endpoint in endpoints {
+                if let Some(record) = known.iter().find(|record| {
+                    record.watch_removed_at.is_some()
+                        && record.sdk_session_id == endpoint.session_id()
+                        && record
+                            .terminal_disposition
+                            .as_ref()
+                            .is_some_and(|disposition| {
+                                disposition.kind == GjcTerminalKind::Retired
+                                    && disposition.evidence.starts_with("runtime gone:")
+                            })
+                }) {
+                    let _ = self.store.reclaim_tombstone(
+                        &record.lane_id,
+                        record.revision,
+                        endpoint.generation(),
+                        Some(worktree.to_string_lossy().into_owned()),
+                        now_text,
+                    );
+                }
+                if known.iter().any(|record| {
+                    record.watch_removed_at.is_none()
+                        && record.sdk_session_id == endpoint.session_id()
+                }) {
+                    continue;
+                }
+                if self
+                    .store
+                    .register_lane(
+                        &GjcLaneRegistrationRequest {
+                            sdk_session_id: endpoint.session_id().to_string(),
+                            worktree: Some(worktree.to_string_lossy().into_owned()),
+                            endpoint_generation: Some(endpoint.generation()),
+                            owner_id: None,
+                            pr: None,
+                        },
+                        now_text,
+                    )
+                    .is_err()
+                {
+                    eprintln!(
+                        "clawhip GJC auto-enrollment rejected endpoint in worktree: {}",
+                        worktree.display()
+                    );
+                }
+            }
+        }
     }
 
     async fn reconcile_pr(
@@ -1740,6 +3019,77 @@ impl GjcReconciler {
             payload,
         });
     }
+
+    async fn replay_pending_alerts(
+        &self,
+        initial: &GjcLaneRecord,
+        now_text: &str,
+    ) -> GjcLaneRecord {
+        let mut current = initial.clone();
+        while let Some(alert) = current.pending_alerts.first().cloned() {
+            current = match self.store.note_pending_alert_attempt(
+                &current.lane_id,
+                current.revision,
+                &alert.event_id,
+                now_text,
+            ) {
+                Ok(updated) => updated,
+                Err(_) => break,
+            };
+            register_alert_delivery_journal(
+                &alert.event_id,
+                Arc::new(GjcPendingAlertJournal {
+                    store: self.store.clone(),
+                    lane_id: current.lane_id.clone(),
+                    event_id: alert.event_id.clone(),
+                }),
+            );
+            let acceptance = register_alert_acceptance(&alert.event_id);
+            let send = tokio::time::timeout(
+                ALERT_ACCEPTANCE_TIMEOUT,
+                self.tx.send(alert.incoming_event()),
+            )
+            .await;
+            if !matches!(send, Ok(Ok(()))) {
+                cancel_alert_acceptance(&alert.event_id);
+                clear_alert_delivery_journal(&alert.event_id);
+                break;
+            }
+            let accepted = matches!(
+                tokio::time::timeout(ALERT_ACCEPTANCE_TIMEOUT, acceptance).await,
+                Ok(Ok(true))
+            );
+            if !accepted {
+                cancel_alert_acceptance(&alert.event_id);
+                clear_alert_delivery_journal(&alert.event_id);
+                current = self.store.record(&current.lane_id).unwrap_or(current);
+                break;
+            }
+            clear_alert_delivery_journal(&alert.event_id);
+            match self.store.acknowledge_pending_alert(
+                &current.lane_id,
+                current.revision,
+                &alert.event_id,
+                now_text,
+            ) {
+                Ok(updated) => current = updated,
+                Err(error) if error.to_string().contains("revision conflict") => {
+                    let latest = self.store.record(&current.lane_id).unwrap_or(current);
+                    current = match self.store.acknowledge_pending_alert(
+                        &latest.lane_id,
+                        latest.revision,
+                        &alert.event_id,
+                        now_text,
+                    ) {
+                        Ok(updated) => updated,
+                        Err(_) => latest,
+                    };
+                }
+                Err(_) => break,
+            }
+        }
+        current
+    }
 }
 
 fn validate_registration(request: &GjcLaneRegistrationRequest) -> Result<()> {
@@ -1766,8 +3116,61 @@ fn validate_registration(request: &GjcLaneRegistrationRequest) -> Result<()> {
         if !valid_hex_sha(&pr.head_sha) {
             bail!("invalid PR head sha");
         }
-        if pr.base_branch.is_empty() || pr.base_branch.len() > 128 {
+        if pr.base_branch.is_empty()
+            || pr.base_branch.len() > 128
+            || pr.base_branch.chars().any(|ch| ch.is_control())
+        {
             bail!("invalid PR base branch");
+        }
+    }
+    Ok(())
+}
+
+fn validate_loaded_state(state: &GjcLaneStateFile) -> Result<()> {
+    if state.lanes.len() > MAX_LANES {
+        bail!("lane-state contains too many lanes");
+    }
+    for (lane_id, record) in &state.lanes {
+        if !valid_session_id(&record.sdk_session_id)
+            || lane_id.is_empty()
+            || lane_id.len() > MAX_SESSION_LEN
+            || lane_id.chars().any(|ch| ch.is_control())
+        {
+            bail!("lane-state contains an invalid lane identity");
+        }
+        if let Some(worktree) = &record.worktree
+            && !valid_worktree(worktree)
+        {
+            bail!("lane-state contains an invalid worktree");
+        }
+        if let Some(gate) = &record.last_gate
+            && (gate
+                .gate_id
+                .as_deref()
+                .is_none_or(|gate_id| !valid_gate_id(gate_id))
+                || gate.revision == 0)
+        {
+            bail!("lane-state contains an invalid gate identity");
+        }
+        if record.pending_alerts.len() > MAX_PENDING_ALERTS {
+            bail!("lane-state contains too many pending alerts");
+        }
+        for alert in &record.pending_alerts {
+            if alert.event_id.is_empty()
+                || alert.event_id.len() > 256
+                || alert.event_id.chars().any(|ch| ch.is_control())
+                || alert.payload.to_string().len() > 64 * 1024
+                || alert.deliveries.len() > MAX_PENDING_ALERT_DELIVERIES
+            {
+                bail!("lane-state contains an invalid pending alert");
+            }
+            if alert.deliveries.keys().any(|destination| {
+                destination.is_empty()
+                    || destination.len() > 512
+                    || destination.chars().any(char::is_control)
+            }) {
+                bail!("lane-state contains an invalid pending alert destination");
+            }
         }
     }
     Ok(())
@@ -1778,7 +3181,7 @@ pub fn health_json(store: &SharedGjcLaneStore, plane_registered: bool) -> Value 
     let records = store.snapshot();
     let mut phases: BTreeMap<String, usize> = BTreeMap::new();
     for record in &records {
-        if record.watch_removed_at.is_some() {
+        if record.watch_removed_at.is_some() || record.terminal_disposition.is_some() {
             continue;
         }
         let key = record
@@ -1789,9 +3192,12 @@ pub fn health_json(store: &SharedGjcLaneStore, plane_registered: bool) -> Value 
     }
     let active = records
         .iter()
-        .filter(|r| r.watch_removed_at.is_none())
+        .filter(|r| r.watch_removed_at.is_none() && r.terminal_disposition.is_none())
         .count();
-    let removed = records.len() - active;
+    let removed = records
+        .iter()
+        .filter(|record| record.watch_removed_at.is_some())
+        .count();
     json!({
         "schema": GJC_LANE_HEALTH_SCHEMA,
         "store": {
@@ -2024,13 +3430,26 @@ mod tests {
         GjcSdkObservation {
             session_id: "sess-1".to_string(),
             worktree: Some("/tmp/worktree".to_string()),
+            branch: Some("feature/test".to_string()),
+            branch_observed: false,
             endpoint_generation: 3,
             revision: 10,
             turn_state: turn,
             turn_id: Some("turn-1".to_string()),
+            prompt_accepted: matches!(
+                turn,
+                GjcTurnState::Running | GjcTurnState::AwaitingInput | GjcTurnState::Failed
+            ),
             gate_state: None,
+            gate_section_present: true,
             gate_id: None,
+            gate_revision: 0,
+            gate_kind: None,
+            gate_workflow_id: None,
+            gate_title: None,
+            gate_options: Vec::new(),
             disposition,
+            error_summary: None,
         }
     }
 
@@ -2245,6 +3664,234 @@ mod tests {
     }
 
     #[test]
+    fn failed_alert_is_staged_before_send_and_survives_restart() {
+        let (dir, store, lane_id) = store_with_lane("failed-alert");
+        let record = store.record(&lane_id).expect("record");
+        let (failed, _) = store
+            .apply_observation(
+                &lane_id,
+                record.revision,
+                &observation(GjcTurnState::Failed, GjcSessionDisposition::Failed),
+                &ts(1_200),
+            )
+            .expect("failed observation");
+        assert_eq!(failed.pending_alerts.len(), 1);
+        assert_eq!(failed.pending_alerts[0].kind, "session.failed");
+        let event_id = failed.pending_alerts[0].event_id.clone();
+
+        drop(store);
+        let reopened = GjcLaneStore::open(&dir.path().join("gjc-lane-state.json")).expect("reopen");
+        let restored = reopened.record(&lane_id).expect("restored record");
+        assert_eq!(restored.pending_alerts.len(), 1);
+        assert_eq!(restored.pending_alerts[0].event_id, event_id);
+    }
+
+    #[test]
+    fn pending_alert_delivery_ownership_is_partial_and_restart_safe() {
+        let (dir, store, lane_id) = store_with_lane("delivery-ownership");
+        let record = store.record(&lane_id).expect("record");
+        let (failed, _) = store
+            .apply_observation(
+                &lane_id,
+                record.revision,
+                &observation(GjcTurnState::Failed, GjcSessionDisposition::Failed),
+                &ts(1_200),
+            )
+            .expect("failed observation");
+        let event_id = failed.pending_alerts[0].event_id.clone();
+
+        assert!(
+            store
+                .claim_pending_alert_delivery(&lane_id, &event_id, "discord:channel:a")
+                .expect("claim a")
+        );
+        assert!(
+            store
+                .record_pending_alert_delivery(&lane_id, &event_id, "discord:channel:a", true)
+                .expect("deliver a")
+        );
+        assert!(
+            store
+                .claim_pending_alert_delivery(&lane_id, &event_id, "discord:channel:b")
+                .expect("claim b")
+        );
+        assert!(
+            store
+                .record_pending_alert_delivery(&lane_id, &event_id, "discord:channel:b", false)
+                .expect("fail b")
+        );
+
+        let partial = store.record(&lane_id).expect("partial record");
+        let alert = &partial.pending_alerts[0];
+        assert_eq!(
+            alert.deliveries["discord:channel:a"].state,
+            GjcPendingAlertDeliveryState::Delivered
+        );
+        assert_eq!(
+            alert.deliveries["discord:channel:b"].state,
+            GjcPendingAlertDeliveryState::Failed
+        );
+
+        drop(store);
+        let reopened =
+            Arc::new(GjcLaneStore::open(&dir.path().join("gjc-lane-state.json")).expect("reopen"));
+        assert_eq!(
+            reopened.pending_alert_delivery_state(&lane_id, &event_id, "discord:channel:a"),
+            Some(GjcPendingAlertDeliveryState::Delivered)
+        );
+        assert_eq!(
+            reopened.pending_alert_delivery_state(&lane_id, &event_id, "discord:channel:b"),
+            Some(GjcPendingAlertDeliveryState::Failed)
+        );
+        assert!(
+            reopened
+                .claim_pending_alert_delivery(&lane_id, &event_id, "discord:channel:b")
+                .expect("retry b")
+        );
+        assert_eq!(
+            reopened.pending_alert_delivery_state(&lane_id, &event_id, "discord:channel:b"),
+            Some(GjcPendingAlertDeliveryState::Claimed)
+        );
+        assert!(
+            reopened
+                .record_pending_alert_delivery(&lane_id, &event_id, "discord:channel:b", true)
+                .expect("deliver b")
+        );
+        assert_eq!(
+            reopened.pending_alert_delivery_state(&lane_id, &event_id, "discord:channel:a"),
+            Some(GjcPendingAlertDeliveryState::Delivered)
+        );
+        assert_eq!(
+            reopened.pending_alert_delivery_state(&lane_id, &event_id, "discord:channel:b"),
+            Some(GjcPendingAlertDeliveryState::Delivered)
+        );
+    }
+
+    #[test]
+    fn clean_success_and_initial_idle_remain_silent() {
+        let (_dir, store, lane_id) = store_with_lane("silent-lane");
+        let record = store.record(&lane_id).expect("record");
+        let (idle, _) = store
+            .apply_observation(
+                &lane_id,
+                record.revision,
+                &observation(GjcTurnState::Idle, GjcSessionDisposition::Live),
+                &ts(1_100),
+            )
+            .expect("idle observation");
+        assert!(idle.pending_alerts.is_empty());
+        let (complete, _) = store
+            .apply_observation(
+                &lane_id,
+                idle.revision,
+                &observation(GjcTurnState::Complete, GjcSessionDisposition::Complete),
+                &ts(1_200),
+            )
+            .expect("complete observation");
+        assert!(complete.pending_alerts.is_empty());
+    }
+
+    #[test]
+    fn endpoint_alerts_dedupe_until_recovery_then_start_new_episode() {
+        let (_dir, store, lane_id) = store_with_lane("endpoint-alert");
+        let record = store.record(&lane_id).expect("record");
+        let (first, _) = store
+            .mark_unavailable(&lane_id, record.revision, "timeout", u32::MAX, &ts(1_100))
+            .expect("first failure");
+        assert_eq!(first.pending_alerts.len(), 1);
+        let first_id = first.pending_alerts[0].event_id.clone();
+        let (second, _) = store
+            .mark_unavailable(
+                &lane_id,
+                first.revision,
+                "connection closed",
+                u32::MAX,
+                &ts(1_200),
+            )
+            .expect("repeat failure");
+        assert_eq!(second.pending_alerts.len(), 1);
+        assert_eq!(second.pending_alerts[0].event_id, first_id);
+
+        let (recovered, _) = store
+            .apply_observation(
+                &lane_id,
+                second.revision,
+                &observation(GjcTurnState::Idle, GjcSessionDisposition::Live),
+                &ts(1_300),
+            )
+            .expect("recovery");
+        let (new_episode, _) = store
+            .mark_unavailable(
+                &lane_id,
+                recovered.revision,
+                "timeout",
+                u32::MAX,
+                &ts(1_400),
+            )
+            .expect("new failure");
+        assert_eq!(new_episode.pending_alerts.len(), 2);
+        assert_ne!(new_episode.pending_alerts[1].event_id, first_id);
+    }
+
+    #[tokio::test]
+    async fn restarted_reconciler_replays_staged_failed_alert_once() {
+        let (dir, store, lane_id) = store_with_lane("failed-replay");
+        let record = store.record(&lane_id).expect("record");
+        let (failed, _) = store
+            .apply_observation(
+                &lane_id,
+                record.revision,
+                &observation(GjcTurnState::Failed, GjcSessionDisposition::Failed),
+                &ts(1_200),
+            )
+            .expect("failed observation");
+        let event_id = failed.pending_alerts[0].event_id.clone();
+        drop(store);
+        let reopened =
+            Arc::new(GjcLaneStore::open(&dir.path().join("gjc-lane-state.json")).expect("reopen"));
+        let plane = Arc::new(ScriptedPlane {
+            responses: Mutex::new(VecDeque::from(vec![Ok(observation(
+                GjcTurnState::Failed,
+                GjcSessionDisposition::Failed,
+            ))])),
+        });
+        let (tx, sink, mut rx) = event_channel(8);
+        let callback_sink = sink.clone();
+        let callback = tokio::spawn(async move {
+            if let Some(event) = rx.recv().await {
+                callback_sink.lock().expect("sink").push(event.clone());
+                crate::dispatch::resolve_alert_acceptance_id(
+                    event.payload["event_id"].as_str().expect("event id"),
+                    true,
+                );
+            }
+        });
+        let reconciler = GjcReconciler::new(
+            plane,
+            None,
+            reopened.clone(),
+            tx,
+            GjcPollingPolicy::default(),
+        );
+        reconciler.poll_once(fixed_now(10_000)).await.expect("poll");
+        callback.await.expect("callback");
+        let events = sink.lock().expect("sink");
+        let alerts = events
+            .iter()
+            .filter(|event| event.kind == "session.failed")
+            .collect::<Vec<_>>();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].payload["event_id"], event_id);
+        assert!(
+            reopened
+                .record(&lane_id)
+                .expect("record")
+                .pending_alerts
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn endpoint_generation_bump_invalidates_stale_review_owner_evidence() {
         let (_dir, store, lane_id) = store_with_lane("sess-1");
         let record = store.record(&lane_id).expect("record");
@@ -2261,13 +3908,127 @@ mod tests {
         assert!(!updated.owner_evidence_valid);
         assert_eq!(updated.evidence_revision, 2);
 
-        // Generation regression is rejected as conflicting upstream state.
+        // Opaque fingerprints are not numerically ordered; a lower value is
+        // still a distinct replacement generation and must be accepted.
         let mut regressed = advanced.clone();
         regressed.endpoint_generation = 2;
-        let error = store
+        let (_, outcome) = store
             .apply_observation(&lane_id, updated.revision, &regressed, &ts(1_300))
-            .expect_err("regression rejected");
-        assert!(error.to_string().contains("regressed"));
+            .expect("replacement generation accepted");
+        assert!(!outcome.evidence_invalidated);
+    }
+
+    #[test]
+    fn gate_revisions_ignore_stale_and_conflicting_equal_observations() {
+        let (_dir, store, lane_id) = store_with_lane("gate-ordering");
+        let mut opened = observation(GjcTurnState::Idle, GjcSessionDisposition::Live);
+        opened.gate_state = Some(GjcGateState::Ready);
+        opened.gate_id = Some("gate-1".into());
+        opened.gate_revision = 5;
+        let record = store.record(&lane_id).expect("record");
+        let (record, _) = store
+            .apply_observation(&lane_id, record.revision, &opened, &ts(1_200))
+            .expect("open gate");
+
+        let mut stale = opened.clone();
+        stale.gate_state = Some(GjcGateState::Closed);
+        stale.gate_revision = 4;
+        let (record, _) = store
+            .apply_observation(&lane_id, record.revision, &stale, &ts(1_300))
+            .expect("ignore stale gate");
+        assert_eq!(record.last_gate.as_ref().expect("gate").revision, 5);
+        assert_eq!(
+            record.last_gate.as_ref().expect("gate").state,
+            GjcGateState::Ready
+        );
+
+        let mut conflicting = opened.clone();
+        conflicting.gate_state = Some(GjcGateState::Closed);
+        assert!(
+            store
+                .apply_observation(&lane_id, record.revision, &conflicting, &ts(1_400))
+                .is_err()
+        );
+
+        let mut newer = opened;
+        newer.gate_state = Some(GjcGateState::Closed);
+        newer.gate_revision = 6;
+        let record = store
+            .apply_observation(&lane_id, record.revision, &newer, &ts(1_500))
+            .expect("new gate revision")
+            .0;
+        assert_eq!(record.last_gate.as_ref().expect("gate").revision, 6);
+        assert_eq!(
+            record.last_gate.as_ref().expect("gate").state,
+            GjcGateState::Closed
+        );
+    }
+
+    #[test]
+    fn malformed_gate_identity_is_rejected_before_durable_mutation() {
+        let (_dir, store, lane_id) = store_with_lane("sess-1");
+        let before = store.record(&lane_id).expect("record");
+
+        let mut malformed_id = observation(GjcTurnState::Idle, GjcSessionDisposition::Live);
+        malformed_id.gate_state = Some(GjcGateState::Ready);
+        malformed_id.gate_id = Some("gate invalid".to_string());
+        malformed_id.gate_revision = 1;
+        let error = store
+            .apply_observation(&lane_id, before.revision, &malformed_id, &ts(1_200))
+            .expect_err("malformed gate id must fail closed");
+        assert!(error.to_string().contains("canonical identity"));
+
+        let mut malformed_revision = malformed_id;
+        malformed_revision.gate_id = Some("gate-1".to_string());
+        malformed_revision.gate_revision = 0;
+        let error = store
+            .apply_observation(&lane_id, before.revision, &malformed_revision, &ts(1_201))
+            .expect_err("zero gate revision must fail closed");
+        assert!(error.to_string().contains("canonical identity"));
+        assert_eq!(store.record(&lane_id).expect("record"), before);
+    }
+
+    #[test]
+    fn gate_episode_deduplication_survives_restart_and_reopens_on_higher_revision() {
+        let (dir, store, lane_id) = store_with_lane("sess-1");
+        let mut opened = observation(GjcTurnState::Idle, GjcSessionDisposition::Live);
+        opened.gate_state = Some(GjcGateState::Ready);
+        opened.gate_id = Some("gate-1".to_string());
+        opened.gate_revision = 7;
+        let record = store.record(&lane_id).expect("record");
+        let (record, _) = store
+            .apply_observation(&lane_id, record.revision, &opened, &ts(1_200))
+            .expect("open gate");
+        assert_eq!(record.pending_alerts.len(), 1);
+        let first_event = record.pending_alerts[0].event_id.clone();
+
+        // Remove the staged event as a successful delivery would, leaving the
+        // durable gate episode watermark behind for restart reconciliation.
+        let record = store
+            .acknowledge_pending_alert(&lane_id, record.revision, &first_event, &ts(1_201))
+            .expect("acknowledge first gate alert");
+        drop(store);
+        let reopened =
+            Arc::new(GjcLaneStore::open(&dir.path().join("gjc-lane-state.json")).expect("reopen"));
+
+        // Replaying the same gate at a newer session revision remains quiet.
+        let mut replay = opened.clone();
+        replay.revision += 1;
+        let (record, _) = reopened
+            .apply_observation(&lane_id, record.revision, &replay, &ts(1_202))
+            .expect("replay gate");
+        assert!(record.pending_alerts.is_empty());
+
+        // Reopening the same id requires a strictly higher gate revision.
+        let mut higher = replay;
+        higher.revision += 1;
+        higher.gate_revision = 8;
+        let record = reopened
+            .apply_observation(&lane_id, record.revision, &higher, &ts(1_203))
+            .expect("higher gate revision")
+            .0;
+        assert_eq!(record.pending_alerts.len(), 1);
+        assert_ne!(record.pending_alerts[0].event_id, first_event);
     }
 
     #[test]
@@ -2429,6 +4190,17 @@ mod tests {
                 .iter()
                 .any(|entry| entry.kind == GjcAuditKind::GhostWatchRemoved)
         );
+        let reclaimed = reopened
+            .reclaim_tombstone(
+                &lane_id,
+                tombstone.revision,
+                tombstone.endpoint_generation,
+                tombstone.worktree.clone(),
+                &ts(1_500),
+            )
+            .expect("reclaim tombstone");
+        assert!(reclaimed.watch_removed_at.is_none());
+        assert!(reclaimed.terminal_disposition.is_none());
     }
 
     #[test]
@@ -2441,10 +4213,11 @@ mod tests {
             GjcLaneStoreStatus::IgnoredInvalid { .. } => {}
             other => panic!("expected ignored-invalid, got {other:?}"),
         }
-        // And remains usable: registrations proceed on the recovered file.
-        store
-            .register_lane(&registration("after-junk"), &ts(1_000))
-            .expect("usable");
+        assert!(
+            store
+                .register_lane(&registration("after-junk"), &ts(1_000))
+                .is_err()
+        );
     }
 
     #[test]
@@ -2462,6 +4235,13 @@ mod tests {
             GjcLaneRegistrationRequest {
                 sdk_session_id: "bad id with spaces".to_string(),
                 worktree: None,
+                endpoint_generation: None,
+                owner_id: None,
+                pr: None,
+            },
+            GjcLaneRegistrationRequest {
+                sdk_session_id: "ok".to_string(),
+                worktree: Some("relative/../worktree".to_string()),
                 endpoint_generation: None,
                 owner_id: None,
                 pr: None,
@@ -2488,6 +4268,18 @@ mod tests {
                     number: 0,
                     head_sha: "a".repeat(40),
                     base_branch: "dev".to_string(),
+                }),
+            },
+            GjcLaneRegistrationRequest {
+                sdk_session_id: "ok".to_string(),
+                worktree: None,
+                endpoint_generation: None,
+                owner_id: None,
+                pr: Some(GjcPrBindingInput {
+                    repo: "Yeachan-Heo/clawhip".to_string(),
+                    number: 1,
+                    head_sha: "a".repeat(40),
+                    base_branch: "dev\nbranch".to_string(),
                 }),
             },
         ] {
@@ -2612,18 +4404,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn automatic_enrollment_discovers_native_session_before_polling() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let worktree = dir.path().join("worktree");
+        let sdk_dir = worktree.join(".gjc/state/sdk");
+        std::fs::create_dir_all(&sdk_dir).expect("sdk state");
+        let session = "01a02ccd-c754-7656-95c7-f40b5a140bc3";
+        std::fs::write(
+            sdk_dir.join(format!("{session}.json")),
+            format!(
+                r#"{{"version":1,"sessionId":"{session}","url":"ws://127.0.0.1:1/","token":"test","pid":{}}}"#,
+                std::process::id()
+            ),
+        )
+        .expect("metadata");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                sdk_dir.join(format!("{session}.json")),
+                std::fs::Permissions::from_mode(0o600),
+            )
+            .expect("metadata permissions");
+        }
+        assert_eq!(
+            crate::gjc_sdk::discover_all(&crate::gjc_sdk::StateRoot::for_worktree(&worktree))
+                .expect("discover metadata")
+                .len(),
+            1
+        );
+        let store =
+            Arc::new(GjcLaneStore::open(&dir.path().join("lane-state.json")).expect("open store"));
+        let (tx, _sink, _rx) = event_channel(8);
+        let mut live = observation(GjcTurnState::Running, GjcSessionDisposition::Live);
+        live.session_id = session.to_string();
+        live.worktree = Some(worktree.to_string_lossy().into_owned());
+        live.revision = 1;
+        let reconciler = GjcReconciler::new(
+            Arc::new(ScriptedPlane {
+                responses: Mutex::new(VecDeque::from([Ok(live)])),
+            }),
+            None,
+            store.clone(),
+            tx,
+            GjcPollingPolicy::default(),
+        )
+        .with_auto_enrollment(vec![worktree]);
+        reconciler.auto_enroll_native_sessions("2026-08-30T00:00:00Z");
+        assert!(store.record_for_session(session).is_some());
+        let outcome = reconciler.poll_once(fixed_now(1_000)).await.expect("poll");
+        assert_eq!(outcome.examined, 1);
+        assert_eq!(store.record_for_session(session).unwrap().sdk_revision, 1);
+    }
+
+    #[tokio::test]
     async fn reconciler_applies_live_evidence_then_removes_terminal_ghost_watch() {
         let (_dir, store, lane_id) = store_with_lane("sess-1");
+        let mut complete_observation =
+            observation(GjcTurnState::Complete, GjcSessionDisposition::Complete);
+        complete_observation.revision = 11;
         let plane = Arc::new(ScriptedPlane {
             responses: Mutex::new(VecDeque::from(vec![
                 Ok(observation(
                     GjcTurnState::Running,
                     GjcSessionDisposition::Live,
                 )),
-                Ok(observation(
-                    GjcTurnState::Complete,
-                    GjcSessionDisposition::Complete,
-                )),
+                Ok(complete_observation),
                 Err(GjcSdkQueryError::SessionNotFound(
                     "session reaped".to_string(),
                 )),
@@ -2854,15 +4700,39 @@ mod tests {
             reconciled.examined
         };
         assert!(total >= 1);
-        assert_eq!(
-            store.record(&lane_id).expect("final").revision,
-            snapshot_revision + 1
+        assert!(
+            store.record(&lane_id).expect("final").revision > snapshot_revision,
+            "one or both concurrent CAS writers must commit"
         );
         // Durable file stays valid JSON after the race.
         let content =
             std::fs::read_to_string(dir.path().join("gjc-lane-state.json")).expect("read state");
         let parsed: Value = serde_json::from_str(&content).expect("valid json after race");
         assert_eq!(parsed["schema"], GJC_LANE_STATE_SCHEMA);
+    }
+
+    #[test]
+    fn migrated_lane_id_remains_a_lookup_and_mutation_alias() {
+        let (dir, store, canonical_id) = store_with_lane("legacy-alias");
+        let legacy_id = "legacy-lane-id".to_string();
+        {
+            let mut state = store.state.lock().expect("state");
+            let mut record = state.lanes.remove(&canonical_id).expect("record");
+            record.lane_id = legacy_id.clone();
+            state.lanes.insert(legacy_id.clone(), record);
+            store.persist_locked(&mut state).expect("persist");
+        }
+
+        let reopened = GjcLaneStore::open(&dir.path().join("gjc-lane-state.json")).expect("reopen");
+        let record = reopened.record(&legacy_id).expect("legacy lookup");
+        assert_eq!(record.lane_id, canonical_id);
+        let updated = reopened
+            .mutate(&legacy_id, record.revision, &ts(80_000), |mut record| {
+                record.phase = Some(GjcLanePhase::Unavailable);
+                Ok(multi_audit(record, vec![]))
+            })
+            .expect("legacy mutation");
+        assert_eq!(updated.phase, Some(GjcLanePhase::Unavailable));
     }
 
     #[test]

--- a/src/gjc_sdk.rs
+++ b/src/gjc_sdk.rs
@@ -159,6 +159,20 @@ impl EndpointMetadata {
         self.stale
     }
 
+    /// Stable opaque generation fingerprint for durable consumers. It never
+    /// exposes the URL or token, but changes whenever endpoint metadata does.
+    pub fn generation(&self) -> u64 {
+        use sha2::{Digest, Sha256};
+        let digest = Sha256::digest(
+            format!(
+                "{}\0{}\0{:?}\0{}",
+                self.url, self.token, self.pid, self.stale
+            )
+            .as_bytes(),
+        );
+        u64::from_be_bytes(digest[..8].try_into().expect("fixed digest length"))
+    }
+
     /// Authenticated websocket URL with the token applied as a query param.
     fn authenticated_url(&self) -> Result<Url> {
         let mut url = Url::parse(&self.url).map_err(|_| SdkTransportError::EndpointMalformed)?;
@@ -493,6 +507,43 @@ pub fn discover(root: &StateRoot) -> Result<Discovery> {
         return Ok(Discovery::Malformed);
     }
     Ok(Discovery::NoMetadata)
+}
+
+/// Discover every live native SDK endpoint under one trusted worktree.
+/// Unlike [`discover`], this is the enrollment surface and never chooses a
+/// single "best" session; each filename remains the authoritative identity.
+pub fn discover_all(root: &StateRoot) -> Result<Vec<EndpointMetadata>> {
+    let sdk_dir = match root.validate_components() {
+        Ok(sdk_dir) => sdk_dir,
+        Err(error)
+            if error
+                .downcast_ref::<SdkTransportError>()
+                .is_some_and(|e| *e == SdkTransportError::EndpointUnavailable) =>
+        {
+            return Ok(Vec::new());
+        }
+        Err(error) => return Err(error),
+    };
+    let mut live = Vec::new();
+    for entry in std::fs::read_dir(sdk_dir)?.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|extension| extension != "json")
+            || validate_metadata_file(&path).is_err()
+        {
+            continue;
+        }
+        let Ok(contents) = std::fs::read(&path) else {
+            continue;
+        };
+        let Ok(metadata) = parse_metadata_file(&path, &contents) else {
+            continue;
+        };
+        if !metadata.stale() && metadata.pid().is_none_or(process_alive) {
+            live.push(metadata);
+        }
+    }
+    live.sort_by(|left, right| left.session_id().cmp(right.session_id()));
+    Ok(live)
 }
 
 /// Bounded transport configuration.
@@ -903,6 +954,9 @@ impl SdkClient {
                     let connection_lost = error
                         .downcast_ref::<SdkTransportError>()
                         .is_some_and(|e| *e == SdkTransportError::ConnectionClosed);
+                    if connection_lost && request.frame_type == "control_request" {
+                        return Err(SdkTransportError::ConnectionClosed.into());
+                    }
                     if !(connection_lost && attempts <= self.limits.max_reconnect_attempts) {
                         if connection_lost {
                             return Err(SdkTransportError::RetryExhausted.into());
@@ -948,6 +1002,10 @@ async fn exchange(
             return Err(SdkTransportError::FrameRejected.into());
         };
         let response = parse_response(&text, limits)?;
+
+        if response.frame_type == "notification" {
+            continue;
+        }
         match response.id.as_deref() {
             Some(id) if id == request.correlation_id() => {
                 if response.frame_type != request.response_frame_type() {

--- a/src/gjc_sdk_events.rs
+++ b/src/gjc_sdk_events.rs
@@ -13,10 +13,10 @@
 //! The bridge owns no transport, polling loop, or durable lane state: sibling
 //! tracks (#322 transport, #323 control, #325 reconciler) feed snapshots in and
 //! enqueue the emitted [`IncomingEvent`]s through the normal daemon pipeline
-//! (router -> ledger -> sinks). Transitions are deduped per session/turn/gate
-//! revision, and every emitted event carries a deterministic `event_id` plus
-//! `idempotency_key` derived from the transition identity so the event ledger
-//! suppresses replays across restarts.
+//! (router -> ledger -> sinks). Transitions are deduped per authoritative
+//! session/turn/gate episode, and every emitted event carries a deterministic
+//! `event_id` plus `idempotency_key` derived from that identity so the event
+//! ledger suppresses replays across restarts.
 //!
 //! Payloads are whitelist-only and public-safe: bounded summaries, collapsed
 //! control characters, and never raw prompts, tokens, or endpoint URLs.
@@ -43,6 +43,7 @@ pub enum GjcSdkTurnPhase {
     WaitingInput,
     Complete,
     Failed,
+    Aborted,
 }
 
 /// Acceptance/progression state of the last submitted prompt.
@@ -85,6 +86,8 @@ pub struct GjcSdkTurn {
     pub id: String,
     pub state: GjcSdkTurnPhase,
     #[serde(default)]
+    pub prompt_accepted: bool,
+    #[serde(default)]
     pub attempt: u64,
     #[serde(default)]
     pub error_summary: Option<String>,
@@ -106,6 +109,12 @@ pub struct GjcSdkGate {
     pub status: GjcSdkGateStatus,
     #[serde(default)]
     pub summary: Option<String>,
+    #[serde(default)]
+    pub workflow_id: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub options: Vec<String>,
 }
 
 /// Typed endpoint-health slice (no URLs, no credentials).
@@ -124,12 +133,21 @@ pub struct GjcSdkEndpoint {
 pub struct GjcSdkStateSnapshot {
     pub session_id: String,
     pub revision: u64,
+    /// Durable endpoint failure episode identity. This is not a local CAS
+    /// revision; callers increment it only when authoritative endpoint health
+    /// recovers and fails again so retries retain one event identity.
+    #[serde(default)]
+    pub endpoint_episode: u64,
     #[serde(default)]
     pub turn: Option<GjcSdkTurn>,
+    #[serde(skip)]
+    pub turn_present: bool,
     #[serde(default)]
     pub prompt: Option<GjcSdkPrompt>,
     #[serde(default)]
     pub gate: Option<GjcSdkGate>,
+    #[serde(skip)]
+    pub gate_present: bool,
     #[serde(default)]
     pub model: Option<String>,
     #[serde(default)]
@@ -148,6 +166,11 @@ pub struct GjcSdkStateSnapshot {
     pub observed_at: Option<String>,
     #[serde(default)]
     pub summary: Option<String>,
+    /// Internal mapper failure. A malformed authoritative query is carried
+    /// as a rejected snapshot so callers that use the historical infallible
+    /// mapper cannot accidentally advance a watermark or emit a guessed gate.
+    #[serde(skip)]
+    pub(crate) mapping_error: Option<String>,
 }
 
 /// Result of feeding one snapshot to the bridge.
@@ -167,23 +190,28 @@ pub struct BridgeStats {
     pub emitted: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 struct SessionTrack {
     last_revision: Option<u64>,
     turn_id: Option<String>,
     attempts: u64,
     terminal_emitted_turn: Option<String>,
     prompt_command: Option<String>,
+    prompt_turn_id: Option<String>,
+    last_prompt_command: Option<String>,
     gate_episode: Option<(String, u64)>,
     model: Option<String>,
     profile: Option<String>,
     endpoint_health: Option<GjcSdkEndpointHealth>,
     endpoint_alerted: bool,
+    endpoint_episode: u64,
     session_started_emitted: bool,
+    in_flight_turn: Option<String>,
+    unexpected_idle_emitted_turn: Option<String>,
 }
 
 /// Per-session transition reducer mapping SDK snapshots onto Clawhip events.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct GjcEventBridge {
     sessions: HashMap<String, SessionTrack>,
     stats: BridgeStats,
@@ -202,9 +230,28 @@ impl GjcEventBridge {
     /// the snapshot was suppressed as a duplicate or stale/out-of-order input.
     pub fn observe(&mut self, snapshot: &GjcSdkStateSnapshot) -> Result<BridgeOutcome, String> {
         self.stats.snapshots += 1;
+        if let Some(error) = snapshot.mapping_error.as_deref() {
+            return Err(error.to_string());
+        }
+        crate::gjc::model::SessionId::new(snapshot.session_id.clone())
+            .map_err(|_| "gjc_bridge_invalid_session_id".to_string())?;
         let session_id = sanitize(&snapshot.session_id);
         if session_id.is_empty() || session_id.chars().count() > MAX_ID_CHARS {
             return Err("gjc_bridge_invalid_session_id".to_string());
+        }
+        if let Some(gate) = &snapshot.gate {
+            if !valid_gate_id(&gate.id) {
+                return Err("gjc_bridge_invalid_gate_id".to_string());
+            }
+            if gate.revision == 0 {
+                return Err("gjc_bridge_invalid_gate_revision".to_string());
+            }
+        }
+        if let Some(prompt) = &snapshot.prompt {
+            let prompt_id = sanitize(&prompt.command_id);
+            if prompt_id.is_empty() || prompt_id.chars().count() > MAX_ID_CHARS {
+                return Err("gjc_bridge_invalid_prompt_id".to_string());
+            }
         }
 
         let track = self.sessions.entry(session_id.clone()).or_default();
@@ -237,9 +284,11 @@ impl GjcEventBridge {
                 track.turn_id = Some(turn_id.clone());
                 track.attempts = 0;
                 track.terminal_emitted_turn = None;
+                track.prompt_command = None;
             }
+            let prompt_accepted = turn.prompt_accepted || track.prompt_command.is_some();
 
-            if turn.attempt > track.attempts {
+            if prompt_accepted && turn.attempt > track.attempts {
                 events.push(lifecycle_event(
                     &context,
                     "session.retry-needed",
@@ -257,7 +306,9 @@ impl GjcEventBridge {
                 track.terminal_emitted_turn.as_deref() == Some(turn_id.as_str());
             match turn.state {
                 GjcSdkTurnPhase::Active => {
-                    if !track.session_started_emitted {
+                    track.in_flight_turn = prompt_accepted.then_some(turn_id.clone());
+                    track.unexpected_idle_emitted_turn = None;
+                    if prompt_accepted && !track.session_started_emitted {
                         events.push(lifecycle_event(
                             &context,
                             "session.started",
@@ -272,7 +323,7 @@ impl GjcEventBridge {
                     }
                 }
                 GjcSdkTurnPhase::Complete | GjcSdkTurnPhase::Failed => {
-                    if !terminal_already_emitted {
+                    if prompt_accepted && !terminal_already_emitted {
                         let failed = turn.state == GjcSdkTurnPhase::Failed;
                         let kind = if failed {
                             "session.failed"
@@ -284,31 +335,98 @@ impl GjcEventBridge {
                             turn.error_summary
                                 .as_deref()
                                 .or(snapshot.summary.as_deref())
-                                .map(sanitize)
+                                .map(public_failure_summary)
                                 .filter(|value| !value.is_empty())
-                                .unwrap_or_else(|| "turn failed".to_string())
+                                .unwrap_or_else(|| "provider turn failed".to_string())
                         });
                         events.push(lifecycle_event(
                             &context,
                             kind,
                             status,
                             0,
-                            snapshot.summary.clone(),
+                            if failed {
+                                error.clone()
+                            } else {
+                                snapshot.summary.clone()
+                            },
                             error,
                             &[if failed { "failed" } else { "complete" }],
                             &[],
                         ));
                         track.terminal_emitted_turn = Some(turn_id);
                     }
+                    track.in_flight_turn = None;
                 }
-                GjcSdkTurnPhase::Idle | GjcSdkTurnPhase::WaitingInput => {}
+                GjcSdkTurnPhase::Idle | GjcSdkTurnPhase::Aborted => {
+                    if track.in_flight_turn.as_deref() == Some(turn_id.as_str())
+                        && track.unexpected_idle_emitted_turn.as_deref() != Some(turn_id.as_str())
+                    {
+                        let mut error = turn
+                            .error_summary
+                            .as_deref()
+                            .map(public_failure_summary)
+                            .unwrap_or_else(|| {
+                                "accepted turn became idle without a terminal receipt".to_string()
+                            });
+                        if turn.state == GjcSdkTurnPhase::Aborted {
+                            error =
+                                "accepted turn was aborted without a successful terminal receipt"
+                                    .to_string();
+                        }
+                        events.push(lifecycle_event(
+                            &context,
+                            "session.stalled",
+                            "unexpected-idle",
+                            0,
+                            Some(error.clone()),
+                            Some(error),
+                            &["unexpected-idle"],
+                            &[],
+                        ));
+                        track.unexpected_idle_emitted_turn = Some(turn_id.clone());
+                    }
+                    track.in_flight_turn = None;
+                }
+                GjcSdkTurnPhase::WaitingInput => {
+                    if prompt_accepted && track.in_flight_turn.is_none() {
+                        track.in_flight_turn = Some(turn_id);
+                    }
+                }
             }
+        }
+
+        if snapshot.turn_present
+            && snapshot.turn.is_none()
+            && let Some(turn_id) = track.in_flight_turn.take()
+            && track.unexpected_idle_emitted_turn.as_deref() != Some(turn_id.as_str())
+        {
+            let message = "accepted turn disappeared without a terminal receipt".to_string();
+            events.push(lifecycle_event(
+                &context,
+                "session.stalled",
+                "unexpected-idle",
+                0,
+                Some(message.clone()),
+                Some(message),
+                &[turn_id.as_str(), "unexpected-idle"],
+                &[],
+            ));
+            track.unexpected_idle_emitted_turn = Some(turn_id);
         }
 
         if let Some(prompt) = &snapshot.prompt {
             let command_id = sanitize(&prompt.command_id);
+            let current_turn_id = snapshot.turn.as_ref().map(|turn| turn.id.as_str());
             if !command_id.is_empty()
                 && prompt.status == GjcSdkPromptStatus::Accepted
+                && snapshot.turn.as_ref().is_some_and(|turn| {
+                    matches!(
+                        turn.state,
+                        GjcSdkTurnPhase::Active | GjcSdkTurnPhase::WaitingInput
+                    )
+                })
+                && (track.last_prompt_command.as_deref() != Some(command_id.as_str())
+                    || track.prompt_turn_id.as_deref() == current_turn_id)
                 && track.prompt_command.as_deref() != Some(command_id.as_str())
             {
                 events.push(lifecycle_event(
@@ -318,18 +436,17 @@ impl GjcEventBridge {
                     0,
                     snapshot.summary.clone(),
                     None,
-                    &[],
+                    &[command_id.as_str()],
                     &[("command_id", Value::from(command_id.as_str()))],
                 ));
                 track.prompt_command = Some(command_id);
+                track.prompt_turn_id = current_turn_id.map(str::to_string);
+                track.last_prompt_command = track.prompt_command.clone();
             }
         }
 
         if let Some(gate) = &snapshot.gate {
-            let gate_id = sanitize(&gate.id);
-            if gate_id.is_empty() || gate_id.chars().count() > MAX_ID_CHARS {
-                return Err("gjc_bridge_invalid_gate_id".to_string());
-            }
+            let gate_id = gate.id.clone();
             match gate.status {
                 GjcSdkGateStatus::Open => {
                     let new_episode = match &track.gate_episode {
@@ -368,13 +485,25 @@ impl GjcEventBridge {
         }
 
         if let Some(endpoint) = &snapshot.endpoint {
+            track.endpoint_episode = track.endpoint_episode.max(snapshot.endpoint_episode);
             let escalated = track.endpoint_health == Some(GjcSdkEndpointHealth::Degraded)
                 && endpoint.health == GjcSdkEndpointHealth::Failed;
             match endpoint.health {
                 GjcSdkEndpointHealth::Ok => track.endpoint_alerted = false,
                 GjcSdkEndpointHealth::Degraded | GjcSdkEndpointHealth::Failed => {
                     if !track.endpoint_alerted || escalated {
-                        events.push(endpoint_failed_event(&context, endpoint));
+                        if !track.endpoint_alerted
+                            && (track.endpoint_health.is_none()
+                                || track.endpoint_health == Some(GjcSdkEndpointHealth::Ok))
+                        {
+                            track.endpoint_episode =
+                                track.endpoint_episode.saturating_add(1).max(1);
+                        }
+                        events.push(endpoint_failed_event(
+                            &context,
+                            endpoint,
+                            track.endpoint_episode,
+                        ));
                         track.endpoint_alerted = true;
                     }
                 }
@@ -400,7 +529,7 @@ pub fn snapshot_from_response_payload(payload: &Value) -> Result<GjcSdkStateSnap
     if !payload.is_object() {
         return Err("gjc_bridge_snapshot_payload_not_object".to_string());
     }
-    let snapshot: GjcSdkStateSnapshot =
+    let mut snapshot: GjcSdkStateSnapshot =
         serde_json::from_value(payload.clone()).map_err(|error| {
             format!(
                 "gjc_bridge_snapshot_malformed: {}",
@@ -409,6 +538,21 @@ pub fn snapshot_from_response_payload(payload: &Value) -> Result<GjcSdkStateSnap
         })?;
     if snapshot.session_id.trim().is_empty() {
         return Err("gjc_bridge_snapshot_missing_session_id".to_string());
+    }
+    crate::gjc::model::SessionId::new(snapshot.session_id.clone())
+        .map_err(|_| "gjc_bridge_invalid_session_id".to_string())?;
+    snapshot.turn_present = payload.get("turn").is_some();
+    snapshot.gate_present = payload.get("gate").is_some();
+    if snapshot
+        .turn
+        .as_ref()
+        .is_some_and(|turn| turn.prompt_accepted)
+        && snapshot
+            .prompt
+            .as_ref()
+            .is_some_and(|prompt| prompt.status != GjcSdkPromptStatus::Accepted)
+    {
+        return Err("gjc_bridge_contradictory_prompt_acceptance".to_string());
     }
     Ok(snapshot)
 }
@@ -426,24 +570,52 @@ pub struct GjcSnapshotIdentity {
 /// typed snapshot input. `revision` is caller-supplied monotonic lane state
 /// (the reconciler's store revision); git routing identity comes from lane
 /// registration because the control-plane model does not carry it. Gate
-/// revisions are synthesized from `raised_at` timestamps so re-raised gates
-/// form new dedupe episodes.
+/// revisions are derived from authoritative `raised_at` timestamps so
+/// re-raised gates form new dedupe episodes. Queries with ambiguous ready
+/// gates or malformed gate identity are carried as rejected snapshots rather
+/// than projected into guessed state.
 pub fn snapshot_from_session_query(
     session_id: &str,
     revision: u64,
     query: &crate::gjc::model::SessionQuery,
     identity: &GjcSnapshotIdentity,
 ) -> GjcSdkStateSnapshot {
+    let gates = query.workflow_gates.as_deref().unwrap_or_default();
+    let ready_count = gates
+        .iter()
+        .filter(|gate| gate.state == crate::gjc::model::WorkflowGateState::Ready)
+        .count();
+    if ready_count > 1 {
+        return rejected_snapshot(
+            session_id,
+            revision,
+            identity,
+            "gjc_bridge_ambiguous_workflow_gates",
+        );
+    }
+    if gates
+        .iter()
+        .any(|gate| !valid_gate_id(&gate.gate_id) || gate_revision(gate) == 0)
+    {
+        return rejected_snapshot(
+            session_id,
+            revision,
+            identity,
+            "gjc_bridge_invalid_gate_identity",
+        );
+    }
+
     let turn = query.turn.as_ref().map(|turn| GjcSdkTurn {
         id: turn.turn_id.clone(),
         state: match turn.status {
-            crate::gjc::model::GjcPromptStatus::Queued
-            | crate::gjc::model::GjcPromptStatus::Running => GjcSdkTurnPhase::Active,
+            crate::gjc::model::GjcPromptStatus::Queued => GjcSdkTurnPhase::Active,
+            crate::gjc::model::GjcPromptStatus::Running => GjcSdkTurnPhase::Active,
             crate::gjc::model::GjcPromptStatus::Succeeded => GjcSdkTurnPhase::Complete,
             crate::gjc::model::GjcPromptStatus::Failed => GjcSdkTurnPhase::Failed,
             crate::gjc::model::GjcPromptStatus::Aborted => GjcSdkTurnPhase::Idle,
         },
         attempt: 0,
+        prompt_accepted: turn.prompt_accepted,
         error_summary: matches!(
             turn.status,
             crate::gjc::model::GjcPromptStatus::Failed
@@ -457,7 +629,6 @@ pub fn snapshot_from_session_query(
         .flatten(),
     });
 
-    let gates = query.workflow_gates.as_deref().unwrap_or_default();
     let gate = gates
         .iter()
         .find(|gate| gate.state == crate::gjc::model::WorkflowGateState::Ready)
@@ -470,18 +641,27 @@ pub fn snapshot_from_session_query(
         })
         .map(|(gate, status)| GjcSdkGate {
             id: gate.gate_id.clone(),
-            kind: GjcSdkGateKind::Workflow,
+            kind: match gate.kind.as_deref() {
+                Some("ask") => GjcSdkGateKind::Ask,
+                _ => GjcSdkGateKind::Workflow,
+            },
             revision: gate_revision(gate),
             status,
             summary: gate.title.clone(),
+            workflow_id: gate.workflow_id.clone(),
+            title: gate.title.clone(),
+            options: gate.options.clone(),
         });
 
     GjcSdkStateSnapshot {
         session_id: session_id.to_string(),
         revision,
+        endpoint_episode: 0,
         turn,
+        turn_present: query.turn_present,
         prompt: None,
         gate,
+        gate_present: query.workflow_gates_present,
         model: query
             .model_profile
             .as_ref()
@@ -503,17 +683,47 @@ pub fn snapshot_from_session_query(
             .metadata
             .as_ref()
             .and_then(|metadata| metadata.title.clone()),
+        mapping_error: None,
     }
 }
 
-/// Deterministic gate episode revision: unix seconds of `raised_at` when it
-/// parses, otherwise a stable fallback that keeps episodes distinct per gate.
-fn gate_revision(gate: &crate::gjc::model::WorkflowGate) -> u64 {
+fn rejected_snapshot(
+    session_id: &str,
+    revision: u64,
+    identity: &GjcSnapshotIdentity,
+    error: &str,
+) -> GjcSdkStateSnapshot {
+    GjcSdkStateSnapshot {
+        session_id: session_id.to_string(),
+        revision,
+        gate_present: true,
+        repo_name: identity.repo_name.clone(),
+        repo_path: identity.repo_path.clone(),
+        worktree_path: identity.worktree_path.clone(),
+        branch: identity.branch.clone(),
+        mapping_error: Some(error.to_string()),
+        ..GjcSdkStateSnapshot::default()
+    }
+}
+
+/// Deterministic gate episode revision: nanoseconds of the authoritative
+/// `raised_at` timestamp. A missing or malformed timestamp is invalid rather
+/// than replaced with a locally invented revision.
+pub(crate) fn gate_revision(gate: &crate::gjc::model::WorkflowGate) -> u64 {
     gate.raised_at
         .as_deref()
         .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok())
-        .map(|time| time.unix_timestamp().max(0) as u64)
-        .unwrap_or(1)
+        .and_then(|time| u64::try_from(time.unix_timestamp_nanos()).ok())
+        .filter(|revision| *revision > 0)
+        .unwrap_or(0)
+}
+
+pub(crate) fn valid_gate_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_ID_CHARS
+        && value
+            .chars()
+            .all(|character| !character.is_control() && !character.is_whitespace())
 }
 
 struct SnapshotContext<'a> {
@@ -527,9 +737,8 @@ impl<'a> SnapshotContext<'a> {
         let timestamp = snapshot
             .observed_at
             .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToString::to_string)
+            .and_then(|value| OffsetDateTime::parse(value.trim(), &Rfc3339).ok())
+            .and_then(|value| value.format(&Rfc3339).ok())
             .unwrap_or_else(rfc3339_now);
         Self {
             session_id,
@@ -550,7 +759,13 @@ fn lifecycle_event(
     identity_parts: &[&str],
     extra_fields: &[(&str, Value)],
 ) -> IncomingEvent {
-    let mut object = base_object(context, kind, status, identity_parts);
+    let attempt_component = attempt.to_string();
+    let mut event_identity = Vec::with_capacity(identity_parts.len() + usize::from(attempt > 0));
+    if attempt > 0 {
+        event_identity.push(attempt_component.as_str());
+    }
+    event_identity.extend_from_slice(identity_parts);
+    let mut object = base_object(context, kind, status, &event_identity);
     if attempt > 0 {
         object.insert("attempt".to_string(), Value::from(attempt));
     }
@@ -573,7 +788,7 @@ fn gate_event(context: &SnapshotContext<'_>, kind: &str, gate: &GjcSdkGate) -> I
     let summary = gate
         .summary
         .as_deref()
-        .map(sanitize)
+        .map(public_text)
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| match gate.kind {
             GjcSdkGateKind::Ask => "operator input requested".to_string(),
@@ -591,6 +806,9 @@ fn gate_event(context: &SnapshotContext<'_>, kind: &str, gate: &GjcSdkGate) -> I
             "kind": gate_kind,
             "revision": gate.revision,
             "summary": summary.clone(),
+            "workflow_id": gate.workflow_id,
+            "title": gate.title,
+            "options": gate.options.iter().map(|option| public_text(option)).collect::<Vec<_>>(),
         }),
     );
     object.insert("question_id".to_string(), Value::from(gate_id.clone()));
@@ -616,7 +834,11 @@ fn gate_event(context: &SnapshotContext<'_>, kind: &str, gate: &GjcSdkGate) -> I
 fn endpoint_failed_event(
     context: &SnapshotContext<'_>,
     endpoint: &GjcSdkEndpoint,
+    endpoint_episode: u64,
 ) -> IncomingEvent {
+    let endpoint_episode = endpoint_episode
+        .max(context.snapshot.endpoint_episode)
+        .max(1);
     let health = match endpoint.health {
         GjcSdkEndpointHealth::Ok => "ok",
         GjcSdkEndpointHealth::Degraded => "degraded",
@@ -625,14 +847,13 @@ fn endpoint_failed_event(
     let detail = endpoint
         .detail
         .as_deref()
-        .map(sanitize)
-        .filter(|value| !value.is_empty())
+        .map(public_endpoint_detail)
         .unwrap_or_else(|| "sdk endpoint unavailable".to_string());
     let mut object = base_object(
         context,
         "session.endpoint-failed",
         "endpoint-failed",
-        &[health],
+        &[health, &format!("episode-{endpoint_episode}")],
     );
     object.insert("endpoint_health".to_string(), Value::from(health));
     object.insert("error_message".to_string(), Value::from(detail.clone()));
@@ -669,6 +890,10 @@ fn model_change_event(
         return None;
     }
 
+    let previous_model = tracked_model.as_deref().unwrap_or("unset").to_string();
+    let previous_profile = tracked_profile.as_deref().unwrap_or("unset").to_string();
+    let current_model = model.as_deref().unwrap_or("unset").to_string();
+    let current_profile = profile.as_deref().unwrap_or("unset").to_string();
     let mut parts = Vec::new();
     if model != *tracked_model {
         parts.push(format!(
@@ -691,8 +916,10 @@ fn model_change_event(
         "session.model-changed",
         "model-changed",
         &[
-            model.as_deref().unwrap_or("unset"),
-            profile.as_deref().unwrap_or("unset"),
+            previous_model.as_str(),
+            current_model.as_str(),
+            previous_profile.as_str(),
+            current_profile.as_str(),
         ],
     );
     if let Some(model) = &model {
@@ -751,13 +978,27 @@ fn base_object(
     let gate_component = gate
         .map(|gate| format!("{}|{}", sanitize(&gate.id), gate.revision))
         .unwrap_or_default();
+    let routing_identity = [
+        context.snapshot.repo_name.as_deref().unwrap_or_default(),
+        context.snapshot.repo_path.as_deref().unwrap_or_default(),
+        context
+            .snapshot
+            .worktree_path
+            .as_deref()
+            .unwrap_or_default(),
+        context.snapshot.branch.as_deref().unwrap_or_default(),
+    ]
+    .into_iter()
+    .map(sanitize)
+    .collect::<Vec<_>>()
+    .join("|");
     let identity = format!(
         "{}|{}|{}|{}|{}|{}",
         kind,
         context.session_id,
-        context.snapshot.revision,
         turn,
         gate_component,
+        routing_identity,
         identity_parts.join("|"),
     );
     let event_id = format!(
@@ -788,7 +1029,7 @@ fn finish_event(kind: &str, object: Map<String, Value>) -> IncomingEvent {
 fn insert_summary(object: &mut Map<String, Value>, summary: Option<String>) {
     if let Some(summary) = summary
         .as_deref()
-        .map(sanitize)
+        .map(public_text)
         .filter(|value| !value.is_empty())
     {
         object.insert("summary".to_string(), Value::from(summary));
@@ -811,6 +1052,60 @@ fn sanitize(value: &str) -> String {
         collapsed.push(mapped);
     }
     collapsed.trim().chars().take(MAX_SUMMARY_CHARS).collect()
+}
+
+fn public_text(value: &str) -> String {
+    let sanitized = sanitize(value);
+    let lower = sanitized.to_ascii_lowercase();
+    let compact: String = lower.chars().filter(char::is_ascii_alphanumeric).collect();
+    if lower.contains("token")
+        || lower.contains("secret")
+        || lower.contains("password")
+        || lower.contains("api_key")
+        || lower.contains("api-key")
+        || lower.contains("authorization")
+        || lower.contains("apikey")
+        || lower.contains("credential")
+        || lower.contains("passwd")
+        || lower.contains("auth:")
+        || compact.contains("privatekey")
+        || lower.contains("auth=")
+        || lower.contains("bearer")
+        || lower.contains("://")
+    {
+        "details redacted".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn public_failure_summary(value: &str) -> String {
+    let normalized = sanitize(value).to_ascii_lowercase();
+    if normalized.contains("401") || normalized.contains("unauthorized") {
+        return "provider authorization failed (401)".to_string();
+    }
+    if normalized.contains("402") && !normalized.contains("403")
+        || (normalized.contains("payment")
+            || normalized.contains("billing")
+            || normalized.contains("credit"))
+            && !normalized.contains("403")
+    {
+        return "provider credits or billing unavailable (402)".to_string();
+    }
+    if normalized.contains("403") || normalized.contains("forbidden") {
+        return "provider access denied (403)".to_string();
+    }
+    if normalized.contains("429")
+        || normalized.contains("rate limit")
+        || normalized.contains("quota")
+    {
+        return "provider rate limit or quota exceeded (429)".to_string();
+    }
+    "provider turn failed".to_string()
+}
+
+fn public_endpoint_detail(_value: &str) -> String {
+    "sdk endpoint unavailable".to_string()
 }
 
 fn rfc3339_now() -> String {
@@ -854,6 +1149,7 @@ mod tests {
         GjcSdkTurn {
             id: id.to_string(),
             state,
+            prompt_accepted: true,
             attempt,
             error_summary: None,
         }
@@ -894,6 +1190,7 @@ mod tests {
         snapshot.turn = Some(GjcSdkTurn {
             id: "t2".to_string(),
             state: GjcSdkTurnPhase::Failed,
+            prompt_accepted: true,
             attempt: 0,
             error_summary: Some("boom".to_string()),
         });
@@ -901,9 +1198,55 @@ mod tests {
         assert_eq!(kinds(&outcome.events), vec!["session.failed".to_string()]);
         assert_eq!(
             outcome.events[0].payload["error_message"],
-            Value::from("boom")
+            Value::from("provider turn failed")
         );
         assert_eq!(bridge.stats().emitted, 4);
+    }
+
+    #[test]
+    fn accepted_turn_becoming_idle_emits_one_unexpected_idle_alert() {
+        let mut bridge = GjcEventBridge::new();
+        let mut snapshot = base_snapshot("sess-idle", 1);
+        snapshot.turn = Some(turn("turn-1", GjcSdkTurnPhase::Active, 0));
+        bridge.observe(&snapshot).unwrap();
+
+        snapshot.revision = 2;
+        snapshot.turn = Some(turn("turn-1", GjcSdkTurnPhase::Idle, 0));
+        let outcome = bridge.observe(&snapshot).unwrap();
+        assert_eq!(kinds(&outcome.events), vec!["session.stalled"]);
+        assert_eq!(outcome.events[0].payload["status"], "unexpected-idle");
+
+        snapshot.revision = 3;
+        assert!(bridge.observe(&snapshot).unwrap().events.is_empty());
+    }
+
+    #[test]
+    fn provider_credit_and_auth_failures_are_public_safe() {
+        let mut bridge = GjcEventBridge::new();
+        for (revision, detail, expected) in [
+            (
+                1,
+                "provider HTTP 403: credit card token=secret",
+                "provider access denied (403)",
+            ),
+            (
+                2,
+                "provider quota exceeded",
+                "provider rate limit or quota exceeded (429)",
+            ),
+        ] {
+            let mut snapshot = base_snapshot("sess-provider", revision);
+            snapshot.turn = Some(GjcSdkTurn {
+                id: format!("turn-{revision}"),
+                state: GjcSdkTurnPhase::Failed,
+                prompt_accepted: true,
+                attempt: 0,
+                error_summary: Some(detail.to_string()),
+            });
+            let events = bridge.observe(&snapshot).unwrap().events;
+            assert_eq!(events[0].payload["error_message"], expected);
+            assert!(!events[0].payload.to_string().contains("secret"));
+        }
     }
 
     #[test]
@@ -972,6 +1315,9 @@ mod tests {
             revision: 3,
             status: GjcSdkGateStatus::Open,
             summary: Some("Approve the deploy?\nsecond line".to_string()),
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
         });
 
         let outcome = bridge.observe(&snapshot).unwrap();
@@ -1024,6 +1370,9 @@ mod tests {
             revision: 7,
             status: GjcSdkGateStatus::Open,
             summary: None,
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
         });
         let outcome = bridge.observe(&snapshot).unwrap();
         assert_eq!(
@@ -1046,6 +1395,9 @@ mod tests {
             revision: 2,
             status: GjcSdkGateStatus::Open,
             summary: None,
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
         });
         let outcome = bridge.observe(&snapshot).unwrap();
         assert_eq!(kinds(&outcome.events), vec!["workflow.gate".to_string()]);
@@ -1121,7 +1473,7 @@ mod tests {
         );
         assert_eq!(
             outcome.events[0].payload["error_message"],
-            Value::from("connect refused")
+            Value::from("sdk endpoint unavailable")
         );
 
         snapshot.revision = 42;
@@ -1154,6 +1506,39 @@ mod tests {
     }
 
     #[test]
+    fn alert_event_ids_ignore_local_snapshot_revisions() {
+        let mut first = base_snapshot("stable-id", 10);
+        first.turn = Some(turn("turn-1", GjcSdkTurnPhase::Failed, 0));
+        let mut second = first.clone();
+        second.revision = 11_000;
+        let left = GjcEventBridge::new().observe(&first).unwrap().events;
+        let right = GjcEventBridge::new().observe(&second).unwrap().events;
+        assert_eq!(left.len(), 1);
+        assert_eq!(right.len(), 1);
+        assert_eq!(left[0].payload["event_id"], right[0].payload["event_id"]);
+
+        let mut prompt_a = base_snapshot("stable-prompt", 1);
+        prompt_a.turn = Some(turn("turn-1", GjcSdkTurnPhase::Active, 0));
+        prompt_a.prompt = Some(GjcSdkPrompt {
+            command_id: "command-1".to_string(),
+            status: GjcSdkPromptStatus::Accepted,
+        });
+        let mut prompt_b = prompt_a.clone();
+        prompt_b.revision = 99;
+        let left = GjcEventBridge::new().observe(&prompt_a).unwrap().events;
+        let right = GjcEventBridge::new().observe(&prompt_b).unwrap().events;
+        let left = left
+            .iter()
+            .find(|event| event.kind == "session.prompt-submitted")
+            .unwrap();
+        let right = right
+            .iter()
+            .find(|event| event.kind == "session.prompt-submitted")
+            .unwrap();
+        assert_eq!(left.payload["event_id"], right.payload["event_id"]);
+    }
+
+    #[test]
     fn restart_produces_identical_event_ids_for_ledger_dedupe() {
         let feed = || {
             let mut snapshots = Vec::new();
@@ -1172,6 +1557,9 @@ mod tests {
                 revision: 4,
                 status: GjcSdkGateStatus::Open,
                 summary: Some("Proceed?".to_string()),
+                workflow_id: None,
+                title: None,
+                options: Vec::new(),
             });
             snapshots.push(snapshot.clone());
             snapshot.revision = 3;
@@ -1235,6 +1623,7 @@ mod tests {
         snapshot.turn = Some(GjcSdkTurn {
             id: "t1".to_string(),
             state: GjcSdkTurnPhase::Failed,
+            prompt_accepted: true,
             attempt: 0,
             error_summary: Some("raw\r\nerror\twith control chars".to_string()),
         });
@@ -1254,7 +1643,7 @@ mod tests {
                 assert!(!summary.contains("secret-token-value"));
             }
             if let Some(error) = object.get("error_message").and_then(Value::as_str) {
-                assert_eq!(error, "raw error with control chars");
+                assert_eq!(error, "provider turn failed");
             }
         }
     }
@@ -1281,6 +1670,9 @@ mod tests {
             revision: 1,
             status: GjcSdkGateStatus::Open,
             summary: Some("Answer me?".to_string()),
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
         });
         snapshots.push(snapshot);
 
@@ -1322,6 +1714,9 @@ mod tests {
             revision: 1,
             status: GjcSdkGateStatus::Open,
             summary: None,
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
         });
         snapshot.endpoint = Some(GjcSdkEndpoint {
             health: GjcSdkEndpointHealth::Failed,
@@ -1354,10 +1749,126 @@ mod tests {
         );
     }
 
+    #[test]
+    fn gate_replays_and_reopens_use_gate_revision_not_snapshot_revision() {
+        let mut bridge = GjcEventBridge::new();
+        let mut snapshot = base_snapshot("gate-replay", 1);
+        snapshot.gate = Some(GjcSdkGate {
+            id: "gate-1".to_string(),
+            kind: GjcSdkGateKind::Workflow,
+            revision: 7,
+            status: GjcSdkGateStatus::Open,
+            summary: None,
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
+        });
+        assert_eq!(bridge.observe(&snapshot).unwrap().events.len(), 1);
+
+        // A replay at a newer session revision is still the same gate episode.
+        snapshot.revision = 2;
+        assert!(bridge.observe(&snapshot).unwrap().events.is_empty());
+
+        // A lower gate revision cannot regress or create a second episode.
+        snapshot.revision = 3;
+        snapshot.gate.as_mut().unwrap().revision = 6;
+        assert!(bridge.observe(&snapshot).unwrap().events.is_empty());
+
+        // Resolution followed by a higher revision on the same id reopens it.
+        snapshot.revision = 4;
+        snapshot.gate.as_mut().unwrap().revision = 7;
+        snapshot.gate.as_mut().unwrap().status = GjcSdkGateStatus::Resolved;
+        assert!(bridge.observe(&snapshot).unwrap().events.is_empty());
+        snapshot.revision = 5;
+        snapshot.gate.as_mut().unwrap().revision = 8;
+        snapshot.gate.as_mut().unwrap().status = GjcSdkGateStatus::Open;
+        let reopened = bridge.observe(&snapshot).unwrap().events;
+        assert_eq!(kinds(&reopened), vec!["workflow.gate"]);
+        assert_eq!(reopened[0].payload["gate_revision"], Value::from(8));
+    }
+
+    #[test]
+    fn plural_ready_gates_are_rejected_before_event_mapping() {
+        let gate = |id: &str| crate::gjc::model::WorkflowGate {
+            gate_id: id.to_string(),
+            kind: None,
+            workflow_id: None,
+            state: crate::gjc::model::WorkflowGateState::Ready,
+            title: Some("Approve merge".to_string()),
+            options: Vec::new(),
+            raised_at: Some("2026-08-23T10:00:00Z".to_string()),
+        };
+        let mut query = control_query(crate::gjc::model::GjcPromptStatus::Running);
+        query.workflow_gates = Some(vec![gate("gate-1"), gate("gate-2")]);
+        let snapshot = snapshot_from_session_query("sess-9", 1, &query, &identity());
+        assert_eq!(
+            GjcEventBridge::new().observe(&snapshot).unwrap_err(),
+            "gjc_bridge_ambiguous_workflow_gates"
+        );
+    }
+
+    #[test]
+    fn malformed_gate_identity_or_revision_is_rejected() {
+        let mut bridge = GjcEventBridge::new();
+        let mut snapshot = base_snapshot("gate-invalid", 1);
+        snapshot.gate = Some(GjcSdkGate {
+            id: "gate invalid".to_string(),
+            kind: GjcSdkGateKind::Workflow,
+            revision: 1,
+            status: GjcSdkGateStatus::Open,
+            summary: None,
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
+        });
+        assert_eq!(
+            bridge.observe(&snapshot).unwrap_err(),
+            "gjc_bridge_invalid_gate_id"
+        );
+        snapshot.gate.as_mut().unwrap().id = "gate-1".to_string();
+        snapshot.gate.as_mut().unwrap().revision = 0;
+        assert_eq!(
+            bridge.observe(&snapshot).unwrap_err(),
+            "gjc_bridge_invalid_gate_revision"
+        );
+    }
+
+    #[test]
+    fn gate_summaries_redact_credential_aliases() {
+        for value in [
+            "authorization=secret",
+            "apikey: secret",
+            "api-key secret",
+            "private_key=secret",
+            "credential secret",
+            "passwd secret",
+            "auth: secret",
+        ] {
+            assert_eq!(public_text(value), "details redacted");
+        }
+    }
+
+    #[test]
+    fn contradictory_prompt_acceptance_fails_closed() {
+        let error = snapshot_from_response_payload(&json!({
+            "session_id": "sess-1",
+            "revision": 1,
+            "turn": {
+                "id": "turn-1",
+                "state": "active",
+                "prompt_accepted": true
+            },
+            "prompt": {"command_id": "turn-1", "status": "progressing"}
+        }))
+        .unwrap_err();
+        assert_eq!(error, "gjc_bridge_contradictory_prompt_acceptance");
+    }
+
     fn control_query(
         status: crate::gjc::model::GjcPromptStatus,
     ) -> crate::gjc::model::SessionQuery {
         crate::gjc::model::SessionQuery {
+            revision: None,
             metadata: Some(crate::gjc::model::SessionMetadata {
                 session_id: "sess-9".to_string(),
                 title: Some("issue 324 lane".to_string()),
@@ -1368,6 +1879,8 @@ mod tests {
                 provider_metadata: Default::default(),
             }),
             stats: None,
+            workflow_gates_present: false,
+            turn_present: true,
             model_profile: Some(crate::gjc::model::SessionModelProfile {
                 model: "model-a".to_string(),
                 profile: Some("profile-x".to_string()),
@@ -1376,6 +1889,7 @@ mod tests {
             turn: Some(crate::gjc::model::SessionTurn {
                 turn_id: "t1".to_string(),
                 status,
+                prompt_accepted: true,
                 started_at: None,
                 finished_at: None,
                 outcome: Some(crate::gjc::model::SessionTurnOutcome {
@@ -1458,10 +1972,11 @@ mod tests {
          -> crate::gjc::model::WorkflowGate {
             crate::gjc::model::WorkflowGate {
                 gate_id: "gate-1".to_string(),
-                workflow_id: None,
+                kind: Some("ask".to_string()),
+                workflow_id: Some("workflow-1".to_string()),
                 state,
                 title: Some("Approve merge".to_string()),
-                options: Vec::new(),
+                options: vec!["approve".to_string(), "reject".to_string()],
                 raised_at: Some(raised_at.to_string()),
             }
         };
@@ -1476,23 +1991,24 @@ mod tests {
         let open = snapshot_from_session_query("sess-9", 10, &query, &identity());
         let gate_state = open.gate.as_ref().unwrap();
         assert_eq!(gate_state.status, GjcSdkGateStatus::Open);
-        assert_eq!(gate_state.revision, 1787479200);
+        assert_eq!(gate_state.revision, 1_787_479_200_000_000_000);
         let events = bridge.observe(&open).unwrap().events;
         assert!(
-            kinds(&events).contains(&"workflow.gate".to_string()),
+            kinds(&events)
+                .iter()
+                .any(|kind| kind == "workflow.question"),
             "{:?}",
             kinds(&events)
         );
         let gate_event = events
             .iter()
-            .find(|event| event.kind == "workflow.gate")
+            .find(|event| event.kind == "workflow.question")
             .unwrap();
         // The adapter maps the #323 WorkflowGate concept onto the workflow gate
         // route key; ask-style questions arrive through the ask surface.
-        assert_eq!(
-            gate_event.payload["question"]["kind"],
-            Value::from("workflow")
-        );
+        assert_eq!(gate_event.payload["question"]["kind"], Value::from("ask"));
+        assert_eq!(gate_event.payload["question"]["workflow_id"], "workflow-1");
+        assert_eq!(gate_event.payload["question"]["options"][0], "approve");
 
         // Same revision again: quiet.
         assert!(bridge.observe(&open).unwrap().events.is_empty());
@@ -1517,13 +2033,15 @@ mod tests {
         let reopened = snapshot_from_session_query("sess-9", 12, &query, &identity());
         let events = bridge.observe(&reopened).unwrap().events;
         assert!(
-            kinds(&events).contains(&"workflow.gate".to_string()),
+            kinds(&events)
+                .iter()
+                .any(|kind| kind == "workflow.question"),
             "{:?}",
             kinds(&events)
         );
         assert_eq!(
             events[0].payload["gate_revision"],
-            Value::from(1787484600u64)
+            Value::from(1_787_484_600_000_000_000u64)
         );
     }
 
@@ -1642,6 +2160,9 @@ mod tests {
             revision: 2,
             status: GjcSdkGateStatus::Open,
             summary: Some("Ship it?".to_string()),
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
         });
         let outcome = bridge.observe(&snapshot).unwrap();
         let event = &outcome.events[0];
@@ -1673,6 +2194,9 @@ mod tests {
             revision: 1,
             status: GjcSdkGateStatus::Open,
             summary: None,
+            workflow_id: None,
+            title: None,
+            options: Vec::new(),
         });
         let outcome = bridge.observe(&snapshot).unwrap();
         assert_eq!(kinds(&outcome.events), vec!["workflow.gate".to_string()]);
@@ -1723,6 +2247,7 @@ mod tests {
             id: "t1".to_string(),
             state: GjcSdkTurnPhase::Failed,
             attempt: 0,
+            prompt_accepted: true,
             error_summary: Some("boom".to_string()),
         });
         let failed = &bridge.observe(&snapshot).unwrap().events[0];
@@ -1731,6 +2256,6 @@ mod tests {
             .render(failed, &MessageFormat::Alert)
             .unwrap();
         assert!(content.contains("gjc sess-1 failed"), "{content}");
-        assert!(content.contains("error=boom"), "{content}");
+        assert!(content.contains("error=provider turn failed"), "{content}");
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -549,9 +549,15 @@ fn route_candidates(kind: &str) -> Vec<&str> {
         "agent.started" | "agent.blocked" | "agent.finished" | "agent.failed" => {
             vec![kind, "agent.*", "session.*"]
         }
-        "session.started" | "session.blocked" | "session.finished" | "session.failed" => {
+        "session.started"
+        | "session.blocked"
+        | "session.finished"
+        | "session.failed"
+        | "session.endpoint-failed"
+        | "session.stalled" => {
             vec![kind, "session.*", "agent.*"]
         }
+        "workflow.question" | "workflow.gate" => vec![kind, "workflow.*"],
         "session.retry-needed"
         | "session.pr-created"
         | "session.test-started"
@@ -1734,6 +1740,25 @@ mod tests {
         assert_eq!(channel, "agent-route");
         assert_eq!(format, MessageFormat::Compact);
         assert!(content.contains("omx issue-65 finished"));
+    }
+
+    #[test]
+    fn gjc_alerts_and_workflow_events_have_wildcard_candidates() {
+        for kind in [
+            "session.endpoint-failed",
+            "session.stalled",
+            "session.retry-needed",
+            "workflow.question",
+            "workflow.gate",
+        ] {
+            let candidates = route_candidates(kind);
+            assert_eq!(candidates.first().copied(), Some(kind));
+            assert!(
+                candidates
+                    .iter()
+                    .any(|candidate| { *candidate == "session.*" || *candidate == "workflow.*" })
+            );
+        }
     }
 
     #[tokio::test]

--- a/tests/common/gjc_fake_server.rs
+++ b/tests/common/gjc_fake_server.rs
@@ -134,6 +134,7 @@ struct FakeState {
     phase: Option<FakePhase>,
 
     acked_controls: Vec<(String, bool)>,
+    control_requests: Vec<(String, String, String)>,
     resolved_controls: Vec<(String, &'static str)>,
     connections_total: u64,
     reject_next_auth: bool,
@@ -239,11 +240,12 @@ impl FakeGjcServer {
 
     /// Write a valid owner-only metadata file under `<worktree>/.gjc/state/sdk/`.
     pub fn write_metadata(&self, worktree: &std::path::Path) -> std::path::PathBuf {
-        write_metadata_file(
+        write_metadata_file_for_session(
             worktree,
             &self.metadata_url(),
             FIXTURE_TOKEN,
             Some(std::process::id()),
+            &self.script.session_id,
         )
     }
 
@@ -281,6 +283,10 @@ impl FakeGjcServer {
 
     pub async fn acked_controls(&self) -> Vec<(String, bool)> {
         self.state.lock().await.acked_controls.clone()
+    }
+
+    pub async fn control_requests(&self) -> Vec<(String, String, String)> {
+        self.state.lock().await.control_requests.clone()
     }
 
     pub async fn resolved_controls(&self) -> Vec<(String, &'static str)> {
@@ -372,6 +378,13 @@ fn sections_for(phase: FakePhase, script: &FakeScript) -> FakeSections {
     FakeSections {
         metadata_session_id: script.session_id.clone(),
         turn_id: script.turn_id.clone(),
+        revision: match phase {
+            FakePhase::Idle => 1,
+            FakePhase::Running => 2,
+            FakePhase::Question => 3,
+            FakePhase::Completed => 4,
+            FakePhase::Retired => 5,
+        },
         turn_status: phase.turn_status(),
         gate: match phase {
             FakePhase::Question => Some(FakeGateSection {
@@ -439,6 +452,21 @@ async fn handle_request(
             {
                 let mut guard = state.lock().await;
                 guard.acked_controls.push((frame.id.clone(), accepted));
+                guard.control_requests.push((
+                    operation.to_string(),
+                    frame
+                        .input
+                        .get("session_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    frame
+                        .input
+                        .get("idempotency_key")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                ));
                 guard
                     .resolved_controls
                     .push((frame.id.clone(), outcome_kind));
@@ -451,6 +479,7 @@ async fn handle_request(
                 accepted,
                 json!({
                     "accepted": accepted,
+                    "session_id": script.session_id,
                     "operation": operation,
                     "command_id": frame.input.get("idempotency_key").cloned().unwrap_or(Value::Null),
                 }),
@@ -490,12 +519,22 @@ pub fn write_metadata_file(
     token: &str,
     pid: Option<u32>,
 ) -> std::path::PathBuf {
+    write_metadata_file_for_session(worktree, url, token, pid, &FakeScript::default().session_id)
+}
+
+/// Write owner-only metadata for an explicit session identity.
+pub fn write_metadata_file_for_session(
+    worktree: &std::path::Path,
+    url: &str,
+    token: &str,
+    pid: Option<u32>,
+    session_id: &str,
+) -> std::path::PathBuf {
     let sdk_dir = worktree.join(".gjc/state/sdk");
     std::fs::create_dir_all(&sdk_dir).expect("create .gjc/state/sdk");
-    let session_id = FakeScript::default().session_id;
     let file = EndpointMetadataFile {
         version: 1,
-        session_id: session_id.clone(),
+        session_id: session_id.to_string(),
         url: url.to_string(),
         token: token.to_string(),
         pid,

--- a/tests/common/gjc_wire.rs
+++ b/tests/common/gjc_wire.rs
@@ -203,6 +203,7 @@ fn decode_notification(value: &Value) -> Option<NotificationFrame> {
 pub struct FakeSections {
     pub metadata_session_id: String,
     pub turn_id: String,
+    pub revision: u64,
     /// queued | running | succeeded | failed | aborted
     pub turn_status: &'static str,
     pub gate: Option<FakeGateSection>,
@@ -222,6 +223,7 @@ impl FakeSections {
         let mut turn = serde_json::json!({
             "turn_id": self.turn_id,
             "status": self.turn_status,
+            "prompt_accepted": true,
             "started_at": "2026-08-23T00:00:00Z",
         });
         if matches!(self.turn_status, "succeeded" | "failed") {
@@ -233,6 +235,7 @@ impl FakeSections {
             });
         }
         let mut result = serde_json::json!({
+            "revision": self.revision,
             "metadata": {"session_id": self.metadata_session_id},
             "turn": turn,
         });
@@ -240,6 +243,7 @@ impl FakeSections {
             result["workflow_gates"] = serde_json::json!([{
                 "gate_id": gate.gate_id,
                 "workflow_id": "workflow-326",
+                "kind": "ask",
                 "state": gate.state,
                 "title": gate.title,
                 "options": gate.options,
@@ -315,6 +319,7 @@ mod tests {
         let sections = FakeSections {
             metadata_session_id: "sess-326".into(),
             turn_id: "turn-1".into(),
+            revision: 1,
             turn_status: "running",
             gate: Some(FakeGateSection {
                 gate_id: "gate-326".into(),

--- a/tests/gjc_sdk_event_bridge.rs
+++ b/tests/gjc_sdk_event_bridge.rs
@@ -125,7 +125,9 @@ fn wait_for_ledger_and_delivery(
                 .map(|content| content.lines().count())
                 .unwrap_or(0);
             last = Some((value.clone(), deliveries));
-            if value["records"] == expected_records
+            let retained_records = value["records"].as_u64().unwrap_or(0)
+                + value["compacted_records"].as_u64().unwrap_or(0);
+            if retained_records == expected_records
                 && value["duplicates"] == expected_duplicates
                 && deliveries == expected_deliveries
             {
@@ -231,7 +233,7 @@ fn snapshot(revision: u64) -> Value {
         "worktree_path": "/wt/issue-324",
         "branch": "feat/issue-324",
         "observed_at": "2026-08-23T00:00:00Z",
-        "turn": {"id": "t1", "state": "active", "attempt": 0},
+        "turn": {"id": "t1", "state": "active", "attempt": 0, "prompt_accepted": true},
         "prompt": {"command_id": "c1", "status": "accepted"}
     })
 }
@@ -287,7 +289,8 @@ fn gjc_bridge_ingest_dedupes_replay_stale_and_restart_boundaries() {
 
     // Question gate carries stable identifiers through to the ledger surface.
     let mut question = snapshot(2);
-    question["turn"] = json!({"id": "t1", "state": "waiting_input", "attempt": 0});
+    question["turn"] =
+        json!({"id": "t1", "state": "waiting_input", "attempt": 0, "prompt_accepted": true});
     question["gate"] = json!({
         "id": "q-1",
         "kind": "ask",
@@ -309,7 +312,8 @@ fn gjc_bridge_ingest_dedupes_replay_stale_and_restart_boundaries() {
 
     // Completion closes the turn.
     let mut completion = snapshot(3);
-    completion["turn"] = json!({"id": "t1", "state": "complete", "attempt": 0});
+    completion["turn"] =
+        json!({"id": "t1", "state": "complete", "attempt": 0, "prompt_accepted": true});
     completion["prompt"] = json!(null);
     completion["gate"] = json!({
         "id": "q-1",

--- a/tests/gjc_sdk_full_loop_e2e.rs
+++ b/tests/gjc_sdk_full_loop_e2e.rs
@@ -22,7 +22,7 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use common::gjc_fake_server::{FakeGjcServer, FakePhase};
+use common::gjc_fake_server::{FakeGjcServer, FakePhase, FakeScript};
 
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -153,6 +153,75 @@ max_records_per_compaction = 100
     (config_path, delivery)
 }
 
+fn write_two_lane_config(
+    temp: &TempDir,
+    port: u16,
+    worktree_a: &Path,
+    delivery_a: &Path,
+    worktree_b: &Path,
+    delivery_b: &Path,
+) -> PathBuf {
+    let config_path = temp.path().join("clawhip-two-lane.toml");
+    let ledger_dir = temp.path().join("two-lane-ledger");
+    let lane_state = temp.path().join("two-lane-gjc-state");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"[daemon]
+bind_host = "127.0.0.1"
+port = {port}
+base_url = "http://127.0.0.1:{port}"
+
+[gjc]
+enabled = true
+
+[gjc_lanes]
+enabled = true
+discovery_worktrees = ["{}", "{}"]
+poll_interval_secs = 1
+initial_backoff_ms = 50
+max_backoff_ms = 200
+state_path = "{}"
+
+[[routes]]
+event = "*"
+filter = {{ worktree_path = "{}" }}
+sink = "localfile"
+local_path = "{}"
+
+[[routes]]
+event = "*"
+filter = {{ worktree_path = "{}" }}
+sink = "localfile"
+local_path = "{}"
+
+[ledger]
+enabled = true
+path = "{}"
+raw_retention_days = 7
+summary_retention_days = 30
+compaction_interval_secs = 1
+max_records = 1000
+max_record_bytes = 4096
+max_keywords = 8
+max_keyword_bytes = 32
+max_query_results = 50
+max_records_per_compaction = 100
+"#,
+            worktree_a.display(),
+            worktree_b.display(),
+            lane_state.display(),
+            worktree_a.display(),
+            delivery_a.display(),
+            worktree_b.display(),
+            delivery_b.display(),
+            ledger_dir.display()
+        ),
+    )
+    .unwrap();
+    config_path
+}
+
 fn spawn_daemon(config_path: &Path, stderr_path: &Path, worktree: Option<&Path>) -> DaemonGuard {
     let stderr = std::fs::File::create(stderr_path).expect("create daemon stderr log");
     let mut command = Command::new(env!("CARGO_BIN_EXE_clawhip"));
@@ -180,7 +249,7 @@ fn delivery_lines(delivery: &Path) -> Vec<Value> {
 }
 
 fn wait_for_delivery_kind(delivery: &Path, kind: &str) -> Value {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
         for line in delivery_lines(delivery) {
             if line["event_kind"] == kind {
@@ -308,7 +377,7 @@ fn full_loop_register_prompt_question_answer_complete_retire_restart() {
             json!({
                 "session_id": session,
                 "revision": 2,
-                "turn": {"id": "fake-turn-1", "state": "active"},
+                "turn": {"id": "fake-turn-1", "state": "active", "prompt_accepted": true},
                 "prompt": {"command_id": "idem-prompt-326", "status": "accepted"},
                 "summary": "turn running",
             }),
@@ -429,7 +498,7 @@ fn full_loop_register_prompt_question_answer_complete_retire_restart() {
         wait_for_health(daemon_port);
 
         // Durable lane store reloads without resurrecting an active watch.
-        let (status, lanes) = request(daemon_port, "GET", "/api/gjc/lanes", None);
+        let (status, lanes) = request(daemon_port, "GET", "/api/gjc/lanes?removed=true", None);
         assert_eq!(status, 200);
         let records = lanes["lanes"].as_array().cloned().unwrap_or_default();
         assert!(
@@ -469,6 +538,308 @@ fn full_loop_register_prompt_question_answer_complete_retire_restart() {
         restarted.0.kill().ok();
         restarted.0.wait().ok();
         server.stop().await;
+    });
+}
+
+#[test]
+fn two_sessions_isolate_endpoints_worktrees_revisions_receipts_and_alerts() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let session_a = "01a02ccd-c754-7656-95c7-f40b5a140bc3";
+        let session_b = "01b02ccd-c754-7656-95c7-f40b5a140bc4";
+        let script_a = FakeScript {
+            session_id: session_a.into(),
+            turn_id: "fake-turn-a".into(),
+            gate_id: "gate-a".into(),
+            question_title: "Approve lane A?".into(),
+            question_options: vec!["yes".into(), "no".into()],
+        };
+        let script_b = FakeScript {
+            session_id: session_b.into(),
+            turn_id: "fake-turn-b".into(),
+            gate_id: "gate-b".into(),
+            question_title: "Approve lane B?".into(),
+            question_options: vec!["yes".into(), "no".into()],
+        };
+        let server_a = FakeGjcServer::start_with(script_a).await;
+        let server_b = FakeGjcServer::start_with(script_b).await;
+        let temp = TempDir::new().unwrap();
+        let worktree_a = temp.path().join("worktree-a");
+        let worktree_b = temp.path().join("worktree-b");
+        let daemon_root = temp.path().join("daemon-root");
+        std::fs::create_dir_all(&worktree_a).unwrap();
+        std::fs::create_dir_all(&worktree_b).unwrap();
+        std::fs::create_dir_all(&daemon_root).unwrap();
+        let metadata_a = server_a.write_metadata(&worktree_a);
+        let metadata_b = server_b.write_metadata(&worktree_b);
+        let metadata_a_value: Value = serde_json::from_str(
+            &std::fs::read_to_string(&metadata_a).expect("read lane A metadata"),
+        )
+        .unwrap();
+        let metadata_b_value: Value = serde_json::from_str(
+            &std::fs::read_to_string(&metadata_b).expect("read lane B metadata"),
+        )
+        .unwrap();
+        assert_eq!(metadata_a_value["sessionId"], session_a);
+        assert_eq!(metadata_b_value["sessionId"], session_b);
+        assert_eq!(metadata_a_value["url"], server_a.metadata_url());
+        assert_eq!(metadata_b_value["url"], server_b.metadata_url());
+        assert_ne!(metadata_a_value["url"], metadata_b_value["url"]);
+
+        let delivery_a = temp.path().join("delivery-a.jsonl");
+        let delivery_b = temp.path().join("delivery-b.jsonl");
+        let daemon_port = unused_port();
+        let config_path = write_two_lane_config(
+            &temp,
+            daemon_port,
+            &worktree_a,
+            &delivery_a,
+            &worktree_b,
+            &delivery_b,
+        );
+        let daemon_log = temp.path().join("two-lane-daemon.log");
+        let mut daemon = spawn_daemon(&config_path, &daemon_log, Some(&daemon_root));
+        wait_for_health(daemon_port);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let records = loop {
+            let (_, lanes) = request(daemon_port, "GET", "/api/gjc/lanes", None);
+            let records = lanes["lanes"].as_array().cloned().unwrap_or_default();
+            if records.iter().any(|r| r["sdk_session_id"] == session_a)
+                && records.iter().any(|r| r["sdk_session_id"] == session_b)
+            {
+                break records;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "automatic enrollment failed: {lanes}"
+            );
+            thread::sleep(Duration::from_millis(50));
+        };
+        let lane_a = records
+            .iter()
+            .find(|r| r["sdk_session_id"] == session_a)
+            .and_then(|r| r["lane_id"].as_str())
+            .unwrap()
+            .to_string();
+        let lane_b = records
+            .iter()
+            .find(|r| r["sdk_session_id"] == session_b)
+            .and_then(|r| r["lane_id"].as_str())
+            .unwrap()
+            .to_string();
+        assert_ne!(lane_a, lane_b);
+
+        let prompt_key_a = "idem-two-session-a";
+        let prompt_key_b = "idem-two-session-b";
+        let (status, receipt_a) = request(
+            daemon_port,
+            "POST",
+            "/api/gjc/prompt",
+            Some(&json!({
+                "session": session_a,
+                "idempotency_key": prompt_key_a,
+                "prompt": "fixed lane A prompt",
+            })),
+        );
+        assert_eq!(status, 200, "lane A prompt failed: {receipt_a}");
+        assert_eq!(receipt_a["status"], "acked");
+        assert_eq!(receipt_a["session_id"], session_a);
+        assert_eq!(receipt_a["idempotency_key"], prompt_key_a);
+        let (status, receipt_b) = request(
+            daemon_port,
+            "POST",
+            "/api/gjc/prompt",
+            Some(&json!({
+                "session": session_b,
+                "idempotency_key": prompt_key_b,
+                "prompt": "fixed lane B prompt",
+            })),
+        );
+        assert_eq!(status, 200, "lane B prompt failed: {receipt_b}");
+        assert_eq!(receipt_b["status"], "acked");
+        assert_eq!(receipt_b["session_id"], session_b);
+        assert_eq!(receipt_b["idempotency_key"], prompt_key_b);
+        assert_ne!(receipt_a["command_id"], receipt_b["command_id"]);
+
+        server_a.set_phase(FakePhase::Running).await;
+        server_b.set_phase(FakePhase::Running).await;
+        thread::sleep(Duration::from_secs(5));
+        server_a.set_phase(FakePhase::Question).await;
+        server_b.set_phase(FakePhase::Question).await;
+        thread::sleep(Duration::from_secs(5));
+
+        let answer_key_a = "idem-two-answer-a";
+        let answer_key_b = "idem-two-answer-b";
+        let (status, answer_a) = request(
+            daemon_port,
+            "POST",
+            "/api/gjc/workflow-gate-answer",
+            Some(&json!({
+                "session": session_a,
+                "idempotency_key": answer_key_a,
+                "gate_id": "gate-a",
+                "option": "yes",
+            })),
+        );
+        assert_eq!(status, 200, "lane A answer failed: {answer_a}");
+        assert_eq!(answer_a["status"], "acked");
+        assert_eq!(answer_a["session_id"], session_a);
+        let (status, answer_b) = request(
+            daemon_port,
+            "POST",
+            "/api/gjc/workflow-gate-answer",
+            Some(&json!({
+                "session": session_b,
+                "idempotency_key": answer_key_b,
+                "gate_id": "gate-b",
+                "option": "yes",
+            })),
+        );
+        assert_eq!(status, 200, "lane B answer failed: {answer_b}");
+        assert_eq!(answer_b["status"], "acked");
+        assert_eq!(answer_b["session_id"], session_b);
+
+        // Both lanes now resume independently after their scoped answers.
+        server_a.set_phase(FakePhase::Completed).await;
+        server_b.set_phase(FakePhase::Completed).await;
+        let (status, query_a) = request(
+            daemon_port,
+            "GET",
+            &format!("/api/gjc/session/{session_a}?sections=metadata,turn"),
+            None,
+        );
+        assert_eq!(status, 200, "lane A query failed: {query_a}");
+        assert_eq!(query_a["metadata"]["session_id"], session_a);
+        assert_eq!(query_a["turn"]["turn_id"], "fake-turn-a");
+        let (status, query_b) = request(
+            daemon_port,
+            "GET",
+            &format!("/api/gjc/session/{session_b}?sections=metadata,turn"),
+            None,
+        );
+        assert_eq!(status, 200, "lane B query failed: {query_b}");
+        assert_eq!(query_b["metadata"]["session_id"], session_b);
+        assert_eq!(query_b["turn"]["turn_id"], "fake-turn-b");
+
+        server_a.set_phase(FakePhase::Completed).await;
+        server_b.set_phase(FakePhase::Completed).await;
+        thread::sleep(Duration::from_secs(5));
+
+        // Receipt lookup is session-bound: the other lane can never observe
+        // this lane's command journal entry.
+        let (status, lookup_a) = request(
+            daemon_port,
+            "GET",
+            &format!("/api/gjc/command/{prompt_key_a}?session={session_a}"),
+            None,
+        );
+        assert_eq!(status, 200);
+        assert_eq!(lookup_a["session_id"], session_a);
+        let (status, wrong_lookup) = request(
+            daemon_port,
+            "GET",
+            &format!("/api/gjc/command/{prompt_key_a}?session={session_b}"),
+            None,
+        );
+        assert_eq!(status, 400, "cross-lane receipt leaked: {wrong_lookup}");
+        let (status, lookup_b) = request(
+            daemon_port,
+            "GET",
+            &format!("/api/gjc/command/{prompt_key_b}?session={session_b}"),
+            None,
+        );
+        assert_eq!(status, 200);
+        assert_eq!(lookup_b["session_id"], session_b);
+
+        let record_a = request(
+            daemon_port,
+            "GET",
+            &format!("/api/gjc/lanes/{lane_a}"),
+            None,
+        );
+        assert_eq!(record_a.0, 200);
+        assert_eq!(record_a.1["sdk_session_id"], session_a);
+        assert_eq!(record_a.1["worktree"], worktree_a.to_str().unwrap());
+        assert_eq!(record_a.1["sdk_revision"], 4);
+        let record_b = request(
+            daemon_port,
+            "GET",
+            &format!("/api/gjc/lanes/{lane_b}"),
+            None,
+        );
+        assert_eq!(record_b.0, 200);
+        assert_eq!(record_b.1["sdk_session_id"], session_b);
+        assert_eq!(record_b.1["worktree"], worktree_b.to_str().unwrap());
+        assert_eq!(record_b.1["sdk_revision"], 4);
+
+        wait_for_delivery_kind(&delivery_a, "workflow.question");
+        wait_for_delivery_kind(&delivery_b, "workflow.question");
+
+        let worktree_a_text = worktree_a.to_str().unwrap();
+        let worktree_b_text = worktree_b.to_str().unwrap();
+        for line in delivery_lines(&delivery_a) {
+            assert_eq!(line["summary_payload"]["session_id"], session_a);
+            if !line["summary_payload"]["repo_path"].is_null() {
+                assert_eq!(line["summary_payload"]["repo_path"], worktree_a_text);
+            }
+            assert!(!line.to_string().contains(session_b));
+            assert!(!line.to_string().contains(worktree_b_text));
+        }
+        for line in delivery_lines(&delivery_b) {
+            assert_eq!(line["summary_payload"]["session_id"], session_b);
+            if !line["summary_payload"]["repo_path"].is_null() {
+                assert_eq!(line["summary_payload"]["repo_path"], worktree_b_text);
+            }
+            assert!(!line.to_string().contains(session_a));
+            assert!(!line.to_string().contains(worktree_a_text));
+        }
+
+        let controls_a = server_a.control_requests().await;
+        let controls_b = server_b.control_requests().await;
+        assert!(
+            controls_a
+                .iter()
+                .all(|(_, session, _)| session == session_a)
+        );
+        assert!(
+            controls_b
+                .iter()
+                .all(|(_, session, _)| session == session_b)
+        );
+        assert!(
+            controls_a
+                .iter()
+                .any(|(operation, _, key)| operation == "prompt" && key == prompt_key_a)
+        );
+        assert!(controls_a.iter().any(|(operation, _, key)| {
+            operation == "workflow_gate_answer" && key == answer_key_a
+        }));
+        assert!(
+            controls_b
+                .iter()
+                .any(|(operation, _, key)| operation == "prompt" && key == prompt_key_b)
+        );
+        assert!(controls_b.iter().any(|(operation, _, key)| {
+            operation == "workflow_gate_answer" && key == answer_key_b
+        }));
+        assert!(
+            controls_a
+                .iter()
+                .all(|(_, session, _)| session != session_b)
+        );
+        assert!(
+            controls_b
+                .iter()
+                .all(|(_, session, _)| session != session_a)
+        );
+
+        daemon.0.kill().ok();
+        daemon.0.wait().ok();
+        server_a.stop().await;
+        server_b.stop().await;
     });
 }
 


### PR DESCRIPTION
Closes #349

## Summary
- Wire the authoritative SDK control plane into durable reconciliation and automatic native endpoint enrollment.
- Add public-safe deduped provider, endpoint, and unexpected-idle alerts with restart-aware lane state.
- Add exact session endpoint discovery, configured worktree enrollment, stable lane identities, and GJC-first operator documentation.

## Verification
- `cargo test --all-targets` passed 1065 tests; one unrelated GitHub backoff test was flaky and passed on exact retry.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo build --release` passed.
- Focused GJC bridge/lane/full-loop suites passed.

## Review evidence
- Exact-head source hash before commit: `sha256:6f7d302abe3862787c691732b28b55e94452d23e40d759dbc4f2bd801276e271`.
- Delegated architecture and adversarial reviews identified remaining expanded-contract blockers; merge is intentionally gated pending remediation.

gaebal-gajae