### PR TITLE
fix(status): surface partial tmux lane watch gaps

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4027,6 +4027,36 @@ mod tests {
     }
 
     #[test]
+    fn tmux_watch_coverage_diagnostics_do_not_degrade_daemon_health() {
+        let payload = health_payload(
+            &AppConfig::default(),
+            25294,
+            1,
+            snapshot_shared(&new_shared_native_hook_observability()),
+            json!({
+                "watch_coverage": {
+                    "live_lane_count": 2,
+                    "registered_live_lane_count": 1,
+                    "unregistered_live_lane_count": 1,
+                    "unregistered_live_lane_sample": ["gc-pr-5280-lane"]
+                }
+            }),
+            &[],
+            GitMonitorLifecycleCounts::default(),
+        );
+
+        assert_eq!(payload["ok"], Value::Bool(true));
+        assert_eq!(
+            payload["tmux"]["watch_coverage"]["unregistered_live_lane_count"],
+            Value::from(1)
+        );
+        assert_eq!(
+            payload["tmux"]["watch_coverage"]["unregistered_live_lane_sample"],
+            json!(["gc-pr-5280-lane"])
+        );
+    }
+
+    #[test]
     fn health_payload_surfaces_gjc_state_without_endpoints_or_tokens() {
         let mut config = AppConfig::default();
         config.gjc.enabled = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,11 +425,7 @@ async fn real_main(cli: Cli) -> Result<()> {
             TmuxCommands::List => {
                 let client = DaemonClient::from_config(config.as_ref());
                 let registrations = client.list_tmux().await?;
-                let health = if registrations.is_empty() {
-                    client.health().await.ok()
-                } else {
-                    None
-                };
+                let health = client.health().await.ok();
                 render_tmux_list(&registrations, health.as_ref());
                 Ok(())
             }
@@ -1193,6 +1189,10 @@ fn format_tmux_list_with_health(
         ));
     }
 
+    if let Some(warning) = tmux_watch_coverage_warning(health) {
+        output.push_str(&format!("WARNING: {warning}\n"));
+    }
+
     output
 }
 
