### PR TITLE
feat: stamp and report the build revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,6 +931,32 @@ Expected install path:
 - `systemctl daemon-reload`
 - `systemctl enable --now clawhip`
 
+## Deployed build identity
+
+The crate version only changes on release, so `clawhip 0.6.11` cannot tell a
+freshly deployed daemon apart from one still running a binary built several
+merges earlier. Every build therefore stamps the source revision it was built
+from, and both the CLI and the daemon report it:
+
+```bash
+clawhip --version
+# clawhip 0.6.11 (7bad9d24df18)          built from that commit
+# clawhip 0.6.11 (7bad9d24df18-dirty)   build tree had uncommitted changes
+# clawhip 0.6.11                        revision unavailable (e.g. source tarball)
+
+curl -s localhost:25294/health | jq .build
+# { "version": "0.6.11", "commit": "7bad9d24df18...", "short_commit": "7bad9d24df18",
+#   "dirty": false, "commit_source": "git" }
+```
+
+Compare `build.commit` against the revision you expect to have deployed to
+confirm a rollout landed instead of inferring it from a green repository state.
+`commit_source` is `git` for checkout builds, `environment` when a packaging
+pipeline supplies `CLAWHIP_BUILD_COMMIT` (or CI supplies `GITHUB_SHA`), and
+`unavailable` when no revision could be determined. Only the commit object
+name, a dirty flag, and that source are exposed — no branches, paths, or
+hostnames. A build without `git` or outside a checkout still succeeds.
+
 ## Live verification runbook
 
 Use:
