### PR TITLE
test: stop rewinding monotonic instants in tmux/git tests

### DIFF
--- a/src/source/git.rs
+++ b/src/source/git.rs
@@ -1169,7 +1169,9 @@ mod tests {
         );
         assert!(rx.try_recv().is_err());
 
-        let before_sparse_probe = probe_at - Duration::from_secs(1);
+        let before_sparse_probe = probe_at
+            .checked_sub(Duration::from_secs(1))
+            .expect("quarantine retry instant is at least one second past boot");
         poll_git_at(&config, &tx, &mut state, &diagnostics, before_sparse_probe)
             .await
             .unwrap();

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -4533,32 +4533,45 @@ error: failed";
 
     #[test]
     fn stale_minutes_zero_disables_stale_detection() {
+        // Advance the observation instant instead of rewinding `Instant::now()`:
+        // `Instant` is monotonic-since-boot, so subtracting an hour panics on a
+        // host that booted less than an hour ago.
+        let last_change = Instant::now();
         let pane = TmuxPaneState {
             session: "test".into(),
             pane_name: "0.0".into(),
             snapshot: String::new(),
             content_hash: 0,
-            last_change: Instant::now() - Duration::from_secs(3600),
+            last_change,
             last_stale_notification: None,
             pane_dead: false,
         };
         // stale_minutes=0 should never emit, even after 1 hour idle
-        assert!(!should_emit_stale(&pane, Instant::now(), 0));
+        assert!(!should_emit_stale(
+            &pane,
+            last_change + Duration::from_secs(3600),
+            0
+        ));
     }
 
     #[test]
     fn stale_minutes_nonzero_still_emits() {
+        let last_change = Instant::now();
         let pane = TmuxPaneState {
             session: "test".into(),
             pane_name: "0.0".into(),
             snapshot: String::new(),
             content_hash: 0,
-            last_change: Instant::now() - Duration::from_secs(3600),
+            last_change,
             last_stale_notification: None,
             pane_dead: false,
         };
         // stale_minutes=1 should emit after 1 hour idle
-        assert!(should_emit_stale(&pane, Instant::now(), 1));
+        assert!(should_emit_stale(
+            &pane,
+            last_change + Duration::from_secs(3600),
+            1
+        ));
     }
 
     #[test]
@@ -4574,17 +4587,22 @@ error: failed";
 
     #[test]
     fn pane_dead_suppresses_stale_alert() {
+        let last_change = Instant::now();
         let pane = TmuxPaneState {
             session: "test".into(),
             pane_name: "0.0".into(),
             snapshot: String::new(),
             content_hash: 0,
-            last_change: Instant::now() - Duration::from_secs(3600),
+            last_change,
             last_stale_notification: None,
             pane_dead: true,
         };
         // Dead pane should never emit stale, even after 1 hour idle
-        assert!(!should_emit_stale(&pane, Instant::now(), 1));
+        assert!(!should_emit_stale(
+            &pane,
+            last_change + Duration::from_secs(3600),
+            1
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #353.

## What

Four tests rewound a monotonic clock (`Instant::now() - Duration::from_secs(3600)` in the tmux stale tests, `probe_at - Duration::from_secs(1)` in the git quarantine test). They now advance the observation instant instead of rewinding "now", and the git probe uses an explicit `checked_sub` with a stated precondition.

## Why

`Instant - Duration` is `checked_sub(..).expect("overflow when subtracting duration from instant")`, and overflow is platform-dependent:

- Linux keeps `Instant` as a signed `Timespec`, so the rewind is representable — verified on a host with 3_820_556s uptime, rewinding by `uptime + 3600s` does not panic.
- Windows keeps `Instant` as an unsigned QPC tick count, so the subtraction panics whenever the rewind exceeds system uptime.

Result: a Windows contributor running the full `cargo test --bin clawhip` on a machine booted less than an hour ago panics in `stale_minutes_zero_disables_stale_detection`, `stale_minutes_nonzero_still_emits`, and `pane_dead_suppresses_stale_alert` for reasons unrelated to what those tests assert. Linux CI never caught it, and the Windows CI job only runs `issue_317` and `config_backup_cleanup`.

`should_emit_stale` only compares `last_change` against the supplied instant, so pinning `last_change` and passing `last_change + 3600s` is semantically identical while being uptime-independent. It also removes an incidental second `Instant::now()` call per test.

## Verification

- `cargo test --bin clawhip` → **1101 passed, 0 failed**
- `cargo fmt --check` → clean
- `cargo clippy --all-targets -- -D warnings` → clean; `clippy::unchecked_duration_subtraction` now reports **0** sites (was 4)
- Test-only change; no production code touched.

Base `dev@7bad9d24df18984a2e68612862246ce7263eae19`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