@@ -1219,25 +1219,51 @@ fn tmux_empty_list_detail(health: Option<&serde_json::Value>) -> String {
     {
         return format!("; live tmux probe failed: {error}");
     }
-    let live_count = tmux
-        .get("live_probe")
-        .and_then(|probe| probe.get("count"))
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(0);
-    if live_count > 0 {
-        return format!(
-            "; {live_count} live tmux session(s) exist but no clawhip watch routes are registered"
-        );
+    if let Some(warning) = tmux_watch_coverage_warning(health) {
+        return format!("; warning: {warning}");
     }
     String::new()
+}
+
+fn tmux_watch_coverage_warning(health: Option<&serde_json::Value>) -> Option<String> {
+    let coverage = health
+        .and_then(|health| health.get("tmux"))?
+        .get("watch_coverage")?;
+    let count = coverage.get("unregistered_live_lane_count")?.as_u64()?;
+    if count == 0 {
+        return None;
+    }
+
+    let sample = coverage
+        .get("unregistered_live_lane_sample")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+    let omitted = count.saturating_sub(sample.len() as u64);
+    let sessions = if sample.is_empty() {
+        String::new()
+    } else {
+        format!(": {}", sample.join(", "))
+    };
+    let remainder = if omitted == 0 {
+        String::new()
+    } else {
+        format!(" (+{omitted} more)")
+    };
+
+    Some(format!(
+        "{count} live GJC lane session(s) are not registered as clawhip watches{sessions}{remainder}"
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        command_repairs_managed_state, format_tmux_list, load_config_for_cli,
-        parse_bind_checkout_overrides, parse_bind_overrides, parse_expect_name_overrides,
-        validate_bind_checkout_repos, verify_bindings_json,
+        command_repairs_managed_state, format_tmux_list, format_tmux_list_with_health,
+        load_config_for_cli, parse_bind_checkout_overrides, parse_bind_overrides,
+        parse_expect_name_overrides, validate_bind_checkout_repos, verify_bindings_json,
     };
     use crate::binding_verify::{BindingAudit, BindingDriftAudit};
     use crate::cli::Commands;
@@ -1486,5 +1512,75 @@ program = "/bin/true"
     #[test]
     fn format_tmux_list_handles_empty_registry() {
         assert_eq!(format_tmux_list(&[]), "No active tmux watches found\n");
+    }
+
+    #[test]
+    fn format_tmux_list_warns_about_partial_lane_coverage() {
+        let registration = RegisteredTmuxSession {
+            session: "gc-issue-367-lane".into(),
+            channel: Some("alerts".into()),
+            mention: None,
+            routing: RoutingMetadata::default(),
+            keywords: Vec::new(),
+            keyword_window_secs: 30,
+            stale_minutes: 10,
+            format: None,
+            registered_at: "2026-09-04T00:00:00Z".into(),
+            registration_source: RegistrationSource::CliWatch,
+            parent_process: None,
+            registration_generation: 0,
+            active_wrapper_monitor: false,
+            lane: None,
+        };
+        let health = serde_json::json!({
+            "tmux": {
+                "watch_coverage": {
+                    "unregistered_live_lane_count": 3,
+                    "unregistered_live_lane_sample": ["gc-pr-5271-lane", "gc-pr-5280-lane"]
+                }
+            }
+        });
+
+        let output = format_tmux_list_with_health(&[registration], Some(&health));
+
+        assert!(output.contains(
+            "WARNING: 3 live GJC lane session(s) are not registered as clawhip watches: gc-pr-5271-lane, gc-pr-5280-lane (+1 more)\n"
+        ));
+    }
+
+    #[test]
+    fn format_tmux_list_warns_about_zero_registration_lane_coverage() {
+        let health = serde_json::json!({
+            "tmux": {
+                "live_probe": { "count": 2 },
+                "watch_coverage": {
+                    "unregistered_live_lane_count": 1,
+                    "unregistered_live_lane_sample": ["gc-issue-367-lane"]
+                }
+            }
+        });
+
+        assert_eq!(
+            format_tmux_list_with_health(&[], Some(&health)),
+            "No active tmux watches found; warning: 1 live GJC lane session(s) are not registered as clawhip watches: gc-issue-367-lane\n"
+        );
+    }
+
+    #[test]
+    fn format_tmux_list_does_not_warn_for_unrelated_live_sessions() {
+        let health = serde_json::json!({
+            "tmux": {
+                "live_probe": { "count": 2 },
+                "watch_coverage": {
+                    "unregistered_live_lane_count": 0,
+                    "unregistered_live_lane_sample": []
+                }
+            }
+        });
+
+        assert_eq!(
+            format_tmux_list_with_health(&[], Some(&health)),
+            "No active tmux watches found\n"
+        );
     }
 }

--- a/src/source/tmux.rs
+++ b/src/source/tmux.rs
@@ -26,6 +26,7 @@ use crate::telemetry;
 pub type SharedTmuxRegistry = Arc<RwLock<HashMap<String, RegisteredTmuxSession>>>;
 static REGISTRY_MUTATION_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 static NEXT_REGISTRATION_GENERATION: AtomicU64 = AtomicU64::new(1);
+const MAX_TMUX_DIAGNOSTIC_SESSION_SAMPLE: usize = 5;
 
 /// Mint a process-wide monotonically increasing registration generation.
 /// Client-supplied values are always overwritten with the daemon-minted
@@ -62,6 +63,7 @@ pub struct TmuxRegistryDiagnostics {
     pub durable_runtime_count: usize,
     pub config_projected_count: usize,
     pub live_probe: TmuxLiveProbeDiagnostics,
+    pub watch_coverage: TmuxWatchCoverageDiagnostics,
     pub registry_state: TmuxRegistryStateDiagnostics,
 }
 
@@ -71,6 +73,14 @@ pub struct TmuxLiveProbeDiagnostics {
     pub count: usize,
     pub sample: Vec<String>,
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TmuxWatchCoverageDiagnostics {
+    pub live_lane_count: usize,
+    pub registered_live_lane_count: usize,
+    pub unregistered_live_lane_count: usize,
+    pub unregistered_live_lane_sample: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1932,31 +1942,42 @@ pub async fn tmux_registry_diagnostics(
     let registered_count = snapshot.len();
     let durable_runtime_count = durable_runtime_entries(&snapshot).len();
     let config_projected_count = registered_count.saturating_sub(durable_runtime_count);
+    let registered_sessions = snapshot.keys().cloned().collect::<HashSet<_>>();
     drop(snapshot);
 
-    let live_probe = match list_tmux_sessions().await {
+    let (live_probe, watch_coverage) = match list_tmux_sessions().await {
         Ok(TmuxSessionInventory::Sessions(sessions)) => {
-            let mut sample = sessions.iter().take(5).cloned().collect::<Vec<_>>();
+            let mut sample = sessions.iter().cloned().collect::<Vec<_>>();
             sample.sort();
+            sample.truncate(MAX_TMUX_DIAGNOSTIC_SESSION_SAMPLE);
+            (
+                TmuxLiveProbeDiagnostics {
+                    ok: true,
+                    count: sessions.len(),
+                    sample,
+                    error: None,
+                },
+                tmux_watch_coverage(&sessions, &registered_sessions),
+            )
+        }
+        Ok(TmuxSessionInventory::NoServer) => (
             TmuxLiveProbeDiagnostics {
                 ok: true,
-                count: sessions.len(),
-                sample,
+                count: 0,
+                sample: Vec::new(),
                 error: None,
-            }
-        }
-        Ok(TmuxSessionInventory::NoServer) => TmuxLiveProbeDiagnostics {
-            ok: true,
-            count: 0,
-            sample: Vec::new(),
-            error: None,
-        },
-        Err(error) => TmuxLiveProbeDiagnostics {
-            ok: false,
-            count: 0,
-            sample: Vec::new(),
-            error: Some(error.to_string()),
-        },
+            },
+            tmux_watch_coverage(&HashSet::new(), &registered_sessions),
+        ),
+        Err(error) => (
+            TmuxLiveProbeDiagnostics {
+                ok: false,
+                count: 0,
+                sample: Vec::new(),
+                error: Some(error.to_string()),
+            },
+            tmux_watch_coverage(&HashSet::new(), &registered_sessions),
+        ),
     };
 
     TmuxRegistryDiagnostics {
@@ -1964,8 +1985,49 @@ pub async fn tmux_registry_diagnostics(
         durable_runtime_count,
         config_projected_count,
         live_probe,
+        watch_coverage,
         registry_state,
     }
+}
+
+fn tmux_watch_coverage(
+    live_sessions: &HashSet<String>,
+    registered_sessions: &HashSet<String>,
+) -> TmuxWatchCoverageDiagnostics {
+    let mut live_lanes = live_sessions
+        .iter()
+        .filter(|session| is_gjc_lane_session(session))
+        .cloned()
+        .collect::<Vec<_>>();
+    live_lanes.sort();
+
+    let live_lane_count = live_lanes.len();
+    let registered_live_lane_count = live_lanes
+        .iter()
+        .filter(|session| registered_sessions.contains(*session))
+        .count();
+    let mut unregistered_live_lanes = live_lanes
+        .into_iter()
+        .filter(|session| !registered_sessions.contains(session))
+        .collect::<Vec<_>>();
+    let unregistered_live_lane_count = unregistered_live_lanes.len();
+    unregistered_live_lanes.truncate(MAX_TMUX_DIAGNOSTIC_SESSION_SAMPLE);
+
+    TmuxWatchCoverageDiagnostics {
+        live_lane_count,
+        registered_live_lane_count,
+        unregistered_live_lane_count,
+        unregistered_live_lane_sample: unregistered_live_lanes,
+    }
+}
+
+fn is_gjc_lane_session(session: &str) -> bool {
+    ["gc-issue-", "gc-pr-"].iter().any(|prefix| {
+        session
+            .strip_prefix(prefix)
+            .and_then(|suffix| suffix.strip_suffix("-lane"))
+            .is_some_and(|lane_id| !lane_id.is_empty())
+    })
 }
 
 pub async fn list_active_tmux_registrations(
@@ -3770,6 +3832,83 @@ PR created #7",
     fn default_registry_state_path_sits_beside_cron_state() {
         let path = default_registry_state_path(Path::new("/tmp/clawhip/cron-state.json"));
         assert_eq!(path, PathBuf::from("/tmp/clawhip/tmux-watch-registry.json"));
+    }
+
+    #[test]
+    fn watch_coverage_reports_sorted_bounded_partial_lane_gaps() {
+        let live = HashSet::from([
+            "gc-pr-9-lane".to_string(),
+            "gc-pr-8-lane".to_string(),
+            "gc-pr-7-lane".to_string(),
+            "gc-pr-6-lane".to_string(),
+            "gc-pr-5-lane".to_string(),
+            "gc-pr-4-lane".to_string(),
+            "gc-pr-3-lane".to_string(),
+            "gc-issue-3-lane".to_string(),
+        ]);
+        let registered = HashSet::from(["gc-issue-3-lane".to_string(), "gc-pr-9-lane".to_string()]);
+
+        let diagnostics = tmux_watch_coverage(&live, &registered);
+
+        assert_eq!(diagnostics.live_lane_count, 8);
+        assert_eq!(diagnostics.registered_live_lane_count, 2);
+        assert_eq!(diagnostics.unregistered_live_lane_count, 6);
+        assert_eq!(
+            diagnostics.unregistered_live_lane_sample,
+            [
+                "gc-pr-3-lane",
+                "gc-pr-4-lane",
+                "gc-pr-5-lane",
+                "gc-pr-6-lane",
+                "gc-pr-7-lane",
+            ]
+        );
+    }
+
+    #[test]
+    fn watch_coverage_reports_zero_registration_lane_gap() {
+        let live = HashSet::from(["gc-issue-367-lane".to_string()]);
+
+        let diagnostics = tmux_watch_coverage(&live, &HashSet::new());
+
+        assert_eq!(diagnostics.live_lane_count, 1);
+        assert_eq!(diagnostics.registered_live_lane_count, 0);
+        assert_eq!(diagnostics.unregistered_live_lane_count, 1);
+        assert_eq!(
+            diagnostics.unregistered_live_lane_sample,
+            ["gc-issue-367-lane"]
+        );
+    }
+
+    #[test]
+    fn watch_coverage_is_clean_for_fully_registered_lanes() {
+        let live = HashSet::from([
+            "gc-issue-367-lane".to_string(),
+            "gc-pr-5280-lane".to_string(),
+        ]);
+
+        let diagnostics = tmux_watch_coverage(&live, &live);
+
+        assert_eq!(diagnostics.live_lane_count, 2);
+        assert_eq!(diagnostics.registered_live_lane_count, 2);
+        assert_eq!(diagnostics.unregistered_live_lane_count, 0);
+        assert!(diagnostics.unregistered_live_lane_sample.is_empty());
+    }
+
+    #[test]
+    fn watch_coverage_ignores_unrelated_tmux_sessions() {
+        let live = HashSet::from([
+            "operator-shell".to_string(),
+            "gc-pr--lane".to_string(),
+            "gc-issue-367".to_string(),
+        ]);
+
+        let diagnostics = tmux_watch_coverage(&live, &HashSet::new());
+
+        assert_eq!(diagnostics.live_lane_count, 0);
+        assert_eq!(diagnostics.registered_live_lane_count, 0);
+        assert_eq!(diagnostics.unregistered_live_lane_count, 0);
+        assert!(diagnostics.unregistered_live_lane_sample.is_empty());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- add bounded, sorted tmux watch-coverage diagnostics for live `gc-issue-*-lane` and `gc-pr-*-lane` sessions
- warn from `clawhip tmux list` for partial or zero-registration lane gaps while ignoring unrelated tmux sessions
- preserve daemon `ok` semantics and add deterministic coverage for partial, zero, full, and unrelated inventories

## Verification
- `cargo test --locked source::tmux::tests::watch_coverage -- --nocapture`
- `cargo test --locked tests::format_tmux_list -- --nocapture`
- `cargo test --locked daemon::tests::tmux_watch_coverage_diagnostics_do_not_degrade_daemon_health -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (1276 passed)

Closes #367

—
[repo owner's gaebal-gajae (clawdbot) 🦞]