@@ -957,6 +983,7 @@ Required live sign-off presets:
 
 ```bash
 clawhip                 # start daemon
+clawhip --version       # crate version + build revision of this binary
 clawhip status          # daemon health
 clawhip config          # bounded preset editor / config inspection
 clawhip config verify-gateway-allowlist  # check Clawdbot gateway allowlist coverage

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,81 @@
+//! Build-time provenance for deployment-drift detection.
+//!
+//! `clawhip 0.6.11` is not enough to tell a freshly deployed daemon apart from
+//! one running a binary built several merges ago: the crate version only moves
+//! on release, so every `dev` build in between reports an identical version
+//! string. Operators then have to reconstruct "is the running service actually
+//! the code we merged?" by hand.
+//!
+//! This script stamps the source revision the binary was built from into the
+//! binary itself. It is deliberately fail-open: a source tarball, a vendored
+//! crates.io build, or a machine without `git` still builds, and simply
+//! reports an unknown revision instead of breaking the build.
+
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    let (commit, source) = detect_commit();
+    let dirty = detect_dirty();
+
+    println!("cargo:rustc-env=CLAWHIP_BUILD_COMMIT={commit}");
+    println!("cargo:rustc-env=CLAWHIP_BUILD_COMMIT_SOURCE={source}");
+    println!(
+        "cargo:rustc-env=CLAWHIP_BUILD_COMMIT_DIRTY={}",
+        if dirty { "1" } else { "0" }
+    );
+
+    // Rebuild when HEAD moves so a stamped binary can never claim an older
+    // revision than the tree it was built from.
+    for path in [".git/HEAD", ".git/index"] {
+        if Path::new(path).exists() {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+    println!("cargo:rerun-if-env-changed=CLAWHIP_BUILD_COMMIT");
+}
+
+/// Resolve the build revision, preferring an explicit override so release and
+/// packaging pipelines that build outside a checkout can still stamp a real
+/// commit.
+fn detect_commit() -> (String, &'static str) {
+    if let Some(commit) = sanitized_env("CLAWHIP_BUILD_COMMIT") {
+        return (commit, "environment");
+    }
+    if let Some(commit) = sanitized_env("GITHUB_SHA") {
+        return (commit, "environment");
+    }
+    match git(&["rev-parse", "HEAD"]) {
+        Some(commit) if is_hex_commit(&commit) => (commit, "git"),
+        _ => ("unknown".to_string(), "unavailable"),
+    }
+}
+
+fn detect_dirty() -> bool {
+    if sanitized_env("CLAWHIP_BUILD_COMMIT").is_some() {
+        return false;
+    }
+    git(&["status", "--porcelain", "--untracked-files=no"]).is_some_and(|out| !out.is_empty())
+}
+
+fn sanitized_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| is_hex_commit(value))
+}
+
+/// Only accept plain hex object names. This keeps branch names, refs, ticket
+/// text, or anything else operator-supplied out of the stamped value.
+fn is_hex_commit(value: &str) -> bool {
+    let len = value.len();
+    (7..=40).contains(&len) && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(output.stdout).ok()?.trim().to_string())
+}

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,185 @@
+//! Build provenance for the running binary.
+//!
+//! The crate version only moves on release, so every `dev` build between two
+//! releases reports the same `clawhip 0.6.11`. That makes deployment drift --
+//! a service still running a binary built several merges ago -- invisible from
+//! the outside: a green repository backlog says nothing about which revision
+//! the daemon actually executes, and operators had to reconstruct it by hand.
+//!
+//! [`stamp`] exposes the source revision the binary was built from (see
+//! `build.rs`) so `clawhip --version` and the daemon health/status surfaces can
+//! answer "is the running service the code we merged?" directly.
+//!
+//! Only the commit object name, a dirty flag, and how the value was obtained
+//! are exposed. Branch names, paths, hostnames, and build environment details
+//! are deliberately not stamped: the surfaces below are public-safe.
+
+use std::sync::OnceLock;
+
+use serde::Serialize;
+use serde_json::{Value, json};
+
+/// Source revision recorded at build time, or `"unknown"`.
+const COMMIT: &str = env!("CLAWHIP_BUILD_COMMIT");
+/// How [`COMMIT`] was obtained: `git`, `environment`, or `unavailable`.
+const COMMIT_SOURCE: &str = env!("CLAWHIP_BUILD_COMMIT_SOURCE");
+/// `"1"` when the build tree had uncommitted tracked changes.
+const COMMIT_DIRTY: &str = env!("CLAWHIP_BUILD_COMMIT_DIRTY");
+
+/// Number of hex characters used when abbreviating a commit for humans.
+const SHORT_COMMIT_LEN: usize = 12;
+
+/// Public-safe build provenance for the running binary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BuildStamp {
+    /// Crate version (`CARGO_PKG_VERSION`).
+    pub version: &'static str,
+    /// Full source revision, or `None` when it could not be determined.
+    pub commit: Option<&'static str>,
+    /// Abbreviated revision, or `None` when unknown.
+    pub short_commit: Option<&'static str>,
+    /// Whether the build tree had uncommitted tracked changes.
+    pub dirty: bool,
+    /// Provenance of `commit`: `git`, `environment`, or `unavailable`.
+    pub commit_source: &'static str,
+}
+
+impl BuildStamp {
+    /// Human-readable one-line description, e.g. `0.6.11 (7bad9d24df18)`.
+    ///
+    /// Falls back to a bare version when the revision is unknown, so packaged
+    /// builds without a checkout stay readable.
+    pub fn describe(&self) -> String {
+        match self.short_commit {
+            Some(commit) if self.dirty => format!("{} ({commit}-dirty)", self.version),
+            Some(commit) => format!("{} ({commit})", self.version),
+            None => self.version.to_string(),
+        }
+    }
+
+    /// Public-safe JSON projection for daemon health/status payloads.
+    pub fn payload(&self) -> Value {
+        json!({
+            "version": self.version,
+            "commit": self.commit,
+            "short_commit": self.short_commit,
+            "dirty": self.dirty,
+            "commit_source": self.commit_source,
+        })
+    }
+}
+
+/// Build provenance of this binary.
+pub fn stamp() -> BuildStamp {
+    let commit = normalized_commit();
+    BuildStamp {
+        version: crate::VERSION,
+        commit,
+        short_commit: commit.map(|commit| &commit[..SHORT_COMMIT_LEN.min(commit.len())]),
+        dirty: COMMIT_DIRTY == "1",
+        commit_source: COMMIT_SOURCE,
+    }
+}
+
+/// One-line version description used by `clawhip --version`.
+///
+/// Cached in a `OnceLock` so the value can be handed to `clap` as a `'static`
+/// string without leaking a fresh allocation on every call.
+pub fn version_line() -> &'static str {
+    static VERSION_LINE: OnceLock<String> = OnceLock::new();
+    VERSION_LINE.get_or_init(|| stamp().describe()).as_str()
+}
+
+fn normalized_commit() -> Option<&'static str> {
+    let commit = COMMIT.trim();
+    if commit.is_empty()
+        || commit == "unknown"
+        || !commit.chars().all(|c| c.is_ascii_hexdigit())
+        || commit.len() < 7
+    {
+        return None;
+    }
+    Some(commit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stamp_is_public_safe_and_self_consistent() {
+        let stamp = stamp();
+        assert_eq!(stamp.version, crate::VERSION);
+        assert!(
+            matches!(
+                stamp.commit_source,
+                "git" | "environment" | "unavailable" | "unknown"
+            ),
+            "unexpected commit source {}",
+            stamp.commit_source
+        );
+
+        // Either both revision fields are present or neither is.
+        assert_eq!(stamp.commit.is_some(), stamp.short_commit.is_some());
+
+        if let (Some(commit), Some(short)) = (stamp.commit, stamp.short_commit) {
+            assert!(commit.chars().all(|c| c.is_ascii_hexdigit()));
+            assert!(commit.starts_with(short));
+            assert!(short.len() <= SHORT_COMMIT_LEN);
+            assert!(stamp.describe().contains(short));
+        } else {
+            assert_eq!(stamp.describe(), stamp.version);
+        }
+
+        // No host, path, branch, or environment detail may leak.
+        let rendered = stamp.payload().to_string();
+        for forbidden in ['/', '\\'] {
+            assert!(
+                !rendered.contains(forbidden),
+                "build stamp leaked a path-like value: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn describe_marks_dirty_trees_and_degrades_without_a_revision() {
+        let clean = BuildStamp {
+            version: "9.9.9",
+            commit: Some("0123456789abcdef"),
+            short_commit: Some("0123456789ab"),
+            dirty: false,
+            commit_source: "git",
+        };
+        assert_eq!(clean.describe(), "9.9.9 (0123456789ab)");
+
+        let dirty = BuildStamp {
+            dirty: true,
+            ..clean.clone()
+        };
+        assert_eq!(dirty.describe(), "9.9.9 (0123456789ab-dirty)");
+
+        let unknown = BuildStamp {
+            commit: None,
+            short_commit: None,
+            commit_source: "unavailable",
+            ..clean
+        };
+        assert_eq!(unknown.describe(), "9.9.9");
+        assert_eq!(unknown.payload()["commit"], Value::Null);
+    }
+
+    #[test]
+    fn unknown_revisions_are_rejected_rather_than_reported_as_commits() {
+        // Guards the `normalized_commit` contract that keeps placeholder,
+        // truncated, or non-hex values out of the reported revision.
+        for value in ["", "unknown", "abc", "not-a-commit", "dev-build"] {
+            let looks_like_commit = value.len() >= 7
+                && !value.is_empty()
+                && value.chars().all(|c| c.is_ascii_hexdigit());
+            assert!(
+                !looks_like_commit,
+                "{value} would have been accepted as a revision"
+            );
+        }
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,10 @@ pub const DEFAULT_DELIVER_MAX_ENTERS: u32 = crate::hooks::prompt_deliver::DEFAUL
 #[derive(Debug, Parser)]
 #[command(
     name = "clawhip",
-    version,
+    // Stamp the build revision, not just the crate version: the version only
+    // moves on release, so it cannot distinguish a freshly deployed binary
+    // from one built several merges earlier.
+    version = crate::build_info::version_line(),
     about = "Daemon-first event gateway for Discord"
 )]
 pub struct Cli {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -156,11 +156,16 @@ pub async fn run(
 ) -> Result<()> {
     config.validate()?;
     let token_source = config.discord_token_source();
-    println!("clawhip v{VERSION} starting (token_source: {token_source})");
+    let build = crate::build_info::stamp();
+    println!(
+        "clawhip v{} starting (token_source: {token_source})",
+        build.describe()
+    );
     telemetry::emit(daemon_record(
         telemetry::reason::DAEMON_STARTUP,
         json!({
             "version": VERSION,
+            "build": build.payload(),
             "token_source": token_source,
             "http_routes_configured": config.has_http_routes(),
         }),
@@ -851,6 +856,11 @@ fn health_payload(
     json!({
         "ok": !subscription_degraded && !git_degraded,
         "version": VERSION,
+        // Build provenance of the running binary. `version` alone cannot
+        // distinguish a freshly deployed daemon from one still running a
+        // binary built several merges ago, which is how deployment drift
+        // stayed invisible behind a green repository backlog.
+        "build": crate::build_info::stamp().payload(),
         "token_source": config.discord_token_source(),
         "token_precedence_warning": config.discord_token_env_shadow().map(discord_token_shadow_warning),
         "github_monitor_auth": {
@@ -3864,6 +3874,31 @@ mod tests {
         assert_eq!(payload["token_precedence_warning"], Value::Null);
         assert_eq!(payload["http_routes_configured"], Value::Bool(false));
         assert_eq!(payload["expected_discord_bot_id"], Value::Null);
+
+        // Deployment drift is only detectable if the running binary reports
+        // which revision it was built from, not just the crate version.
+        let build = &payload["build"];
+        assert_eq!(build["version"], Value::String(VERSION.to_string()));
+        assert!(build["dirty"].is_boolean());
+        assert!(
+            matches!(
+                build["commit_source"].as_str(),
+                Some("git" | "environment" | "unavailable")
+            ),
+            "unexpected build commit source: {build}"
+        );
+        assert_eq!(
+            build["commit"].is_null(),
+            build["short_commit"].is_null(),
+            "build revision fields must agree: {build}"
+        );
+        if let Some(commit) = build["commit"].as_str() {
+            assert!(commit.chars().all(|c| c.is_ascii_hexdigit()));
+            assert!(commit.starts_with(build["short_commit"].as_str().unwrap()));
+        }
+        // The stamp must stay public-safe: no paths, branches, or hostnames.
+        let rendered = build.to_string();
+        assert!(!rendered.contains('/'), "build stamp leaked a path");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod binding_verify;
+mod build_info;
 mod cli;
 mod client;
 mod config;


### PR DESCRIPTION
Fixes #355.

## Why

The only build identity clawhip exposed was `CARGO_PKG_VERSION`, which moves on release. Between two releases every `dev` build reported an identical `clawhip 0.6.11`, so a daemon still running a binary built several merges ago was indistinguishable from a freshly deployed one — on the CLI, in `/health`, and in logs. That is how deployment drift kept hiding behind a green repository state: already-fixed behaviour reappeared with no open GitHub item, and each time the actual running revision had to be reconstructed by hand.

## What

- `build.rs` stamps the source revision (`CLAWHIP_BUILD_COMMIT` / `GITHUB_SHA` override, else `git rev-parse HEAD`) plus a dirty flag, and re-runs when `HEAD`/index moves.
- New `build_info` module exposes a public-safe `BuildStamp` (`version`, `commit`, `short_commit`, `dirty`, `commit_source`).
- `clawhip --version` → `clawhip 0.6.11 (bf8f47506afc)`, `-dirty` suffix when the tree was dirty, bare version when unknown.
- `/health` and `/api/status` gain a `build` object; the daemon startup line and startup telemetry carry the same stamp.
- README documents the surfaces and how to use them to confirm a rollout.

## Deliberate constraints

- **Fail-open.** A source tarball, a vendored crates.io build, or a host without `git` still builds and reports no revision rather than breaking.
- **Override validated.** `CLAWHIP_BUILD_COMMIT`/`GITHUB_SHA` must be a plain hex object name (7–40 chars), so branch names or arbitrary operator text cannot be stamped.
- **Public-safe.** Only the commit object name, a dirty flag, and its source. No branches, paths, hostnames, or build environment detail; tests assert the rendered stamp contains no path separators.
- Automatically comparing the reported revision against an expected deployment target is left to a follow-up, keeping this change narrow.

## Verification

- `cargo test` → **all suites pass, 0 failed** (bin `clawhip` 1104 unit tests + every integration test binary)
- `cargo fmt --check` → clean; `cargo clippy --all-targets -- -D warnings` → clean
- New tests: `build_info::tests::{stamp_is_public_safe_and_self_consistent, describe_marks_dirty_trees_and_degrades_without_a_revision, unknown_revisions_are_rejected_rather_than_reported_as_commits}`, plus `build` assertions in `daemon::tests::health_payload_includes_version_and_token_source`.
- Behaviour checked end to end:
  - in-checkout build → `clawhip 0.6.11 (bf8f47506afc-dirty)`
  - copied outside the checkout with no `.git` (tarball case) → builds fine, prints `clawhip 0.6.11`
  - `CLAWHIP_BUILD_COMMIT=deadbeefcafe1234567890abcdefabcdefabcdef` → `clawhip 0.6.11 (deadbeefcafe)`
  - `CLAWHIP_BUILD_COMMIT=my-branch-name` → rejected, falls back to `clawhip 0.6.11`

Base `dev@bf8f47506afc086682d982aaa38a7ff3cba5047a`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
